### PR TITLE
add rst fileType with link regex

### DIFF
--- a/.doc-detective.json
+++ b/.doc-detective.json
@@ -53,6 +53,28 @@
           ]
         }
       ]
+    },
+    {
+      "name": "reStructuredText",
+      "extensions": [".rst"],
+      "testStartStatementOpen": ".. (test start",
+      "testStartStatementClose": ")",
+      "testIgnoreStatement": ".. (test ignore)",
+      "testEndStatement": ".. (test end)",
+      "stepStatementOpen": ".. (step",
+      "stepStatementClose": ")",
+      "markup": [
+        {
+          "name": "Hyperlink",
+          "regex": ["(?<= <)https?[^>]+(?=>`_)"],
+          "actions": ["checkLink"]
+        },
+        {
+          "name": "Anonymous hyperlink",
+          "regex": ["(?<=__ )https?[\\S]+"],
+          "actions": ["checkLink"]
+        }
+      ]
     }
   ],
   "telemetry": {


### PR DESCRIPTION
Basic support for matching URLs in reStructuredText (`.rst`) files.

- Uses `..` comment syntax for required test statement delimiters.
- Adds `checkLink` actions for two formats of reStructuredText hyperlinks. These are not exhaustive — more could be added based on the [reference](https://docutils.sourceforge.io/docs/user/rst/quickref.html#contents)