### PR TITLE
v2.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "doc-detective",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective",
-      "version": "2.13.1",
+      "version": "2.14.0",
       "license": "MIT",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "doc-detective-common": "^1.17.0",
-        "doc-detective-core": "^2.13.0",
+        "doc-detective-common": "^1.18.0",
+        "doc-detective-core": "^2.14.0",
         "prompt-sync": "^4.2.0",
         "yargs": "^17.7.2"
       },
@@ -20,7 +20,7 @@
       },
       "devDependencies": {
         "chai": "^5.1.1",
-        "mocha": "^10.4.0"
+        "mocha": "^10.6.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -40,17 +40,17 @@
       }
     },
     "node_modules/@appium/base-driver": {
-      "version": "9.10.3",
-      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-9.10.3.tgz",
-      "integrity": "sha512-xPv2StYa8hHzgXF70bvQtc/5dOdqCR1DcwwSjSTOt49FTPGg6bYCSSobAfdHr80iR/alwNXe66qVkiOn1rO1iw==",
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-9.11.1.tgz",
+      "integrity": "sha512-gil/4mE/I9SusprGkCgePSkqnvLhv+D2CZ3xS2GkOPmCv07M0Gpsf9y9IuN9LmgyNUDalDtnXjErSn+LDjZd9g==",
       "dependencies": {
-        "@appium/support": "^5.0.3",
-        "@appium/types": "^0.20.3",
+        "@appium/support": "^5.1.1",
+        "@appium/types": "^0.21.0",
         "@colors/colors": "1.6.0",
         "@types/async-lock": "1.4.2",
         "@types/bluebird": "3.5.42",
         "@types/express": "4.17.21",
-        "@types/lodash": "4.17.5",
+        "@types/lodash": "4.17.6",
         "@types/method-override": "0.0.35",
         "@types/serve-favicon": "2.5.7",
         "async-lock": "1.4.1",
@@ -61,13 +61,13 @@
         "express": "4.19.2",
         "http-status-codes": "2.3.0",
         "lodash": "4.17.21",
-        "lru-cache": "10.2.2",
+        "lru-cache": "10.3.0",
         "method-override": "3.0.0",
         "morgan": "1.10.0",
-        "path-to-regexp": "6.2.2",
+        "path-to-regexp": "7.0.0",
         "serve-favicon": "2.5.0",
         "source-map-support": "0.5.21",
-        "type-fest": "4.20.0",
+        "type-fest": "4.20.1",
         "validate.js": "0.13.1"
       },
       "engines": {
@@ -79,12 +79,12 @@
       }
     },
     "node_modules/@appium/base-plugin": {
-      "version": "2.2.39",
-      "resolved": "https://registry.npmjs.org/@appium/base-plugin/-/base-plugin-2.2.39.tgz",
-      "integrity": "sha512-IP97zRJ3CiHqcIqFRk+3giyQVa76FEzSKJMtQW0rtDlELq4eRKbvTgOkIK0+U8uSDCKDzlklhjQ/36unSyzD9g==",
+      "version": "2.2.41",
+      "resolved": "https://registry.npmjs.org/@appium/base-plugin/-/base-plugin-2.2.41.tgz",
+      "integrity": "sha512-xaVrg+3IXckdkQg6MRpL3QSXuDGZd2KnHJDxRhGS1KazOGiPjCDkgnNOuwhMXstRjvuq74ujTP/JANZClz866w==",
       "dependencies": {
-        "@appium/base-driver": "^9.10.3",
-        "@appium/support": "^5.0.3"
+        "@appium/base-driver": "^9.11.1",
+        "@appium/support": "^5.1.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -92,11 +92,11 @@
       }
     },
     "node_modules/@appium/docutils": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-1.0.15.tgz",
-      "integrity": "sha512-R8gxGLdtZIKkhOfz4ZuwYMO1K9xdZJm0UWRua3bkoifugkgInFdXNJT4y+UBOP39DvlV1qGYKS0euvPdoN8KQw==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-1.0.17.tgz",
+      "integrity": "sha512-SXJftkyY2YRvPouPFuYAUrv9Yw8tkKHUUoBFQrOH5yvMOxt4RIx6G9TktHcisZ8p0y66fa+pr8ic87jnDPlCvA==",
       "dependencies": {
-        "@appium/support": "^5.0.3",
+        "@appium/support": "^5.1.1",
         "@appium/tsconfig": "^0.3.3",
         "@sliphua/lilconfig-ts-loader": "3.2.2",
         "@types/which": "3.0.4",
@@ -110,9 +110,9 @@
         "read-pkg": "5.2.0",
         "semver": "7.6.2",
         "source-map-support": "0.5.21",
-        "teen_process": "2.1.4",
-        "type-fest": "4.20.0",
-        "typescript": "5.4.5",
+        "teen_process": "2.1.6",
+        "type-fest": "4.20.1",
+        "typescript": "5.5.2",
         "yaml": "2.4.5",
         "yargs": "17.7.2",
         "yargs-parser": "21.1.1"
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@appium/logger": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@appium/logger/-/logger-1.4.2.tgz",
-      "integrity": "sha512-ifHuA4wuBa8xLx77lYhYmNi9qNPuGb1QgUQreME58Ugh5K2M6C+4xq6dD9KiQpHf0sy64m8fflxy24jrRPJ8ZA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@appium/logger/-/logger-1.5.0.tgz",
+      "integrity": "sha512-wij7z6RgCxiu66jgpySQHxj0dcuGfSn7v97MBwZ9+IEiqFDrbZR1+ExrXpbmqNXkVWOqWvNFXCYROW0g5dfKuA==",
       "dependencies": {
         "console-control-strings": "1.1.0",
         "lodash": "4.17.21",
@@ -165,13 +165,13 @@
       }
     },
     "node_modules/@appium/support": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@appium/support/-/support-5.0.3.tgz",
-      "integrity": "sha512-MCfaP3lg6WyRlBqk2yKr2q51tYhHBbOpJKX9rcHaFenlvf6lCKTrdazY4U/GP8MzW7/RxQE4l8jCJUXomLRfbQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@appium/support/-/support-5.1.1.tgz",
+      "integrity": "sha512-YwludQ+V5mgGYJQjkuDJ29X0LSJehBeC5IwvaZxKdv/VKLKAbOl3QZqv3RKIGJqQInP6ZOD+doG3OVP64Y/txQ==",
       "dependencies": {
-        "@appium/logger": "^1.4.2",
+        "@appium/logger": "^1.5.0",
         "@appium/tsconfig": "^0.3.3",
-        "@appium/types": "^0.20.3",
+        "@appium/types": "^0.21.0",
         "@colors/colors": "1.6.0",
         "@types/archiver": "6.0.2",
         "@types/base64-stream": "1.0.5",
@@ -186,7 +186,7 @@
         "@types/shell-quote": "1.7.5",
         "@types/supports-color": "8.1.3",
         "@types/teen_process": "2.0.4",
-        "@types/uuid": "9.0.8",
+        "@types/uuid": "10.0.0",
         "@types/which": "3.0.4",
         "archiver": "7.0.1",
         "axios": "1.7.2",
@@ -196,7 +196,7 @@
         "bplist-parser": "0.3.2",
         "form-data": "4.0.0",
         "get-stream": "6.0.1",
-        "glob": "10.4.1",
+        "glob": "10.4.2",
         "jsftp": "2.1.3",
         "klaw": "4.1.0",
         "lockfile": "1.0.4",
@@ -216,9 +216,9 @@
         "shell-quote": "1.8.1",
         "source-map-support": "0.5.21",
         "supports-color": "8.1.1",
-        "teen_process": "2.1.4",
-        "type-fest": "4.20.0",
-        "uuid": "9.0.1",
+        "teen_process": "2.1.6",
+        "type-fest": "4.20.1",
+        "uuid": "10.0.0",
         "which": "4.0.0",
         "yauzl": "3.1.3"
       },
@@ -239,18 +239,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@appium/support/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@appium/support/node_modules/yauzl": {
@@ -278,16 +266,16 @@
       }
     },
     "node_modules/@appium/types": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.20.3.tgz",
-      "integrity": "sha512-5PTxTAyMvJbSY1ByBiXbnaLOejjPh2B0X+jadoOu6dciuPYMt+12yaH9yk/FfpFI4E7v/tbe1Vov5K/aIKm/jA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.21.0.tgz",
+      "integrity": "sha512-Z2kx1W6oLwXTzu/aETBJ1AivdjTSWtlT5xBPckR9Nzh+JpGboBJtJsiAhmPHeEBLhEB/pqXKxKVlh9NV8eKGaw==",
       "dependencies": {
-        "@appium/logger": "^1.4.2",
+        "@appium/logger": "^1.5.0",
         "@appium/schema": "^0.6.1",
         "@appium/tsconfig": "^0.3.3",
         "@types/express": "4.17.21",
         "@types/ws": "8.5.10",
-        "type-fest": "4.20.0"
+        "type-fest": "4.20.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -1210,9 +1198,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.3.tgz",
-      "integrity": "sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==",
+      "version": "4.19.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1267,9 +1255,9 @@
       "integrity": "sha512-Q8oFIHJHr+htLrTXN2FuZfg+WXVHQRwU/hC2GpUu+Q8e3FUM9EDkS2pE3R2AO1ZGu56f479ybdMCNF1DAu8cAQ=="
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw=="
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.6.tgz",
+      "integrity": "sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA=="
     },
     "node_modules/@types/method-override": {
       "version": "0.0.35",
@@ -1389,9 +1377,9 @@
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
     },
     "node_modules/@types/which": {
       "version": "3.0.4",
@@ -1671,9 +1659,9 @@
       }
     },
     "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -1718,18 +1706,18 @@
       }
     },
     "node_modules/appium": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/appium/-/appium-2.10.3.tgz",
-      "integrity": "sha512-old7FJBVCFLIgEYiRszmfaElhUOAGHSLxPXC8UkLvq6ioA/hELc9kfU1QkCzXRaTMFHRQwgXbT5HTa6Wy2YPnA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/appium/-/appium-2.11.1.tgz",
+      "integrity": "sha512-OrWwx3n+zx0I4ExClDCjPyFW26tvpw7jl7+1y1YEbsbuSZ81+ydMTHsQEr4wJzT0oRiFHWnB5SQ3sBMJxw2T0Q==",
       "hasInstallScript": true,
       "dependencies": {
-        "@appium/base-driver": "^9.10.3",
-        "@appium/base-plugin": "^2.2.39",
-        "@appium/docutils": "^1.0.15",
-        "@appium/logger": "^1.4.2",
+        "@appium/base-driver": "^9.11.1",
+        "@appium/base-plugin": "^2.2.41",
+        "@appium/docutils": "^1.0.17",
+        "@appium/logger": "^1.5.0",
         "@appium/schema": "^0.6.1",
-        "@appium/support": "^5.0.3",
-        "@appium/types": "^0.20.3",
+        "@appium/support": "^5.1.1",
+        "@appium/types": "^0.21.0",
         "@sidvind/better-ajv-errors": "2.1.3",
         "@types/argparse": "2.0.16",
         "@types/bluebird": "3.5.42",
@@ -1747,17 +1735,17 @@
         "cross-env": "7.0.3",
         "lilconfig": "3.1.2",
         "lodash": "4.17.21",
-        "lru-cache": "10.2.2",
+        "lru-cache": "10.3.0",
         "ora": "5.4.1",
         "package-changed": "3.0.0",
         "resolve-from": "5.0.0",
         "semver": "7.6.2",
         "source-map-support": "0.5.21",
-        "teen_process": "2.1.4",
-        "type-fest": "4.20.0",
+        "teen_process": "2.1.6",
+        "type-fest": "4.20.1",
         "winston": "3.13.0",
         "wrap-ansi": "7.0.0",
-        "ws": "8.17.0",
+        "ws": "8.17.1",
         "yaml": "2.4.5"
       },
       "bin": {
@@ -5861,9 +5849,9 @@
       }
     },
     "node_modules/appium-geckodriver": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/appium-geckodriver/-/appium-geckodriver-1.3.6.tgz",
-      "integrity": "sha512-5XvCVFipFk1IRZjiwOwRuBAH4uISUGzW/S414JsVLF27sRY0Qmn8GDXSOjLrxzkmFL3QjOFNGiciuS5oSqvBKw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/appium-geckodriver/-/appium-geckodriver-1.3.7.tgz",
+      "integrity": "sha512-Xr3k3huF36Gr0FGgmPnCafKbFfD3AYhlOtppInlMOj0vWu3lkkTYySW7tRmyddefbD6G36qYdaZQmiNeWBnQ+w==",
       "hasShrinkwrap": true,
       "dependencies": {
         "appium-adb": "^12.0.3",
@@ -5882,10 +5870,24 @@
         "appium": "^2.4.1"
       }
     },
+    "node_modules/appium-geckodriver/node_modules/@appium/logger": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@appium/logger/-/logger-1.4.2.tgz",
+      "integrity": "sha512-ifHuA4wuBa8xLx77lYhYmNi9qNPuGb1QgUQreME58Ugh5K2M6C+4xq6dD9KiQpHf0sy64m8fflxy24jrRPJ8ZA==",
+      "dependencies": {
+        "console-control-strings": "1.1.0",
+        "lodash": "4.17.21",
+        "set-blocking": "2.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=8"
+      }
+    },
     "node_modules/appium-geckodriver/node_modules/@appium/schema": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.5.0.tgz",
-      "integrity": "sha512-HFed9HtFU6+kLdVyp/xpS/Wfcge8PuMS37LJVShviT6OuzHOYvNFx1/y8+KMa/l0Npvll5eafdfHmUsWlRnUAA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.6.1.tgz",
+      "integrity": "sha512-tk4ytYaQQ94h5pqz97V2yKqZAmGnBd4ld50ZEw4Tt8QL2VBXOuTuizKDH+AMpyyL6hn/+dMFtcSVjy19iKrsUg==",
       "dependencies": {
         "@types/json-schema": "7.0.15",
         "json-schema": "0.4.0",
@@ -5897,12 +5899,13 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/@appium/support": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@appium/support/-/support-4.2.6.tgz",
-      "integrity": "sha512-uX4OMlatb3zsTOmh2YPZb3owtxdCMfMk9IbcFilIzCMLRAhYEYw29Z8vNe19QN+td2tS0i0NOFae5tz7lB72Uw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@appium/support/-/support-5.0.3.tgz",
+      "integrity": "sha512-MCfaP3lg6WyRlBqk2yKr2q51tYhHBbOpJKX9rcHaFenlvf6lCKTrdazY4U/GP8MzW7/RxQE4l8jCJUXomLRfbQ==",
       "dependencies": {
+        "@appium/logger": "^1.4.2",
         "@appium/tsconfig": "^0.3.3",
-        "@appium/types": "^0.18.0",
+        "@appium/types": "^0.20.3",
         "@colors/colors": "1.6.0",
         "@types/archiver": "6.0.2",
         "@types/base64-stream": "1.0.5",
@@ -5912,14 +5915,13 @@
         "@types/lockfile": "1.0.4",
         "@types/mv": "2.1.4",
         "@types/ncp": "2.0.8",
-        "@types/npmlog": "7.0.0",
         "@types/pluralize": "0.0.33",
         "@types/semver": "7.5.8",
         "@types/shell-quote": "1.7.5",
         "@types/supports-color": "8.1.3",
         "@types/teen_process": "2.0.4",
         "@types/uuid": "9.0.8",
-        "@types/which": "3.0.3",
+        "@types/which": "3.0.4",
         "archiver": "7.0.1",
         "axios": "1.7.2",
         "base64-stream": "1.0.0",
@@ -5937,7 +5939,6 @@
         "moment": "2.30.1",
         "mv": "2.1.1",
         "ncp": "2.0.0",
-        "npmlog": "7.0.1",
         "opencv-bindings": "4.5.5",
         "pkg-dir": "5.0.0",
         "plist": "3.1.0",
@@ -5949,8 +5950,8 @@
         "shell-quote": "1.8.1",
         "source-map-support": "0.5.21",
         "supports-color": "8.1.1",
-        "teen_process": "2.1.3",
-        "type-fest": "4.18.3",
+        "teen_process": "2.1.4",
+        "type-fest": "4.20.0",
         "uuid": "9.0.1",
         "which": "4.0.0",
         "yauzl": "3.1.3"
@@ -5964,9 +5965,9 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/@appium/support/node_modules/teen_process": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.1.3.tgz",
-      "integrity": "sha512-OBxmDvVOGavBQscCaKn365B5KuQ04uGRekAcKbwCu/2M1YvICpeNgVpqR+z9AhWSYOdB4zKLLwk4M1fyfAwPjw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.1.4.tgz",
+      "integrity": "sha512-TEaxCYk/aCBsNBCZmgUNXqtCWq8RX94nGoyYYu7YiNR+RnmawMFshTkYe1SFhiNCX6FsYb6wL/irs6NhvfoF5g==",
       "dependencies": {
         "bluebird": "^3.7.2",
         "lodash": "^4.17.21",
@@ -5991,16 +5992,16 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/@appium/types": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.18.0.tgz",
-      "integrity": "sha512-gvR75CbtbHP1dqUr1arWlLzI9ABAtosn/qDTqwjG5OX59ael6OwsWlfrR7wIDiGy7CjmHMRZJ38g+O4QwB9GCQ==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.20.3.tgz",
+      "integrity": "sha512-5PTxTAyMvJbSY1ByBiXbnaLOejjPh2B0X+jadoOu6dciuPYMt+12yaH9yk/FfpFI4E7v/tbe1Vov5K/aIKm/jA==",
       "dependencies": {
-        "@appium/schema": "^0.5.0",
+        "@appium/logger": "^1.4.2",
+        "@appium/schema": "^0.6.1",
         "@appium/tsconfig": "^0.3.3",
         "@types/express": "4.17.21",
-        "@types/npmlog": "7.0.0",
         "@types/ws": "8.5.10",
-        "type-fest": "4.18.3"
+        "type-fest": "4.20.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -6008,11 +6009,11 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/@babel/code-frame": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.6.tgz",
-      "integrity": "sha512-ZJhac6FkEd1yhG2AHOmfcXG4ceoLltoCVJjN5XsWN9BifBQr+cHJbWi0h68HZuSORq+3WtJ2z0hwF2NG1b5kcA==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "dependencies": {
-        "@babel/highlight": "^7.24.6",
+        "@babel/highlight": "^7.24.7",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -6020,19 +6021,19 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz",
-      "integrity": "sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/appium-geckodriver/node_modules/@babel/highlight": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.6.tgz",
-      "integrity": "sha512-2YnuOp4HAk2BsBrJJvYCbItHx0zWscI1C3zgWkz+wDyD9I7GIVrfnLyrR4Y1VR+7p+chAEcrgRQYZAGIKMV7vQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.6",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -6322,9 +6323,9 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/@types/express-serve-static-core": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.3.tgz",
-      "integrity": "sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==",
+      "version": "4.19.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -6369,9 +6370,9 @@
       "integrity": "sha512-Q8oFIHJHr+htLrTXN2FuZfg+WXVHQRwU/hC2GpUu+Q8e3FUM9EDkS2pE3R2AO1ZGu56f479ybdMCNF1DAu8cAQ=="
     },
     "node_modules/appium-geckodriver/node_modules/@types/lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==",
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==",
       "extraneous": true
     },
     "node_modules/appium-geckodriver/node_modules/@types/mime": {
@@ -6393,9 +6394,9 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/@types/node": {
-      "version": "20.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.1.tgz",
-      "integrity": "sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==",
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -6404,14 +6405,6 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
-    },
-    "node_modules/appium-geckodriver/node_modules/@types/npmlog": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-7.0.0.tgz",
-      "integrity": "sha512-hJWbrKFvxKyWwSUXjZMYTINsSOY6IclhvGOZ97M8ac2tmR9hMwmTnYaMdpGhvju9ctWLTPhCS+eLfQNluiEjQQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/appium-geckodriver/node_modules/@types/pluralize": {
       "version": "0.0.33",
@@ -6484,9 +6477,9 @@
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
     },
     "node_modules/appium-geckodriver/node_modules/@types/which": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.3.tgz",
-      "integrity": "sha512-2C1+XoY0huExTbs8MQv1DuS5FS86+SEjdM9F/+GS61gg5Hqbtj8ZiDSx8MfWcyei907fIPbfPGCOrNUTnVHY1g=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.4.tgz",
+      "integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w=="
     },
     "node_modules/appium-geckodriver/node_modules/@types/ws": {
       "version": "8.5.10",
@@ -6538,11 +6531,11 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/appium-adb": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/appium-adb/-/appium-adb-12.4.2.tgz",
-      "integrity": "sha512-iBU61R59NblxZWM4b0JiHiSCEm4TzSR1ZVQ1tnQiFdYKucosrqpyMGL10MY5cfOztsn67yi0bxanGJC2WiV5XQ==",
+      "version": "12.4.4",
+      "resolved": "https://registry.npmjs.org/appium-adb/-/appium-adb-12.4.4.tgz",
+      "integrity": "sha512-q+vN6NgnUlcWT6FV12ryc1d8bFZSQOtcXpJJuUtgWYwVhebJB8hJE+6mcqUG5LOrcEWLOQXkx1oVQSx+VQosTQ==",
       "dependencies": {
-        "@appium/support": "^4.0.0",
+        "@appium/support": "^5.0.3",
         "@devicefarmer/adbkit-apkreader": "^3.2.4",
         "async-lock": "^1.0.0",
         "asyncbox": "^3.0.0",
@@ -6558,11 +6551,6 @@
         "node": ">=14",
         "npm": ">=8"
       }
-    },
-    "node_modules/appium-geckodriver/node_modules/aproba": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
     },
     "node_modules/appium-geckodriver/node_modules/archiver": {
       "version": "7.0.1",
@@ -6596,15 +6584,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/appium-geckodriver/node_modules/are-we-there-yet": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-4.0.2.tgz",
-      "integrity": "sha512-ncSWAawFhKMJDTdoAeOV+jyW1VCMj5QIAwULIBV0SSR7B/RLPPEQiknKcg/RIIZlUQrxELpsxMiTUoAQ4sIUyg==",
-      "deprecated": "This package is no longer supported.",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/appium-geckodriver/node_modules/arg": {
@@ -6668,9 +6647,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/appium-geckodriver/node_modules/bare-events": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.3.1.tgz",
-      "integrity": "sha512-sJnSOTVESURZ61XgEleqmP255T6zTYwHPwE4r6SssIh0U9/uDvfpdoJYpVUerJJZH2fueO+CdT8ZT+OC/7aZDA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
       "optional": true
     },
     "node_modules/appium-geckodriver/node_modules/base64-js": {
@@ -6892,14 +6871,6 @@
         "simple-swizzle": "^0.2.2"
       }
     },
-    "node_modules/appium-geckodriver/node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/appium-geckodriver/node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -7052,15 +7023,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/appium-geckodriver/node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-      "extraneous": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/appium-geckodriver/node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -7178,9 +7140,9 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -7254,54 +7216,6 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/appium-geckodriver/node_modules/gauge": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-5.0.2.tgz",
-      "integrity": "sha512-pMaFftXPtiGIHCJHdcUUx9Rby/rFT/Kkt3fIIGCs+9PMDIljSyRiqraTlxNtBReJRDfUefpa263RQ3vnp5G/LQ==",
-      "deprecated": "This package is no longer supported.",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^4.0.1",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/appium-geckodriver/node_modules/gauge/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/appium-geckodriver/node_modules/gauge/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/appium-geckodriver/node_modules/gauge/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/appium-geckodriver/node_modules/get-caller-file": {
@@ -7425,11 +7339,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/appium-geckodriver/node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
-    },
     "node_modules/appium-geckodriver/node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -7494,11 +7403,14 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/appium-geckodriver/node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+      "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7551,9 +7463,9 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/jackspeak": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.2.3.tgz",
-      "integrity": "sha512-htOzIMPbpLid/Gq9/zaz9SfExABxqRe1sSCdxntlO/aMD6u0issZQiY25n2GKQUtJ02j7z5sfptlAOMpWWOmvw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -7688,12 +7600,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/appium-geckodriver/node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "extraneous": true
     },
     "node_modules/appium-geckodriver/node_modules/lodash.isfinite": {
       "version": "3.3.2",
@@ -7907,26 +7813,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/appium-geckodriver/node_modules/npmlog": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-7.0.1.tgz",
-      "integrity": "sha512-uJ0YFk/mCQpLBt+bxN88AKd+gyqZvZDbtiNxk6Waqcj2aPRyfVx8ITawkyQynxUagInjdYT1+qj4NfA5KJJUxg==",
-      "deprecated": "This package is no longer supported.",
-      "dependencies": {
-        "are-we-there-yet": "^4.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^5.0.0",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/appium-geckodriver/node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
       "extraneous": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -8055,12 +7949,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/appium-geckodriver/node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-      "extraneous": true
     },
     "node_modules/appium-geckodriver/node_modules/pend": {
       "version": "1.2.0",
@@ -8627,9 +8515,9 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/teen_process": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.1.4.tgz",
-      "integrity": "sha512-TEaxCYk/aCBsNBCZmgUNXqtCWq8RX94nGoyYYu7YiNR+RnmawMFshTkYe1SFhiNCX6FsYb6wL/irs6NhvfoF5g==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.1.6.tgz",
+      "integrity": "sha512-VCbxLX0EMjnq3kYS+UJBlqAIJJeNfAxDExLLX0jvWa8KyRPbVLzc+CHFwigwR8fTWIdsVOXR2f7owrSq1xtYrw==",
       "dependencies": {
         "bluebird": "^3.7.2",
         "lodash": "^4.17.21",
@@ -8663,15 +8551,15 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
       "extraneous": true
     },
     "node_modules/appium-geckodriver/node_modules/type-fest": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.3.tgz",
-      "integrity": "sha512-Q08/0IrpvM+NMY9PA2rti9Jb+JejTddwmwmVQGskAlhtcrw1wsRzoR6ode6mR+OAabNa75w/dxedSUY2mlphaQ==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.20.0.tgz",
+      "integrity": "sha512-MBh+PHUHHisjXf4tlx0CFWoMdjx8zCMLJHOjnV1prABYZFHqtFOyauCIK2/7w4oIfwkF8iNhLtnJEfVY2vn3iw==",
       "engines": {
         "node": ">=16"
       },
@@ -8680,9 +8568,9 @@
       }
     },
     "node_modules/appium-geckodriver/node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "extraneous": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8748,32 +8636,6 @@
       },
       "engines": {
         "node": "^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/appium-geckodriver/node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/appium-geckodriver/node_modules/wide-align/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/appium-geckodriver/node_modules/wide-align/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/appium-geckodriver/node_modules/wrap-ansi": {
@@ -8992,9 +8854,9 @@
       }
     },
     "node_modules/appium-safari-driver": {
-      "version": "3.5.15",
-      "resolved": "https://registry.npmjs.org/appium-safari-driver/-/appium-safari-driver-3.5.15.tgz",
-      "integrity": "sha512-nHg+yKByvkLuM08th8WqHoHLKhd5YwFQtYCDoKZ3CeLx8+Ygvja6K5iaBcmVhVnZnqzQlq4hFy/n5PPBwGmQUQ==",
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/appium-safari-driver/-/appium-safari-driver-3.5.16.tgz",
+      "integrity": "sha512-HkrSxuFbFTJYGgpAaQxemGBi5sQStxRgnZMSbNw/7eeQPWUbKJ3qtz883FuGu0YHd6STmhzmkl5N2EAxc0nbEg==",
       "hasShrinkwrap": true,
       "dependencies": {
         "asyncbox": "^3.0.0",
@@ -9013,10 +8875,24 @@
         "appium": "^2.0.0"
       }
     },
+    "node_modules/appium-safari-driver/node_modules/@appium/logger": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@appium/logger/-/logger-1.4.2.tgz",
+      "integrity": "sha512-ifHuA4wuBa8xLx77lYhYmNi9qNPuGb1QgUQreME58Ugh5K2M6C+4xq6dD9KiQpHf0sy64m8fflxy24jrRPJ8ZA==",
+      "dependencies": {
+        "console-control-strings": "1.1.0",
+        "lodash": "4.17.21",
+        "set-blocking": "2.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=8"
+      }
+    },
     "node_modules/appium-safari-driver/node_modules/@appium/schema": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.5.0.tgz",
-      "integrity": "sha512-HFed9HtFU6+kLdVyp/xpS/Wfcge8PuMS37LJVShviT6OuzHOYvNFx1/y8+KMa/l0Npvll5eafdfHmUsWlRnUAA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.6.1.tgz",
+      "integrity": "sha512-tk4ytYaQQ94h5pqz97V2yKqZAmGnBd4ld50ZEw4Tt8QL2VBXOuTuizKDH+AMpyyL6hn/+dMFtcSVjy19iKrsUg==",
       "extraneous": true,
       "dependencies": {
         "@types/json-schema": "7.0.15",
@@ -9042,17 +8918,17 @@
       }
     },
     "node_modules/appium-safari-driver/node_modules/@appium/types": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.18.0.tgz",
-      "integrity": "sha512-gvR75CbtbHP1dqUr1arWlLzI9ABAtosn/qDTqwjG5OX59ael6OwsWlfrR7wIDiGy7CjmHMRZJ38g+O4QwB9GCQ==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.20.3.tgz",
+      "integrity": "sha512-5PTxTAyMvJbSY1ByBiXbnaLOejjPh2B0X+jadoOu6dciuPYMt+12yaH9yk/FfpFI4E7v/tbe1Vov5K/aIKm/jA==",
       "extraneous": true,
       "dependencies": {
-        "@appium/schema": "^0.5.0",
+        "@appium/logger": "^1.4.2",
+        "@appium/schema": "^0.6.1",
         "@appium/tsconfig": "^0.3.3",
         "@types/express": "4.17.21",
-        "@types/npmlog": "7.0.0",
         "@types/ws": "8.5.10",
-        "type-fest": "4.18.3"
+        "type-fest": "4.20.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -9060,12 +8936,12 @@
       }
     },
     "node_modules/appium-safari-driver/node_modules/@babel/code-frame": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.6.tgz",
-      "integrity": "sha512-ZJhac6FkEd1yhG2AHOmfcXG4ceoLltoCVJjN5XsWN9BifBQr+cHJbWi0h68HZuSORq+3WtJ2z0hwF2NG1b5kcA==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "extraneous": true,
       "dependencies": {
-        "@babel/highlight": "^7.24.6",
+        "@babel/highlight": "^7.24.7",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -9073,21 +8949,21 @@
       }
     },
     "node_modules/appium-safari-driver/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz",
-      "integrity": "sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "extraneous": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/appium-safari-driver/node_modules/@babel/highlight": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.6.tgz",
-      "integrity": "sha512-2YnuOp4HAk2BsBrJJvYCbItHx0zWscI1C3zgWkz+wDyD9I7GIVrfnLyrR4Y1VR+7p+chAEcrgRQYZAGIKMV7vQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "extraneous": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.6",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -9288,9 +9164,9 @@
       }
     },
     "node_modules/appium-safari-driver/node_modules/@types/express-serve-static-core": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.3.tgz",
-      "integrity": "sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==",
+      "version": "4.19.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
       "extraneous": true,
       "dependencies": {
         "@types/node": "*",
@@ -9312,9 +9188,9 @@
       "extraneous": true
     },
     "node_modules/appium-safari-driver/node_modules/@types/lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==",
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==",
       "extraneous": true
     },
     "node_modules/appium-safari-driver/node_modules/@types/mime": {
@@ -9324,9 +9200,9 @@
       "extraneous": true
     },
     "node_modules/appium-safari-driver/node_modules/@types/node": {
-      "version": "20.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.1.tgz",
-      "integrity": "sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==",
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
       "extraneous": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -9337,15 +9213,6 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "extraneous": true
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/npmlog": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-7.0.0.tgz",
-      "integrity": "sha512-hJWbrKFvxKyWwSUXjZMYTINsSOY6IclhvGOZ97M8ac2tmR9hMwmTnYaMdpGhvju9ctWLTPhCS+eLfQNluiEjQQ==",
-      "extraneous": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/appium-safari-driver/node_modules/@types/qs": {
       "version": "6.9.15",
@@ -9438,11 +9305,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/appium-safari-driver/node_modules/aproba": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
-    },
     "node_modules/appium-safari-driver/node_modules/archiver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
@@ -9477,15 +9339,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/are-we-there-yet": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-4.0.2.tgz",
-      "integrity": "sha512-ncSWAawFhKMJDTdoAeOV+jyW1VCMj5QIAwULIBV0SSR7B/RLPPEQiknKcg/RIIZlUQrxELpsxMiTUoAQ4sIUyg==",
-      "deprecated": "This package is no longer supported.",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/appium-safari-driver/node_modules/arg": {
@@ -9531,9 +9384,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/appium-safari-driver/node_modules/bare-events": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.3.1.tgz",
-      "integrity": "sha512-sJnSOTVESURZ61XgEleqmP255T6zTYwHPwE4r6SssIh0U9/uDvfpdoJYpVUerJJZH2fueO+CdT8ZT+OC/7aZDA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
       "extraneous": true
     },
     "node_modules/appium-safari-driver/node_modules/base64-js": {
@@ -9704,14 +9557,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/appium-safari-driver/node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/appium-safari-driver/node_modules/compress-commons": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
@@ -9836,15 +9681,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/appium-safari-driver/node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-      "extraneous": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/appium-safari-driver/node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -9935,9 +9771,9 @@
       }
     },
     "node_modules/appium-safari-driver/node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -9967,54 +9803,6 @@
       "extraneous": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/gauge": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-5.0.2.tgz",
-      "integrity": "sha512-pMaFftXPtiGIHCJHdcUUx9Rby/rFT/Kkt3fIIGCs+9PMDIljSyRiqraTlxNtBReJRDfUefpa263RQ3vnp5G/LQ==",
-      "deprecated": "This package is no longer supported.",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^4.0.1",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/gauge/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/appium-safari-driver/node_modules/gauge/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/gauge/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/appium-safari-driver/node_modules/get-caller-file": {
@@ -10141,11 +9929,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/appium-safari-driver/node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
-    },
     "node_modules/appium-safari-driver/node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -10208,12 +9991,15 @@
       "extraneous": true
     },
     "node_modules/appium-safari-driver/node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+      "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
       "extraneous": true,
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10268,9 +10054,9 @@
       }
     },
     "node_modules/appium-safari-driver/node_modules/jackspeak": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.2.3.tgz",
-      "integrity": "sha512-htOzIMPbpLid/Gq9/zaz9SfExABxqRe1sSCdxntlO/aMD6u0issZQiY25n2GKQUtJ02j7z5sfptlAOMpWWOmvw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -10376,12 +10162,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/appium-safari-driver/node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "extraneous": true
-    },
     "node_modules/appium-safari-driver/node_modules/lodash.isfinite": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
@@ -10457,15 +10237,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/appium-safari-driver/node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "extraneous": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/appium-safari-driver/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -10473,24 +10244,36 @@
       "extraneous": true
     },
     "node_modules/appium-safari-driver/node_modules/node-simctl": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-7.4.5.tgz",
-      "integrity": "sha512-GqNIoWIQgnL2auJQnq0aGRC4N5HeN3Tj47IuCEpM7DwpcEXGbotER3mt1romkeBtY0iIvGomh/apR8M8FJeetw==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/node-simctl/-/node-simctl-7.5.2.tgz",
+      "integrity": "sha512-ap0QEMMcHbd+r86UQHRc9EsDvgP0PIio56B0Phh3iwQ5STEClCUGEGVwCVrxqlrwSCRYM26Glx39vwgGUyHUPA==",
       "dependencies": {
+        "@appium/logger": "^1.3.0",
         "asyncbox": "^3.0.0",
         "bluebird": "^3.5.1",
         "lodash": "^4.2.1",
-        "npmlog": "^7.0.1",
         "rimraf": "^5.0.0",
         "semver": "^7.0.0",
         "source-map-support": "^0.x",
         "teen_process": "^2.0.0",
-        "uuid": "^9.0.0",
+        "uuid": "^10.0.0",
         "which": "^4.0.0"
       },
       "engines": {
         "node": ">=14",
         "npm": ">=8"
+      }
+    },
+    "node_modules/appium-safari-driver/node_modules/node-simctl/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/appium-safari-driver/node_modules/normalize-package-data": {
@@ -10523,26 +10306,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/appium-safari-driver/node_modules/npmlog": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-7.0.1.tgz",
-      "integrity": "sha512-uJ0YFk/mCQpLBt+bxN88AKd+gyqZvZDbtiNxk6Waqcj2aPRyfVx8ITawkyQynxUagInjdYT1+qj4NfA5KJJUxg==",
-      "deprecated": "This package is no longer supported.",
-      "dependencies": {
-        "are-we-there-yet": "^4.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^5.0.0",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/appium-safari-driver/node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
       "extraneous": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -10656,12 +10427,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/appium-safari-driver/node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-      "extraneous": true
     },
     "node_modules/appium-safari-driver/node_modules/pend": {
       "version": "1.2.0",
@@ -11134,9 +10899,9 @@
       }
     },
     "node_modules/appium-safari-driver/node_modules/teen_process": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.1.4.tgz",
-      "integrity": "sha512-TEaxCYk/aCBsNBCZmgUNXqtCWq8RX94nGoyYYu7YiNR+RnmawMFshTkYe1SFhiNCX6FsYb6wL/irs6NhvfoF5g==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.1.6.tgz",
+      "integrity": "sha512-VCbxLX0EMjnq3kYS+UJBlqAIJJeNfAxDExLLX0jvWa8KyRPbVLzc+CHFwigwR8fTWIdsVOXR2f7owrSq1xtYrw==",
       "dependencies": {
         "bluebird": "^3.7.2",
         "lodash": "^4.17.21",
@@ -11164,15 +10929,15 @@
       "extraneous": true
     },
     "node_modules/appium-safari-driver/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
       "extraneous": true
     },
     "node_modules/appium-safari-driver/node_modules/type-fest": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.3.tgz",
-      "integrity": "sha512-Q08/0IrpvM+NMY9PA2rti9Jb+JejTddwmwmVQGskAlhtcrw1wsRzoR6ode6mR+OAabNa75w/dxedSUY2mlphaQ==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.20.0.tgz",
+      "integrity": "sha512-MBh+PHUHHisjXf4tlx0CFWoMdjx8zCMLJHOjnV1prABYZFHqtFOyauCIK2/7w4oIfwkF8iNhLtnJEfVY2vn3iw==",
       "extraneous": true,
       "engines": {
         "node": ">=16"
@@ -11182,9 +10947,9 @@
       }
     },
     "node_modules/appium-safari-driver/node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "extraneous": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11205,18 +10970,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "extraneous": true
-    },
-    "node_modules/appium-safari-driver/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/appium-safari-driver/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -11240,32 +10993,6 @@
       },
       "engines": {
         "node": "^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/wide-align/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/appium-safari-driver/node_modules/wide-align/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/appium-safari-driver/node_modules/wrap-ansi": {
@@ -12805,9 +12532,9 @@
       }
     },
     "node_modules/doc-detective-common": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.17.0.tgz",
-      "integrity": "sha512-0rLM2OC5XeiawDdpEJ10pRIUCtRCr5k4OkE6jeSNdgMcnDqp9j+vuXsGB2dsW1IOQ+bK0C4kTm3ZxstYLu/37w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.18.0.tgz",
+      "integrity": "sha512-0xe37SRtgEVoiCtoAffGx655lBCmXrI+xgYvt7OJ3Vh7TPx1rgiNvqm29ZU5EBsNI9U0IvnM78oQKqlNYedMrQ==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.4",
         "ajv": "^8.16.0",
@@ -12818,57 +12545,30 @@
       }
     },
     "node_modules/doc-detective-core": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/doc-detective-core/-/doc-detective-core-2.13.0.tgz",
-      "integrity": "sha512-4r5dY9LjryD+6NyG5Ha5UlbKWAl7919EaxHEQFY0Uk+pN7F6D3lTcwrRqUa6ey1mGSEIyYktzT2PIU1SRRL+4w==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/doc-detective-core/-/doc-detective-core-2.14.0.tgz",
+      "integrity": "sha512-+fY7nPlNzWgCYZljJQiUWE65hnx3XciLyS2sTYAHMdt8u26oAHUvNk0QoUYA5M+PeZFiplENPMlQl15RwHmKkA==",
       "hasInstallScript": true,
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@puppeteer/browsers": "^2.2.3",
-        "appium": "^2.10.3",
+        "appium": "^2.11.1",
         "appium-chromium-driver": "1.3.26",
-        "appium-geckodriver": "^1.3.6",
-        "appium-safari-driver": "^3.5.15",
+        "appium-geckodriver": "^1.3.7",
+        "appium-safari-driver": "^3.5.16",
         "axios": "^1.7.2",
-        "doc-detective-common": "^1.17.0",
+        "doc-detective-common": "^1.18.0",
         "dotenv": "^16.4.5",
         "edgedriver": "^5.6.0",
         "geckodriver": "^4.4.1",
         "node-jq": "^4.4.0",
-        "pixelmatch": "^5.3.0",
+        "pixelmatch": "^6.0.0",
         "pngjs": "^7.0.0",
         "posthog-node": "^4.0.1",
         "prompt-sync": "^4.2.0",
         "tree-kill": "^1.2.2",
         "uuid": "^10.0.0",
         "webdriverio": "^8.39.0"
-      }
-    },
-    "node_modules/doc-detective-core/node_modules/pixelmatch": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
-      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
-      "dependencies": {
-        "pngjs": "^6.0.0"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
-      }
-    },
-    "node_modules/doc-detective-core/node_modules/pixelmatch/node_modules/pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/doc-detective-core/node_modules/pngjs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
-      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
-      "engines": {
-        "node": ">=14.19.0"
       }
     },
     "node_modules/dotenv": {
@@ -13779,14 +13479,15 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
         "minimatch": "^9.0.4",
         "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
         "path-scurry": "^1.11.1"
       },
       "bin": {
@@ -14173,11 +13874,14 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+      "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -14738,9 +14442,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.0.tgz",
+      "integrity": "sha512-CQl19J/g+Hbjbv4Y3mFNNXFEL/5t/KCg8POCuUqd4rMKjGG+j1ybER83hxV58zL+dFI1PTkt3GNFSHRt+d8qEQ==",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -14921,31 +14625,31 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mocha": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.4.0.tgz",
-      "integrity": "sha512-eqhGB8JKapEYcC4ytX/xrzKforgEc3j1pGlAXVy3eRwrtAy5/nIfT1SvgGzfN0XZZxeLq0aQWkOUAmqIJiv+bA==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.6.0.tgz",
+      "integrity": "sha512-hxjt4+EEB0SA0ZDygSS015t65lJw/I2yRCS3Ae+SJ5FrbzrXgfYwJr96f0OvIXdj7h4lv/vLCrH3rkiuizFSvw==",
       "dev": true,
       "dependencies": {
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.4",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "8.1.0",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "5.0.1",
-        "ms": "2.1.3",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "workerpool": "6.2.1",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
@@ -14975,14 +14679,28 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "node_modules/mocha/node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+    "node_modules/mocha/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
       "engines": {
-        "node": ">=0.3.1"
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/mocha/node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/mocha/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -15022,9 +14740,9 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -15084,9 +14802,9 @@
       }
     },
     "node_modules/mocha/node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -15333,9 +15051,12 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -15567,6 +15288,11 @@
         "package-changed": "bin/package-changed.js"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw=="
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -15650,9 +15376,12 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-7.0.0.tgz",
+      "integrity": "sha512-58Y94bQqF3zBIASFNiufRPH1NfgZth1qwZ35radL87sg8pgbVqr6uikAhqZtFD+w65MGH6SWnY/ly3GbrM4fbg==",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/pathval": {
       "version": "2.0.0",
@@ -15712,6 +15441,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pixelmatch": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-6.0.0.tgz",
+      "integrity": "sha512-FYpL4XiIWakTnIqLqvt3uN4L9B3TsuHIvhLILzTiJZMJUsGvmKNeL4H3b6I99LRyerK9W4IuOXw+N28AtRgK2g==",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
@@ -15742,6 +15482,14 @@
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/posthog-node": {
@@ -16529,9 +16277,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -17126,9 +16874,9 @@
       }
     },
     "node_modules/teen_process": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.1.4.tgz",
-      "integrity": "sha512-TEaxCYk/aCBsNBCZmgUNXqtCWq8RX94nGoyYYu7YiNR+RnmawMFshTkYe1SFhiNCX6FsYb6wL/irs6NhvfoF5g==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-2.1.6.tgz",
+      "integrity": "sha512-VCbxLX0EMjnq3kYS+UJBlqAIJJeNfAxDExLLX0jvWa8KyRPbVLzc+CHFwigwR8fTWIdsVOXR2f7owrSq1xtYrw==",
       "dependencies": {
         "bluebird": "^3.7.2",
         "lodash": "^4.17.21",
@@ -17302,9 +17050,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.20.0.tgz",
-      "integrity": "sha512-MBh+PHUHHisjXf4tlx0CFWoMdjx8zCMLJHOjnV1prABYZFHqtFOyauCIK2/7w4oIfwkF8iNhLtnJEfVY2vn3iw==",
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.20.1.tgz",
+      "integrity": "sha512-R6wDsVsoS9xYOpy8vgeBlqpdOyzJ12HNfQhC/aAKWM3YoCV9TtunJzh/QpkMgeDhkoynDcw5f1y+qF9yc/HHyg==",
       "engines": {
         "node": ">=16"
       },
@@ -17325,9 +17073,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17742,9 +17490,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -17860,9 +17608,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "Treat doc content as testable assertions to validate doc accuracy and product UX.",
   "bin": {
     "doc-detective": "src/index.js"
@@ -32,13 +32,13 @@
   "homepage": "https://github.com/doc-detective/doc-detective#readme",
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "doc-detective-common": "^1.17.0",
-    "doc-detective-core": "^2.13.0",
+    "doc-detective-common": "^1.18.0",
+    "doc-detective-core": "^2.14.0",
     "prompt-sync": "^4.2.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
     "chai": "^5.1.1",
-    "mocha": "^10.4.0"
+    "mocha": "^10.6.0"
   }
 }


### PR DESCRIPTION
- New `timeout` option for `runShell` and `httpRequest` actions. If an action exceeds its timeout, the step fails. Timeouts default to 1 minute.
- New `savePath`, `saveDirectory`, and `overwrite` options for `runShell` and `httpRequest`. Save the output of a command or request to file for future reference or to include in your docs!
- New `maxVariation` option for `runShell` and `httpRequest`. Much like screenshot diffing with `saveScreenshot`, this option compares command or response output against previous outputs and runs a percentage diff, failing the step if the diff is above the specified acceptable variation. Plays nice with the `overwrite` option's `byVariation` value.
- New `allowAdditionalFields` option for `httpRequest` actions. If `false`, fails the step if the actual response data contains fields that aren't specified in `responseData`, allowing for strict object matching. Defaults to `true`.
- `httpRequest` actions now return a `actualResponseData` field with the exact payload returned by the request. This mirrors `runShell` returning `stdout` and `stderr` values.
- `find`'s `matchText` can now match with regular expressions as well as strings. To specify a regular expression, begin and end the value with `/`. This mirrors `runShell`'s `output` option.
- New `setVariables` option for the `find` action sets variables from an element's text value that match a regular expression. Same formatting and behavior as `runShell`'s `setVariables` option.