### PR TITLE
Yaml input support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ async function main(argv) {
   - 'runTests' - Run tests defined in specifications and documentation source files.
   - 'runCoverage' - Calculate test coverage of doc content.
   
-  You can skip this next time by running 'npx doc-detective <command>'. You can also set 'defaultCommand' in your .doc-detective.json config file.
+  You can skip this next time by running 'npx doc-detective <command>'. You can also set 'defaultCommand' in your .doc-detective.json or .doc-detective.yaml config file.
   
   For more info, visit https://doc-detective.com.
   

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,6 +70,19 @@ function setConfig(config, args) {
   if (args.config) {
     const configPath = path.resolve(args.config);
     configContent = require(configPath);
+    const extension = path.extname(configPath).toLowerCase();
+
+    try {
+      const fileContent = fs.readFileSync(configPath, "utf8");
+
+      if (extension === ".yml" || extension === ".yaml") {
+        configContent = YAML.parse(fileContent);
+      }
+    } catch (error) {
+      console.error(`Error parsing config file: ${error.message}`);
+      process.exit(1);
+    }
+
     // Validate config
     const validation = validate("config_v2", configContent);
     if (validation.valid) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,7 @@ function setArgs(args) {
   let argv = yargs(hideBin(args))
     .option("config", {
       alias: "c",
-      description: "Path to a `config.json` file.",
+      description: "Path to a `config.json or config.yaml` file.",
       type: "string",
     })
     .option("input", {

--- a/test/artifacts/config.yaml
+++ b/test/artifacts/config.yaml
@@ -1,0 +1,41 @@
+envVariables: ""
+input: "."
+output: "."
+recursive: true
+logLevel: debug
+runTests:
+  input: "./test/artifacts/test.spec.json"
+  output: "."
+  setup: ""
+  cleanup: ""
+  recursive: true
+  detectSteps: false
+  mediaDirectory: "."
+  downloadDirectory: "."
+  contexts:
+    - app:
+        name: firefox
+      platforms:
+        - windows
+        - mac
+        - linux
+    - app:
+        name: chrome
+        options:
+          headless: true
+      platforms:
+        - windows
+        - mac
+        - linux
+runCoverage:
+  recursive: true
+  input: ".dev/"
+  output: "."
+  markup: []
+suggestTests:
+  recursive: true
+  input: "."
+  output: "."
+  markup: []
+telemetry:
+  send: false

--- a/test/runTests.test.js
+++ b/test/runTests.test.js
@@ -4,26 +4,43 @@ const assert = require("assert").strict;
 const fs = require("fs");
 const artifactPath = path.resolve(__dirname,"./artifacts");
 
-describe("Run tests sucessfully", function () {
+describe("Run tests successfully", function () {
   // Set indefinite timeout
   this.timeout(0);
-  it("All specs pass", async () => {
-    const runTests = await spawnCommand(
-      `node ./src/index.js runTests -c ${artifactPath}/config.json -i ${artifactPath} -o ${artifactPath}`
-    );
-    // Find output file
-    console.log(runTests.stdout)
-    const outputFiles = runTests.stdout.split("See results at ");
-    const outputFile = outputFiles[outputFiles.length - 1].trim();
-    console.log(outputFile);
-    console.log(fs.existsSync(outputFile));
-    // If output file is not found, throw an error
-    if (!outputFile) {
-      throw new Error(`Output file not found.\nOutput file: ${outputFile}\nCWD: ${process.cwd()}\nstdout: ${runTests.stdout}`);
-    }
-    const result = JSON.parse(
-      fs.readFileSync(outputFile, { encoding: "utf8" })
-    );
-    assert.equal(result.summary.specs.fail, 0);
+
+  const configFiles = [
+    { name: "JSON", file: "config.json" },
+    { name: "YAML", file: "config.yaml" }
+  ];
+
+  configFiles.forEach(({ name, file }) => {
+    it(`All specs pass with ${name} config`, async () => {
+      const configPath = path.join(artifactPath, file);
+      
+      // Ensure the config file exists
+      if (!fs.existsSync(configPath)) {
+        throw new Error(`Config file not found: ${configPath}`);
+      }
+
+      const runTests = await spawnCommand(
+        `node ./src/index.js runTests -c ${configPath} -i ${artifactPath} -o ${artifactPath}`
+      );
+
+      console.log(runTests.stdout);
+      const outputFiles = runTests.stdout.split("See results at ");
+      const outputFile = outputFiles[outputFiles.length - 1].trim();
+      console.log(outputFile);
+      console.log(fs.existsSync(outputFile));
+
+      // If output file is not found, throw an error
+      if (!outputFile) {
+        throw new Error(`Output file not found.\nOutput file: ${outputFile}\nCWD: ${process.cwd()}\nstdout: ${runTests.stdout}`);
+      }
+
+      const result = JSON.parse(
+        fs.readFileSync(outputFile, { encoding: "utf8" })
+      );
+      assert.equal(result.summary.specs.fail, 0);
+    });
   });
 });


### PR DESCRIPTION
Adding support for .YAML config files.

## Approach
- Updated the `setConfig` function. The function now handles the file by reading the config file as raw text and then parsing based on the given extension. This approach should be trivial to extend to cover further config types that can be parsed to JSON if we want to add TOML for some reason.
- Scanned through program strings and tried to update mentions of the doc-detective config.json to also mention .yaml.
- I've updated the mocha tests in `runTests.test.js` to run multiple iterations to cover both .json and .yaml support. I tried to set it up in a way where adding a test to cover another config language should be very easy.


## How was it tested?
- Tested with updated assertion test.
- Converted existing config.json to YAML. 
- Tested by running the command `npx doc-detective  -c test/artifacts/config.yaml -i samples/kitten-search.spec.json`
  - Expected output: Success.
  - Real output: Success.
- Tested by running command `npx doc-detective  -c test/artifacts/config.json -i samples/kitten-search.spec.json`
  - Expected output: Success.
  - Real output: Success.
- Created a toml file and tested by running the command `npx doc-detective  -c test/artifacts/config.toml -i samples/kitten-search.spec.json`
  -  Expected output: Fail due to unsupported filetype.
  - `❯ npx doc-detective  -c test/artifacts/config.toml -i samples/kitten-search.spec.json
Error parsing config file: Unsupported config file format. Config file must be .json, .yml, or .yaml.`
