### PR TITLE
Fix samples

### DIFF
--- a/samples/.doc-detective.json
+++ b/samples/.doc-detective.json
@@ -65,6 +65,7 @@
           "regex": ["!\\[.+?\\]\\((.+?)\\)"],
           "actions": [
             {
+              "id": "reference",
               "action": "saveScreenshot",
               "maxVariation": 5,
               "overwrite": "byVariation"

--- a/samples/doc-content-detect.md
+++ b/samples/doc-content-detect.md
@@ -4,7 +4,7 @@
 
 - The landing page discusses what Doc Detective is, what it does, and who might find it useful.
 
-- [Get started](https://doc-detective.com/docs/get-started.html) covers how to quickly get up and running with Doc Detective.
+- [Get started](https://doc-detective.com/docs/get-started/intro) covers how to quickly get up and running with Doc Detective.
 
 - The [references](https://doc-detective.com/docs/category/schemas) detail the various JSON objects that Doc Detective expects for [configs](https://doc-detective.com/docs/references/schemas/config.html), [test specifications](https://doc-detective.com/docs/references/schemas/specification.html), [tests](https://doc-detective.com/docs/references/schemas/test), actions, and more. Open [typeKeys](https://doc-detective.com/docs/references/schemas/typeKeys.html)--or any other schema--and you'll find two sections: **Fields** and **Examples**.
 

--- a/samples/doc-content-inline-tests.md
+++ b/samples/doc-content-inline-tests.md
@@ -8,9 +8,9 @@
 
 - The landing page discusses what Doc Detective is, what it does, and who might find it useful.
 
-- [Get started](https://doc-detective.com/docs/get-started.html) covers how to quickly get up and running with Doc Detective.
+- [Get started](https://doc-detective.com/docs/get-started/intro) covers how to quickly get up and running with Doc Detective.
 
-  [comment]: # (step {"action":"checkLink", "url":"https://doc-detective.com/docs/get-started.html"})
+  [comment]: # (step {"action":"checkLink", "url":"https://doc-detective.com/docs/get-started/intro"})
 
 - The [references](https://doc-detective.com/docs/category/schemas) detail the various JSON objects that Doc Detective expects for [configs](https://doc-detective.com/docs/references/schemas/config.html), [test specifications](https://doc-detective.com/docs/references/schemas/specification.html), [tests](https://doc-detective.com/docs/references/schemas/test), actions, and more. Open [typeKeys](https://doc-detective.com/docs/references/schemas/typeKeys.html)--or any other schema--and you'll find two sections: **Fields** and **Examples**.
 

--- a/test/artifacts/doc-content.md
+++ b/test/artifacts/doc-content.md
@@ -6,8 +6,8 @@
 [comment]: # (step {"action":"goTo", "url":"https://doc-detective.com"})
 
 -   The landing page discusses what Doc Detective is, what it does, and who might find it useful.
--   [Get started](https://doc-detective.com/docs/get-started.html) covers how to quickly get up and running with Doc Detective.
-    [comment]: # (step {"action":"goTo", "url":"https://doc-detective.com/docs/get-started.html"})
+-   [Get started](https://doc-detective.com/docs/get-started/intro) covers how to quickly get up and running with Doc Detective.
+    [comment]: # (step {"action":"goTo", "url":"https://doc-detective.com/docs/get-started/intro"})
 -   The [references](https://doc-detective.com/docs/references/schemas/typeKeys) detail the various JSON objects that Doc Detective expects for configs, test specifications, tests, actions, and more. Each object schema includes an object description, field definitions, and examples.
     [comment]: # (step {"action":"goTo", "url":"https://doc-detective.com/docs/references/schemas/typeKeys"})
     [comment]: # (step {"action":"find", "selector":"h2#fields", "matchText":"Fields"})


### PR DESCRIPTION
The Get Started URL was changed without adding any redirects. So, this PR updates the samples with the new URLs.
I also found that the `samples/doc-content-detect.md` sample generated screenshots with random filenames, so I added an ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated "Get started" documentation links across multiple files to point to new URL: `https://doc-detective.com/docs/get-started/intro`

- **Configuration**
	- Added a new `"id": "reference"` property for Image markup in configuration file to enhance image handling functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->