### PR TITLE
Remove runCoverage and suggestTests operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Doc Detective has multiple components to integrate with your workflows as you ne
 
 1. In a terminal, install Doc Detective globally:
 
-    ```bash
-    npm i -g doc-detective
-    ```
+   ```bash
+   npm i -g doc-detective
+   ```
 
-    If you don't install Doc Detective globally, you'll be prompted to install the first time you run an `npx` command.
+   If you don't install Doc Detective globally, you'll be prompted to install the first time you run an `npx` command.
 
-    **Note:** If you're working in a cloned `doc-detective` repository, run `npm i` to install local dependencies or the `npx` command in the next step will fail.
+   **Note:** If you're working in a cloned `doc-detective` repository, run `npm i` to install local dependencies or the `npx` command in the next step will fail.
 
 ## Run tests
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Doc Detective has multiple components to integrate with your workflows as you ne
 
 1. Install prerequisites:
 
-   - [Node.js](https://nodejs.org/) (tested on v18 and v20)
+   - [Node.js](https://nodejs.org/) (tested on v20 and v22)
 
 1. In a terminal, install Doc Detective globally:
 
@@ -37,22 +37,22 @@ Doc Detective has multiple components to integrate with your workflows as you ne
 
 ## Run tests
 
-To run your tests, use the `runTests` command:
+To run your tests, use the following command:
 
 ```bash
-npx doc-detective runTests
+npx doc-detective
 ```
 
 By default, Doc Detective scans the current directory for valid tests, but you can specify your test file with the `--input` argument. For example, to run tests in a file named `doc-content-inline-tests.md`, run the following command:
 
 ```bash
-npx doc-detective runTests --input doc-content-inline-tests.md
+npx doc-detective --input doc-content-inline-tests.md
 ```
 
 To customize your test, file type, and directory options, create a `.doc-detective.json` [config](https://doc-detective.com/docs/references/schemas/config.html) file. If a `.doc-detective.json` file exists in the directory when you run the comment, Doc Detective loads the config. Otherwise, you can specify a config path with the `--config` argument.
 
 ```bash
-npx doc-detective runTests --config .doc-detective.json
+npx doc-detective --config .doc-detective.json
 ```
 
 **Note**: All paths are relative to the current working directory, regardless where the config file is located.
@@ -60,20 +60,12 @@ npx doc-detective runTests --config .doc-detective.json
 You can override config options with command-line arguments. For example, to run tests in a file named `tests.spec.json`, even if that isn't included in your config, run the following command:
 
 ```bash
-npx doc-detective runTests --config .doc-detective.json --input tests.spec.json
+npx doc-detective --config .doc-detective.json --input tests.spec.json
 ```
 
 ### Check out some samples
 
 You can find test and config samples in the [samples](https://github.com/doc-detective/doc-detective/tree/main/samples) directory.
-
-## Check your test coverage
-
-You can check the test coverage of your documentation source files with the `runCoverage` command, specifying the source file or directory of source files with the `--input` argument. Doc Detective identifies potential areas of test coverage with file-format-specific regex, and supports CommonMark syntax natively. If you want to test coverage of a file with different syntax, update the `fileTypes` object of your [config](https://doc-detective.com/docs/references/schemas/config.html) file accordingly.
-
-```bash
-npx doc-detective runCoverage --config .doc-detective.json --input doc-content.md
-```
 
 ## Concepts
 
@@ -92,14 +84,6 @@ npx doc-detective runCoverage --config .doc-detective.json --input doc-content.m
   - [**typeKeys**](https://doc-detective.com/docs/references/schemas/typeKeys.html): Type keys. To type special keys, begin and end the string with `$` and use the special key’s enum. For example, to type the Escape key, enter `$ESCAPE$`.
   - [**wait**](https://doc-detective.com/docs/references/schemas/wait.html): Pause before performing the next action.
 - [**Context**](https://doc-detective.com/docs/references/schemas/context.html): An application and platforms that support the tests.
-
-## Roadmap
-
-Future updates may include support for the following items:
-
-- Apps: iOS Safari, Android Chrome, native Windows, native macOS, native Linux
-- Platforms: iOS, Android
-- Commands: `suggestTests` stable release
 
 ## Develop
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "doc-detective",
-  "version": "3.0.0-dev.0",
+  "version": "3.0.0-dev.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective",
-      "version": "3.0.0-dev.0",
+      "version": "3.0.0-dev.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "doc-detective-common": "^3.0.0-dev.1",
-        "doc-detective-core": "^3.0.0-dev.1",
-        "prompt-sync": "^4.2.0",
+        "doc-detective-common": "^3.0.0-dev.4",
+        "doc-detective-core": "^3.0.0-dev.4",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -11963,9 +11962,9 @@
       }
     },
     "node_modules/doc-detective-common": {
-      "version": "3.0.0-dev.1",
-      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-3.0.0-dev.1.tgz",
-      "integrity": "sha512-HzHFkI/VelwrbYNffsLaJuZrRvxh9GFv0ZU3ZsbhWcoYEcyF+exADxR0IL5ZRH7zte0wsPFaDXg5eRQRE2mvew==",
+      "version": "3.0.0-dev.4",
+      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-3.0.0-dev.4.tgz",
+      "integrity": "sha512-5z9pAKGmo8/smAJ98fb9JBuYvOZ774WE8//9AVQy6EeeisQ8kE7v705pDPUnBGeQUYoPQq/kvEk7AeajUv8PMw==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^12.0.1",
@@ -11979,9 +11978,9 @@
       }
     },
     "node_modules/doc-detective-core": {
-      "version": "3.0.0-dev.1",
-      "resolved": "https://registry.npmjs.org/doc-detective-core/-/doc-detective-core-3.0.0-dev.1.tgz",
-      "integrity": "sha512-19uEtcvNJ1+a+IOExL2gDRNgxAU6UPj/XKusw/66cubFkogEEXlQ7cDW3tXTHsXNpI4bVktM+Ds/Ry8CLTYdpw==",
+      "version": "3.0.0-dev.4",
+      "resolved": "https://registry.npmjs.org/doc-detective-core/-/doc-detective-core-3.0.0-dev.4.tgz",
+      "integrity": "sha512-gH/u5dGBBebXWb0U8MQG8fdm4J8g4KwSGwtYos87vO9n/IRlBoYGvUgQi/YDNb8ppWsaleG8g7dvnytCf3t/dA==",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -11994,7 +11993,7 @@
         "appium-geckodriver": "^1.4.3",
         "appium-safari-driver": "^3.5.23",
         "axios": "^1.8.4",
-        "doc-detective-common": "^3.0.0-dev.1",
+        "doc-detective-common": "^3.0.0-dev.4",
         "dotenv": "^16.5.0",
         "edgedriver": "^6.1.1",
         "geckodriver": "^5.0.0",
@@ -14828,33 +14827,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/prompt-sync": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/prompt-sync/-/prompt-sync-4.2.0.tgz",
-      "integrity": "sha512-BuEzzc5zptP5LsgV5MZETjDaKSWfchl5U9Luiu8SKp7iZWD5tZalOxvNcZRwv+d2phNFr8xlbxmFNcRKfJOzJw==",
-      "dependencies": {
-        "strip-ansi": "^5.0.0"
-      }
-    },
-    "node_modules/prompt-sync/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/prompt-sync/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective",
-  "version": "3.0.0-dev.0",
+  "version": "3.0.0-dev.3",
   "description": "Treat doc content as testable assertions to validate doc accuracy and product UX.",
   "bin": {
     "doc-detective": "src/index.js"
@@ -11,8 +11,7 @@
     "test": "mocha test/*.test.js",
     "prerunTests": "node ./src/checkDependencies.js",
     "runTests": "node ./src/index.js runTests",
-    "prerunCoverage": "node ./src/checkDependencies.js",
-    "runCoverage": "node ./src/index.js runCoverage",
+    "start": "node ./src/index.js",
     "dev": "node ./dev"
   },
   "repository": {
@@ -34,9 +33,8 @@
   "homepage": "https://github.com/doc-detective/doc-detective#readme",
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "doc-detective-common": "^3.0.0-dev.1",
-    "doc-detective-core": "^3.0.0-dev.1",
-    "prompt-sync": "^4.2.0",
+    "doc-detective-common": "^3.0.0-dev.4",
+    "doc-detective-core": "^3.0.0-dev.4",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ async function main(argv) {
   config = await setConfig(config, argv, configPath || ".");
 
   // Run tests
-  const output = config.outputDirectory;
+  const output = config.output;
   const results = await runTests(config);
 
   // Output results

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,22 +33,6 @@ function setArgs(args) {
         "Path of the directory in which to store the output of Doc Detective commands.",
       type: "string",
     })
-    .option("setup", {
-      description:
-        "Path to test specifications to perform before those specified by `input`. Useful for setting up testing environments.",
-      type: "string",
-    })
-    .option("cleanup", {
-      description:
-        "Path to test specifications to perform after those specified by input. Useful for cleaning up testing environments.",
-      type: "string",
-    })
-    .option("recursive", {
-      alias: "r",
-      description:
-        "Boolean.  If true searches input, setup, and cleanup paths recursively for test specificaions and source files. Defaults to `true`.",
-      type: "string",
-    })
     .option("logLevel", {
       alias: "l",
       description:
@@ -61,66 +45,16 @@ function setArgs(args) {
   return argv;
 }
 
-// Override config values based on args
-async function setConfig(config, args) {
-  // If no args, return config
-  if (!args) return config;
-
-  // Load config from file
-  if (args.config) {
-    const configPath = path.resolve(args.config);
-    configContent = await readFile({ fileURLOrPath: configPath });
-    if (!configContent || typeof configContent !== "object") {
-      console.error(`Error reading config file: ${configPath}`);
-      process.exit(1);
-    }
-    // Validate config
-    const validation = validate({
-      schemaKey: "config_v3",
-      object: configContent,
-    });
-    if (validation.valid) {
-      config = configContent;
-      config = await resolvePaths(config, config, configPath);
-    } else {
-      // Output validation errors
-      console.error("Invalid config file:");
-      validation.errors.forEach((error) => {
-        console.error(error);
-      });
-      process.exit(1);
-    }
-  }
-
+// Override config values based on args and validate the config
+async function setConfig(config, args, configPath) {
   // Override config values
-  if (
-    (args.setup || args.cleanup || args.input || args.output) &&
-    !config.runTests
-  )
-    config.runTests = {};
-  if (
-    (args.setup || args.cleanup || args.input || args.output) &&
-    !config.runCoverage
-  )
-    config.runCoverage = {};
   if (args.input) {
     config.input = args.input;
-    config.runCoverage.input = args.input;
-    config.runTests.input = args.input;
   }
   if (args.output) {
     config.output = args.output;
-    config.runCoverage.output = args.output;
-    config.runTests.output = args.output;
-  }
-  if (args.recursive) {
-    config.recursive = args.recursive;
-    config.runCoverage.recursive = args.recursive;
-    config.runTests.recursive = args.recursive;
   }
   if (args.logLevel) config.logLevel = args.logLevel;
-  if (args.setup) config.runTests.setup = args.setup;
-  if (args.cleanup) config.runTests.cleanup = args.cleanup;
 
   // Validate config
   const validation = validate({
@@ -135,6 +69,29 @@ async function setConfig(config, args) {
     });
     process.exit(1);
   }
+  // Accept coerced and defaulted values
+  config = validation.object;
+  // Set default values
+  config = {
+    ...config,
+    input: config.input || ".",
+    outputDirectory: config.outputDirectory || ".",
+    recursive: config.recursive || true,
+    relativePathBase: config.relativePathBase || "file",
+    loadVariables: config.loadVariables || ".env",
+    detectSteps: config.detectSteps || true,
+    logLevel: config.logLevel || "info",
+    fileTypes: config.fileTypes || ["markdown", "asciidoc", "html", "xml"],
+    telemetry: config.telemetry || { send: true },
+  }
+  // Resolve paths
+  config = await resolvePaths({
+    config: config,
+    object: config,
+    filePath: configPath,
+    nested: false,
+    objectType: "config",
+  });
 
   return config;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,15 +47,6 @@ function setArgs(args) {
 
 // Override config values based on args and validate the config
 async function setConfig(config, args, configPath) {
-  // Override config values
-  if (args.input) {
-    config.input = args.input;
-  }
-  if (args.output) {
-    config.output = args.output;
-  }
-  if (args.logLevel) config.logLevel = args.logLevel;
-
   // Validate config
   const validation = validate({
     schemaKey: "config_v3",
@@ -75,15 +66,23 @@ async function setConfig(config, args, configPath) {
   config = {
     ...config,
     input: config.input || ".",
-    outputDirectory: config.outputDirectory || ".",
+    output: config.output || ".",
     recursive: config.recursive || true,
     relativePathBase: config.relativePathBase || "file",
     loadVariables: config.loadVariables || ".env",
     detectSteps: config.detectSteps || true,
     logLevel: config.logLevel || "info",
-    fileTypes: config.fileTypes || ["markdown", "asciidoc", "html", "xml"],
+    fileTypes: config.fileTypes || ["markdown","asciidoc", "html"],
     telemetry: config.telemetry || { send: true },
   }
+  // Override config values
+  if (args.input) {
+    config.input = args.input;
+  }
+  if (args.output) {
+    config.output = args.output;
+  }
+  if (args.logLevel) config.logLevel = args.logLevel;
   // Resolve paths
   config = await resolvePaths({
     config: config,

--- a/test/artifacts/cleanup.spec.json
+++ b/test/artifacts/cleanup.spec.json
@@ -5,7 +5,7 @@
         "steps": [
           {
             "action": "setVariables",
-            "path": ".env"
+            "path": "env"
           },
           {
             "action": "runShell",

--- a/test/artifacts/setup.spec.json
+++ b/test/artifacts/setup.spec.json
@@ -5,7 +5,7 @@
       "steps": [
         {
           "action": "setVariables",
-          "path": ".env"
+          "path": "env"
         },
         {
           "action": "runShell",

--- a/test/artifacts/test.spec.json
+++ b/test/artifacts/test.spec.json
@@ -9,7 +9,7 @@
       "steps": [
         {
           "action": "setVariables",
-          "path": ".env"
+          "path": "env"
         },
         {
           "action": "runShell",

--- a/test/runTests.test.js
+++ b/test/runTests.test.js
@@ -1,11 +1,11 @@
 const path = require("path");
-const { spawnCommand } = require(path.resolve(__dirname, "../src/utils"));
+const { spawnCommand } = require("../src/utils");
 const assert = require("assert").strict;
 const fs = require("fs");
 const artifactPath = path.resolve(__dirname, "./artifacts");
 const outputFile = path.resolve(`${artifactPath}/testResults.json`);
 
-describe("Run tests sucessfully", function () {
+describe("Run tests successfully", function () {
   // Set indefinite timeout
   this.timeout(0);
   it("All specs pass", async () => {

--- a/test/runTests.test.js
+++ b/test/runTests.test.js
@@ -10,7 +10,7 @@ describe("Run tests sucessfully", function () {
   this.timeout(0);
   it("All specs pass", async () => {
     await spawnCommand(
-      `node ./src/index.js runTests -c ${artifactPath}/config.json -i ${artifactPath} -o ${outputFile}`
+      `node ./src/index.js -c ${artifactPath}/config.json -i ${artifactPath} -o ${outputFile}`
     );
     // Wait until the file is written
     while (!fs.existsSync(outputFile)) {}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -60,35 +60,6 @@ describe("Util tests", function () {
           c: "config.json",
         },
       },
-      {
-        args: [
-          "node",
-          "runTests.js",
-          "--input",
-          "input.spec.json",
-          "--output",
-          ".",
-          "--logLevel",
-          "debug",
-          "--config",
-          "config.json",
-          "--recursive",
-          "false",
-          "--setup",
-          "setup.spec.json",
-          "--cleanup",
-          "cleanup.spec.json",
-        ],
-        expected: {
-          i: "input.spec.json",
-          o: ".",
-          l: "debug",
-          c: "config.json",
-          r: "false",
-          setup: "setup.spec.json",
-          cleanup: "cleanup.spec.json",
-        },
-      },
     ];
     argSets.forEach((argSet) => {
       expect(setArgs(argSet.args)).to.deep.include(argSet.expected);
@@ -124,13 +95,10 @@ describe("Util tests", function () {
           "input.spec.json",
           "--logLevel",
           "debug",
-          "--setup",
-          "setup.spec.json",
         ],
         expected: {
           input: "input.spec.json",
           logLevel: "debug",
-          runTests: { setup: "setup.spec.json" },
         },
       },
       {
@@ -141,10 +109,6 @@ describe("Util tests", function () {
           output: ".",
           logLevel: "silent",
           recursive: true,
-          runTests: {
-            setup: ".",
-            cleanup: ".",
-          },
         },
       },
       {
@@ -162,10 +126,6 @@ describe("Util tests", function () {
           output: ".",
           logLevel: "silent",
           recursive: true,
-          runTests: {
-            setup: ".",
-            cleanup: ".",
-          },
         },
       },
     ];


### PR DESCRIPTION
Eliminate the `runCoverage` and `suggestTests` commands from the application, simplifying the testing process and updating related documentation accordingly. Adjustments made to ensure the remaining commands function correctly without these operations.