### PR TITLE
Add version information to command-line arguments

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,6 +73,7 @@ function setArgs(args: any): any {
       description: "Allow execution of potentially unsafe tests",
       type: "boolean",
     })
+    .version(require("../package.json").version)
     .help()
     .alias("help", "h").argv;
 


### PR DESCRIPTION
Include the package version in the command-line help output to provide users with version context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI now supports the `--version` flag to display the application version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->