### PR TITLE
fix: recording on macOS

### DIFF
--- a/src/core/tests/stopRecording.ts
+++ b/src/core/tests/stopRecording.ts
@@ -46,7 +46,14 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
         result.status = "FAIL";
         result.description =
           "Recording was not properly started. The recorder object doesn't exist in the browser context.";
+        const allHandles = await driver.getWindowHandles();
         await driver.closeWindow();
+        const remainingHandles = allHandles.filter(
+          (h: string) => h !== config.recording.tab
+        );
+        if (remainingHandles.length > 0) {
+          await driver.switchToWindow(remainingHandles[0]);
+        }
         config.recording = null;
         return result;
       }

--- a/test/core-artifacts/recording.spec.json
+++ b/test/core-artifacts/recording.spec.json
@@ -1,6 +1,6 @@
 {
   "specId": "recording",
-  "description": "Tests for screen recording start/stop lifecycle. Requires Chrome with screen recording permissions for non-headless tests. Doesn't run on Linux due to lack of support for screen recording in headless mode.",
+  "description": "Tests for screen recording start/stop lifecycle. Non-headless tests require Chrome with screen recording permissions and only run on Windows and macOS. Headless tests verify skip/guard behavior on all platforms.",
   "tests": [
     {
       "testId": "recording-basic",
@@ -40,7 +40,7 @@
       "description": "Start and stop recording with mp4 output.",
       "runOn": [
         {
-          "platforms": ["windows", "mac", "linux"],
+          "platforms": ["windows", "mac"],
           "browsers": {
             "name": "chrome",
             "headless": false


### PR DESCRIPTION
Improve recording functionality with better error handling and logging. Ensure the recorder is properly initialized before stopping and update result statuses for failed attempts. Include tests for the recording lifecycle to validate functionality across different scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling, cleanup, and recovery during screen recording start/stop; added guards to prevent failures and restore state on error.

* **Tests**
  * Added end-to-end tests covering the screen recording lifecycle across platforms and modes, including start/stop, headless skip, and stop-without-start scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->