### PR TITLE
fix(screenshot): shift-rather-than-shrink crop clamp on macOS flake

### DIFF
--- a/src/core/tests/saveScreenshot.ts
+++ b/src/core/tests/saveScreenshot.ts
@@ -15,7 +15,42 @@ async function getPixelmatch() {
   return pixelmatch;
 }
 
-export { saveScreenshot };
+export { saveScreenshot, clampCropRect, aspectRatiosMatch };
+
+type Rect = { x: number; y: number; width: number; height: number };
+
+// Shift the rect into image bounds without shrinking. When the rect fits
+// inside the image, output dimensions depend only on the requested rect,
+// not on where it sits — so two crops of the same element with the same
+// padding stay dimensionally stable even if the element's viewport
+// position drifts by a few pixels between calls.
+function clampCropRect(rect: Rect, imgW: number, imgH: number): Rect {
+  let { x, y, width, height } = rect;
+  if (width > imgW) {
+    x = 0;
+    width = imgW;
+  } else {
+    if (x < 0) x = 0;
+    if (x + width > imgW) x = imgW - width;
+  }
+  if (height > imgH) {
+    y = 0;
+    height = imgH;
+  } else {
+    if (y < 0) y = 0;
+    if (y + height > imgH) y = imgH - height;
+  }
+  return { x, y, width, height };
+}
+
+function aspectRatiosMatch(
+  a: { width: number; height: number },
+  b: { width: number; height: number },
+): boolean {
+  const ra = a.width / a.height;
+  const rb = b.width / b.height;
+  return Math.abs(ra - rb) / Math.max(ra, rb) <= 0.05;
+}
 
 async function saveScreenshot({ config, step, driver }: { config: any; step: any; driver: any }) {
   let result: any = {
@@ -255,20 +290,11 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
 
     // Clamp values to stay within image bounds
     const imgMeta = await sharp(filePath).metadata();
-    if (rect.x < 0) {
-      rect.width += rect.x;
-      rect.x = 0;
-    }
-    if (rect.y < 0) {
-      rect.height += rect.y;
-      rect.y = 0;
-    }
-    if (rect.x + rect.width > imgMeta.width!) {
-      rect.width = imgMeta.width! - rect.x;
-    }
-    if (rect.y + rect.height > imgMeta.height!) {
-      rect.height = imgMeta.height! - rect.y;
-    }
+    const clamped = clampCropRect(rect, imgMeta.width!, imgMeta.height!);
+    rect.x = clamped.x;
+    rect.y = clamped.y;
+    rect.width = clamped.width;
+    rect.height = clamped.height;
 
     log(config, "debug", { padded_rect: rect });
 
@@ -320,10 +346,7 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
       const img2 = PNG.sync.read(fs.readFileSync(filePath));
 
       // Compare aspect ratio of images
-      if (
-        Math.round((img1.width / img1.height) * 100) / 100 !==
-        Math.round((img2.width / img2.height) * 100) / 100
-      ) {
+      if (!aspectRatiosMatch(img1, img2)) {
         result.status = "FAIL";
         result.description = `Couldn't compare images. Images have different aspect ratios.`;
         if (existFilePath && filePath !== existFilePath && fs.existsSync(filePath)) {

--- a/test/saveScreenshot.test.js
+++ b/test/saveScreenshot.test.js
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import {
+  clampCropRect,
+  aspectRatiosMatch,
+} from "../dist/core/tests/saveScreenshot.js";
+
+describe("clampCropRect", function () {
+  it("produces identical dimensions when requested rect straddles y=0 vs sits just below", function () {
+    const imgW = 2400;
+    const imgH = 1600;
+    const clamped = clampCropRect(
+      { x: 77, y: -5, width: 199, height: 32 },
+      imgW,
+      imgH,
+    );
+    const unclamped = clampCropRect(
+      { x: 77, y: 0, width: 199, height: 32 },
+      imgW,
+      imgH,
+    );
+    assert.equal(clamped.width, unclamped.width);
+    assert.equal(clamped.height, unclamped.height);
+  });
+
+  it("shifts down when y is negative (does not shrink height)", function () {
+    const r = clampCropRect(
+      { x: 10, y: -4, width: 50, height: 20 },
+      1000,
+      1000,
+    );
+    assert.equal(r.y, 0);
+    assert.equal(r.height, 20);
+  });
+
+  it("shifts right when x is negative (does not shrink width)", function () {
+    const r = clampCropRect(
+      { x: -3, y: 10, width: 50, height: 20 },
+      1000,
+      1000,
+    );
+    assert.equal(r.x, 0);
+    assert.equal(r.width, 50);
+  });
+
+  it("shifts up when rect overflows bottom", function () {
+    const r = clampCropRect(
+      { x: 0, y: 990, width: 10, height: 20 },
+      1000,
+      1000,
+    );
+    assert.equal(r.y, 980);
+    assert.equal(r.height, 20);
+  });
+
+  it("shifts left when rect overflows right", function () {
+    const r = clampCropRect(
+      { x: 990, y: 0, width: 20, height: 10 },
+      1000,
+      1000,
+    );
+    assert.equal(r.x, 980);
+    assert.equal(r.width, 20);
+  });
+
+  it("falls back to shrink when requested rect is larger than the image", function () {
+    const r = clampCropRect(
+      { x: 0, y: 0, width: 2000, height: 2000 },
+      1000,
+      1000,
+    );
+    assert.equal(r.width, 1000);
+    assert.equal(r.height, 1000);
+  });
+
+  it("leaves an already-in-bounds rect untouched", function () {
+    const r = clampCropRect(
+      { x: 50, y: 50, width: 100, height: 100 },
+      1000,
+      1000,
+    );
+    assert.deepEqual(r, { x: 50, y: 50, width: 100, height: 100 });
+  });
+});
+
+describe("aspectRatiosMatch", function () {
+  it("rejects the bug's 7.37 vs 6.22 case", function () {
+    assert.equal(
+      aspectRatiosMatch({ width: 199, height: 27 }, { width: 199, height: 32 }),
+      false,
+    );
+  });
+
+  it("accepts sub-pixel rounding jitter within 5%", function () {
+    assert.equal(
+      aspectRatiosMatch({ width: 199, height: 32 }, { width: 200, height: 32 }),
+      true,
+    );
+  });
+
+  it("accepts identical ratios", function () {
+    assert.equal(
+      aspectRatiosMatch({ width: 100, height: 50 }, { width: 200, height: 100 }),
+      true,
+    );
+  });
+
+  it("rejects clearly different ratios (2:1 vs 1:1)", function () {
+    assert.equal(
+      aspectRatiosMatch({ width: 200, height: 100 }, { width: 100, height: 100 }),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the `test (macos-latest, *)` flake where the `screenshot` core spec fails with `Couldn't compare images. Images have different aspect ratios.` (~37% rate observed during the PR #254 window).

## Root cause

When a `{crop, padding}` screenshot's padded rect extends above the viewport (`rect.y < 0`), the clamp in `src/core/tests/saveScreenshot.ts` shrinks `height` by the overshoot instead of shifting the box:

```ts
if (rect.y < 0) { rect.height += rect.y; rect.y = 0; }
```

So two sequential screenshots of the same element with the same padding yield different dimensions whenever the element's viewport y drifts by a few pixels between calls. That drift only happens reliably on macOS Chrome (element sits 0.3–5.5 px from the viewport top; ubuntu/windows sit it consistently lower). The downstream 2-decimal aspect-ratio equality check then hard-FAILs before `maxVariation` can absorb it.

Full investigation: [`.claude/notes/macos-screenshot-flake-investigation.md`](https://github.com/doc-detective/doc-detective/blob/claude/wonderful-kilby-b89f33/.claude/notes/macos-screenshot-flake-investigation.md).

## What changed

- Extracted two pure helpers from `saveScreenshot.ts` so the math is unit-testable:
  - `clampCropRect(rect, imgW, imgH)` — shifts into bounds instead of shrinking; only falls back to shrink when the requested rect is larger than the image itself. Output dimensions now depend only on the requested rect.
  - `aspectRatiosMatch(a, b)` — 5% relative tolerance instead of 2-decimal equality, so sub-pixel rounding jitter can't ever hard-FAIL before `maxVariation` gets a chance.
- Added `test/saveScreenshot.test.js` — 11 unit tests built TDD-style (red first against the extracted-but-unchanged buggy helpers, then green after the body swaps). Pins the exact `{x:77,y:-5,w:199,h:32}` vs `{x:77,y:0,w:199,h:32}` dimension-drift case from the investigation, plus all clamp directions and aspect-ratio edges.

## Why this approach

- "Shift, don't shrink" matches the user's intent — `element.bounds + padding` should fully determine the crop dimensions, so repeat screenshots of the same element produce comparable images.
- Option 1B (sharp `extend` with transparent pixels) was rejected because synthesized pixels would break visual comparison against real baselines.
- A test-level workaround (force `scrollIntoView` before each step) was rejected because it would leave the bug live for any end user doing the same thing.

## Test plan

- [x] Unit tests pass: `npx mocha test/saveScreenshot.test.js` → 11 passing
- [x] Verified red→green transition (6 failing before body swap, 0 after)
- [ ] CI: `test (macos-latest, 20)` and `test (macos-latest, 22)` pass without retries
- [ ] CI: ubuntu/windows stay green (no behavior change expected)
- [ ] The pre-existing WARNING-level 0.06/0.05 variation on `test/artifacts/doc-content.md` remains a WARNING (not promoted to FAIL)

## Notes for reviewer

- `src/core/tests/saveScreenshot.ts` lines 211-297 (crop) and 302-396 (compare) are the hot zone. The two inline math blocks at the former clamp and aspect-ratio-check sites are now one-liners that call the helpers.
- No changes to `test/core-artifacts/screenshot.spec.json` — it remains the e2e regression case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot crop rectangle handling with more robust boundary clamping for edge cases.
  * Enhanced aspect ratio matching with tolerance-based comparison (±5%) for more flexible validation.

* **Tests**
  * Added comprehensive test coverage for crop rectangle and aspect ratio matching functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->