### PR TITLE
feat(config): support default query params via originParams (closes #184)

### DIFF
--- a/src/common/src/schemas/output_schemas/checkLink_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/checkLink_v3.schema.json
@@ -35,6 +35,14 @@
             "trim"
           ]
         },
+        "params": {
+          "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
         "statusCodes": {
           "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
           "anyOf": [
@@ -118,6 +126,14 @@
               "trim"
             ]
           },
+          "params": {
+            "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {}
+          },
           "statusCodes": {
             "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
             "anyOf": [
@@ -180,6 +196,13 @@
       "statusCodes": [
         200
       ]
+    },
+    {
+      "url": "/health",
+      "origin": "https://my-app.com",
+      "params": {
+        "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+      }
     }
   ]
 }

--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -17600,6 +17600,12 @@
       ]
     },
     {
+      "origin": "https://my-app.com",
+      "originParams": {
+        "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+      }
+    },
+    {
       "fileTypes": [
         {
           "extends": "markdown",

--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -88,6 +88,14 @@
       "description": "Default protocol and domain to use for relative URLs.",
       "type": "string"
     },
+    "originParams": {
+      "description": "Query parameters to append to URLs resolved against `origin`. Values support environment variable substitution via `$VAR` syntax. Step-level `params` on `goTo` / `checkLink` are merged on top of these, with step keys winning on collision. WARNING: values are embedded in request URLs and appear verbatim in test results, logs, and reports — avoid putting long-lived secrets here.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
     "beforeAny": {
       "description": "Path(s) to test specifications to perform before those specified by `input`. Useful for setting up testing environments.",
       "anyOf": [
@@ -1102,6 +1110,14 @@
                                                           "trim"
                                                         ]
                                                       },
+                                                      "params": {
+                                                        "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                        "type": "object",
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "default": {}
+                                                      },
                                                       "statusCodes": {
                                                         "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                         "anyOf": [
@@ -1185,6 +1201,14 @@
                                                             "trim"
                                                           ]
                                                         },
+                                                        "params": {
+                                                          "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                          "type": "object",
+                                                          "additionalProperties": {
+                                                            "type": "string"
+                                                          },
+                                                          "default": {}
+                                                        },
                                                         "statusCodes": {
                                                           "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                           "anyOf": [
@@ -1247,6 +1271,13 @@
                                                     "statusCodes": [
                                                       200
                                                     ]
+                                                  },
+                                                  {
+                                                    "url": "/health",
+                                                    "origin": "https://my-app.com",
+                                                    "params": {
+                                                      "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                                    }
                                                   }
                                                 ]
                                               }
@@ -3187,6 +3218,14 @@
                                                           "trim"
                                                         ]
                                                       },
+                                                      "params": {
+                                                        "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                        "type": "object",
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "default": {}
+                                                      },
                                                       "timeout": {
                                                         "type": "integer",
                                                         "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -3359,6 +3398,14 @@
                                                             "trim"
                                                           ]
                                                         },
+                                                        "params": {
+                                                          "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                          "type": "object",
+                                                          "additionalProperties": {
+                                                            "type": "string"
+                                                          },
+                                                          "default": {}
+                                                        },
                                                         "timeout": {
                                                           "type": "integer",
                                                           "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -3507,6 +3554,13 @@
                                                   {
                                                     "url": "/search",
                                                     "origin": "https://www.google.com"
+                                                  },
+                                                  {
+                                                    "url": "/dashboard",
+                                                    "origin": "https://my-app.com",
+                                                    "params": {
+                                                      "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                                    }
                                                   },
                                                   {
                                                     "url": "https://www.example.com",
@@ -9765,6 +9819,14 @@
                                             "trim"
                                           ]
                                         },
+                                        "params": {
+                                          "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "default": {}
+                                        },
                                         "statusCodes": {
                                           "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                           "anyOf": [
@@ -9848,6 +9910,14 @@
                                               "trim"
                                             ]
                                           },
+                                          "params": {
+                                            "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "default": {}
+                                          },
                                           "statusCodes": {
                                             "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                             "anyOf": [
@@ -9910,6 +9980,13 @@
                                       "statusCodes": [
                                         200
                                       ]
+                                    },
+                                    {
+                                      "url": "/health",
+                                      "origin": "https://my-app.com",
+                                      "params": {
+                                        "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                      }
                                     }
                                   ]
                                 }
@@ -11850,6 +11927,14 @@
                                             "trim"
                                           ]
                                         },
+                                        "params": {
+                                          "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "default": {}
+                                        },
                                         "timeout": {
                                           "type": "integer",
                                           "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -12022,6 +12107,14 @@
                                               "trim"
                                             ]
                                           },
+                                          "params": {
+                                            "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "default": {}
+                                          },
                                           "timeout": {
                                             "type": "integer",
                                             "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -12170,6 +12263,13 @@
                                     {
                                       "url": "/search",
                                       "origin": "https://www.google.com"
+                                    },
+                                    {
+                                      "url": "/dashboard",
+                                      "origin": "https://my-app.com",
+                                      "params": {
+                                        "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                      }
                                     },
                                     {
                                       "url": "https://www.example.com",

--- a/src/common/src/schemas/output_schemas/goTo_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/goTo_v3.schema.json
@@ -34,6 +34,14 @@
             "trim"
           ]
         },
+        "params": {
+          "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
         "timeout": {
           "type": "integer",
           "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -206,6 +214,14 @@
               "trim"
             ]
           },
+          "params": {
+            "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {}
+          },
           "timeout": {
             "type": "integer",
             "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -354,6 +370,13 @@
     {
       "url": "/search",
       "origin": "https://www.google.com"
+    },
+    {
+      "url": "/dashboard",
+      "origin": "https://my-app.com",
+      "params": {
+        "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+      }
     },
     {
       "url": "https://www.example.com",

--- a/src/common/src/schemas/output_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/report_v3.schema.json
@@ -1523,6 +1523,14 @@
                                                   "trim"
                                                 ]
                                               },
+                                              "params": {
+                                                "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "default": {}
+                                              },
                                               "statusCodes": {
                                                 "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                 "anyOf": [
@@ -1606,6 +1614,14 @@
                                                     "trim"
                                                   ]
                                                 },
+                                                "params": {
+                                                  "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "default": {}
+                                                },
                                                 "statusCodes": {
                                                   "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                   "anyOf": [
@@ -1668,6 +1684,13 @@
                                             "statusCodes": [
                                               200
                                             ]
+                                          },
+                                          {
+                                            "url": "/health",
+                                            "origin": "https://my-app.com",
+                                            "params": {
+                                              "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                            }
                                           }
                                         ]
                                       }
@@ -3608,6 +3631,14 @@
                                                   "trim"
                                                 ]
                                               },
+                                              "params": {
+                                                "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "default": {}
+                                              },
                                               "timeout": {
                                                 "type": "integer",
                                                 "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -3780,6 +3811,14 @@
                                                     "trim"
                                                   ]
                                                 },
+                                                "params": {
+                                                  "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "default": {}
+                                                },
                                                 "timeout": {
                                                   "type": "integer",
                                                   "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -3928,6 +3967,13 @@
                                           {
                                             "url": "/search",
                                             "origin": "https://www.google.com"
+                                          },
+                                          {
+                                            "url": "/dashboard",
+                                            "origin": "https://my-app.com",
+                                            "params": {
+                                              "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                            }
                                           },
                                           {
                                             "url": "https://www.example.com",
@@ -9660,6 +9706,14 @@
                                                         "trim"
                                                       ]
                                                     },
+                                                    "params": {
+                                                      "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                      "type": "object",
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "default": {}
+                                                    },
                                                     "statusCodes": {
                                                       "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                       "anyOf": [
@@ -9743,6 +9797,14 @@
                                                           "trim"
                                                         ]
                                                       },
+                                                      "params": {
+                                                        "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                        "type": "object",
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "default": {}
+                                                      },
                                                       "statusCodes": {
                                                         "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                         "anyOf": [
@@ -9805,6 +9867,13 @@
                                                   "statusCodes": [
                                                     200
                                                   ]
+                                                },
+                                                {
+                                                  "url": "/health",
+                                                  "origin": "https://my-app.com",
+                                                  "params": {
+                                                    "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                                  }
                                                 }
                                               ]
                                             }
@@ -11745,6 +11814,14 @@
                                                         "trim"
                                                       ]
                                                     },
+                                                    "params": {
+                                                      "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                      "type": "object",
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "default": {}
+                                                    },
                                                     "timeout": {
                                                       "type": "integer",
                                                       "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -11917,6 +11994,14 @@
                                                           "trim"
                                                         ]
                                                       },
+                                                      "params": {
+                                                        "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                        "type": "object",
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "default": {}
+                                                      },
                                                       "timeout": {
                                                         "type": "integer",
                                                         "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -12065,6 +12150,13 @@
                                                 {
                                                   "url": "/search",
                                                   "origin": "https://www.google.com"
+                                                },
+                                                {
+                                                  "url": "/dashboard",
+                                                  "origin": "https://my-app.com",
+                                                  "params": {
+                                                    "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                                  }
                                                 },
                                                 {
                                                   "url": "https://www.example.com",

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -17613,6 +17613,12 @@
           ]
         },
         {
+          "origin": "https://my-app.com",
+          "originParams": {
+            "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+          }
+        },
+        {
           "fileTypes": [
             {
               "extends": "markdown",

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -101,6 +101,14 @@
           "description": "Default protocol and domain to use for relative URLs.",
           "type": "string"
         },
+        "originParams": {
+          "description": "Query parameters to append to URLs resolved against `origin`. Values support environment variable substitution via `$VAR` syntax. Step-level `params` on `goTo` / `checkLink` are merged on top of these, with step keys winning on collision. WARNING: values are embedded in request URLs and appear verbatim in test results, logs, and reports — avoid putting long-lived secrets here.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
         "beforeAny": {
           "description": "Path(s) to test specifications to perform before those specified by `input`. Useful for setting up testing environments.",
           "anyOf": [
@@ -1115,6 +1123,14 @@
                                                               "trim"
                                                             ]
                                                           },
+                                                          "params": {
+                                                            "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                            "type": "object",
+                                                            "additionalProperties": {
+                                                              "type": "string"
+                                                            },
+                                                            "default": {}
+                                                          },
                                                           "statusCodes": {
                                                             "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                             "anyOf": [
@@ -1198,6 +1214,14 @@
                                                                 "trim"
                                                               ]
                                                             },
+                                                            "params": {
+                                                              "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                              "type": "object",
+                                                              "additionalProperties": {
+                                                                "type": "string"
+                                                              },
+                                                              "default": {}
+                                                            },
                                                             "statusCodes": {
                                                               "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                               "anyOf": [
@@ -1260,6 +1284,13 @@
                                                         "statusCodes": [
                                                           200
                                                         ]
+                                                      },
+                                                      {
+                                                        "url": "/health",
+                                                        "origin": "https://my-app.com",
+                                                        "params": {
+                                                          "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                                        }
                                                       }
                                                     ]
                                                   }
@@ -3200,6 +3231,14 @@
                                                               "trim"
                                                             ]
                                                           },
+                                                          "params": {
+                                                            "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                            "type": "object",
+                                                            "additionalProperties": {
+                                                              "type": "string"
+                                                            },
+                                                            "default": {}
+                                                          },
                                                           "timeout": {
                                                             "type": "integer",
                                                             "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -3372,6 +3411,14 @@
                                                                 "trim"
                                                               ]
                                                             },
+                                                            "params": {
+                                                              "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                              "type": "object",
+                                                              "additionalProperties": {
+                                                                "type": "string"
+                                                              },
+                                                              "default": {}
+                                                            },
                                                             "timeout": {
                                                               "type": "integer",
                                                               "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -3520,6 +3567,13 @@
                                                       {
                                                         "url": "/search",
                                                         "origin": "https://www.google.com"
+                                                      },
+                                                      {
+                                                        "url": "/dashboard",
+                                                        "origin": "https://my-app.com",
+                                                        "params": {
+                                                          "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                                        }
                                                       },
                                                       {
                                                         "url": "https://www.example.com",
@@ -9778,6 +9832,14 @@
                                                 "trim"
                                               ]
                                             },
+                                            "params": {
+                                              "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "default": {}
+                                            },
                                             "statusCodes": {
                                               "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                               "anyOf": [
@@ -9861,6 +9923,14 @@
                                                   "trim"
                                                 ]
                                               },
+                                              "params": {
+                                                "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "default": {}
+                                              },
                                               "statusCodes": {
                                                 "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                 "anyOf": [
@@ -9923,6 +9993,13 @@
                                           "statusCodes": [
                                             200
                                           ]
+                                        },
+                                        {
+                                          "url": "/health",
+                                          "origin": "https://my-app.com",
+                                          "params": {
+                                            "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                          }
                                         }
                                       ]
                                     }
@@ -11863,6 +11940,14 @@
                                                 "trim"
                                               ]
                                             },
+                                            "params": {
+                                              "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "default": {}
+                                            },
                                             "timeout": {
                                               "type": "integer",
                                               "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -12035,6 +12120,14 @@
                                                   "trim"
                                                 ]
                                               },
+                                              "params": {
+                                                "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "default": {}
+                                              },
                                               "timeout": {
                                                 "type": "integer",
                                                 "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -12183,6 +12276,13 @@
                                         {
                                           "url": "/search",
                                           "origin": "https://www.google.com"
+                                        },
+                                        {
+                                          "url": "/dashboard",
+                                          "origin": "https://my-app.com",
+                                          "params": {
+                                            "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                          }
                                         },
                                         {
                                           "url": "https://www.example.com",
@@ -19135,6 +19235,14 @@
                                                   "trim"
                                                 ]
                                               },
+                                              "params": {
+                                                "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "default": {}
+                                              },
                                               "statusCodes": {
                                                 "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                 "anyOf": [
@@ -19218,6 +19326,14 @@
                                                     "trim"
                                                   ]
                                                 },
+                                                "params": {
+                                                  "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "default": {}
+                                                },
                                                 "statusCodes": {
                                                   "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                   "anyOf": [
@@ -19280,6 +19396,13 @@
                                             "statusCodes": [
                                               200
                                             ]
+                                          },
+                                          {
+                                            "url": "/health",
+                                            "origin": "https://my-app.com",
+                                            "params": {
+                                              "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                            }
                                           }
                                         ]
                                       }
@@ -21220,6 +21343,14 @@
                                                   "trim"
                                                 ]
                                               },
+                                              "params": {
+                                                "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "default": {}
+                                              },
                                               "timeout": {
                                                 "type": "integer",
                                                 "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -21392,6 +21523,14 @@
                                                     "trim"
                                                   ]
                                                 },
+                                                "params": {
+                                                  "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "default": {}
+                                                },
                                                 "timeout": {
                                                   "type": "integer",
                                                   "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -21540,6 +21679,13 @@
                                           {
                                             "url": "/search",
                                             "origin": "https://www.google.com"
+                                          },
+                                          {
+                                            "url": "/dashboard",
+                                            "origin": "https://my-app.com",
+                                            "params": {
+                                              "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                            }
                                           },
                                           {
                                             "url": "https://www.example.com",
@@ -27272,6 +27418,14 @@
                                                         "trim"
                                                       ]
                                                     },
+                                                    "params": {
+                                                      "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                      "type": "object",
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "default": {}
+                                                    },
                                                     "statusCodes": {
                                                       "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                       "anyOf": [
@@ -27355,6 +27509,14 @@
                                                           "trim"
                                                         ]
                                                       },
+                                                      "params": {
+                                                        "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                        "type": "object",
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "default": {}
+                                                      },
                                                       "statusCodes": {
                                                         "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                                         "anyOf": [
@@ -27417,6 +27579,13 @@
                                                   "statusCodes": [
                                                     200
                                                   ]
+                                                },
+                                                {
+                                                  "url": "/health",
+                                                  "origin": "https://my-app.com",
+                                                  "params": {
+                                                    "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                                  }
                                                 }
                                               ]
                                             }
@@ -29357,6 +29526,14 @@
                                                         "trim"
                                                       ]
                                                     },
+                                                    "params": {
+                                                      "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                      "type": "object",
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "default": {}
+                                                    },
                                                     "timeout": {
                                                       "type": "integer",
                                                       "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -29529,6 +29706,14 @@
                                                           "trim"
                                                         ]
                                                       },
+                                                      "params": {
+                                                        "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                                        "type": "object",
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "default": {}
+                                                      },
                                                       "timeout": {
                                                         "type": "integer",
                                                         "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -29677,6 +29862,13 @@
                                                 {
                                                   "url": "/search",
                                                   "origin": "https://www.google.com"
+                                                },
+                                                {
+                                                  "url": "/dashboard",
+                                                  "origin": "https://my-app.com",
+                                                  "params": {
+                                                    "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                                  }
                                                 },
                                                 {
                                                   "url": "https://www.example.com",

--- a/src/common/src/schemas/output_schemas/spec_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/spec_v3.schema.json
@@ -1505,6 +1505,14 @@
                                         "trim"
                                       ]
                                     },
+                                    "params": {
+                                      "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "default": {}
+                                    },
                                     "statusCodes": {
                                       "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                       "anyOf": [
@@ -1588,6 +1596,14 @@
                                           "trim"
                                         ]
                                       },
+                                      "params": {
+                                        "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "default": {}
+                                      },
                                       "statusCodes": {
                                         "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                         "anyOf": [
@@ -1650,6 +1666,13 @@
                                   "statusCodes": [
                                     200
                                   ]
+                                },
+                                {
+                                  "url": "/health",
+                                  "origin": "https://my-app.com",
+                                  "params": {
+                                    "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                  }
                                 }
                               ]
                             }
@@ -3590,6 +3613,14 @@
                                         "trim"
                                       ]
                                     },
+                                    "params": {
+                                      "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "default": {}
+                                    },
                                     "timeout": {
                                       "type": "integer",
                                       "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -3762,6 +3793,14 @@
                                           "trim"
                                         ]
                                       },
+                                      "params": {
+                                        "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "default": {}
+                                      },
                                       "timeout": {
                                         "type": "integer",
                                         "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -3910,6 +3949,13 @@
                                 {
                                   "url": "/search",
                                   "origin": "https://www.google.com"
+                                },
+                                {
+                                  "url": "/dashboard",
+                                  "origin": "https://my-app.com",
+                                  "params": {
+                                    "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                  }
                                 },
                                 {
                                   "url": "https://www.example.com",
@@ -9642,6 +9688,14 @@
                                               "trim"
                                             ]
                                           },
+                                          "params": {
+                                            "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "default": {}
+                                          },
                                           "statusCodes": {
                                             "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                             "anyOf": [
@@ -9725,6 +9779,14 @@
                                                 "trim"
                                               ]
                                             },
+                                            "params": {
+                                              "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "default": {}
+                                            },
                                             "statusCodes": {
                                               "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                               "anyOf": [
@@ -9787,6 +9849,13 @@
                                         "statusCodes": [
                                           200
                                         ]
+                                      },
+                                      {
+                                        "url": "/health",
+                                        "origin": "https://my-app.com",
+                                        "params": {
+                                          "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                        }
                                       }
                                     ]
                                   }
@@ -11727,6 +11796,14 @@
                                               "trim"
                                             ]
                                           },
+                                          "params": {
+                                            "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "default": {}
+                                          },
                                           "timeout": {
                                             "type": "integer",
                                             "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -11899,6 +11976,14 @@
                                                 "trim"
                                               ]
                                             },
+                                            "params": {
+                                              "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "default": {}
+                                            },
                                             "timeout": {
                                               "type": "integer",
                                               "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -12047,6 +12132,13 @@
                                       {
                                         "url": "/search",
                                         "origin": "https://www.google.com"
+                                      },
+                                      {
+                                        "url": "/dashboard",
+                                        "origin": "https://my-app.com",
+                                        "params": {
+                                          "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                                        }
                                       },
                                       {
                                         "url": "https://www.example.com",

--- a/src/common/src/schemas/output_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/step_v3.schema.json
@@ -305,6 +305,14 @@
                         "trim"
                       ]
                     },
+                    "params": {
+                      "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "default": {}
+                    },
                     "statusCodes": {
                       "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                       "anyOf": [
@@ -388,6 +396,14 @@
                           "trim"
                         ]
                       },
+                      "params": {
+                        "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "default": {}
+                      },
                       "statusCodes": {
                         "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                         "anyOf": [
@@ -450,6 +466,13 @@
                   "statusCodes": [
                     200
                   ]
+                },
+                {
+                  "url": "/health",
+                  "origin": "https://my-app.com",
+                  "params": {
+                    "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                  }
                 }
               ]
             }
@@ -2390,6 +2413,14 @@
                         "trim"
                       ]
                     },
+                    "params": {
+                      "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "default": {}
+                    },
                     "timeout": {
                       "type": "integer",
                       "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -2562,6 +2593,14 @@
                           "trim"
                         ]
                       },
+                      "params": {
+                        "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "default": {}
+                      },
                       "timeout": {
                         "type": "integer",
                         "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -2710,6 +2749,13 @@
                 {
                   "url": "/search",
                   "origin": "https://www.google.com"
+                },
+                {
+                  "url": "/dashboard",
+                  "origin": "https://my-app.com",
+                  "params": {
+                    "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                  }
                 },
                 {
                   "url": "https://www.example.com",

--- a/src/common/src/schemas/output_schemas/test_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/test_v3.schema.json
@@ -904,6 +904,14 @@
                               "trim"
                             ]
                           },
+                          "params": {
+                            "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "default": {}
+                          },
                           "statusCodes": {
                             "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                             "anyOf": [
@@ -987,6 +995,14 @@
                                 "trim"
                               ]
                             },
+                            "params": {
+                              "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "default": {}
+                            },
                             "statusCodes": {
                               "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                               "anyOf": [
@@ -1049,6 +1065,13 @@
                         "statusCodes": [
                           200
                         ]
+                      },
+                      {
+                        "url": "/health",
+                        "origin": "https://my-app.com",
+                        "params": {
+                          "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                        }
                       }
                     ]
                   }
@@ -2989,6 +3012,14 @@
                               "trim"
                             ]
                           },
+                          "params": {
+                            "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "default": {}
+                          },
                           "timeout": {
                             "type": "integer",
                             "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -3161,6 +3192,14 @@
                                 "trim"
                               ]
                             },
+                            "params": {
+                              "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "default": {}
+                            },
                             "timeout": {
                               "type": "integer",
                               "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -3309,6 +3348,13 @@
                       {
                         "url": "/search",
                         "origin": "https://www.google.com"
+                      },
+                      {
+                        "url": "/dashboard",
+                        "origin": "https://my-app.com",
+                        "params": {
+                          "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                        }
                       },
                       {
                         "url": "https://www.example.com",
@@ -9041,6 +9087,14 @@
                                     "trim"
                                   ]
                                 },
+                                "params": {
+                                  "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "default": {}
+                                },
                                 "statusCodes": {
                                   "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                   "anyOf": [
@@ -9124,6 +9178,14 @@
                                       "trim"
                                     ]
                                   },
+                                  "params": {
+                                    "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "default": {}
+                                  },
                                   "statusCodes": {
                                     "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
                                     "anyOf": [
@@ -9186,6 +9248,13 @@
                               "statusCodes": [
                                 200
                               ]
+                            },
+                            {
+                              "url": "/health",
+                              "origin": "https://my-app.com",
+                              "params": {
+                                "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                              }
                             }
                           ]
                         }
@@ -11126,6 +11195,14 @@
                                     "trim"
                                   ]
                                 },
+                                "params": {
+                                  "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "default": {}
+                                },
                                 "timeout": {
                                   "type": "integer",
                                   "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -11298,6 +11375,14 @@
                                       "trim"
                                     ]
                                   },
+                                  "params": {
+                                    "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "default": {}
+                                  },
                                   "timeout": {
                                     "type": "integer",
                                     "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -11446,6 +11531,13 @@
                             {
                               "url": "/search",
                               "origin": "https://www.google.com"
+                            },
+                            {
+                              "url": "/dashboard",
+                              "origin": "https://my-app.com",
+                              "params": {
+                                "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+                              }
                             },
                             {
                               "url": "https://www.example.com",

--- a/src/common/src/schemas/src_schemas/checkLink_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/checkLink_v3.schema.json
@@ -44,6 +44,14 @@
               "trim"
             ]
           },
+          "params": {
+            "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {}
+          },
           "statusCodes": {
             "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
             "anyOf": [
@@ -106,6 +114,13 @@
       "statusCodes": [
         200
       ]
+    },
+    {
+      "url": "/health",
+      "origin": "https://my-app.com",
+      "params": {
+        "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+      }
     }
   ]
 }

--- a/src/common/src/schemas/src_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/config_v3.schema.json
@@ -65,6 +65,14 @@
       "description": "Default protocol and domain to use for relative URLs.",
       "type": "string"
     },
+    "originParams": {
+      "description": "Query parameters to append to URLs resolved against `origin`. Values support environment variable substitution via `$VAR` syntax. Step-level `params` on `goTo` / `checkLink` are merged on top of these, with step keys winning on collision. WARNING: values are embedded in request URLs and appear verbatim in test results, logs, and reports — avoid putting long-lived secrets here.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
     "beforeAny": {
       "description": "Path(s) to test specifications to perform before those specified by `input`. Useful for setting up testing environments.",
       "anyOf": [

--- a/src/common/src/schemas/src_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/config_v3.schema.json
@@ -544,6 +544,12 @@
       "reporters": ["terminal", "json", "html"]
     },
     {
+      "origin": "https://my-app.com",
+      "originParams": {
+        "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+      }
+    },
+    {
       "fileTypes": [
         {
           "extends": "markdown",

--- a/src/common/src/schemas/src_schemas/goTo_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/goTo_v3.schema.json
@@ -35,6 +35,14 @@
             "description": "Protocol and domain to navigate to. Prepended to `url`.",
             "transform": ["trim"]
           },
+          "params": {
+            "description": "Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {}
+          },
           "timeout": {
             "type": "integer",
             "description": "Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.",
@@ -169,6 +177,13 @@
     {
       "url": "/search",
       "origin": "https://www.google.com"
+    },
+    {
+      "url": "/dashboard",
+      "origin": "https://my-app.com",
+      "params": {
+        "__clerk_testing_token": "$CLERK_TESTING_TOKEN"
+      }
     },
     {
       "url": "https://www.example.com",

--- a/src/common/src/types/generated/checkLink_v3.ts
+++ b/src/common/src/types/generated/checkLink_v3.ts
@@ -28,6 +28,12 @@ export interface CheckLinkDetailed1 {
    */
   origin?: string;
   /**
+   * Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.
+   */
+  params?: {
+    [k: string]: string;
+  };
+  /**
    * Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.
    */
   statusCodes?: number | number[];

--- a/src/common/src/types/generated/config_v3.ts
+++ b/src/common/src/types/generated/config_v3.ts
@@ -77,6 +77,12 @@ export interface Config {
    */
   origin?: string;
   /**
+   * Query parameters to append to URLs resolved against `origin`. Values support environment variable substitution via `$VAR` syntax. Step-level `params` on `goTo` / `checkLink` are merged on top of these, with step keys winning on collision. WARNING: values are embedded in request URLs and appear verbatim in test results, logs, and reports — avoid putting long-lived secrets here.
+   */
+  originParams?: {
+    [k: string]: string;
+  };
+  /**
    * Path(s) to test specifications to perform before those specified by `input`. Useful for setting up testing environments.
    */
   beforeAny?: string | string[];

--- a/src/common/src/types/generated/goTo_v3.ts
+++ b/src/common/src/types/generated/goTo_v3.ts
@@ -23,6 +23,12 @@ export interface GoToURLDetailed {
    */
   origin?: string;
   /**
+   * Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.
+   */
+  params?: {
+    [k: string]: string;
+  };
+  /**
    * Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.
    */
   timeout?: number;

--- a/src/common/src/types/generated/resolvedTests_v3.ts
+++ b/src/common/src/types/generated/resolvedTests_v3.ts
@@ -114,6 +114,12 @@ export interface Config {
    */
   origin?: string;
   /**
+   * Query parameters to append to URLs resolved against `origin`. Values support environment variable substitution via `$VAR` syntax. Step-level `params` on `goTo` / `checkLink` are merged on top of these, with step keys winning on collision. WARNING: values are embedded in request URLs and appear verbatim in test results, logs, and reports — avoid putting long-lived secrets here.
+   */
+  originParams?: {
+    [k: string]: string;
+  };
+  /**
    * Path(s) to test specifications to perform before those specified by `input`. Useful for setting up testing environments.
    */
   beforeAny?: string | string[];

--- a/src/common/src/types/generated/step_v3.ts
+++ b/src/common/src/types/generated/step_v3.ts
@@ -270,6 +270,12 @@ export interface CheckLinkDetailed1 {
    */
   origin?: string;
   /**
+   * Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.
+   */
+  params?: {
+    [k: string]: string;
+  };
+  /**
    * Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.
    */
   statusCodes?: number | number[];
@@ -509,6 +515,12 @@ export interface GoToURLDetailed {
    * Protocol and domain to navigate to. Prepended to `url`.
    */
   origin?: string;
+  /**
+   * Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.
+   */
+  params?: {
+    [k: string]: string;
+  };
   /**
    * Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.
    */

--- a/src/common/src/types/generated/test_v3.ts
+++ b/src/common/src/types/generated/test_v3.ts
@@ -833,6 +833,12 @@ export interface CheckLinkDetailed1 {
    */
   origin?: string;
   /**
+   * Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.
+   */
+  params?: {
+    [k: string]: string;
+  };
+  /**
    * Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.
    */
   statusCodes?: number | number[];
@@ -1072,6 +1078,12 @@ export interface GoToURLDetailed {
    * Protocol and domain to navigate to. Prepended to `url`.
    */
   origin?: string;
+  /**
+   * Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.
+   */
+  params?: {
+    [k: string]: string;
+  };
   /**
    * Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.
    */
@@ -2314,6 +2326,12 @@ export interface CheckLinkDetailed3 {
    */
   origin?: string;
   /**
+   * Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.
+   */
+  params?: {
+    [k: string]: string;
+  };
+  /**
    * Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.
    */
   statusCodes?: number | number[];
@@ -2553,6 +2571,12 @@ export interface GoToURLDetailed1 {
    * Protocol and domain to navigate to. Prepended to `url`.
    */
   origin?: string;
+  /**
+   * Query parameters to append to the resolved URL. Merged on top of `originParams` from config; step keys win on collision. If `url` already contains a colliding query key, the value here replaces it. Values support environment variable substitution via `$VAR` syntax. WARNING: values are embedded in the request URL and appear in test results, logs, and reports.
+   */
+  params?: {
+    [k: string]: string;
+  };
   /**
    * Maximum time in milliseconds to wait for the page to be ready. If exceeded, the goTo action fails.
    */

--- a/src/core/tests/checkLink.ts
+++ b/src/core/tests/checkLink.ts
@@ -131,8 +131,10 @@ async function checkLink({ config, step }: { config: any; step: any }) {
     step.checkLink = { url: step.checkLink };
   }
 
+  const relative = isRelativeUrl(step.checkLink.url);
+
   // Set origin for relative URLs
-  if (isRelativeUrl(step.checkLink.url)) {
+  if (relative) {
     if (!step.checkLink.origin && !config.origin) {
       result.status = "FAIL";
       result.description =
@@ -148,12 +150,16 @@ async function checkLink({ config, step }: { config: any; step: any }) {
       step.checkLink.origin += "/";
     }
     step.checkLink.url = step.checkLink.origin + step.checkLink.url;
-    // Merge config.originParams with step.checkLink.params; step keys win on
-    // collision. Merge (rather than replace) means adding a per-step param
-    // won't silently drop a config-level token.
-    const params = { ...config.originParams, ...step.checkLink.params };
-    step.checkLink.url = appendQueryParams(step.checkLink.url, params);
   }
+
+  // config.originParams only apply to URLs resolved against an origin;
+  // step.checkLink.params applies regardless so per-step params on absolute
+  // URLs aren't silently dropped. Step keys win on collision.
+  const params = {
+    ...(relative ? config.originParams : undefined),
+    ...step.checkLink.params,
+  };
+  step.checkLink.url = appendQueryParams(step.checkLink.url, params);
 
   // Make sure there's a protocol
   if (step.checkLink.url && !step.checkLink.url.includes("://"))

--- a/src/core/tests/checkLink.ts
+++ b/src/core/tests/checkLink.ts
@@ -154,12 +154,24 @@ async function checkLink({ config, step }: { config: any; step: any }) {
 
   // config.originParams only apply to URLs resolved against an origin;
   // step.checkLink.params applies regardless so per-step params on absolute
-  // URLs aren't silently dropped. Step keys win on collision.
-  const params = {
-    ...(relative ? config.originParams : undefined),
-    ...step.checkLink.params,
-  };
-  step.checkLink.url = appendQueryParams(step.checkLink.url, params);
+  // URLs aren't silently dropped.
+  //
+  // Apply each source in a separate pass instead of pre-merging via
+  // object spread. Spreading would convert an accidentally-array-shaped
+  // input (e.g. `originParams: ["x"]`) into `{0: "x"}`, sneaking past
+  // appendQueryParams's `Array.isArray` guard. Two passes route each
+  // source through the guard independently. Step wins on collision
+  // because the second pass dedupes against the first.
+  if (relative) {
+    step.checkLink.url = appendQueryParams(
+      step.checkLink.url,
+      config.originParams
+    );
+  }
+  step.checkLink.url = appendQueryParams(
+    step.checkLink.url,
+    step.checkLink.params
+  );
 
   // Make sure there's a protocol
   if (step.checkLink.url && !step.checkLink.url.includes("://"))

--- a/src/core/tests/checkLink.ts
+++ b/src/core/tests/checkLink.ts
@@ -1,5 +1,5 @@
 import { validate } from "../../common/src/validate.js";
-import { isRelativeUrl } from "../utils.js";
+import { isRelativeUrl, appendQueryParams } from "../utils.js";
 import axios from "axios";
 
 export { checkLink };
@@ -148,6 +148,11 @@ async function checkLink({ config, step }: { config: any; step: any }) {
       step.checkLink.origin += "/";
     }
     step.checkLink.url = step.checkLink.origin + step.checkLink.url;
+    // Merge config.originParams with step.checkLink.params; step keys win on
+    // collision. Merge (rather than replace) means adding a per-step param
+    // won't silently drop a config-level token.
+    const params = { ...config.originParams, ...step.checkLink.params };
+    step.checkLink.url = appendQueryParams(step.checkLink.url, params);
   }
 
   // Make sure there's a protocol

--- a/src/core/tests/goTo.ts
+++ b/src/core/tests/goTo.ts
@@ -13,8 +13,10 @@ async function goTo({ config, step, driver }: { config: any; step: any; driver: 
     step.goTo = { url: step.goTo };
   }
 
+  const relative = isRelativeUrl(step.goTo.url);
+
   // Set origin for relative URLs
-  if (isRelativeUrl(step.goTo.url)) {
+  if (relative) {
     if (!step.goTo.origin && !config.origin) {
       result.status = "FAIL";
       result.description =
@@ -27,12 +29,16 @@ async function goTo({ config, step, driver }: { config: any; step: any; driver: 
       step.goTo.origin += "/";
     }
     step.goTo.url = step.goTo.origin + step.goTo.url;
-    // Merge config.originParams with step.goTo.params; step keys win on
-    // collision. Merge (rather than replace) means adding a per-step param
-    // won't silently drop a config-level token.
-    const params = { ...config.originParams, ...step.goTo.params };
-    step.goTo.url = appendQueryParams(step.goTo.url, params);
   }
+
+  // config.originParams only apply to URLs resolved against an origin;
+  // step.goTo.params applies regardless so per-step params on absolute URLs
+  // aren't silently dropped. Step keys win on collision.
+  const params = {
+    ...(relative ? config.originParams : undefined),
+    ...step.goTo.params,
+  };
+  step.goTo.url = appendQueryParams(step.goTo.url, params);
 
   // Make sure there's a protocol
   if (step.goTo.url && !step.goTo.url.includes("://"))

--- a/src/core/tests/goTo.ts
+++ b/src/core/tests/goTo.ts
@@ -33,12 +33,18 @@ async function goTo({ config, step, driver }: { config: any; step: any; driver: 
 
   // config.originParams only apply to URLs resolved against an origin;
   // step.goTo.params applies regardless so per-step params on absolute URLs
-  // aren't silently dropped. Step keys win on collision.
-  const params = {
-    ...(relative ? config.originParams : undefined),
-    ...step.goTo.params,
-  };
-  step.goTo.url = appendQueryParams(step.goTo.url, params);
+  // aren't silently dropped.
+  //
+  // Apply each source in a separate pass instead of pre-merging via
+  // object spread. Spreading would convert an accidentally-array-shaped
+  // input (e.g. `originParams: ["x"]`) into `{0: "x"}`, sneaking past
+  // appendQueryParams's `Array.isArray` guard. Two passes route each
+  // source through the guard independently. Step wins on collision
+  // because the second pass dedupes against the first.
+  if (relative) {
+    step.goTo.url = appendQueryParams(step.goTo.url, config.originParams);
+  }
+  step.goTo.url = appendQueryParams(step.goTo.url, step.goTo.params);
 
   // Make sure there's a protocol
   if (step.goTo.url && !step.goTo.url.includes("://"))

--- a/src/core/tests/goTo.ts
+++ b/src/core/tests/goTo.ts
@@ -1,5 +1,5 @@
 import { validate } from "../../common/src/validate.js";
-import { isRelativeUrl } from "../utils.js";
+import { isRelativeUrl, appendQueryParams } from "../utils.js";
 import { findElement } from "./findElement.js";
 
 export { goTo };
@@ -27,6 +27,11 @@ async function goTo({ config, step, driver }: { config: any; step: any; driver: 
       step.goTo.origin += "/";
     }
     step.goTo.url = step.goTo.origin + step.goTo.url;
+    // Merge config.originParams with step.goTo.params; step keys win on
+    // collision. Merge (rather than replace) means adding a per-step param
+    // won't silently drop a config-level token.
+    const params = { ...config.originParams, ...step.goTo.params };
+    step.goTo.url = appendQueryParams(step.goTo.url, params);
   }
 
   // Make sure there's a protocol

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -35,7 +35,7 @@ function appendQueryParams(
   url: string,
   params: Record<string, unknown> | undefined | null
 ): string {
-  if (!params || typeof params !== "object") return url;
+  if (!params || typeof params !== "object" || Array.isArray(params)) return url;
   const entries = Object.entries(params).filter(
     ([, v]) => v !== undefined && v !== null
   );

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -56,29 +56,34 @@ function appendQueryParams(
   const pathAndAuthority = queryIdx >= 0 ? base.slice(0, queryIdx) : base;
   const existingQuery = queryIdx >= 0 ? base.slice(queryIdx + 1) : "";
 
-  // Check whether any new key collides with one already in the URL. If
-  // not, we can append `&k=v` raw and preserve the existing query
-  // verbatim — `URLSearchParams` would otherwise re-encode it (`+` for
-  // spaces, percent-encoding of `:` / `,` etc.), which can break signed
-  // URLs and strict backends. Only fall back to parse-set-serialize
-  // when we actually need dedupe.
-  const existingKeys = new Set(new URLSearchParams(existingQuery).keys());
-  const hasCollision = entries.some(([k]) => existingKeys.has(k));
+  // Walk the existing query and drop only the segments whose key collides
+  // with a new entry; everything else is preserved byte-for-byte. Then
+  // append the new pairs (encoded fresh). This avoids re-encoding any
+  // non-colliding pair — `URLSearchParams.toString()` would otherwise
+  // normalize `+` for spaces and percent-encode `:` / `,` etc., which
+  // breaks signed URLs and strict backends. New params always go through
+  // encodeURIComponent so callers can pass arbitrary strings.
+  const newKeys = new Set(entries.map(([k]) => k));
+  const preservedSegments = existingQuery
+    ? existingQuery.split("&").filter((segment) => {
+        if (!segment) return false;
+        const eqIdx = segment.indexOf("=");
+        const rawKey = eqIdx >= 0 ? segment.slice(0, eqIdx) : segment;
+        let decodedKey: string;
+        try {
+          decodedKey = decodeURIComponent(rawKey);
+        } catch {
+          decodedKey = rawKey;
+        }
+        return !newKeys.has(decodedKey);
+      })
+    : [];
+  const newPairs = entries.map(
+    ([k, v]) =>
+      `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`
+  );
 
-  let query: string;
-  if (hasCollision) {
-    const searchParams = new URLSearchParams(existingQuery);
-    for (const [k, v] of entries) searchParams.set(k, String(v));
-    query = searchParams.toString();
-  } else {
-    const newPairs = entries
-      .map(
-        ([k, v]) =>
-          `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`
-      )
-      .join("&");
-    query = existingQuery ? `${existingQuery}&${newPairs}` : newPairs;
-  }
+  const query = [...preservedSegments, ...newPairs].join("&");
   return pathAndAuthority + (query ? "?" + query : "") + fragment;
 }
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -17,6 +17,7 @@ export {
   calculateFractionalDifference,
   fetchFile,
   isRelativeUrl,
+  appendQueryParams,
 };
 
 function isRelativeUrl(url: string) {
@@ -28,6 +29,33 @@ function isRelativeUrl(url: string) {
     // If URL constructor throws an error, it's a relative URL
     return true;
   }
+}
+
+function appendQueryParams(
+  url: string,
+  params: Record<string, unknown> | undefined | null
+): string {
+  if (!params || typeof params !== "object") return url;
+  const entries = Object.entries(params).filter(
+    ([, v]) => v !== undefined && v !== null
+  );
+  if (entries.length === 0) return url;
+
+  // Split off the fragment so new params land before it, not inside.
+  const hashIdx = url.indexOf("#");
+  const fragment = hashIdx >= 0 ? url.slice(hashIdx) : "";
+  const base = hashIdx >= 0 ? url.slice(0, hashIdx) : url;
+
+  // Parse any existing query string so duplicate keys get replaced rather
+  // than doubled up.
+  const queryIdx = base.indexOf("?");
+  const pathAndAuthority = queryIdx >= 0 ? base.slice(0, queryIdx) : base;
+  const existingQuery = queryIdx >= 0 ? base.slice(queryIdx + 1) : "";
+  const searchParams = new URLSearchParams(existingQuery);
+  for (const [k, v] of entries) searchParams.set(k, String(v));
+
+  const query = searchParams.toString();
+  return pathAndAuthority + (query ? "?" + query : "") + fragment;
 }
 
 // Delete all contents of doc-detective temp directory

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -52,15 +52,33 @@ function appendQueryParams(
   const fragment = hashIdx >= 0 ? url.slice(hashIdx) : "";
   const base = hashIdx >= 0 ? url.slice(0, hashIdx) : url;
 
-  // Parse any existing query string so duplicate keys get replaced rather
-  // than doubled up.
   const queryIdx = base.indexOf("?");
   const pathAndAuthority = queryIdx >= 0 ? base.slice(0, queryIdx) : base;
   const existingQuery = queryIdx >= 0 ? base.slice(queryIdx + 1) : "";
-  const searchParams = new URLSearchParams(existingQuery);
-  for (const [k, v] of entries) searchParams.set(k, String(v));
 
-  const query = searchParams.toString();
+  // Check whether any new key collides with one already in the URL. If
+  // not, we can append `&k=v` raw and preserve the existing query
+  // verbatim — `URLSearchParams` would otherwise re-encode it (`+` for
+  // spaces, percent-encoding of `:` / `,` etc.), which can break signed
+  // URLs and strict backends. Only fall back to parse-set-serialize
+  // when we actually need dedupe.
+  const existingKeys = new Set(new URLSearchParams(existingQuery).keys());
+  const hasCollision = entries.some(([k]) => existingKeys.has(k));
+
+  let query: string;
+  if (hasCollision) {
+    const searchParams = new URLSearchParams(existingQuery);
+    for (const [k, v] of entries) searchParams.set(k, String(v));
+    query = searchParams.toString();
+  } else {
+    const newPairs = entries
+      .map(
+        ([k, v]) =>
+          `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`
+      )
+      .join("&");
+    query = existingQuery ? `${existingQuery}&${newPairs}` : newPairs;
+  }
   return pathAndAuthority + (query ? "?" + query : "") + fragment;
 }
 

--- a/test/checkLink.test.js
+++ b/test/checkLink.test.js
@@ -22,8 +22,9 @@ before(async function () {
   server = http.createServer((req, res) => {
     const url = req.url;
 
-    if (url === "/echo-headers") {
+    if (url.split("?")[0] === "/echo-headers") {
       requestLog["echo-headers"] = { ...req.headers };
+      requestLog["echo-headers-url"] = req.url;
       res.writeHead(200, { "Content-Type": "text/plain" });
       res.end("ok");
       return;
@@ -395,6 +396,117 @@ describe("checkLink retry, headers, and HEAD fallback", function () {
     });
     assert.equal(result.status, "PASS");
     assert.equal(requestLog["echo-headers"]["user-agent"], "custom-ua/1.0");
+  });
+});
+
+describe("checkLink originParams / params", function () {
+  this.timeout(30000);
+
+  it("appends config.originParams to URL resolved against origin", async function () {
+    delete requestLog["echo-headers-url"];
+    const result = await checkLink({
+      config: {
+        origin: `http://localhost:${serverPort}`,
+        originParams: { token: "abc", version: "v2" },
+      },
+      step: { checkLink: { url: "/echo-headers" } },
+    });
+    assert.equal(result.status, "PASS", result.description);
+    const received = requestLog["echo-headers-url"];
+    assert.ok(received.startsWith("/echo-headers?"), `got ${received}`);
+    const qs = new URLSearchParams(received.split("?")[1]);
+    assert.equal(qs.get("token"), "abc");
+    assert.equal(qs.get("version"), "v2");
+  });
+
+  it("merges step-level params with config.originParams; step wins on collision", async function () {
+    delete requestLog["echo-headers-url"];
+    const result = await checkLink({
+      config: {
+        origin: `http://localhost:${serverPort}`,
+        originParams: { token: "from-config", keep: "k" },
+      },
+      step: {
+        checkLink: {
+          url: "/echo-headers",
+          params: { token: "from-step", extra: "e" },
+        },
+      },
+    });
+    assert.equal(result.status, "PASS", result.description);
+    const qs = new URLSearchParams(
+      requestLog["echo-headers-url"].split("?")[1]
+    );
+    assert.equal(qs.get("token"), "from-step");
+    assert.equal(qs.get("keep"), "k");
+    assert.equal(qs.get("extra"), "e");
+  });
+
+  it("replaces an existing query-string key rather than duplicating", async function () {
+    delete requestLog["echo-headers-url"];
+    const result = await checkLink({
+      config: {
+        origin: `http://localhost:${serverPort}`,
+        originParams: { token: "new" },
+      },
+      step: { checkLink: { url: "/echo-headers?token=old&keep=y" } },
+    });
+    assert.equal(result.status, "PASS", result.description);
+    const qs = new URLSearchParams(
+      requestLog["echo-headers-url"].split("?")[1]
+    );
+    assert.deepEqual(qs.getAll("token"), ["new"]);
+    assert.equal(qs.get("keep"), "y");
+  });
+
+  it("does NOT append params when the step URL is absolute", async function () {
+    delete requestLog["echo-headers-url"];
+    const result = await checkLink({
+      config: {
+        origin: `http://localhost:${serverPort}`,
+        originParams: { token: "should-not-appear" },
+      },
+      step: {
+        checkLink: { url: `http://localhost:${serverPort}/echo-headers` },
+      },
+    });
+    assert.equal(result.status, "PASS", result.description);
+    assert.equal(requestLog["echo-headers-url"], "/echo-headers");
+  });
+
+  it("substitutes $VAR references in params via replaceEnvs upstream", async function () {
+    // Note: replaceEnvs runs over the step object inside runTests.ts, not checkLink()
+    // directly. For this test we pre-substitute to mimic that step.
+    process.env.TEST_DD_TOKEN = "env-token-xyz";
+    delete requestLog["echo-headers-url"];
+    const result = await checkLink({
+      config: { origin: `http://localhost:${serverPort}` },
+      step: {
+        checkLink: {
+          url: "/echo-headers",
+          params: { token: process.env.TEST_DD_TOKEN },
+        },
+      },
+    });
+    assert.equal(result.status, "PASS", result.description);
+    const qs = new URLSearchParams(
+      requestLog["echo-headers-url"].split("?")[1]
+    );
+    assert.equal(qs.get("token"), "env-token-xyz");
+    delete process.env.TEST_DD_TOKEN;
+  });
+
+  it("leaves URL unchanged when params is empty", async function () {
+    delete requestLog["echo-headers-url"];
+    const result = await checkLink({
+      config: {
+        origin: `http://localhost:${serverPort}`,
+        originParams: {},
+      },
+      step: { checkLink: { url: "/echo-headers" } },
+    });
+    assert.equal(result.status, "PASS", result.description);
+    assert.equal(requestLog["echo-headers-url"], "/echo-headers");
   });
 });
 

--- a/test/checkLink.test.js
+++ b/test/checkLink.test.js
@@ -1,6 +1,7 @@
 import http from "node:http";
 import assert from "node:assert/strict";
 import { checkLink } from "../dist/core/tests/checkLink.js";
+import { replaceEnvs } from "../dist/core/utils.js";
 
 let server;
 let serverPort;
@@ -475,25 +476,31 @@ describe("checkLink originParams / params", function () {
   });
 
   it("substitutes $VAR references in params via replaceEnvs upstream", async function () {
-    // Note: replaceEnvs runs over the step object inside runTests.ts, not checkLink()
-    // directly. For this test we pre-substitute to mimic that step.
+    // Mirror the real runTests flow: `$VAR` lives in params as a literal
+    // string, and replaceEnvs substitutes it on the step object before the
+    // step executor runs.
     process.env.TEST_DD_TOKEN = "env-token-xyz";
     delete requestLog["echo-headers-url"];
-    const result = await checkLink({
-      config: { origin: `http://localhost:${serverPort}` },
-      step: {
+    try {
+      const step = {
         checkLink: {
           url: "/echo-headers",
-          params: { token: process.env.TEST_DD_TOKEN },
+          params: { token: "$TEST_DD_TOKEN" },
         },
-      },
-    });
-    assert.equal(result.status, "PASS", result.description);
-    const qs = new URLSearchParams(
-      requestLog["echo-headers-url"].split("?")[1]
-    );
-    assert.equal(qs.get("token"), "env-token-xyz");
-    delete process.env.TEST_DD_TOKEN;
+      };
+      const substituted = replaceEnvs(step);
+      const result = await checkLink({
+        config: { origin: `http://localhost:${serverPort}` },
+        step: substituted,
+      });
+      assert.equal(result.status, "PASS", result.description);
+      const qs = new URLSearchParams(
+        requestLog["echo-headers-url"].split("?")[1]
+      );
+      assert.equal(qs.get("token"), "env-token-xyz");
+    } finally {
+      delete process.env.TEST_DD_TOKEN;
+    }
   });
 
   it("leaves URL unchanged when params is empty", async function () {

--- a/test/goTo.test.js
+++ b/test/goTo.test.js
@@ -148,4 +148,25 @@ describe("goTo originParams / params", function () {
     });
     assert.equal(calls.url, "https://my-app.com/p");
   });
+
+  it("ignores array-shaped config.originParams (no sneak-past via spread)", async function () {
+    // If originParams was pre-merged via object spread, an accidentally
+    // array-shaped value (`["x", "y"]`) would become `{0: "x", 1: "y"}`
+    // and bypass appendQueryParams's Array.isArray guard. Two-pass apply
+    // routes each source through the guard independently. (config isn't
+    // re-validated at the goTo runtime layer, so this is the realistic
+    // sneak-past path.)
+    const { driver, calls } = stubDriver();
+    const step = { goTo: { url: "/p" } };
+    await goTo({
+      config: {
+        origin: "https://my-app.com",
+        originParams: ["bad-config-array"],
+      },
+      step,
+      driver,
+    });
+    assert.notEqual(calls.url, undefined);
+    assert.equal(calls.url, "https://my-app.com/p");
+  });
 });

--- a/test/goTo.test.js
+++ b/test/goTo.test.js
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { goTo } from "../dist/core/tests/goTo.js";
+
+// Minimal driver stub: captures the URL passed to `driver.url()` and then
+// throws so goTo short-circuits its wait-loop. We only care about the URL
+// resolution side-effect on `step.goTo.url`, which happens before the driver
+// is invoked.
+function stubDriver() {
+  const calls = { url: undefined };
+  return {
+    driver: {
+      url: async (u) => {
+        calls.url = u;
+        throw new Error("stub-short-circuit");
+      },
+    },
+    calls,
+  };
+}
+
+describe("goTo originParams / params", function () {
+  this.timeout(5000);
+
+  it("appends config.originParams to URL resolved against origin", async function () {
+    const { driver, calls } = stubDriver();
+    const step = { goTo: { url: "/dashboard" } };
+    await goTo({
+      config: {
+        origin: "https://my-app.com",
+        originParams: { __clerk_testing_token: "abc" },
+      },
+      step,
+      driver,
+    });
+    assert.equal(calls.url, "https://my-app.com/dashboard?__clerk_testing_token=abc");
+  });
+
+  it("merges step params with config.originParams; step wins on collision", async function () {
+    const { driver, calls } = stubDriver();
+    const step = {
+      goTo: { url: "/p", params: { token: "step-wins", extra: "e" } },
+    };
+    await goTo({
+      config: {
+        origin: "https://my-app.com",
+        originParams: { token: "config-loses", keep: "k" },
+      },
+      step,
+      driver,
+    });
+    const qs = new URLSearchParams(calls.url.split("?")[1]);
+    assert.equal(qs.get("token"), "step-wins");
+    assert.equal(qs.get("extra"), "e");
+    assert.equal(qs.get("keep"), "k");
+  });
+
+  it("does NOT append params when the step URL is absolute", async function () {
+    const { driver, calls } = stubDriver();
+    const step = { goTo: { url: "https://my-app.com/dashboard" } };
+    await goTo({
+      config: {
+        origin: "https://my-app.com",
+        originParams: { should_not_appear: "1" },
+      },
+      step,
+      driver,
+    });
+    assert.equal(calls.url, "https://my-app.com/dashboard");
+  });
+
+  it("preserves a URL fragment when merging params", async function () {
+    const { driver, calls } = stubDriver();
+    const step = { goTo: { url: "/p#section" } };
+    await goTo({
+      config: {
+        origin: "https://my-app.com",
+        originParams: { t: "x" },
+      },
+      step,
+      driver,
+    });
+    assert.equal(calls.url, "https://my-app.com/p?t=x#section");
+  });
+
+  it("replaces an existing query-string key rather than duplicating it", async function () {
+    const { driver, calls } = stubDriver();
+    const step = { goTo: { url: "/p?token=old&keep=y" } };
+    await goTo({
+      config: {
+        origin: "https://my-app.com",
+        originParams: { token: "new" },
+      },
+      step,
+      driver,
+    });
+    const qs = new URLSearchParams(calls.url.split("?")[1]);
+    assert.deepEqual(qs.getAll("token"), ["new"]);
+    assert.equal(qs.get("keep"), "y");
+  });
+
+  it("leaves URL unchanged when neither config nor step provides params", async function () {
+    const { driver, calls } = stubDriver();
+    const step = { goTo: { url: "/p" } };
+    await goTo({
+      config: { origin: "https://my-app.com" },
+      step,
+      driver,
+    });
+    assert.equal(calls.url, "https://my-app.com/p");
+  });
+});

--- a/test/goTo.test.js
+++ b/test/goTo.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { goTo } from "../dist/core/tests/goTo.js";
+import { replaceEnvs } from "../dist/core/utils.js";
 
 // Minimal driver stub: captures the URL passed to `driver.url()` and then
 // throws so goTo short-circuits its wait-loop. We only care about the URL
@@ -54,7 +55,7 @@ describe("goTo originParams / params", function () {
     assert.equal(qs.get("keep"), "k");
   });
 
-  it("does NOT append params when the step URL is absolute", async function () {
+  it("does NOT apply config.originParams to an absolute step URL", async function () {
     const { driver, calls } = stubDriver();
     const step = { goTo: { url: "https://my-app.com/dashboard" } };
     await goTo({
@@ -65,7 +66,46 @@ describe("goTo originParams / params", function () {
       step,
       driver,
     });
+    assert.notEqual(calls.url, undefined, "driver.url was never invoked");
     assert.equal(calls.url, "https://my-app.com/dashboard");
+  });
+
+  it("still applies step.params to an absolute step URL", async function () {
+    const { driver, calls } = stubDriver();
+    const step = {
+      goTo: {
+        url: "https://other.com/x",
+        params: { from_step: "yes" },
+      },
+    };
+    await goTo({
+      config: { originParams: { not_mine: "n" } },
+      step,
+      driver,
+    });
+    assert.notEqual(calls.url, undefined, "driver.url was never invoked");
+    const qs = new URLSearchParams(calls.url.split("?")[1]);
+    assert.equal(qs.get("from_step"), "yes");
+    assert.equal(qs.get("not_mine"), null, "config params must not leak onto absolute URLs");
+  });
+
+  it("substitutes $VAR in originParams via replaceEnvs", async function () {
+    process.env.TEST_DD_GOTO_TOKEN = "goto-env-xyz";
+    try {
+      const { driver, calls } = stubDriver();
+      const step = { goTo: { url: "/dashboard" } };
+      const config = {
+        origin: "https://my-app.com",
+        originParams: { token: "$TEST_DD_GOTO_TOKEN" },
+      };
+      const resolvedConfig = replaceEnvs(config);
+      await goTo({ config: resolvedConfig, step, driver });
+      assert.notEqual(calls.url, undefined, "driver.url was never invoked");
+      const qs = new URLSearchParams(calls.url.split("?")[1]);
+      assert.equal(qs.get("token"), "goto-env-xyz");
+    } finally {
+      delete process.env.TEST_DD_GOTO_TOKEN;
+    }
   });
 
   it("preserves a URL fragment when merging params", async function () {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -758,6 +758,19 @@ describe("appendQueryParams", function () {
     expect(qs.get("keep")).to.equal("yes");
   });
 
+  it("preserves the existing query-string verbatim when there is no key collision", function () {
+    // URLSearchParams round-tripping would normalize `+` for spaces and
+    // percent-encode `:` / `,` — that breaks signed URLs and strict
+    // backends. When no key collides, we append raw to the existing query.
+    const out = appendQueryParams(
+      "https://example.com/p?sig=abc:123,xyz&q=hello+world",
+      { token: "new" }
+    );
+    expect(out).to.equal(
+      "https://example.com/p?sig=abc:123,xyz&q=hello+world&token=new"
+    );
+  });
+
   it("inserts params before a URL fragment (not inside it)", function () {
     const out = appendQueryParams("https://example.com/p#section", {
       token: "t",

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -771,6 +771,19 @@ describe("appendQueryParams", function () {
     );
   });
 
+  it("on collision, replaces only the colliding key and keeps non-colliding pairs verbatim", function () {
+    // Same signed-URL shape as the no-collision test, but now there's
+    // also a colliding `token=old`. Only that segment should be dropped;
+    // `sig=abc:123,xyz` and `q=hello+world` must come through untouched.
+    const out = appendQueryParams(
+      "https://example.com/p?sig=abc:123,xyz&token=old&q=hello+world",
+      { token: "new" }
+    );
+    expect(out).to.equal(
+      "https://example.com/p?sig=abc:123,xyz&q=hello+world&token=new"
+    );
+  });
+
   it("inserts params before a URL fragment (not inside it)", function () {
     const out = appendQueryParams("https://example.com/p#section", {
       token: "t",

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,5 @@
 import { setArgs, setConfig, outputResults } from "../dist/utils.js";
+import { appendQueryParams } from "../dist/core/utils.js";
 import path from "node:path";
 import fs from "node:fs";
 import { createRequire } from "node:module";
@@ -716,6 +717,90 @@ describe("Util tests", function () {
         delete process.env.DOC_DETECTIVE_CONFIG;
       }
     }
+  });
+});
+
+describe("appendQueryParams", function () {
+  it("returns URL unchanged when params is undefined, null, or empty", function () {
+    const url = "https://example.com/foo";
+    expect(appendQueryParams(url, undefined)).to.equal(url);
+    expect(appendQueryParams(url, null)).to.equal(url);
+    expect(appendQueryParams(url, {})).to.equal(url);
+  });
+
+  it("appends params with ? when URL has no existing query string", function () {
+    const out = appendQueryParams("https://example.com/foo", {
+      a: "1",
+      b: "two",
+    });
+    const qs = new URLSearchParams(out.split("?")[1]);
+    expect(out.startsWith("https://example.com/foo?")).to.equal(true);
+    expect(qs.get("a")).to.equal("1");
+    expect(qs.get("b")).to.equal("two");
+  });
+
+  it("appends params with & when URL already has a query string", function () {
+    const out = appendQueryParams("https://example.com/foo?x=0", { a: "1" });
+    expect(out).to.equal("https://example.com/foo?x=0&a=1");
+  });
+
+  it("replaces existing query-string keys rather than duplicating them", function () {
+    const out = appendQueryParams("https://example.com/p?token=old&keep=yes", {
+      token: "new",
+    });
+    const qs = new URLSearchParams(out.split("?")[1]);
+    expect(qs.getAll("token")).to.deep.equal(["new"]);
+    expect(qs.get("keep")).to.equal("yes");
+  });
+
+  it("inserts params before a URL fragment (not inside it)", function () {
+    const out = appendQueryParams("https://example.com/p#section", {
+      token: "t",
+    });
+    expect(out).to.equal("https://example.com/p?token=t#section");
+  });
+
+  it("preserves existing query AND fragment when appending", function () {
+    const out = appendQueryParams("https://example.com/p?x=1#section", {
+      token: "t",
+    });
+    const [base, rest] = out.split("?");
+    const [qs, frag] = rest.split("#");
+    expect(base).to.equal("https://example.com/p");
+    const params = new URLSearchParams(qs);
+    expect(params.get("x")).to.equal("1");
+    expect(params.get("token")).to.equal("t");
+    expect(frag).to.equal("section");
+  });
+
+  it("URL-encodes special characters in values", function () {
+    const out = appendQueryParams("https://example.com/", {
+      q: "hello world&=?",
+    });
+    const qs = new URLSearchParams(out.split("?")[1]);
+    expect(qs.get("q")).to.equal("hello world&=?");
+  });
+
+  it("coerces non-string values to strings", function () {
+    const out = appendQueryParams("https://example.com/", {
+      n: 42,
+      b: true,
+    });
+    const qs = new URLSearchParams(out.split("?")[1]);
+    expect(qs.get("n")).to.equal("42");
+    expect(qs.get("b")).to.equal("true");
+  });
+
+  it("drops entries whose values are null or undefined", function () {
+    const out = appendQueryParams("https://example.com/", {
+      keep: "yes",
+      drop1: null,
+      drop2: undefined,
+    });
+    const qs = new URLSearchParams(out.split("?")[1]);
+    expect(qs.get("keep")).to.equal("yes");
+    expect(qs.has("drop1")).to.equal(false);
+    expect(qs.has("drop2")).to.equal(false);
   });
 });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -728,6 +728,11 @@ describe("appendQueryParams", function () {
     expect(appendQueryParams(url, {})).to.equal(url);
   });
 
+  it("returns URL unchanged when params is an array (defensive)", function () {
+    const url = "https://example.com/foo";
+    expect(appendQueryParams(url, ["a", "b"])).to.equal(url);
+  });
+
   it("appends params with ? when URL has no existing query string", function () {
     const out = appendQueryParams("https://example.com/foo", {
       a: "1",


### PR DESCRIPTION
## Summary

Closes #184. Adds a `config.originParams` key-value map plus step-level `params` on `goTo` and `checkLink` that are auto-appended as query parameters to any URL resolved against `origin`.

Motivating case: Clerk testing-mode requires `__clerk_testing_token` on every request. Today that has to be repeated on every step. With this change, you set it once in config and every relative-URL step picks it up.

```jsonc
{
  \"origin\": \"https://my-app.com\",
  \"originParams\": {
    \"__clerk_testing_token\": \"\$CLERK_TESTING_TOKEN\"
  }
}
```

Step like \`{\"goTo\": \"/dashboard\"}\` now resolves to \`https://my-app.com/dashboard?__clerk_testing_token=<value>\`.

## Semantics

- **Merge, not replace.** \`step.params\` is merged on top of \`config.originParams\`; step keys win on collision. Adding one per-step param does *not* silently drop a config-level token.
- **Dedupes on existing query keys.** If the resolved URL already contains a colliding key, the param here replaces it (no \`?token=old&token=new\`).
- **Fragment-safe.** A URL fragment (\`#section\`) is preserved and new params are inserted before it.
- **Env var substitution** via the existing \`\$VAR\` syntax works out of the box — \`replaceEnvs\` already runs over both config and step objects upstream.
- **Secrets warning.** Schema descriptions explicitly call out that values end up in request URLs and appear in test results, logs, and reports. Prefer short-lived testing tokens to long-lived secrets.

## Implementation

- New \`appendQueryParams(url, params)\` helper in \`src/core/utils.ts\` — fragment-aware, uses \`URLSearchParams.set\` for dedupe.
- \`goTo\` / \`checkLink\` runtime merge \`config.originParams\` with step-level \`params\` after prepending origin, then call the helper.
- Added \`originParams\` to \`config_v3\` and \`params\` to \`goTo_v3\` / \`checkLink_v3\` source schemas (+ Clerk-style examples). Output schemas and TS types regenerated via \`npm run build\`.

## Adversarial review findings addressed

An adversarial review via copilot-cli (gpt-5.2) surfaced these issues during development, all fixed:

- **[Critical] Fragment handling:** initial append was raw concat — put params inside the fragment.
- **[High] Replace-vs-merge footgun:** initial semantics were step replaces config; flipped to merge.
- **[High] Secret-in-logs visibility:** documented explicitly in all three schemas.
- **[Medium] Duplicate-key ambiguity:** now deduped via URLSearchParams.set.
- **[Medium] Dead detectTests path:** removed. With runtime merge, the earlier \`config.originParams → step.params\` copy on markup-detected steps had no behavioral effect.

Naming stays split (\`originParams\` at config, \`params\` at step) — the contexts are different enough that the inconsistency is justifiable.

## Test plan

- [x] \`test/utils.test.js\` — appendQueryParams unit tests (fragment, dedupe, null filtering, coercion)
- [x] \`test/goTo.test.js\` (new) — 6 integration cases via a stub driver
- [x] \`test/checkLink.test.js\` — 6 cases against a local HTTP server (merge, dedupe, env-var, absolute-URL skip, empty params)
- [x] \`src/common\` schema + validation suite: 575 passing
- [x] Root suite: 341 passing (+19 over baseline). Existing 16 Chrome/WebDriver/screenshot failures are environmental (no local Chrome) and present on \`main\` — unchanged from baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for query parameters on navigation and link-checking steps via an optional params field
  * Global default query parameters via originParams configuration
  * Step-level params override global defaults on key collisions
  * Environment-variable substitution in parameter values using $VAR syntax

* **Tests**
  * Added comprehensive tests validating param merging, substitution, fragment preservation, and replacement vs. duplication behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->