### PR TITLE
feat(screenshot): accept URL paths as read-only reference images

### DIFF
--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -5775,7 +5775,7 @@
                                                     "title": "Screenshot (simple)",
                                                     "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                     "type": "string",
-                                                    "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                    "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                     "transform": [
                                                       "trim"
                                                     ]
@@ -5788,7 +5788,7 @@
                                                         "title": "Screenshot (simple)",
                                                         "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                         "type": "string",
-                                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                        "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                         "transform": [
                                                           "trim"
                                                         ]
@@ -6021,7 +6021,7 @@
                                                       "title": "Screenshot (simple)",
                                                       "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                       "type": "string",
-                                                      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                      "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                       "transform": [
                                                         "trim"
                                                       ]
@@ -6034,7 +6034,7 @@
                                                           "title": "Screenshot (simple)",
                                                           "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                           "type": "string",
-                                                          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                          "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                           "transform": [
                                                             "trim"
                                                           ]
@@ -14444,7 +14444,7 @@
                                       "title": "Screenshot (simple)",
                                       "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                       "type": "string",
-                                      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                      "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                       "transform": [
                                         "trim"
                                       ]
@@ -14457,7 +14457,7 @@
                                           "title": "Screenshot (simple)",
                                           "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                           "type": "string",
-                                          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                          "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                           "transform": [
                                             "trim"
                                           ]
@@ -14690,7 +14690,7 @@
                                         "title": "Screenshot (simple)",
                                         "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                         "type": "string",
-                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                        "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                         "transform": [
                                           "trim"
                                         ]
@@ -14703,7 +14703,7 @@
                                             "title": "Screenshot (simple)",
                                             "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                             "type": "string",
-                                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                            "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                             "transform": [
                                               "trim"
                                             ]

--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -5773,9 +5773,9 @@
                                                 "anyOf": [
                                                   {
                                                     "title": "Screenshot (simple)",
-                                                    "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                    "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                     "type": "string",
-                                                    "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                    "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                     "transform": [
                                                       "trim"
                                                     ]
@@ -5786,9 +5786,9 @@
                                                     "properties": {
                                                       "path": {
                                                         "title": "Screenshot (simple)",
-                                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                         "type": "string",
-                                                        "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                         "transform": [
                                                           "trim"
                                                         ]
@@ -6019,9 +6019,9 @@
                                                   "schemas": {
                                                     "path": {
                                                       "title": "Screenshot (simple)",
-                                                      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                       "type": "string",
-                                                      "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                       "transform": [
                                                         "trim"
                                                       ]
@@ -6032,9 +6032,9 @@
                                                       "properties": {
                                                         "path": {
                                                           "title": "Screenshot (simple)",
-                                                          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                           "type": "string",
-                                                          "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                           "transform": [
                                                             "trim"
                                                           ]
@@ -6416,6 +6416,12 @@
                                                   "image.png",
                                                   "static/images/image.png",
                                                   "/User/manny/projects/doc-detective/static/images/image.png",
+                                                  "https://example.com/static/images/image.png",
+                                                  {
+                                                    "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                                                    "maxVariation": 0.05,
+                                                    "overwrite": "aboveVariation"
+                                                  },
                                                   {
                                                     "path": "image.png",
                                                     "directory": "static/images",
@@ -14436,9 +14442,9 @@
                                   "anyOf": [
                                     {
                                       "title": "Screenshot (simple)",
-                                      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                       "type": "string",
-                                      "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                       "transform": [
                                         "trim"
                                       ]
@@ -14449,9 +14455,9 @@
                                       "properties": {
                                         "path": {
                                           "title": "Screenshot (simple)",
-                                          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                           "type": "string",
-                                          "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                           "transform": [
                                             "trim"
                                           ]
@@ -14682,9 +14688,9 @@
                                     "schemas": {
                                       "path": {
                                         "title": "Screenshot (simple)",
-                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                         "type": "string",
-                                        "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                         "transform": [
                                           "trim"
                                         ]
@@ -14695,9 +14701,9 @@
                                         "properties": {
                                           "path": {
                                             "title": "Screenshot (simple)",
-                                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                             "type": "string",
-                                            "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                             "transform": [
                                               "trim"
                                             ]
@@ -15079,6 +15085,12 @@
                                     "image.png",
                                     "static/images/image.png",
                                     "/User/manny/projects/doc-detective/static/images/image.png",
+                                    "https://example.com/static/images/image.png",
+                                    {
+                                      "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                                      "maxVariation": 0.05,
+                                      "overwrite": "aboveVariation"
+                                    },
                                     {
                                       "path": "image.png",
                                       "directory": "static/images",

--- a/src/common/src/schemas/output_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/report_v3.schema.json
@@ -6196,7 +6196,7 @@
                                             "title": "Screenshot (simple)",
                                             "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                             "type": "string",
-                                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                            "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                             "transform": [
                                               "trim"
                                             ]
@@ -6209,7 +6209,7 @@
                                                 "title": "Screenshot (simple)",
                                                 "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                 "type": "string",
-                                                "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                 "transform": [
                                                   "trim"
                                                 ]
@@ -6442,7 +6442,7 @@
                                               "title": "Screenshot (simple)",
                                               "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                               "type": "string",
-                                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                              "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                               "transform": [
                                                 "trim"
                                               ]
@@ -6455,7 +6455,7 @@
                                                   "title": "Screenshot (simple)",
                                                   "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                   "type": "string",
-                                                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                  "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                   "transform": [
                                                     "trim"
                                                   ]
@@ -14339,7 +14339,7 @@
                                                   "title": "Screenshot (simple)",
                                                   "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                   "type": "string",
-                                                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                  "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                   "transform": [
                                                     "trim"
                                                   ]
@@ -14352,7 +14352,7 @@
                                                       "title": "Screenshot (simple)",
                                                       "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                       "type": "string",
-                                                      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                      "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                       "transform": [
                                                         "trim"
                                                       ]
@@ -14585,7 +14585,7 @@
                                                     "title": "Screenshot (simple)",
                                                     "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                     "type": "string",
-                                                    "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                    "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                     "transform": [
                                                       "trim"
                                                     ]
@@ -14598,7 +14598,7 @@
                                                         "title": "Screenshot (simple)",
                                                         "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                         "type": "string",
-                                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                        "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                         "transform": [
                                                           "trim"
                                                         ]

--- a/src/common/src/schemas/output_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/report_v3.schema.json
@@ -6194,9 +6194,9 @@
                                         "anyOf": [
                                           {
                                             "title": "Screenshot (simple)",
-                                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                             "type": "string",
-                                            "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                             "transform": [
                                               "trim"
                                             ]
@@ -6207,9 +6207,9 @@
                                             "properties": {
                                               "path": {
                                                 "title": "Screenshot (simple)",
-                                                "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                 "type": "string",
-                                                "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                 "transform": [
                                                   "trim"
                                                 ]
@@ -6440,9 +6440,9 @@
                                           "schemas": {
                                             "path": {
                                               "title": "Screenshot (simple)",
-                                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                               "type": "string",
-                                              "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                               "transform": [
                                                 "trim"
                                               ]
@@ -6453,9 +6453,9 @@
                                               "properties": {
                                                 "path": {
                                                   "title": "Screenshot (simple)",
-                                                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                   "type": "string",
-                                                  "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                   "transform": [
                                                     "trim"
                                                   ]
@@ -6837,6 +6837,12 @@
                                           "image.png",
                                           "static/images/image.png",
                                           "/User/manny/projects/doc-detective/static/images/image.png",
+                                          "https://example.com/static/images/image.png",
+                                          {
+                                            "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                                            "maxVariation": 0.05,
+                                            "overwrite": "aboveVariation"
+                                          },
                                           {
                                             "path": "image.png",
                                             "directory": "static/images",
@@ -14331,9 +14337,9 @@
                                               "anyOf": [
                                                 {
                                                   "title": "Screenshot (simple)",
-                                                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                   "type": "string",
-                                                  "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                   "transform": [
                                                     "trim"
                                                   ]
@@ -14344,9 +14350,9 @@
                                                   "properties": {
                                                     "path": {
                                                       "title": "Screenshot (simple)",
-                                                      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                       "type": "string",
-                                                      "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                       "transform": [
                                                         "trim"
                                                       ]
@@ -14577,9 +14583,9 @@
                                                 "schemas": {
                                                   "path": {
                                                     "title": "Screenshot (simple)",
-                                                    "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                    "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                     "type": "string",
-                                                    "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                    "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                     "transform": [
                                                       "trim"
                                                     ]
@@ -14590,9 +14596,9 @@
                                                     "properties": {
                                                       "path": {
                                                         "title": "Screenshot (simple)",
-                                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                         "type": "string",
-                                                        "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                         "transform": [
                                                           "trim"
                                                         ]
@@ -14974,6 +14980,12 @@
                                                 "image.png",
                                                 "static/images/image.png",
                                                 "/User/manny/projects/doc-detective/static/images/image.png",
+                                                "https://example.com/static/images/image.png",
+                                                {
+                                                  "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                                                  "maxVariation": 0.05,
+                                                  "overwrite": "aboveVariation"
+                                                },
                                                 {
                                                   "path": "image.png",
                                                   "directory": "static/images",

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -5788,7 +5788,7 @@
                                                         "title": "Screenshot (simple)",
                                                         "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                         "type": "string",
-                                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                        "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                         "transform": [
                                                           "trim"
                                                         ]
@@ -5801,7 +5801,7 @@
                                                             "title": "Screenshot (simple)",
                                                             "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                             "type": "string",
-                                                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                            "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                             "transform": [
                                                               "trim"
                                                             ]
@@ -6034,7 +6034,7 @@
                                                           "title": "Screenshot (simple)",
                                                           "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                           "type": "string",
-                                                          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                          "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                           "transform": [
                                                             "trim"
                                                           ]
@@ -6047,7 +6047,7 @@
                                                               "title": "Screenshot (simple)",
                                                               "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                               "type": "string",
-                                                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                              "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                               "transform": [
                                                                 "trim"
                                                               ]
@@ -14457,7 +14457,7 @@
                                           "title": "Screenshot (simple)",
                                           "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                           "type": "string",
-                                          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                          "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                           "transform": [
                                             "trim"
                                           ]
@@ -14470,7 +14470,7 @@
                                               "title": "Screenshot (simple)",
                                               "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                               "type": "string",
-                                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                              "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                               "transform": [
                                                 "trim"
                                               ]
@@ -14703,7 +14703,7 @@
                                             "title": "Screenshot (simple)",
                                             "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                             "type": "string",
-                                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                            "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                             "transform": [
                                               "trim"
                                             ]
@@ -14716,7 +14716,7 @@
                                                 "title": "Screenshot (simple)",
                                                 "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                 "type": "string",
-                                                "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                 "transform": [
                                                   "trim"
                                                 ]
@@ -23820,7 +23820,7 @@
                                             "title": "Screenshot (simple)",
                                             "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                             "type": "string",
-                                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                            "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                             "transform": [
                                               "trim"
                                             ]
@@ -23833,7 +23833,7 @@
                                                 "title": "Screenshot (simple)",
                                                 "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                 "type": "string",
-                                                "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                 "transform": [
                                                   "trim"
                                                 ]
@@ -24066,7 +24066,7 @@
                                               "title": "Screenshot (simple)",
                                               "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                               "type": "string",
-                                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                              "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                               "transform": [
                                                 "trim"
                                               ]
@@ -24079,7 +24079,7 @@
                                                   "title": "Screenshot (simple)",
                                                   "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                   "type": "string",
-                                                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                  "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                   "transform": [
                                                     "trim"
                                                   ]
@@ -31963,7 +31963,7 @@
                                                   "title": "Screenshot (simple)",
                                                   "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                   "type": "string",
-                                                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                  "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                   "transform": [
                                                     "trim"
                                                   ]
@@ -31976,7 +31976,7 @@
                                                       "title": "Screenshot (simple)",
                                                       "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                       "type": "string",
-                                                      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                      "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                       "transform": [
                                                         "trim"
                                                       ]
@@ -32209,7 +32209,7 @@
                                                     "title": "Screenshot (simple)",
                                                     "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                     "type": "string",
-                                                    "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                    "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                     "transform": [
                                                       "trim"
                                                     ]
@@ -32222,7 +32222,7 @@
                                                         "title": "Screenshot (simple)",
                                                         "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                         "type": "string",
-                                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                        "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                                         "transform": [
                                                           "trim"
                                                         ]

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -5786,9 +5786,9 @@
                                                     "anyOf": [
                                                       {
                                                         "title": "Screenshot (simple)",
-                                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                         "type": "string",
-                                                        "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                         "transform": [
                                                           "trim"
                                                         ]
@@ -5799,9 +5799,9 @@
                                                         "properties": {
                                                           "path": {
                                                             "title": "Screenshot (simple)",
-                                                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                             "type": "string",
-                                                            "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                             "transform": [
                                                               "trim"
                                                             ]
@@ -6032,9 +6032,9 @@
                                                       "schemas": {
                                                         "path": {
                                                           "title": "Screenshot (simple)",
-                                                          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                           "type": "string",
-                                                          "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                           "transform": [
                                                             "trim"
                                                           ]
@@ -6045,9 +6045,9 @@
                                                           "properties": {
                                                             "path": {
                                                               "title": "Screenshot (simple)",
-                                                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                               "type": "string",
-                                                              "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                               "transform": [
                                                                 "trim"
                                                               ]
@@ -6429,6 +6429,12 @@
                                                       "image.png",
                                                       "static/images/image.png",
                                                       "/User/manny/projects/doc-detective/static/images/image.png",
+                                                      "https://example.com/static/images/image.png",
+                                                      {
+                                                        "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                                                        "maxVariation": 0.05,
+                                                        "overwrite": "aboveVariation"
+                                                      },
                                                       {
                                                         "path": "image.png",
                                                         "directory": "static/images",
@@ -14449,9 +14455,9 @@
                                       "anyOf": [
                                         {
                                           "title": "Screenshot (simple)",
-                                          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                           "type": "string",
-                                          "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                           "transform": [
                                             "trim"
                                           ]
@@ -14462,9 +14468,9 @@
                                           "properties": {
                                             "path": {
                                               "title": "Screenshot (simple)",
-                                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                               "type": "string",
-                                              "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                               "transform": [
                                                 "trim"
                                               ]
@@ -14695,9 +14701,9 @@
                                         "schemas": {
                                           "path": {
                                             "title": "Screenshot (simple)",
-                                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                             "type": "string",
-                                            "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                             "transform": [
                                               "trim"
                                             ]
@@ -14708,9 +14714,9 @@
                                             "properties": {
                                               "path": {
                                                 "title": "Screenshot (simple)",
-                                                "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                 "type": "string",
-                                                "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                 "transform": [
                                                   "trim"
                                                 ]
@@ -15092,6 +15098,12 @@
                                         "image.png",
                                         "static/images/image.png",
                                         "/User/manny/projects/doc-detective/static/images/image.png",
+                                        "https://example.com/static/images/image.png",
+                                        {
+                                          "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                                          "maxVariation": 0.05,
+                                          "overwrite": "aboveVariation"
+                                        },
                                         {
                                           "path": "image.png",
                                           "directory": "static/images",
@@ -23806,9 +23818,9 @@
                                         "anyOf": [
                                           {
                                             "title": "Screenshot (simple)",
-                                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                             "type": "string",
-                                            "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                             "transform": [
                                               "trim"
                                             ]
@@ -23819,9 +23831,9 @@
                                             "properties": {
                                               "path": {
                                                 "title": "Screenshot (simple)",
-                                                "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                 "type": "string",
-                                                "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                 "transform": [
                                                   "trim"
                                                 ]
@@ -24052,9 +24064,9 @@
                                           "schemas": {
                                             "path": {
                                               "title": "Screenshot (simple)",
-                                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                               "type": "string",
-                                              "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                               "transform": [
                                                 "trim"
                                               ]
@@ -24065,9 +24077,9 @@
                                               "properties": {
                                                 "path": {
                                                   "title": "Screenshot (simple)",
-                                                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                   "type": "string",
-                                                  "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                   "transform": [
                                                     "trim"
                                                   ]
@@ -24449,6 +24461,12 @@
                                           "image.png",
                                           "static/images/image.png",
                                           "/User/manny/projects/doc-detective/static/images/image.png",
+                                          "https://example.com/static/images/image.png",
+                                          {
+                                            "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                                            "maxVariation": 0.05,
+                                            "overwrite": "aboveVariation"
+                                          },
                                           {
                                             "path": "image.png",
                                             "directory": "static/images",
@@ -31943,9 +31961,9 @@
                                               "anyOf": [
                                                 {
                                                   "title": "Screenshot (simple)",
-                                                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                   "type": "string",
-                                                  "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                   "transform": [
                                                     "trim"
                                                   ]
@@ -31956,9 +31974,9 @@
                                                   "properties": {
                                                     "path": {
                                                       "title": "Screenshot (simple)",
-                                                      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                       "type": "string",
-                                                      "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                       "transform": [
                                                         "trim"
                                                       ]
@@ -32189,9 +32207,9 @@
                                                 "schemas": {
                                                   "path": {
                                                     "title": "Screenshot (simple)",
-                                                    "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                    "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                     "type": "string",
-                                                    "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                    "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                     "transform": [
                                                       "trim"
                                                     ]
@@ -32202,9 +32220,9 @@
                                                     "properties": {
                                                       "path": {
                                                         "title": "Screenshot (simple)",
-                                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                                         "type": "string",
-                                                        "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                                         "transform": [
                                                           "trim"
                                                         ]
@@ -32586,6 +32604,12 @@
                                                 "image.png",
                                                 "static/images/image.png",
                                                 "/User/manny/projects/doc-detective/static/images/image.png",
+                                                "https://example.com/static/images/image.png",
+                                                {
+                                                  "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                                                  "maxVariation": 0.05,
+                                                  "overwrite": "aboveVariation"
+                                                },
                                                 {
                                                   "path": "image.png",
                                                   "directory": "static/images",

--- a/src/common/src/schemas/output_schemas/screenshot_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/screenshot_v3.schema.json
@@ -5,9 +5,9 @@
   "anyOf": [
     {
       "title": "Screenshot (simple)",
-      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
       "type": "string",
-      "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
       "transform": [
         "trim"
       ]
@@ -18,9 +18,9 @@
       "properties": {
         "path": {
           "title": "Screenshot (simple)",
-          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
           "type": "string",
-          "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
           "transform": [
             "trim"
           ]
@@ -251,9 +251,9 @@
     "schemas": {
       "path": {
         "title": "Screenshot (simple)",
-        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
         "type": "string",
-        "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
         "transform": [
           "trim"
         ]
@@ -264,9 +264,9 @@
         "properties": {
           "path": {
             "title": "Screenshot (simple)",
-            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
             "type": "string",
-            "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
             "transform": [
               "trim"
             ]
@@ -648,6 +648,12 @@
     "image.png",
     "static/images/image.png",
     "/User/manny/projects/doc-detective/static/images/image.png",
+    "https://example.com/static/images/image.png",
+    {
+      "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+      "maxVariation": 0.05,
+      "overwrite": "aboveVariation"
+    },
     {
       "path": "image.png",
       "directory": "static/images",

--- a/src/common/src/schemas/output_schemas/screenshot_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/screenshot_v3.schema.json
@@ -7,7 +7,7 @@
       "title": "Screenshot (simple)",
       "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
       "type": "string",
-      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+      "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
       "transform": [
         "trim"
       ]
@@ -20,7 +20,7 @@
           "title": "Screenshot (simple)",
           "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
           "type": "string",
-          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+          "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
           "transform": [
             "trim"
           ]
@@ -253,7 +253,7 @@
         "title": "Screenshot (simple)",
         "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
         "type": "string",
-        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+        "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
         "transform": [
           "trim"
         ]
@@ -266,7 +266,7 @@
             "title": "Screenshot (simple)",
             "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
             "type": "string",
-            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+            "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
             "transform": [
               "trim"
             ]

--- a/src/common/src/schemas/output_schemas/spec_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/spec_v3.schema.json
@@ -6176,9 +6176,9 @@
                               "anyOf": [
                                 {
                                   "title": "Screenshot (simple)",
-                                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                   "type": "string",
-                                  "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                   "transform": [
                                     "trim"
                                   ]
@@ -6189,9 +6189,9 @@
                                   "properties": {
                                     "path": {
                                       "title": "Screenshot (simple)",
-                                      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                       "type": "string",
-                                      "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                       "transform": [
                                         "trim"
                                       ]
@@ -6422,9 +6422,9 @@
                                 "schemas": {
                                   "path": {
                                     "title": "Screenshot (simple)",
-                                    "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                    "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                     "type": "string",
-                                    "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                    "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                     "transform": [
                                       "trim"
                                     ]
@@ -6435,9 +6435,9 @@
                                     "properties": {
                                       "path": {
                                         "title": "Screenshot (simple)",
-                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                         "type": "string",
-                                        "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                         "transform": [
                                           "trim"
                                         ]
@@ -6819,6 +6819,12 @@
                                 "image.png",
                                 "static/images/image.png",
                                 "/User/manny/projects/doc-detective/static/images/image.png",
+                                "https://example.com/static/images/image.png",
+                                {
+                                  "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                                  "maxVariation": 0.05,
+                                  "overwrite": "aboveVariation"
+                                },
                                 {
                                   "path": "image.png",
                                   "directory": "static/images",
@@ -14313,9 +14319,9 @@
                                     "anyOf": [
                                       {
                                         "title": "Screenshot (simple)",
-                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                         "type": "string",
-                                        "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                         "transform": [
                                           "trim"
                                         ]
@@ -14326,9 +14332,9 @@
                                         "properties": {
                                           "path": {
                                             "title": "Screenshot (simple)",
-                                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                             "type": "string",
-                                            "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                             "transform": [
                                               "trim"
                                             ]
@@ -14559,9 +14565,9 @@
                                       "schemas": {
                                         "path": {
                                           "title": "Screenshot (simple)",
-                                          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                           "type": "string",
-                                          "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                           "transform": [
                                             "trim"
                                           ]
@@ -14572,9 +14578,9 @@
                                           "properties": {
                                             "path": {
                                               "title": "Screenshot (simple)",
-                                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                               "type": "string",
-                                              "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                               "transform": [
                                                 "trim"
                                               ]
@@ -14956,6 +14962,12 @@
                                       "image.png",
                                       "static/images/image.png",
                                       "/User/manny/projects/doc-detective/static/images/image.png",
+                                      "https://example.com/static/images/image.png",
+                                      {
+                                        "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                                        "maxVariation": 0.05,
+                                        "overwrite": "aboveVariation"
+                                      },
                                       {
                                         "path": "image.png",
                                         "directory": "static/images",

--- a/src/common/src/schemas/output_schemas/spec_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/spec_v3.schema.json
@@ -6178,7 +6178,7 @@
                                   "title": "Screenshot (simple)",
                                   "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                   "type": "string",
-                                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                  "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                   "transform": [
                                     "trim"
                                   ]
@@ -6191,7 +6191,7 @@
                                       "title": "Screenshot (simple)",
                                       "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                       "type": "string",
-                                      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                      "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                       "transform": [
                                         "trim"
                                       ]
@@ -6424,7 +6424,7 @@
                                     "title": "Screenshot (simple)",
                                     "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                     "type": "string",
-                                    "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                    "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                     "transform": [
                                       "trim"
                                     ]
@@ -6437,7 +6437,7 @@
                                         "title": "Screenshot (simple)",
                                         "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                         "type": "string",
-                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                        "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                         "transform": [
                                           "trim"
                                         ]
@@ -14321,7 +14321,7 @@
                                         "title": "Screenshot (simple)",
                                         "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                         "type": "string",
-                                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                        "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                         "transform": [
                                           "trim"
                                         ]
@@ -14334,7 +14334,7 @@
                                             "title": "Screenshot (simple)",
                                             "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                             "type": "string",
-                                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                            "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                             "transform": [
                                               "trim"
                                             ]
@@ -14567,7 +14567,7 @@
                                           "title": "Screenshot (simple)",
                                           "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                           "type": "string",
-                                          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                          "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                           "transform": [
                                             "trim"
                                           ]
@@ -14580,7 +14580,7 @@
                                               "title": "Screenshot (simple)",
                                               "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                               "type": "string",
-                                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                              "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                               "transform": [
                                                 "trim"
                                               ]

--- a/src/common/src/schemas/output_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/step_v3.schema.json
@@ -4976,9 +4976,9 @@
               "anyOf": [
                 {
                   "title": "Screenshot (simple)",
-                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                   "type": "string",
-                  "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                   "transform": [
                     "trim"
                   ]
@@ -4989,9 +4989,9 @@
                   "properties": {
                     "path": {
                       "title": "Screenshot (simple)",
-                      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                      "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                       "type": "string",
-                      "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                       "transform": [
                         "trim"
                       ]
@@ -5222,9 +5222,9 @@
                 "schemas": {
                   "path": {
                     "title": "Screenshot (simple)",
-                    "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                    "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                     "type": "string",
-                    "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                    "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                     "transform": [
                       "trim"
                     ]
@@ -5235,9 +5235,9 @@
                     "properties": {
                       "path": {
                         "title": "Screenshot (simple)",
-                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                         "type": "string",
-                        "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                         "transform": [
                           "trim"
                         ]
@@ -5619,6 +5619,12 @@
                 "image.png",
                 "static/images/image.png",
                 "/User/manny/projects/doc-detective/static/images/image.png",
+                "https://example.com/static/images/image.png",
+                {
+                  "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                  "maxVariation": 0.05,
+                  "overwrite": "aboveVariation"
+                },
                 {
                   "path": "image.png",
                   "directory": "static/images",

--- a/src/common/src/schemas/output_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/step_v3.schema.json
@@ -4978,7 +4978,7 @@
                   "title": "Screenshot (simple)",
                   "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                   "type": "string",
-                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                  "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                   "transform": [
                     "trim"
                   ]
@@ -4991,7 +4991,7 @@
                       "title": "Screenshot (simple)",
                       "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                       "type": "string",
-                      "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                      "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                       "transform": [
                         "trim"
                       ]
@@ -5224,7 +5224,7 @@
                     "title": "Screenshot (simple)",
                     "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                     "type": "string",
-                    "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                    "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                     "transform": [
                       "trim"
                     ]
@@ -5237,7 +5237,7 @@
                         "title": "Screenshot (simple)",
                         "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                         "type": "string",
-                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                        "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                         "transform": [
                           "trim"
                         ]

--- a/src/common/src/schemas/output_schemas/test_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/test_v3.schema.json
@@ -5577,7 +5577,7 @@
                         "title": "Screenshot (simple)",
                         "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                         "type": "string",
-                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                        "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                         "transform": [
                           "trim"
                         ]
@@ -5590,7 +5590,7 @@
                             "title": "Screenshot (simple)",
                             "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                             "type": "string",
-                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                            "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                             "transform": [
                               "trim"
                             ]
@@ -5823,7 +5823,7 @@
                           "title": "Screenshot (simple)",
                           "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                           "type": "string",
-                          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                          "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                           "transform": [
                             "trim"
                           ]
@@ -5836,7 +5836,7 @@
                               "title": "Screenshot (simple)",
                               "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                               "type": "string",
-                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                              "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                               "transform": [
                                 "trim"
                               ]
@@ -13720,7 +13720,7 @@
                               "title": "Screenshot (simple)",
                               "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                               "type": "string",
-                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                              "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                               "transform": [
                                 "trim"
                               ]
@@ -13733,7 +13733,7 @@
                                   "title": "Screenshot (simple)",
                                   "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                   "type": "string",
-                                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                  "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                   "transform": [
                                     "trim"
                                   ]
@@ -13966,7 +13966,7 @@
                                 "title": "Screenshot (simple)",
                                 "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                 "type": "string",
-                                "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                 "transform": [
                                   "trim"
                                 ]
@@ -13979,7 +13979,7 @@
                                     "title": "Screenshot (simple)",
                                     "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                     "type": "string",
-                                    "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                    "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
                                     "transform": [
                                       "trim"
                                     ]

--- a/src/common/src/schemas/output_schemas/test_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/test_v3.schema.json
@@ -5575,9 +5575,9 @@
                     "anyOf": [
                       {
                         "title": "Screenshot (simple)",
-                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                         "type": "string",
-                        "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                         "transform": [
                           "trim"
                         ]
@@ -5588,9 +5588,9 @@
                         "properties": {
                           "path": {
                             "title": "Screenshot (simple)",
-                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                            "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                             "type": "string",
-                            "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                            "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                             "transform": [
                               "trim"
                             ]
@@ -5821,9 +5821,9 @@
                       "schemas": {
                         "path": {
                           "title": "Screenshot (simple)",
-                          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                          "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                           "type": "string",
-                          "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                          "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                           "transform": [
                             "trim"
                           ]
@@ -5834,9 +5834,9 @@
                           "properties": {
                             "path": {
                               "title": "Screenshot (simple)",
-                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                               "type": "string",
-                              "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                               "transform": [
                                 "trim"
                               ]
@@ -6218,6 +6218,12 @@
                       "image.png",
                       "static/images/image.png",
                       "/User/manny/projects/doc-detective/static/images/image.png",
+                      "https://example.com/static/images/image.png",
+                      {
+                        "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                        "maxVariation": 0.05,
+                        "overwrite": "aboveVariation"
+                      },
                       {
                         "path": "image.png",
                         "directory": "static/images",
@@ -13712,9 +13718,9 @@
                           "anyOf": [
                             {
                               "title": "Screenshot (simple)",
-                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                              "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                               "type": "string",
-                              "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                              "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                               "transform": [
                                 "trim"
                               ]
@@ -13725,9 +13731,9 @@
                               "properties": {
                                 "path": {
                                   "title": "Screenshot (simple)",
-                                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                  "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                   "type": "string",
-                                  "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                  "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                   "transform": [
                                     "trim"
                                   ]
@@ -13958,9 +13964,9 @@
                             "schemas": {
                               "path": {
                                 "title": "Screenshot (simple)",
-                                "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                 "type": "string",
-                                "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                 "transform": [
                                   "trim"
                                 ]
@@ -13971,9 +13977,9 @@
                                 "properties": {
                                   "path": {
                                     "title": "Screenshot (simple)",
-                                    "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+                                    "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
                                     "type": "string",
-                                    "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+                                    "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
                                     "transform": [
                                       "trim"
                                     ]
@@ -14355,6 +14361,12 @@
                             "image.png",
                             "static/images/image.png",
                             "/User/manny/projects/doc-detective/static/images/image.png",
+                            "https://example.com/static/images/image.png",
+                            {
+                              "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+                              "maxVariation": 0.05,
+                              "overwrite": "aboveVariation"
+                            },
                             {
                               "path": "image.png",
                               "directory": "static/images",

--- a/src/common/src/schemas/src_schemas/screenshot_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/screenshot_v3.schema.json
@@ -19,9 +19,9 @@
     "schemas": {
       "path": {
         "title": "Screenshot (simple)",
-        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.",
+        "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
         "type": "string",
-        "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
         "transform": [
           "trim"
         ]
@@ -216,6 +216,12 @@
     "image.png",
     "static/images/image.png",
     "/User/manny/projects/doc-detective/static/images/image.png",
+    "https://example.com/static/images/image.png",
+    {
+      "path": "https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/request-changes-button-0c851bb3.png",
+      "maxVariation": 0.05,
+      "overwrite": "aboveVariation"
+    },
     {
       "path": "image.png",
       "directory": "static/images",

--- a/src/common/src/schemas/src_schemas/screenshot_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/screenshot_v3.schema.json
@@ -21,7 +21,7 @@
         "title": "Screenshot (simple)",
         "description": "File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.",
         "type": "string",
-        "pattern": "(^https?:\\/\\/.+\\.(png|PNG)(\\?.*)?$|[A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)",
+        "pattern": "^(?:https?:\\/\\/.+\\.(?:png|PNG)(?:\\?.*)?|[A-Za-z]:[\\/\\\\].*\\.(?:png|PNG)|[\\/\\\\]?[A-Za-z0-9_.\\/\\\\-]*\\.(?:png|PNG)|\\$[A-Za-z0-9_]+)$",
         "transform": [
           "trim"
         ]

--- a/src/common/src/types/generated/screenshot_v3.ts
+++ b/src/common/src/types/generated/screenshot_v3.ts
@@ -9,11 +9,11 @@
  */
 export type Screenshot = ScreenshotSimple | CaptureScreenshotDetailed | CaptureScreenshot;
 /**
- * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.
+ * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.
  */
 export type ScreenshotSimple = string;
 /**
- * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.
+ * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.
  */
 export type ScreenshotSimple1 = string;
 /**

--- a/src/common/src/types/generated/step_v3.ts
+++ b/src/common/src/types/generated/step_v3.ts
@@ -101,11 +101,11 @@ export type TypeKeysSimple1 = string | string[];
  */
 export type Screenshot1 = ScreenshotSimple | CaptureScreenshotDetailed | CaptureScreenshot;
 /**
- * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.
+ * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.
  */
 export type ScreenshotSimple = string;
 /**
- * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.
+ * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.
  */
 export type ScreenshotSimple1 = string;
 /**

--- a/src/common/src/types/generated/test_v3.ts
+++ b/src/common/src/types/generated/test_v3.ts
@@ -192,11 +192,11 @@ export type TypeKeysSimple1 = string | string[];
  */
 export type Screenshot1 = ScreenshotSimple | CaptureScreenshotDetailed | CaptureScreenshot;
 /**
- * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.
+ * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.
  */
 export type ScreenshotSimple = string;
 /**
- * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.
+ * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.
  */
 export type ScreenshotSimple1 = string;
 /**
@@ -486,11 +486,11 @@ export type TypeKeysSimple3 = string | string[];
  */
 export type Screenshot3 = ScreenshotSimple2 | CaptureScreenshotDetailed1 | CaptureScreenshot1;
 /**
- * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.
+ * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.
  */
 export type ScreenshotSimple2 = string;
 /**
- * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step.
+ * File path of the PNG file. Accepts absolute paths. If not specified, the file name is the ID of the step. If an `http(s)` URL is supplied, the remote image is downloaded and used as a read-only reference for comparison; the new capture is written to a local run-specific folder instead of being uploaded back to the URL.
  */
 export type ScreenshotSimple3 = string;
 /**

--- a/src/core/tests/saveScreenshot.ts
+++ b/src/core/tests/saveScreenshot.ts
@@ -418,7 +418,6 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
           : `Couldn't decode PNG for comparison. ${error}`;
         if (
           !isUrlPath &&
-          existFilePath &&
           filePath !== existFilePath &&
           fs.existsSync(filePath)
         ) {
@@ -433,7 +432,6 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
         result.description = `Couldn't compare images. Images have different aspect ratios.`;
         if (
           !isUrlPath &&
-          existFilePath &&
           filePath !== existFilePath &&
           fs.existsSync(filePath)
         ) {

--- a/src/core/tests/saveScreenshot.ts
+++ b/src/core/tests/saveScreenshot.ts
@@ -5,6 +5,7 @@ import {
   fetchFile,
   getOrInitRunTimestamp,
   redactUrlForOutput,
+  sanitizeFilesystemName,
 } from "../utils.js";
 import path from "node:path";
 import fs from "node:fs";
@@ -147,10 +148,11 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
     const rawBase = path.basename(
       urlPathname.split("?")[0].split("#")[0].replace(/\\/g, "/")
     );
-    const safeBase =
-      !rawBase || rawBase === "." || rawBase === ".." || rawBase.includes("\0")
-        ? `${step.stepId}.png`
-        : rawBase;
+    // Also strip characters that are invalid in filenames on Windows
+    // (`< > : " | ? *` and control chars). Without this, a URL segment like
+    // `img:v2.png` would build a path the Windows file system refuses to
+    // create. Shared helper so the rule stays consistent with fetchFile.
+    const safeBase = sanitizeFilesystemName(rawBase, `${step.stepId}.png`);
 
     dir = path.join(
       process.cwd(),

--- a/src/core/tests/saveScreenshot.ts
+++ b/src/core/tests/saveScreenshot.ts
@@ -1,6 +1,6 @@
 import { validate } from "../../common/src/validate.js";
 import { findElement } from "./findElement.js";
-import { log } from "../utils.js";
+import { log, fetchFile, getOrInitRunTimestamp } from "../utils.js";
 import path from "node:path";
 import fs from "node:fs";
 import { PNG } from "pngjs";
@@ -108,26 +108,90 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
   }
 
   let filePath = step.screenshot.path;
-
-  // Set path directory
-  const dir = path.dirname(step.screenshot.path);
-  // If `dir` doesn't exist, create it
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-
-  // Check if file already exists
   let existFilePath;
-  if (fs.existsSync(filePath)) {
-    if (step.screenshot.overwrite == "false") {
-      // File already exists
-      result.status = "SKIPPED";
-      result.description = `File already exists: ${filePath}`;
+  let dir: string;
+
+  // Detect URL paths. A URL `path` is treated as a read-only reference:
+  // we download it to a temp file for comparison, and write the new capture
+  // to a local run-specific folder (URLs can't be written back to).
+  const isUrlPath = /^https?:\/\//i.test(filePath);
+  const originalUrlPath = isUrlPath ? filePath : undefined;
+
+  if (isUrlPath) {
+    const fetched: any = await fetchFile(originalUrlPath!, { binary: true });
+    if (fetched.result !== "success") {
+      result.status = "FAIL";
+      result.description = `Couldn't fetch remote reference image (${originalUrlPath}): ${fetched.message}`;
       return result;
-    } else {
-      // Set temp file path
-      existFilePath = filePath;
-      filePath = path.join(dir, `${step.stepId}_${Date.now()}.png`);
+    }
+    existFilePath = fetched.path;
+
+    // URL-derived names can contain path separators (`/`, `\`) or `..`
+    // segments. `path.basename` on a slash-normalized string strips directory
+    // components; we also sanitize any residual traversal and prepend stepId
+    // so two URL screenshots with the same basename don't clobber each other.
+    let urlPathname: string;
+    try {
+      urlPathname = new URL(originalUrlPath!).pathname;
+    } catch {
+      urlPathname = originalUrlPath!;
+    }
+    const rawBase = path.basename(
+      urlPathname.split("?")[0].split("#")[0].replace(/\\/g, "/")
+    );
+    const safeBase =
+      !rawBase || rawBase === "." || rawBase === ".." || rawBase.includes("\0")
+        ? `${step.stepId}.png`
+        : rawBase;
+
+    dir = path.join(
+      process.cwd(),
+      "doc-detective-runs",
+      getOrInitRunTimestamp(config)
+    );
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    filePath = path.join(dir, `${step.stepId}_${safeBase}`);
+
+    // Defense in depth: the resolved capture path must stay inside `dir`.
+    const resolvedDir = path.resolve(dir);
+    const resolvedFile = path.resolve(filePath);
+    if (!resolvedFile.startsWith(resolvedDir + path.sep)) {
+      result.status = "FAIL";
+      result.description = `Refusing to write screenshot outside run folder: ${resolvedFile}`;
+      return result;
+    }
+
+    // Overwrite semantics can't apply to a URL. Force comparison-only.
+    if (step.screenshot.overwrite !== "false") {
+      log(
+        config,
+        "debug",
+        `Screenshot path is a URL (${originalUrlPath}); overwrite is ignored, running comparison only.`
+      );
+    }
+    step.screenshot.overwrite = "aboveVariation";
+  } else {
+    // Set path directory
+    dir = path.dirname(step.screenshot.path);
+    // If `dir` doesn't exist, create it
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    // Check if file already exists
+    if (fs.existsSync(filePath)) {
+      if (step.screenshot.overwrite == "false") {
+        // File already exists
+        result.status = "SKIPPED";
+        result.description = `File already exists: ${filePath}`;
+        return result;
+      } else {
+        // Set temp file path
+        existFilePath = filePath;
+        filePath = path.join(dir, `${step.stepId}_${Date.now()}.png`);
+      }
     }
   }
 
@@ -342,14 +406,37 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
 
     // Perform numerical pixel diff with pixelmatch
     if (step.screenshot.maxVariation != null) {
-      const img1 = PNG.sync.read(fs.readFileSync(existFilePath));
-      const img2 = PNG.sync.read(fs.readFileSync(filePath));
+      let img1: any;
+      let img2: any;
+      try {
+        img1 = PNG.sync.read(fs.readFileSync(existFilePath));
+        img2 = PNG.sync.read(fs.readFileSync(filePath));
+      } catch (error) {
+        result.status = "FAIL";
+        result.description = isUrlPath
+          ? `Couldn't decode PNG for comparison. The URL reference (${originalUrlPath}) may not be a valid PNG. ${error}`
+          : `Couldn't decode PNG for comparison. ${error}`;
+        if (
+          !isUrlPath &&
+          existFilePath &&
+          filePath !== existFilePath &&
+          fs.existsSync(filePath)
+        ) {
+          fs.unlinkSync(filePath);
+        }
+        return result;
+      }
 
       // Compare aspect ratio of images
       if (!aspectRatiosMatch(img1, img2)) {
         result.status = "FAIL";
         result.description = `Couldn't compare images. Images have different aspect ratios.`;
-        if (existFilePath && filePath !== existFilePath && fs.existsSync(filePath)) {
+        if (
+          !isUrlPath &&
+          existFilePath &&
+          filePath !== existFilePath &&
+          fs.existsSync(filePath)
+        ) {
           fs.unlinkSync(filePath);
         }
         return result;
@@ -401,7 +488,7 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
       });
 
       if (fractionalDiff > step.screenshot.maxVariation) {
-        if (step.screenshot.overwrite == "aboveVariation") {
+        if (step.screenshot.overwrite == "aboveVariation" && !isUrlPath) {
           // Replace old file with new file
           fs.renameSync(filePath, existFilePath);
         }
@@ -412,7 +499,10 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
           step.screenshot.maxVariation
         }).`;
         result.outputs.changed = true;
-        result.outputs.screenshotPath = existFilePath;
+        result.outputs.screenshotPath = isUrlPath ? filePath : existFilePath;
+        if (isUrlPath) {
+          result.outputs.referenceUrl = originalUrlPath;
+        }
         // Preserve sourceIntegration metadata for upload processing
         if (step.screenshot.sourceIntegration) {
           result.outputs.sourceIntegration = step.screenshot.sourceIntegration;
@@ -422,12 +512,15 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
         result.description += ` Screenshots are within maximum accepted variation: ${fractionalDiff.toFixed(
           2
         )}.`;
-        result.outputs.screenshotPath = existFilePath;
+        result.outputs.screenshotPath = isUrlPath ? filePath : existFilePath;
+        if (isUrlPath) {
+          result.outputs.referenceUrl = originalUrlPath;
+        }
         // Preserve sourceIntegration metadata
         if (step.screenshot.sourceIntegration) {
           result.outputs.sourceIntegration = step.screenshot.sourceIntegration;
         }
-        if (step.screenshot.overwrite != "true") {
+        if (step.screenshot.overwrite != "true" && !isUrlPath) {
           fs.unlinkSync(filePath);
         }
       }

--- a/src/core/tests/saveScreenshot.ts
+++ b/src/core/tests/saveScreenshot.ts
@@ -1,6 +1,11 @@
 import { validate } from "../../common/src/validate.js";
 import { findElement } from "./findElement.js";
-import { log, fetchFile, getOrInitRunTimestamp } from "../utils.js";
+import {
+  log,
+  fetchFile,
+  getOrInitRunTimestamp,
+  redactUrlForOutput,
+} from "../utils.js";
 import path from "node:path";
 import fs from "node:fs";
 import { PNG } from "pngjs";
@@ -116,12 +121,15 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
   // to a local run-specific folder (URLs can't be written back to).
   const isUrlPath = /^https?:\/\//i.test(filePath);
   const originalUrlPath = isUrlPath ? filePath : undefined;
+  // Safe form for logs/descriptions/outputs: strips query + fragment so
+  // presigned-URL signatures/tokens don't leak into the report.
+  const redactedUrl = isUrlPath ? redactUrlForOutput(filePath) : undefined;
 
   if (isUrlPath) {
     const fetched: any = await fetchFile(originalUrlPath!, { binary: true });
     if (fetched.result !== "success") {
       result.status = "FAIL";
-      result.description = `Couldn't fetch remote reference image (${originalUrlPath}): ${fetched.message}`;
+      result.description = `Couldn't fetch remote reference image (${redactedUrl}): ${fetched.message}`;
       return result;
     }
     existFilePath = fetched.path;
@@ -152,7 +160,10 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
-    filePath = path.join(dir, `${step.stepId}_${safeBase}`);
+    // Append a per-capture suffix so URL refs that share a basename (or a
+    // future code path that reuses `stepId`) can't clobber each other.
+    const captureId = `${step.stepId || "screenshot"}_${Date.now()}`;
+    filePath = path.join(dir, `${captureId}_${safeBase}`);
 
     // Defense in depth: the resolved capture path must stay inside `dir`.
     const resolvedDir = path.resolve(dir);
@@ -171,7 +182,7 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
       log(
         config,
         "debug",
-        `Screenshot path is a URL (${originalUrlPath}); overwrite is ignored, running comparison only.`
+        `Screenshot path is a URL (${redactedUrl}); overwrite is ignored, running comparison only.`
       );
     }
   } else {
@@ -419,7 +430,7 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
       } catch (error) {
         result.status = "FAIL";
         result.description = isUrlPath
-          ? `Couldn't decode PNG for comparison. The URL reference (${originalUrlPath}) may not be a valid PNG. ${error}`
+          ? `Couldn't decode PNG for comparison. The URL reference (${redactedUrl}) may not be a valid PNG. ${error}`
           : `Couldn't decode PNG for comparison. ${error}`;
         if (
           !isUrlPath &&
@@ -509,7 +520,7 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
           // drift signal lives in `result.status === "WARNING"` + the local
           // capture path + referenceUrl.
           result.outputs.screenshotPath = filePath;
-          result.outputs.referenceUrl = originalUrlPath;
+          result.outputs.referenceUrl = redactedUrl;
         } else {
           result.outputs.changed = true;
           result.outputs.screenshotPath = existFilePath;
@@ -524,7 +535,7 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
         )}.`;
         if (isUrlPath) {
           result.outputs.screenshotPath = filePath;
-          result.outputs.referenceUrl = originalUrlPath;
+          result.outputs.referenceUrl = redactedUrl;
         } else {
           result.outputs.screenshotPath = existFilePath;
           if (step.screenshot.sourceIntegration) {

--- a/src/core/tests/saveScreenshot.ts
+++ b/src/core/tests/saveScreenshot.ts
@@ -163,7 +163,10 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
       return result;
     }
 
-    // Overwrite semantics can't apply to a URL. Force comparison-only.
+    // Overwrite semantics can't apply to a URL. The comparison block below
+    // gates every mutating branch on `!isUrlPath`, so we log the user's
+    // original value and leave `step.screenshot.overwrite` untouched — the
+    // reported step object continues to reflect what they actually specified.
     if (step.screenshot.overwrite !== "false") {
       log(
         config,
@@ -171,7 +174,6 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
         `Screenshot path is a URL (${originalUrlPath}); overwrite is ignored, running comparison only.`
       );
     }
-    step.screenshot.overwrite = "aboveVariation";
   } else {
     // Set path directory
     dir = path.dirname(step.screenshot.path);
@@ -390,7 +392,10 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
   // If overwrite is true, replace old file with new file
   // If overwrite is aboveVariation, compare files and replace if variance is greater than threshold
   if (existFilePath) {
-    if (step.screenshot.overwrite == "true") {
+    // URL paths never take the "overwrite=true" fast path: existFilePath is a
+    // temp download, not a user-owned reference, and the local capture is
+    // kept in the run folder for inspection.
+    if (step.screenshot.overwrite == "true" && !isUrlPath) {
       // Replace old file with new file
       result.description += ` Overwrote existing file.`;
       fs.renameSync(filePath, existFilePath);
@@ -496,30 +501,38 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
         )}) is greater than the max accepted variation (${
           step.screenshot.maxVariation
         }).`;
-        result.outputs.changed = true;
-        result.outputs.screenshotPath = isUrlPath ? filePath : existFilePath;
         if (isUrlPath) {
+          // URL references are read-only: we can't write back to the remote.
+          // Leave `outputs.changed` at its default (false) so upload pipelines
+          // like collectChangedFiles()/Heretto don't treat this as something
+          // to push, and omit sourceIntegration for the same reason. The
+          // drift signal lives in `result.status === "WARNING"` + the local
+          // capture path + referenceUrl.
+          result.outputs.screenshotPath = filePath;
           result.outputs.referenceUrl = originalUrlPath;
-        }
-        // Preserve sourceIntegration metadata for upload processing
-        if (step.screenshot.sourceIntegration) {
-          result.outputs.sourceIntegration = step.screenshot.sourceIntegration;
+        } else {
+          result.outputs.changed = true;
+          result.outputs.screenshotPath = existFilePath;
+          if (step.screenshot.sourceIntegration) {
+            result.outputs.sourceIntegration = step.screenshot.sourceIntegration;
+          }
         }
         return result;
       } else {
         result.description += ` Screenshots are within maximum accepted variation: ${fractionalDiff.toFixed(
           2
         )}.`;
-        result.outputs.screenshotPath = isUrlPath ? filePath : existFilePath;
         if (isUrlPath) {
+          result.outputs.screenshotPath = filePath;
           result.outputs.referenceUrl = originalUrlPath;
-        }
-        // Preserve sourceIntegration metadata
-        if (step.screenshot.sourceIntegration) {
-          result.outputs.sourceIntegration = step.screenshot.sourceIntegration;
-        }
-        if (step.screenshot.overwrite != "true" && !isUrlPath) {
-          fs.unlinkSync(filePath);
+        } else {
+          result.outputs.screenshotPath = existFilePath;
+          if (step.screenshot.sourceIntegration) {
+            result.outputs.sourceIntegration = step.screenshot.sourceIntegration;
+          }
+          if (step.screenshot.overwrite != "true") {
+            fs.unlinkSync(filePath);
+          }
         }
       }
     }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -10,6 +10,7 @@ export {
   loadEnvs,
   log,
   timestamp,
+  getOrInitRunTimestamp,
   replaceEnvs,
   spawnCommand,
   inContainer,
@@ -46,28 +47,77 @@ function cleanTemp() {
   }
 }
 
-// Fetch a file from a URL and save to a temp directory
-// If the file is not JSON, return the contents as a string
-// If the file is not found, return an error
-async function fetchFile(fileURL: string) {
+// Fetch a file from a URL and save to a temp directory.
+// With `{ binary: true }`, fetches as arraybuffer and preserves raw bytes —
+// required for images and other non-text payloads. Binary fetches also apply
+// hard limits (timeout, max body size, max redirects) so a misbehaving server
+// can't stall or OOM the run.
+// Otherwise, non-JSON responses are stringified (text pass-through).
+// Returns `{ result: "error", message }` on failure.
+const FETCH_BINARY_DEFAULTS = {
+  responseType: "arraybuffer" as const,
+  timeout: 30_000,
+  maxContentLength: 50 * 1024 * 1024,
+  maxBodyLength: 50 * 1024 * 1024,
+  maxRedirects: 5,
+};
+
+// Derive a safe on-disk filename from a URL. URL-derived strings can contain
+// path separators (`/`, `\`) or traversal segments (`..`); `path.basename`
+// strips directory components, and we reject any residual traversal so a
+// crafted URL can't escape its intended directory.
+function safeFilenameFromUrl(fileURL: string, fallback: string): string {
+  let raw: string;
   try {
-    const response = await axios.get(fileURL);
-    if (typeof response.data === "object") {
-      response.data = JSON.stringify(response.data, null, 2);
+    raw = new URL(fileURL).pathname;
+  } catch {
+    raw = fileURL;
+  }
+  raw = raw.split("?")[0].split("#")[0];
+  const base = path.basename(raw.replace(/\\/g, "/"));
+  if (!base || base === "." || base === ".." || base.includes("\0")) {
+    return fallback;
+  }
+  return base;
+}
+
+async function fetchFile(
+  fileURL: string,
+  opts: { binary?: boolean } = {}
+) {
+  try {
+    const response = await axios.get(
+      fileURL,
+      opts.binary ? FETCH_BINARY_DEFAULTS : undefined
+    );
+    let data: Buffer | string;
+    if (opts.binary) {
+      data = Buffer.from(response.data);
+    } else if (typeof response.data === "object") {
+      data = JSON.stringify(response.data, null, 2);
     } else {
-      response.data = response.data.toString();
+      data = response.data.toString();
     }
-    const fileName = fileURL.split("/").pop() || "fetched_file";
-    const hash = crypto.createHash("md5").update(response.data).digest("hex");
+    const fileName = safeFilenameFromUrl(fileURL, "fetched_file");
+    const hash = crypto.createHash("md5").update(data).digest("hex");
     const ddTempDir = path.join(os.tmpdir(), "doc-detective");
     const filePath = path.join(ddTempDir, `${hash}_${fileName}`);
-    // If doc-detective temp directory doesn't exist, create it
+    // Defense in depth: ensure the resolved path is still inside ddTempDir.
+    const resolvedDir = path.resolve(ddTempDir);
+    const resolvedFile = path.resolve(filePath);
+    if (!resolvedFile.startsWith(resolvedDir + path.sep)) {
+      return {
+        result: "error",
+        message: new Error(
+          `Refusing to write outside temp dir: ${resolvedFile}`
+        ),
+      };
+    }
     if (!fs.existsSync(ddTempDir)) {
       fs.mkdirSync(ddTempDir, { recursive: true });
     }
-    // If file doesn't exist, write it
     if (!fs.existsSync(filePath)) {
-      fs.writeFileSync(filePath, response.data);
+      fs.writeFileSync(filePath, data);
     }
     return { result: "success", path: filePath };
   } catch (error) {
@@ -199,6 +249,16 @@ function timestamp() {
   ).slice(-2)}${("0" + timestamp.getMinutes()).slice(-2)}${(
     "0" + timestamp.getSeconds()
   ).slice(-2)}`;
+}
+
+// Memoize one timestamp per run on the config object so every URL-referenced
+// screenshot in a single run lands in the same folder.
+function getOrInitRunTimestamp(config: any): string {
+  if (!config) return timestamp();
+  if (!config.__runTimestamp) {
+    config.__runTimestamp = timestamp();
+  }
+  return config.__runTimestamp;
 }
 
 // Perform a native command in the current working directory.

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import crypto from "node:crypto";
+import dns from "node:dns/promises";
+import net from "node:net";
 import axios from "axios";
 import { spawn } from "node:child_process";
 
@@ -18,6 +20,8 @@ export {
   calculateFractionalDifference,
   fetchFile,
   isRelativeUrl,
+  redactUrlForOutput,
+  assertUrlHostIsPublic,
 };
 
 function isRelativeUrl(url: string) {
@@ -81,11 +85,124 @@ function safeFilenameFromUrl(fileURL: string, fallback: string): string {
   return base;
 }
 
+// Strip query string and fragment from a URL for display/logging. S3
+// pre-signed URLs carry tokens/signatures in the query; leaking them into
+// step descriptions, debug logs, or result outputs exposes credentials.
+// The full URL with query is still used for the fetch itself — only the
+// *reported* form is redacted.
+function redactUrlForOutput(value: string): string {
+  try {
+    const url = new URL(value);
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return value.split("?")[0].split("#")[0];
+  }
+}
+
+// Private/loopback/link-local IP ranges that binary URL fetches refuse to
+// reach by default. Covers IPv4 RFC1918, loopback, link-local (169.254/16),
+// carrier-grade NAT (100.64/10), and the cloud-metadata special cases
+// (169.254.169.254 is inside link-local and thus covered).
+function isPrivateOrLoopbackAddress(ip: string): boolean {
+  if (!ip) return false;
+  if (net.isIPv4(ip)) {
+    const [a, b] = ip.split(".").map(Number);
+    if (a === 10) return true;
+    if (a === 127) return true;
+    if (a === 0) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true;
+    return false;
+  }
+  if (net.isIPv6(ip)) {
+    const normalized = ip.toLowerCase();
+    if (normalized === "::1") return true;
+    if (normalized === "::") return true;
+    if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true; // unique local
+    if (normalized.startsWith("fe80:")) return true; // link-local
+    if (normalized.startsWith("::ffff:")) {
+      // IPv4-mapped: recurse on the embedded v4
+      return isPrivateOrLoopbackAddress(normalized.replace("::ffff:", ""));
+    }
+    return false;
+  }
+  return false;
+}
+
+// Reject URLs whose host resolves to a loopback/private IP, unless the
+// caller explicitly opts in (DOC_DETECTIVE_ALLOW_LOCAL_URLS=true). Tests
+// and trusted internal integrations set the env var; normal doc-spec input
+// does not, so an untrusted spec can't pivot through doc-detective to hit
+// cloud metadata or intranet services.
+//
+// Note: this is a best-effort check. DNS rebinding and TOCTOU races are
+// possible between resolution and connect; for true SSRF-grade isolation,
+// wire in an agent that validates the actual remote address at connect
+// time. This guard covers the common misuse cases.
+async function assertUrlHostIsPublic(fileURL: string): Promise<void> {
+  if (process.env.DOC_DETECTIVE_ALLOW_LOCAL_URLS === "true") return;
+  let parsed: URL;
+  try {
+    parsed = new URL(fileURL);
+  } catch {
+    throw new Error(`Invalid URL: ${redactUrlForOutput(fileURL)}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(
+      `Unsupported URL scheme (${parsed.protocol}) for ${redactUrlForOutput(
+        fileURL
+      )}`
+    );
+  }
+  const host = parsed.hostname.replace(/^\[|\]$/g, "");
+  // Direct IP literals: check immediately.
+  if (net.isIP(host)) {
+    if (isPrivateOrLoopbackAddress(host)) {
+      throw new Error(
+        `Refusing to fetch private/loopback address (${host}). Set DOC_DETECTIVE_ALLOW_LOCAL_URLS=true to allow.`
+      );
+    }
+    return;
+  }
+  // Hostnames: resolve and check every answer (A + AAAA).
+  const lower = host.toLowerCase();
+  if (lower === "localhost" || lower.endsWith(".localhost")) {
+    throw new Error(
+      `Refusing to fetch localhost (${host}). Set DOC_DETECTIVE_ALLOW_LOCAL_URLS=true to allow.`
+    );
+  }
+  let addresses: { address: string }[];
+  try {
+    addresses = await dns.lookup(host, { all: true });
+  } catch (error) {
+    throw new Error(
+      `Couldn't resolve host ${host} for SSRF check: ${(error as Error).message}`
+    );
+  }
+  for (const { address } of addresses) {
+    if (isPrivateOrLoopbackAddress(address)) {
+      throw new Error(
+        `Host ${host} resolves to a private/loopback address (${address}); refusing to fetch. Set DOC_DETECTIVE_ALLOW_LOCAL_URLS=true to allow.`
+      );
+    }
+  }
+}
+
 async function fetchFile(
   fileURL: string,
   opts: { binary?: boolean } = {}
 ) {
   try {
+    if (opts.binary) {
+      // Only gate binary fetches for now — the text path is an internal
+      // loader used by the test-detection pipeline and pre-dates this
+      // change; expanding SSRF coverage there belongs in its own PR.
+      await assertUrlHostIsPublic(fileURL);
+    }
     const response = await axios.get(
       fileURL,
       opts.binary ? FETCH_BINARY_DEFAULTS : undefined

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -22,6 +22,7 @@ export {
   isRelativeUrl,
   redactUrlForOutput,
   assertUrlHostIsPublic,
+  sanitizeFilesystemName,
 };
 
 function isRelativeUrl(url: string) {
@@ -66,10 +67,24 @@ const FETCH_BINARY_DEFAULTS = {
   maxRedirects: 5,
 };
 
+// Replace characters that are invalid in filenames on Windows (and often
+// problematic on other platforms) with `_`. Keeps dots, hyphens, and
+// alphanumerics untouched so names stay recognizable. Also rejects leading
+// dots that could turn the file into a traversal segment.
+function sanitizeFilesystemName(name: string, fallback: string): string {
+  if (!name || name === "." || name === "..") return fallback;
+  // Control chars 0x00-0x1f + Windows reserved: < > : " / \ | ? *
+  const cleaned = name.replace(/[\x00-\x1f<>:"/\\|?*]/g, "_");
+  // After replacement, guard against all-dots or empty results.
+  if (!cleaned || /^\.+$/.test(cleaned)) return fallback;
+  return cleaned;
+}
+
 // Derive a safe on-disk filename from a URL. URL-derived strings can contain
-// path separators (`/`, `\`) or traversal segments (`..`); `path.basename`
-// strips directory components, and we reject any residual traversal so a
-// crafted URL can't escape its intended directory.
+// path separators (`/`, `\`), traversal segments (`..`), or characters that
+// are invalid in filenames on Windows (`:<>"|?*`). `path.basename` strips
+// directory components; `sanitizeFilesystemName` then neutralizes remaining
+// unsafe characters so `fetchFile` works on every platform.
 function safeFilenameFromUrl(fileURL: string, fallback: string): string {
   let raw: string;
   try {
@@ -79,10 +94,7 @@ function safeFilenameFromUrl(fileURL: string, fallback: string): string {
   }
   raw = raw.split("?")[0].split("#")[0];
   const base = path.basename(raw.replace(/\\/g, "/"));
-  if (!base || base === "." || base === ".." || base.includes("\0")) {
-    return fallback;
-  }
-  return base;
+  return sanitizeFilesystemName(base, fallback);
 }
 
 // Strip query string and fragment from a URL for display/logging. S3

--- a/test/core-screenshot.test.js
+++ b/test/core-screenshot.test.js
@@ -286,11 +286,26 @@ describe("Screenshot with URL `path` (remote reference)", function () {
   const runsDir = path.resolve("./doc-detective-runs");
   const url = "http://localhost:8092/url-reference-fixture.png";
 
+  let runsDirExistedBefore = false;
+  let runsDirEntriesBefore = [];
+  const originalAllowLocalUrls = process.env.DOC_DETECTIVE_ALLOW_LOCAL_URLS;
+
   // Seed the fixture by taking a real screenshot of the test page, then copy
   // it into the static-served dir so the URL and a subsequent local capture
   // share dimensions / aspect ratio.
   before(async function () {
     this.timeout(300000);
+    // These tests drive URL fetches against http://localhost:8092, which the
+    // production SSRF guard blocks by default. Opt in for the duration of
+    // this suite and restore the prior value in `after`.
+    process.env.DOC_DETECTIVE_ALLOW_LOCAL_URLS = "true";
+    // Snapshot the current contents of doc-detective-runs so teardown only
+    // removes run folders this suite created, not pre-existing artifacts or
+    // folders created by unrelated tests or developer work.
+    runsDirExistedBefore = fs.existsSync(runsDir);
+    runsDirEntriesBefore = runsDirExistedBefore
+      ? new Set(fs.readdirSync(runsDir))
+      : new Set();
     if (!fs.existsSync(tempDir)) fs.mkdirSync(tempDir, { recursive: true });
     const seedShot = path.join(tempDir, "seed-screenshot.png");
     const seedSpecPath = path.join(tempDir, "seed-spec.json");
@@ -316,15 +331,31 @@ describe("Screenshot with URL `path` (remote reference)", function () {
   });
 
   after(function () {
+    if (originalAllowLocalUrls === undefined) {
+      delete process.env.DOC_DETECTIVE_ALLOW_LOCAL_URLS;
+    } else {
+      process.env.DOC_DETECTIVE_ALLOW_LOCAL_URLS = originalAllowLocalUrls;
+    }
     if (fs.existsSync(referenceFixture)) fs.unlinkSync(referenceFixture);
     if (fs.existsSync(notAPngFixture)) fs.unlinkSync(notAPngFixture);
     if (fs.existsSync(tempDir)) {
       for (const f of fs.readdirSync(tempDir)) fs.unlinkSync(path.join(tempDir, f));
       fs.rmdirSync(tempDir);
     }
-    // Best-effort cleanup of the run-specific folder the feature creates.
+    // Only remove run folders this suite created, not pre-existing ones.
     if (fs.existsSync(runsDir)) {
-      fs.rmSync(runsDir, { recursive: true, force: true });
+      for (const f of fs.readdirSync(runsDir)) {
+        if (!runsDirEntriesBefore.has(f)) {
+          fs.rmSync(path.join(runsDir, f), { recursive: true, force: true });
+        }
+      }
+      if (!runsDirExistedBefore) {
+        try {
+          fs.rmdirSync(runsDir);
+        } catch {
+          // Another test may have added entries; leave the dir in place.
+        }
+      }
     }
   });
 
@@ -518,6 +549,80 @@ describe("Screenshot with URL `path` (remote reference)", function () {
       );
     } finally {
       if (fs.existsSync(specPath)) fs.unlinkSync(specPath);
+    }
+  });
+
+  it("redacts query-string credentials from outputs.referenceUrl", async function () {
+    // Simulate an S3-style presigned URL; the query string carries what
+    // would be a signature in production. It must be stripped from the
+    // reported reference URL.
+    const specPath = path.join(tempDir, "url-redact-spec.json");
+    const presignedUrl =
+      url + "?X-Amz-Signature=SECRET_TOKEN&X-Amz-Expires=60";
+
+    const spec = {
+      tests: [
+        {
+          steps: [
+            { goTo: "http://localhost:8092" },
+            {
+              screenshot: {
+                path: presignedUrl,
+                maxVariation: 0.95,
+                overwrite: "aboveVariation",
+              },
+            },
+          ],
+        },
+      ],
+    };
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    try {
+      const result = await runTests({ input: specPath, logLevel: "silent" });
+      const step = result.specs[0].tests[0].contexts[0].steps[1];
+      assert.ok(
+        step.result === "PASS" || step.result === "WARNING",
+        `expected PASS or WARNING, got ${step.result}: ${step.resultDescription}`
+      );
+      assert.ok(step.outputs.referenceUrl, "referenceUrl must be set");
+      assert.ok(
+        !step.outputs.referenceUrl.includes("SECRET_TOKEN"),
+        `referenceUrl must not carry the signature token; got ${step.outputs.referenceUrl}`
+      );
+      assert.ok(
+        !step.outputs.referenceUrl.includes("?"),
+        `referenceUrl must have no query string; got ${step.outputs.referenceUrl}`
+      );
+      assert.equal(step.outputs.referenceUrl, url);
+    } finally {
+      if (fs.existsSync(specPath)) fs.unlinkSync(specPath);
+    }
+  });
+
+  it("rejects private/loopback URLs unless DOC_DETECTIVE_ALLOW_LOCAL_URLS is set", async function () {
+    // Temporarily un-opt-in so the default SSRF guard fires.
+    const saved = process.env.DOC_DETECTIVE_ALLOW_LOCAL_URLS;
+    delete process.env.DOC_DETECTIVE_ALLOW_LOCAL_URLS;
+    const specPath = path.join(tempDir, "url-ssrf-spec.json");
+    const spec = {
+      tests: [
+        {
+          steps: [
+            { goTo: "http://localhost:8092" },
+            { screenshot: { path: url, maxVariation: 0.05 } },
+          ],
+        },
+      ],
+    };
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    try {
+      const result = await runTests({ input: specPath, logLevel: "silent" });
+      const step = result.specs[0].tests[0].contexts[0].steps[1];
+      assert.equal(step.result, "FAIL");
+      assert.match(step.resultDescription, /Couldn't fetch remote reference image/);
+    } finally {
+      if (fs.existsSync(specPath)) fs.unlinkSync(specPath);
+      process.env.DOC_DETECTIVE_ALLOW_LOCAL_URLS = saved;
     }
   });
 

--- a/test/core-screenshot.test.js
+++ b/test/core-screenshot.test.js
@@ -371,11 +371,100 @@ describe("Screenshot with URL `path` (remote reference)", function () {
         fs.existsSync(step.outputs.screenshotPath),
         "new capture should exist on disk for inspection"
       );
+      // URL references are read-only references, not files we can upload
+      // back to. `outputs.changed` must stay false so upload pipelines
+      // (collectChangedFiles, Heretto, etc.) don't try to push anywhere.
+      assert.equal(
+        step.outputs.changed,
+        false,
+        "outputs.changed must be false for URL references to prevent upload flows"
+      );
       // Remote fixture must not have been overwritten.
       assert.equal(
         fs.statSync(referenceFixture).mtimeMs,
         mtimeBefore,
         "served reference file should be untouched"
+      );
+    } finally {
+      if (fs.existsSync(specPath)) fs.unlinkSync(specPath);
+    }
+  });
+
+  it("does not leak sourceIntegration onto outputs for URL paths", async function () {
+    // URL references can't be written back to; if the user (or the resolver)
+    // attaches a sourceIntegration whose filePath is URL-derived, passing it
+    // through would cause downstream uploaders (e.g. Heretto's posix path
+    // normalization) to misbehave. Omit it entirely.
+    const specPath = path.join(tempDir, "url-sourceintegration-spec.json");
+    const spec = {
+      tests: [
+        {
+          steps: [
+            { goTo: "http://localhost:8092" },
+            {
+              screenshot: {
+                path: url,
+                maxVariation: 0.95,
+                overwrite: "aboveVariation",
+                sourceIntegration: {
+                  type: "heretto",
+                  integrationName: "url-test",
+                  filePath: url,
+                  contentPath: "/content/url-topic.dita",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    try {
+      const result = await runTests({ input: specPath, logLevel: "silent" });
+      const step = result.specs[0].tests[0].contexts[0].steps[1];
+      assert.ok(
+        step.result === "PASS" || step.result === "WARNING",
+        `expected PASS or WARNING, got ${step.result}: ${step.resultDescription}`
+      );
+      assert.equal(
+        step.outputs.sourceIntegration,
+        undefined,
+        "sourceIntegration must not be set on outputs for URL paths"
+      );
+      assert.equal(step.outputs.changed, false);
+    } finally {
+      if (fs.existsSync(specPath)) fs.unlinkSync(specPath);
+    }
+  });
+
+  it("leaves `step.screenshot.overwrite` unchanged in the reported spec (no mutation)", async function () {
+    // If the user wrote overwrite: "true", the report should show that value
+    // regardless of how we internally chose to treat URL paths.
+    const specPath = path.join(tempDir, "url-no-mutate-spec.json");
+    const spec = {
+      tests: [
+        {
+          steps: [
+            { goTo: "http://localhost:8092" },
+            {
+              screenshot: {
+                path: url,
+                maxVariation: 0.95,
+                overwrite: "true",
+              },
+            },
+          ],
+        },
+      ],
+    };
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    try {
+      const result = await runTests({ input: specPath, logLevel: "silent" });
+      const step = result.specs[0].tests[0].contexts[0].steps[1];
+      assert.equal(
+        step.screenshot.overwrite,
+        "true",
+        "step.screenshot.overwrite must reflect what the user wrote, not be mutated to aboveVariation"
       );
     } finally {
       if (fs.existsSync(specPath)) fs.unlinkSync(specPath);

--- a/test/core-screenshot.test.js
+++ b/test/core-screenshot.test.js
@@ -275,3 +275,260 @@ describe("Screenshot sourceIntegration preservation", function () {
     }
   });
 });
+
+describe("Screenshot with URL `path` (remote reference)", function () {
+  this.timeout(300000);
+
+  const tempDir = path.resolve("./test/temp-screenshot-url-tests");
+  const publicDir = path.resolve("./test/server/public");
+  const referenceFixture = path.join(publicDir, "url-reference-fixture.png");
+  const notAPngFixture = path.join(publicDir, "not-a-real.png");
+  const runsDir = path.resolve("./doc-detective-runs");
+  const url = "http://localhost:8092/url-reference-fixture.png";
+
+  // Seed the fixture by taking a real screenshot of the test page, then copy
+  // it into the static-served dir so the URL and a subsequent local capture
+  // share dimensions / aspect ratio.
+  before(async function () {
+    this.timeout(300000);
+    if (!fs.existsSync(tempDir)) fs.mkdirSync(tempDir, { recursive: true });
+    const seedShot = path.join(tempDir, "seed-screenshot.png");
+    const seedSpecPath = path.join(tempDir, "seed-spec.json");
+    fs.writeFileSync(
+      seedSpecPath,
+      JSON.stringify({
+        tests: [
+          {
+            steps: [
+              { goTo: "http://localhost:8092" },
+              { screenshot: { path: seedShot, overwrite: "true" } },
+            ],
+          },
+        ],
+      })
+    );
+    await runTests({ input: seedSpecPath, logLevel: "silent" });
+    assert.ok(fs.existsSync(seedShot), "seed screenshot must have been captured");
+    fs.copyFileSync(seedShot, referenceFixture);
+    // A fixture served under a .png URL but whose bytes are clearly not a PNG,
+    // used to verify PNG.sync.read failures turn into a clean step FAIL.
+    fs.writeFileSync(notAPngFixture, "<!DOCTYPE html><p>not a png</p>");
+  });
+
+  after(function () {
+    if (fs.existsSync(referenceFixture)) fs.unlinkSync(referenceFixture);
+    if (fs.existsSync(notAPngFixture)) fs.unlinkSync(notAPngFixture);
+    if (fs.existsSync(tempDir)) {
+      for (const f of fs.readdirSync(tempDir)) fs.unlinkSync(path.join(tempDir, f));
+      fs.rmdirSync(tempDir);
+    }
+    // Best-effort cleanup of the run-specific folder the feature creates.
+    if (fs.existsSync(runsDir)) {
+      fs.rmSync(runsDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fetches the URL reference, writes the new capture to a run-specific local folder, and leaves the remote fixture on disk untouched", async function () {
+    const specPath = path.join(tempDir, "url-spec.json");
+    const mtimeBefore = fs.statSync(referenceFixture).mtimeMs;
+
+    const spec = {
+      tests: [
+        {
+          steps: [
+            { goTo: "http://localhost:8092" },
+            {
+              screenshot: {
+                path: url,
+                maxVariation: 0.95,
+                overwrite: "aboveVariation",
+              },
+            },
+          ],
+        },
+      ],
+    };
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+
+    try {
+      const result = await runTests({ input: specPath, logLevel: "silent" });
+      const step = result.specs[0].tests[0].contexts[0].steps[1];
+
+      // The step may PASS (within tolerance) or WARNING (exceeded tolerance)
+      // depending on page rendering — but it must NEVER FAIL on this path,
+      // and the output must point at the local run folder, not the URL.
+      assert.ok(
+        step.result === "PASS" || step.result === "WARNING",
+        `expected PASS or WARNING, got ${step.result}: ${step.resultDescription}`
+      );
+      assert.equal(step.outputs.referenceUrl, url);
+      assert.ok(
+        step.outputs.screenshotPath &&
+          step.outputs.screenshotPath.includes("doc-detective-runs"),
+        `screenshotPath should live under doc-detective-runs/, got ${step.outputs.screenshotPath}`
+      );
+      assert.ok(
+        fs.existsSync(step.outputs.screenshotPath),
+        "new capture should exist on disk for inspection"
+      );
+      // Remote fixture must not have been overwritten.
+      assert.equal(
+        fs.statSync(referenceFixture).mtimeMs,
+        mtimeBefore,
+        "served reference file should be untouched"
+      );
+    } finally {
+      if (fs.existsSync(specPath)) fs.unlinkSync(specPath);
+    }
+  });
+
+  it("ignores overwrite=true for URL paths (never writes back to the remote reference)", async function () {
+    const specPath = path.join(tempDir, "url-overwrite-spec.json");
+    const bytesBefore = fs.readFileSync(referenceFixture);
+
+    const spec = {
+      tests: [
+        {
+          steps: [
+            { goTo: "http://localhost:8092" },
+            {
+              screenshot: {
+                path: url,
+                maxVariation: 0.95,
+                overwrite: "true", // would normally replace the reference
+              },
+            },
+          ],
+        },
+      ],
+    };
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+
+    try {
+      const result = await runTests({ input: specPath, logLevel: "silent" });
+      const step = result.specs[0].tests[0].contexts[0].steps[1];
+
+      // Strong assertions — without these, a regression that FAILs the step
+      // before the overwrite branch would still leave the bytes untouched
+      // and silently "pass" this test.
+      assert.ok(
+        step.result === "PASS" || step.result === "WARNING",
+        `expected PASS or WARNING, got ${step.result}: ${step.resultDescription}`
+      );
+      assert.equal(step.outputs.referenceUrl, url);
+      assert.ok(
+        step.outputs.screenshotPath &&
+          step.outputs.screenshotPath.includes("doc-detective-runs"),
+        `screenshotPath should live under doc-detective-runs/, got ${step.outputs.screenshotPath}`
+      );
+
+      const bytesAfter = fs.readFileSync(referenceFixture);
+      assert.ok(
+        bytesBefore.equals(bytesAfter),
+        "overwrite=true with URL path must not mutate the remote reference file"
+      );
+    } finally {
+      if (fs.existsSync(specPath)) fs.unlinkSync(specPath);
+    }
+  });
+
+  it("FAILs gracefully when the URL body is not a valid PNG", async function () {
+    const specPath = path.join(tempDir, "url-notpng-spec.json");
+    const notPngUrl = "http://localhost:8092/not-a-real.png";
+
+    const spec = {
+      tests: [
+        {
+          steps: [
+            { goTo: "http://localhost:8092" },
+            { screenshot: { path: notPngUrl, maxVariation: 0.05 } },
+          ],
+        },
+      ],
+    };
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+
+    try {
+      const result = await runTests({ input: specPath, logLevel: "silent" });
+      const step = result.specs[0].tests[0].contexts[0].steps[1];
+      assert.equal(step.result, "FAIL");
+      assert.match(step.resultDescription, /Couldn't decode PNG/);
+    } finally {
+      if (fs.existsSync(specPath)) fs.unlinkSync(specPath);
+    }
+  });
+
+  it("contains the new capture inside the run folder even when the URL path tries to traverse out", async function () {
+    const specPath = path.join(tempDir, "url-traversal-spec.json");
+    // URL-encoded `..%2f` decodes to `../` after URL.pathname → a raw
+    // `split("/").pop()` would surface it; our sanitization must neutralize it.
+    const traversalUrl =
+      "http://localhost:8092/foo/..%2Furl-reference-fixture.png";
+
+    const spec = {
+      tests: [
+        {
+          steps: [
+            { goTo: "http://localhost:8092" },
+            {
+              screenshot: {
+                path: traversalUrl,
+                maxVariation: 0.95,
+                overwrite: "aboveVariation",
+              },
+            },
+          ],
+        },
+      ],
+    };
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+
+    try {
+      const result = await runTests({ input: specPath, logLevel: "silent" });
+      const step = result.specs[0].tests[0].contexts[0].steps[1];
+
+      if (step.result === "FAIL") {
+        // Acceptable: sanitization rejected the traversal outright.
+        return;
+      }
+      assert.ok(
+        step.outputs.screenshotPath,
+        "screenshotPath should be set on non-FAIL outcomes"
+      );
+      const resolvedOut = path.resolve(step.outputs.screenshotPath);
+      const resolvedRunsDir = path.resolve(runsDir);
+      assert.ok(
+        resolvedOut.startsWith(resolvedRunsDir + path.sep),
+        `screenshot must live under ${resolvedRunsDir}; got ${resolvedOut}`
+      );
+    } finally {
+      if (fs.existsSync(specPath)) fs.unlinkSync(specPath);
+    }
+  });
+
+  it("FAILs the step with a clear message when the URL can't be fetched", async function () {
+    const specPath = path.join(tempDir, "url-404-spec.json");
+    const missingUrl = "http://localhost:8092/does-not-exist.png";
+
+    const spec = {
+      tests: [
+        {
+          steps: [
+            { goTo: "http://localhost:8092" },
+            { screenshot: { path: missingUrl, maxVariation: 0.05 } },
+          ],
+        },
+      ],
+    };
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+
+    try {
+      const result = await runTests({ input: specPath, logLevel: "silent" });
+      const step = result.specs[0].tests[0].contexts[0].steps[1];
+      assert.equal(step.result, "FAIL");
+      assert.match(step.resultDescription, /Couldn't fetch remote reference image/);
+    } finally {
+      if (fs.existsSync(specPath)) fs.unlinkSync(specPath);
+    }
+  });
+});

--- a/test/fetchFile-binary.test.js
+++ b/test/fetchFile-binary.test.js
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import sinon from "sinon";
+import axios from "axios";
+
+describe("fetchFile binary mode", function () {
+  let fetchFile;
+
+  before(async function () {
+    ({ fetchFile } = await import("../dist/core/utils.js"));
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("writes PNG bytes verbatim when { binary: true }", async function () {
+    // Arbitrary bytes including a 0x00 so we prove .toString() would corrupt them.
+    const bytes = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      0x00, 0x00, 0x00, 0x0d, 0xff, 0xfe, 0xfd, 0xfc,
+    ]);
+    sinon.stub(axios, "get").resolves({ data: bytes });
+
+    const result = await fetchFile(
+      "https://example.com/image.png",
+      { binary: true }
+    );
+
+    assert.equal(result.result, "success");
+    const onDisk = fs.readFileSync(result.path);
+    assert.ok(bytes.equals(onDisk), "on-disk bytes must match the source buffer");
+
+    // Cache key is content-addressed by md5 of the raw bytes.
+    const expectedHash = crypto.createHash("md5").update(bytes).digest("hex");
+    assert.ok(
+      result.path.includes(expectedHash),
+      `temp path should embed md5(${expectedHash}), got ${result.path}`
+    );
+  });
+
+  it("passes responseType: arraybuffer to axios when { binary: true }", async function () {
+    const bytes = Buffer.from([0x01, 0x02, 0x03]);
+    const stub = sinon.stub(axios, "get").resolves({ data: bytes });
+
+    await fetchFile("https://example.com/x.png", { binary: true });
+
+    assert.equal(stub.callCount, 1);
+    assert.equal(stub.firstCall.args[1].responseType, "arraybuffer");
+  });
+
+  it("strips query string from the temp file name", async function () {
+    const bytes = Buffer.from([0x42]);
+    sinon.stub(axios, "get").resolves({ data: bytes });
+
+    const result = await fetchFile(
+      "https://bucket.s3.example.com/path/to/img.png?X-Amz-Signature=abc123",
+      { binary: true }
+    );
+
+    assert.equal(result.result, "success");
+    assert.ok(
+      result.path.endsWith("img.png"),
+      `temp path should end with img.png (no query string), got ${result.path}`
+    );
+    assert.ok(!result.path.includes("?"), "temp path must not contain '?'");
+  });
+
+  it("still works as a text fetcher without the binary flag (no regression)", async function () {
+    sinon.stub(axios, "get").resolves({ data: "plain text body" });
+
+    const result = await fetchFile("https://example.com/notes.txt");
+    assert.equal(result.result, "success");
+    assert.equal(fs.readFileSync(result.path, "utf8"), "plain text body");
+  });
+
+  it("returns an error envelope when the fetch throws", async function () {
+    sinon.stub(axios, "get").rejects(new Error("boom"));
+
+    const result = await fetchFile("https://example.com/x.png", { binary: true });
+    assert.equal(result.result, "error");
+    assert.ok(result.message);
+  });
+
+  it("applies hard timeout + size limits on the axios call when binary", async function () {
+    const stub = sinon.stub(axios, "get").resolves({ data: Buffer.from([0x01]) });
+    await fetchFile("https://example.com/x.png", { binary: true });
+    const opts = stub.firstCall.args[1];
+    assert.ok(opts.timeout > 0, "timeout must be set");
+    assert.ok(opts.maxContentLength > 0, "maxContentLength must be set");
+    assert.ok(opts.maxBodyLength > 0, "maxBodyLength must be set");
+    assert.ok(
+      typeof opts.maxRedirects === "number",
+      "maxRedirects must be set"
+    );
+  });
+
+  it("neutralizes path-traversal segments in URL-derived filenames", async function () {
+    const bytes = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+    sinon.stub(axios, "get").resolves({ data: bytes });
+
+    const result = await fetchFile(
+      "https://evil.example.com/foo/..%2Fpwn.png",
+      { binary: true }
+    );
+    assert.equal(result.result, "success");
+    // The on-disk filename must not escape the doc-detective temp dir.
+    const os = await import("node:os");
+    const expectedPrefix = path.resolve(
+      path.join(os.default.tmpdir(), "doc-detective")
+    );
+    assert.ok(
+      path.resolve(result.path).startsWith(expectedPrefix + path.sep),
+      `path must stay inside ${expectedPrefix}, got ${result.path}`
+    );
+    // And must not contain a raw separator after the hash_ prefix.
+    const base = path.basename(result.path);
+    assert.ok(
+      !base.includes("/") && !base.includes("\\"),
+      `sanitized basename must not contain separators, got ${base}`
+    );
+  });
+});

--- a/test/fetchFile-binary.test.js
+++ b/test/fetchFile-binary.test.js
@@ -112,6 +112,31 @@ describe("fetchFile binary mode", function () {
     );
   });
 
+  it("replaces Windows-invalid filename characters in URL-derived names", async function () {
+    const bytes = Buffer.from([0x01]);
+    sinon.stub(axios, "get").resolves({ data: bytes });
+    // URL path segment containing `:` — legal in URLs, invalid in Windows
+    // filenames. The on-disk name must not contain any of `<>:"/\|?*` or
+    // control chars after sanitization.
+    const result = await fetchFile(
+      "https://example.com/artwork/render:v2.png",
+      { binary: true }
+    );
+    assert.equal(result.result, "success");
+    const base = path.basename(result.path);
+    const invalidChars = /[\x00-\x1f<>:"|?*]/;
+    assert.ok(
+      !invalidChars.test(base),
+      `on-disk basename must not contain Windows-invalid chars, got ${base}`
+    );
+    assert.ok(
+      base.endsWith("render_v2.png") ||
+        base.endsWith("render_v2_png") ||
+        /render_v2\.png$/.test(base),
+      `expected sanitized suffix like render_v2.png, got ${base}`
+    );
+  });
+
   it("neutralizes path-traversal segments in URL-derived filenames", async function () {
     const bytes = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
     sinon.stub(axios, "get").resolves({ data: bytes });

--- a/test/fetchFile-binary.test.js
+++ b/test/fetchFile-binary.test.js
@@ -7,9 +7,24 @@ import axios from "axios";
 
 describe("fetchFile binary mode", function () {
   let fetchFile;
+  const savedAllowLocal = process.env.DOC_DETECTIVE_ALLOW_LOCAL_URLS;
 
   before(async function () {
+    // These tests stub axios at the module level; we don't want the real
+    // DNS resolution path in assertUrlHostIsPublic to run for every test
+    // (and flake on CI without network). Opt into the local-URL bypass so
+    // the SSRF gate is a no-op; it's covered separately in the integration
+    // suite against an actual localhost server.
+    process.env.DOC_DETECTIVE_ALLOW_LOCAL_URLS = "true";
     ({ fetchFile } = await import("../dist/core/utils.js"));
+  });
+
+  after(function () {
+    if (savedAllowLocal === undefined) {
+      delete process.env.DOC_DETECTIVE_ALLOW_LOCAL_URLS;
+    } else {
+      process.env.DOC_DETECTIVE_ALLOW_LOCAL_URLS = savedAllowLocal;
+    }
   });
 
   afterEach(function () {


### PR DESCRIPTION
## Summary

Closes [#198](https://github.com/doc-detective/doc-detective/issues/198). The `screenshot` step's `path` now accepts `http(s)://…png` URLs as a **read-only reference image** for pixel comparison:

- The URL is downloaded once per run and used as the reference in the existing pixelmatch/`aspectRatiosMatch`/`sharp` comparison pipeline (no change to the comparison itself).
- The freshly captured screenshot is written to `./doc-detective-runs/<run-timestamp>/<stepId>_<basename>.png` so users can inspect or manually upload the drifted image.
- `overwrite` semantics are ignored for URL paths — remote storage is never mutated. The step reports `PASS` when within `maxVariation` and `WARNING` when it exceeds.
- `outputs.referenceUrl` is added to the step result for traceability.

## What changed

- **`src/common/src/schemas/src_schemas/screenshot_v3.schema.json`** — `path` pattern expanded to accept anchored `^https?://…\.(png|PNG)(\?.*)?$`; two URL examples added; schemas rebuilt.
- **`src/core/utils.ts`** — `fetchFile(url, { binary: true })` now uses `responseType: arraybuffer` and preserves raw bytes (the prior text path silently corrupted PNGs via `.toString()`), with hard limits on timeout (30s), body size (50MB), and redirects (5). New `safeFilenameFromUrl()` helper + `getOrInitRunTimestamp(config)` helper (one folder per run).
- **`src/core/tests/saveScreenshot.ts`** — new URL branch before the local-exists block; `PNG.sync.read` wrapped in try/catch so non-PNG bodies produce a clean step `FAIL`; the two `fs.renameSync`/`fs.unlinkSync` call sites in the comparison block are guarded by `!isUrlPath` so nothing tries to write back to the temp reference or delete the user-visible local capture.
- **`test/core-screenshot.test.js`** — 5 new integration tests covering the happy path, `overwrite=true` → compare-only, non-PNG body → clean FAIL, URL-encoded `..%2F` traversal → capture stays inside the run folder, and 404 → FAIL with a clear message.
- **`test/fetchFile-binary.test.js`** — 7 sinon-stubbed unit tests covering byte-exact round-trip, `arraybuffer` response type, axios limits, query-string stripping, text-mode non-regression, error envelope, and path-traversal sanitization.

## Security hardening (post-review)

An adversarial code review (Copilot gpt-5.2) surfaced path-traversal risk in the URL-derived filename handling — a crafted URL such as `https://…/foo/..%2Fpwn.png` could have escaped `doc-detective-runs/` on Windows. The PR includes:

- `new URL(url).pathname` + `path.basename()` sanitization (rejects `..`, `.`, null bytes).
- Defense-in-depth `path.resolve(...).startsWith(dirWithSep)` containment checks in both `fetchFile` and the URL branch of `saveScreenshot`.
- Collision-proof output filenames by prepending `stepId_` to the basename.
- Axios `timeout` / `maxContentLength` / `maxBodyLength` / `maxRedirects` limits on binary fetches to cap DoS exposure.

## What reviewers should know

- The URL branch is fully gated by `isUrlPath` — local-path behavior is unchanged. All 4 pre-existing `sourceIntegration` tests still pass.
- The existing schema pattern for local paths was not tightened; that's pre-existing behavior (`"static/images/image.png"` must still validate).
- Not addressed in this PR: localhost / private-IP SSRF denylist. It would break the test suite (which relies on `http://localhost:8092`) and is best handled as a separately config-gated hardening pass.
- `fetchFile`'s temp cache is still content-addressed (md5 of body); URL-keyed caching is a pre-existing design choice.

## Test plan

- [x] `npm run build:common` — 575 schema/validation tests green (includes new URL schema examples).
- [x] `npm run compile` — TypeScript clean.
- [x] `npx mocha --exit test/core-screenshot.test.js` — 9/9 (4 pre-existing + 5 new URL tests).
- [x] `npx mocha --exit test/fetchFile-binary.test.js test/saveScreenshot.test.js` — 18/18.
- [ ] Manual smoke test against a real S3-hosted PNG per the issue's example markdown — recommended for reviewers with access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Screenshot paths now accept HTTP(S) URLs pointing to PNG images as read-only references for comparison.
  * Newly captured screenshots are automatically saved to local run-specific folders instead of being uploaded to remote URLs.

* **Improvements**
  * Enhanced error handling for PNG decoding failures and unreachable remote images.
  * Added path safety validations to ensure screenshots remain within designated directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->