### PR TITLE
fix(security): drop shell:true default in spawnCommand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "appium-geckodriver": "^2.2.0",
         "appium-safari-driver": "^4.1.9",
         "axios": "^1.13.6",
+        "cross-spawn": "^7.0.6",
         "dotenv": "^17.3.1",
         "fast-xml-parser": "^5.3.3",
         "geckodriver": "^6.1.0",
@@ -46,6 +47,7 @@
       },
       "devDependencies": {
         "@types/adm-zip": "^0.5.8",
+        "@types/cross-spawn": "^6.0.6",
         "@types/node": "^25.5.0",
         "@types/yargs": "^17.0.35",
         "body-parser": "^2.2.2",
@@ -2388,6 +2390,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2399,7 +2411,8 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/lodash": {
       "version": "4.17.24",
@@ -2766,6 +2779,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7828,6 +7842,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -16353,6 +16368,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "appium-geckodriver": "^2.2.0",
     "appium-safari-driver": "^4.1.9",
     "axios": "^1.13.6",
+    "cross-spawn": "^7.0.6",
     "dotenv": "^17.3.1",
     "fast-xml-parser": "^5.3.3",
     "geckodriver": "^6.1.0",
@@ -132,6 +133,7 @@
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.8",
+    "@types/cross-spawn": "^6.0.6",
     "@types/node": "^25.5.0",
     "@types/yargs": "^17.0.35",
     "body-parser": "^2.2.2",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -602,7 +602,11 @@ async function getAvailableApps({ config }: any) {
     const installedBrowsers = await browsers.getInstalledBrowsers({
       cacheDir: path.resolve("browser-snapshots"),
     });
-    const installedAppiumDrivers = await spawnCommand("npx appium driver list");
+    const installedAppiumDrivers = await spawnCommand("npx", [
+      "appium",
+      "driver",
+      "list",
+    ]);
 
     // Note: Edge/Microsoft Edge detection is intentionally excluded
     // Only Chrome, Firefox, and Safari are supported browsers
@@ -646,9 +650,11 @@ async function getAvailableApps({ config }: any) {
 
     // Detect Safari
     if (config.environment.platform === "mac") {
-      const safariVersion = await spawnCommand(
-        "defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString"
-      );
+      const safariVersion = await spawnCommand("defaults", [
+        "read",
+        "/Applications/Safari.app/Contents/Info.plist",
+        "CFBundleShortVersionString",
+      ]);
       const appiumSafari = installedAppiumDrivers.stderr.match(
         /\n.*safari.*installed \(npm\).*\n/
       );

--- a/src/core/tests/runShell.ts
+++ b/src/core/tests/runShell.ts
@@ -48,9 +48,12 @@ async function runShell({ config, step }: { config: any; step: any }) {
     timeout: step.runShell.timeout || 60000,
   };
 
-  // Execute command
+  // Execute command. runShell is the explicit user-facing shell-execution
+  // step type, so opt in to `shell: true` here. The command + args are
+  // authored by the test author as part of writing the test spec; the
+  // trust boundary is at the spec author, not at runShell.
   const timeout = step.runShell.timeout;
-  const options: any = {};
+  const options: any = { shell: true };
   if (step.runShell.workingDirectory)
     options.cwd = step.runShell.workingDirectory;
   const commandPromise = spawnCommand(

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 import axios from "axios";
 import { spawn } from "node:child_process";
+import crossSpawn from "cross-spawn";
 
 export {
   outputResults,
@@ -203,27 +204,41 @@ function timestamp() {
 
 // Perform a native command in the current working directory.
 /**
- * Executes a command in a child process using the `spawn` function from the `child_process` module.
+ * Executes a command in a child process.
+ *
+ * Defaults to `shell: false` to avoid command-injection risk: callers must
+ * pass `cmd` as the executable name and `args` as a separate array.
+ * `cross-spawn` handles Windows .cmd/.bat shim resolution so callers don't
+ * need to enable a shell just to launch `npx`/`npm` etc.
+ *
+ * Pass `options.shell: true` to opt in to a shell (e.g. for `runShell`,
+ * which intentionally executes user-authored shell commands).
+ *
  * @param {string} cmd - The command to execute.
  * @param {string[]} args - The arguments to pass to the command.
  * @param {object} options - The options for the command execution.
- * @param {boolean} options.workingDirectory - Directory in which to execute the command.
+ * @param {string} options.cwd - Directory in which to execute the command.
+ * @param {boolean} options.shell - If true, run via shell. Default: false.
  * @param {boolean} options.debug - Whether to enable debug mode.
  * @returns {Promise<object>} A promise that resolves to an object containing the stdout, stderr, and exit code of the command.
  */
 async function spawnCommand(cmd: string, args: string[] = [], options: any = {}) {
-  // Set spawnOptions based on OS
+  const useShell = options.shell === true;
   const spawnOptions: any = {
-    shell: true,
+    shell: useShell,
+    windowsHide: process.platform === "win32",
   };
-  if (process.platform === "win32") {
-    spawnOptions.windowsHide = true;
-  }
   if (options.cwd) {
     spawnOptions.cwd = options.cwd;
   }
 
-  const runCommand = spawn(cmd, args, spawnOptions);
+  // Use cross-spawn when not using a shell so Windows .cmd/.bat shims
+  // (npx, npm, etc.) resolve correctly without shell interpretation.
+  // When the caller explicitly opts into a shell, fall back to node's
+  // built-in spawn since the shell itself handles resolution.
+  const runCommand = useShell
+    ? spawn(cmd, args, spawnOptions)
+    : crossSpawn(cmd, args, spawnOptions);
   runCommand.on("error", (error) => {});
 
   // Set up exit code promise BEFORE consuming streams to avoid race condition
@@ -231,17 +246,21 @@ async function spawnCommand(cmd: string, args: string[] = [], options: any = {})
     runCommand.on("close", resolve);
   });
 
-  // Capture stdout and stderr concurrently to avoid deadlock
+  // Capture stdout and stderr concurrently to avoid deadlock.
+  // The streams are non-null because we don't pass stdio: "ignore".
+  // (cross-spawn's return type is wider than node's spawn so TS needs a hint.)
+  const childStdout = runCommand.stdout!;
+  const childStderr = runCommand.stderr!;
   let stdout = "";
   let stderr = "";
   const stdoutPromise = (async () => {
-    for await (const chunk of runCommand.stdout) {
+    for await (const chunk of childStdout) {
       stdout += chunk;
       if (options.debug) console.log(chunk.toString());
     }
   })();
   const stderrPromise = (async () => {
-    for await (const chunk of runCommand.stderr) {
+    for await (const chunk of childStderr) {
       stderr += chunk;
       if (options.debug) console.log(chunk.toString());
     }
@@ -260,9 +279,14 @@ async function spawnCommand(cmd: string, args: string[] = [], options: any = {})
 async function inContainer() {
   if (process.env.IN_CONTAINER === "true") return true;
   if (process.platform === "linux") {
-    const result = await spawnCommand(
-      `grep -sq "docker\|lxc\|kubepods" /proc/1/cgroup`
-    );
+    // -E enables ERE so `|` is alternation. The previous template-literal
+    // form (`"docker\|lxc\|kubepods"`) silently lost the backslashes in JS,
+    // so `grep` was searching for the literal pipe char and never matched.
+    const result = await spawnCommand("grep", [
+      "-sqE",
+      "docker|lxc|kubepods",
+      "/proc/1/cgroup",
+    ]);
     if (result.exitCode === 0) return true;
   }
   return false;

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -236,35 +236,54 @@ async function spawnCommand(cmd: string, args: string[] = [], options: any = {})
   // (npx, npm, etc.) resolve correctly without shell interpretation.
   // When the caller explicitly opts into a shell, fall back to node's
   // built-in spawn since the shell itself handles resolution.
+  //
+  // CodeQL `js/command-line-injection`: the shell-true branch is the
+  // explicit user-facing shell-execution sink (used by `runShell`); the
+  // trust boundary is at the spec author. The shell-false branch passes
+  // `cmd` and `args` directly to the OS without any shell interpretation,
+  // so each `args[i]` is a literal argv entry — no metacharacter expansion.
   const runCommand = useShell
     ? spawn(cmd, args, spawnOptions)
     : crossSpawn(cmd, args, spawnOptions);
-  runCommand.on("error", (error) => {});
 
-  // Set up exit code promise BEFORE consuming streams to avoid race condition
-  const exitCodePromise = new Promise((resolve) => {
-    runCommand.on("close", resolve);
+  // Track spawn errors (e.g. ENOENT when cmd isn't on PATH) so we can
+  // surface them in stderr instead of crashing or hanging.
+  let spawnError: NodeJS.ErrnoException | null = null;
+  runCommand.on("error", (err: NodeJS.ErrnoException) => {
+    spawnError = err;
   });
 
-  // Capture stdout and stderr concurrently to avoid deadlock.
-  // The streams are non-null because we don't pass stdio: "ignore".
-  // (cross-spawn's return type is wider than node's spawn so TS needs a hint.)
-  const childStdout = runCommand.stdout!;
-  const childStderr = runCommand.stderr!;
+  // Resolve the exit-code promise on either `close` (normal exit) or
+  // `error` (spawn never actually started). With `shell: false` the
+  // `error` event is much more likely (missing executable surfaces as
+  // ENOENT) and may fire without a subsequent `close`, so we must not
+  // wait on `close` alone.
+  const exitCodePromise = new Promise<number | null>((resolve) => {
+    runCommand.on("close", (code) => resolve(code));
+    runCommand.on("error", () => resolve(null));
+  });
+
+  // Capture stdout and stderr concurrently to avoid deadlock. When spawn
+  // fails before the child is created, these streams can be null —
+  // iterating them would TypeError.
   let stdout = "";
   let stderr = "";
-  const stdoutPromise = (async () => {
-    for await (const chunk of childStdout) {
-      stdout += chunk;
-      if (options.debug) console.log(chunk.toString());
-    }
-  })();
-  const stderrPromise = (async () => {
-    for await (const chunk of childStderr) {
-      stderr += chunk;
-      if (options.debug) console.log(chunk.toString());
-    }
-  })();
+  const stdoutPromise = runCommand.stdout
+    ? (async () => {
+        for await (const chunk of runCommand.stdout!) {
+          stdout += chunk;
+          if (options.debug) console.log(chunk.toString());
+        }
+      })()
+    : Promise.resolve();
+  const stderrPromise = runCommand.stderr
+    ? (async () => {
+        for await (const chunk of runCommand.stderr!) {
+          stderr += chunk;
+          if (options.debug) console.log(chunk.toString());
+        }
+      })()
+    : Promise.resolve();
   await Promise.all([stdoutPromise, stderrPromise]);
   // Remove trailing newlines
   stdout = stdout.replace(/\n$/, "");
@@ -272,6 +291,13 @@ async function spawnCommand(cmd: string, args: string[] = [], options: any = {})
 
   // Capture exit code
   const exitCode = await exitCodePromise;
+
+  // If spawn itself failed (ENOENT, EACCES, ...), surface the error
+  // message in stderr so callers (DITA detection, runCode, runShell)
+  // can detect missing tools without crashing.
+  if (spawnError && !stderr) {
+    stderr = (spawnError as NodeJS.ErrnoException).message ?? String(spawnError);
+  }
 
   return { stdout, stderr, exitCode };
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -214,13 +214,17 @@ function timestamp() {
  * Pass `options.shell: true` to opt in to a shell (e.g. for `runShell`,
  * which intentionally executes user-authored shell commands).
  *
+ * On spawn failure (ENOENT, EACCES, etc.) `exitCode` is `1` and the OS
+ * error message is surfaced in `stderr` — `exitCode` is always a number
+ * so callers can use simple comparisons (`exitCode === 0`).
+ *
  * @param {string} cmd - The command to execute.
  * @param {string[]} args - The arguments to pass to the command.
  * @param {object} options - The options for the command execution.
  * @param {string} options.cwd - Directory in which to execute the command.
  * @param {boolean} options.shell - If true, run via shell. Default: false.
  * @param {boolean} options.debug - Whether to enable debug mode.
- * @returns {Promise<object>} A promise that resolves to an object containing the stdout, stderr, and exit code of the command.
+ * @returns {Promise<{stdout: string, stderr: string, exitCode: number}>}
  */
 async function spawnCommand(cmd: string, args: string[] = [], options: any = {}) {
   const useShell = options.shell === true;
@@ -258,9 +262,14 @@ async function spawnCommand(cmd: string, args: string[] = [], options: any = {})
   // `error` event is much more likely (missing executable surfaces as
   // ENOENT) and may fire without a subsequent `close`, so we must not
   // wait on `close` alone.
-  const exitCodePromise = new Promise<number | null>((resolve) => {
-    runCommand.on("close", (code) => resolve(code));
-    runCommand.on("error", () => resolve(null));
+  //
+  // Normalize a non-numeric (null) close to `1` so callers can rely on
+  // `exitCode` always being a number. The diagnostic detail is preserved
+  // in `stderr` (set below from the spawn error). This matches the
+  // convention in `src/agents/spawn-helper.ts:safeSpawn`.
+  const exitCodePromise = new Promise<number>((resolve) => {
+    runCommand.on("close", (code) => resolve(typeof code === "number" ? code : 1));
+    runCommand.on("error", () => resolve(1));
   });
 
   // Capture stdout and stderr concurrently to avoid deadlock. When spawn

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -732,15 +732,14 @@ describe("spawnCommand", function () {
 
   it("does not hang when the command does not exist (ENOENT)", async function () {
     // Without the error-event handling, this would await forever waiting
-    // for `close` that never fires when spawn itself fails.
+    // for `close` that never fires when spawn itself fails. exitCode is
+    // normalized to 1 (always a number) so callers can use plain
+    // numeric comparisons; the actual error surfaces in stderr.
     const result = await spawnCommand(
       "this-command-definitely-does-not-exist-1234567890"
     );
-    // exitCode should resolve (null) rather than hang.
-    expect(result.exitCode).to.satisfy(
-      (c) => c === null || typeof c === "number"
-    );
-    // Spawn error message should surface in stderr.
+    expect(result.exitCode).to.equal(1);
+    expect(typeof result.exitCode).to.equal("number");
     expect(result.stderr.length).to.be.greaterThan(0);
   });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,5 @@
 import { setArgs, setConfig, outputResults } from "../dist/utils.js";
+import { spawnCommand } from "../dist/core/utils.js";
 import path from "node:path";
 import fs from "node:fs";
 import { createRequire } from "node:module";
@@ -716,6 +717,38 @@ describe("Util tests", function () {
         delete process.env.DOC_DETECTIVE_CONFIG;
       }
     }
+  });
+});
+
+describe("spawnCommand", function () {
+  this.timeout(10000);
+
+  it("returns successfully for an executable that exists", async function () {
+    // `node --version` works on every supported platform without a shell.
+    const result = await spawnCommand(process.execPath, ["--version"]);
+    expect(result.exitCode).to.equal(0);
+    expect(result.stdout).to.match(/^v\d+\./);
+  });
+
+  it("does not hang when the command does not exist (ENOENT)", async function () {
+    // Without the error-event handling, this would await forever waiting
+    // for `close` that never fires when spawn itself fails.
+    const result = await spawnCommand(
+      "this-command-definitely-does-not-exist-1234567890"
+    );
+    // exitCode should resolve (null) rather than hang.
+    expect(result.exitCode).to.satisfy(
+      (c) => c === null || typeof c === "number"
+    );
+    // Spawn error message should surface in stderr.
+    expect(result.stderr.length).to.be.greaterThan(0);
+  });
+
+  it("supports shell:true opt-in (used by runShell)", async function () {
+    // With shell:true, `echo` resolves via the shell on every platform.
+    const result = await spawnCommand("echo", ["hello"], { shell: true });
+    expect(result.exitCode).to.equal(0);
+    expect(result.stdout).to.match(/hello/);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the three CodeQL alerts surfaced on PR #261 (and present on every PR that touches `src/core/utils.ts` or `src/core/detectTests.ts`):

- **Critical** `js/command-line-injection` — `src/core/utils.ts:spawnCommand`
- **Medium** `js/shell-command-constructed-from-input` — `src/core/utils.ts:spawnCommand`
- **Medium** `js/shell-command-constructed-from-input` — `src/core/detectTests.ts` (DITA invocation)

Root cause: `spawnCommand` called `child_process.spawn(cmd, args, { shell: true })`. With `shell: true`, every value in `cmd` and `args[]` is interpreted by `/bin/sh -c` (or `cmd.exe /c` on Windows), so any shell metacharacter in caller-supplied data is a potential injection vector. CodeQL flags every caller transitively.

## What changed

- **`spawnCommand` defaults to `shell: false`.** Callers must pass `cmd` as the executable and `args[]` as a separate array. An explicit `options.shell: true` opts back in.
- **`cross-spawn`** (already a transitive dep, now a direct dep) handles Windows `.cmd`/`.bat` shim resolution (`npx`, `npm`, etc.) without needing a shell. `node:child_process.spawn` is still used when a caller explicitly opts in to a shell.
- **`runShell`** (the explicit user-facing shell-execution step type) opts in to `shell: true` with an inline comment explaining why — its trust boundary is the spec author, not the executor.
- **`config.ts`** rewrites the two single-string callers (`npx appium driver list`, macOS `defaults read ...`) into `cmd + args[]` form.
- **`inContainer`** rewrites its `grep` call into `cmd + args[]` form. Side-effect: fixes a latent bug where the previous template literal `"docker\|lxc\|kubepods"` silently lost its backslashes in JS, so `grep` was searching for the literal `|` character and never matched. Linux container detection now actually works via cgroup (was previously only working via `IN_CONTAINER=true`). Switched to `-E` for ERE alternation to keep the pattern readable.

## Test plan

- [x] Cross-platform: `cross-spawn` resolves `npx` correctly without a shell on Windows. Verified locally — `npx appium driver list` returns the same driver list as before.
- [x] `runShell` regression: `runShell.spec.json` artifact (`echo $TEST` with shell expansion) still passes via the new `{ shell: true }` opt-in.
- [x] Root suite: 336 passing (up from 322 baseline), 13 pending, 0 failing.
- [x] Common suite: 573 passing, 0 failing.
- [x] CI must verify CodeQL: the three alerts (`js/command-line-injection`, `js/shell-command-constructed-from-input` x2) should clear once `shell: true` is no longer the default sink.

## Notes for reviewers

- This unblocks the red CodeQL check on #261 and any future PR touching `utils.ts` / `detectTests.ts`.
- `runShell` will likely still be flagged by CodeQL (its `shell: true` is intentional). If the alert appears, suppress it with a `lgtm`/CodeQL inline annotation explaining the trust model — happy to add that as a follow-up if CI confirms.
- Latent `inContainer` bug fix is in-scope because the call had to be rewritten anyway. If reviewers prefer to keep observable behavior unchanged, we can drop `-E` and use `-G "docker\|lxc\|kubepods"` instead — same effect but more obviously equivalent to the (intended) original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved subprocess execution reliability and error handling for command operations
  * Enhanced command execution with better argument parsing and proper error recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->