### PR TITLE
feat(ci): stage → smoke → promote release pipeline

### DIFF
--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -26,9 +26,10 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/test.yml
-    with:
-      include_heretto_secrets: ${{ github.event_name == 'workflow_dispatch' }}
     secrets:
-      HERETTO_ORG_ID: ${{ secrets.HERETTO_ORG_ID }}
-      HERETTO_USERNAME: ${{ secrets.HERETTO_USERNAME }}
-      HERETTO_TOKEN: ${{ secrets.HERETTO_TOKEN }}
+      # Only forward HERETTO_* on trusted contexts (manual dispatch). PR
+      # runs — especially from forks — receive empty strings, so the
+      # called workflow never has access to the real values.
+      HERETTO_ORG_ID: ${{ github.event_name == 'workflow_dispatch' && secrets.HERETTO_ORG_ID || '' }}
+      HERETTO_USERNAME: ${{ github.event_name == 'workflow_dispatch' && secrets.HERETTO_USERNAME || '' }}
+      HERETTO_TOKEN: ${{ github.event_name == 'workflow_dispatch' && secrets.HERETTO_TOKEN || '' }}

--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -31,35 +31,8 @@ permissions:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
-        node:
-          - 20
-          - 22
-          - 24
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-
-      - run: npm install
-      - run: npm run build
-      - run: npm test
-        env:
-          HERETTO_ORG_ID: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && secrets.HERETTO_ORG_ID || '' }}
-          HERETTO_USERNAME: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && secrets.HERETTO_USERNAME || '' }}
-          HERETTO_TOKEN: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && secrets.HERETTO_TOKEN || '' }}
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
 
   test-github-action:
     name: Test GitHub Action

--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -1,14 +1,15 @@
-# Matrix tests on every push/PR. Post-release jobs (Docker build, GitHub Action
-# smoke test, downstream dispatch) run on `release.published` events, which are
-# fired by semantic-release (see .github/workflows/release.yml) when a stable
-# release is cut on main. Prereleases from `next` and `feat/**` are skipped.
+# Matrix tests on PRs and post-release jobs (Docker build, GitHub Action smoke
+# test, downstream dispatch) that run on `release.published` events fired by
+# semantic-release (see .github/workflows/release.yml). Prereleases from `next`
+# and `feat/**` are skipped for the post-release jobs.
+#
+# Note: the matrix that GATES semantic-release on push to a release branch
+# lives in release.yml, not here. This workflow intentionally does NOT run on
+# push so we don't duplicate that matrix.
 
 name: Test (& Publish)
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types:
       - opened

--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -1,6 +1,6 @@
 # PR gate: runs the reusable test matrix on pull requests so reviewers see
 # matrix failures before merge. All release-side work (publish, smoke-test
-# staged build, promote to @latest, Docker, downstream dispatch) lives in
+# staged build, promote to @latest, Docker build) lives in
 # .github/workflows/release.yml, which has a linear needs-chain that only
 # advances @latest after the smoke test passes.
 

--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -1,15 +1,10 @@
-# Matrix tests on PRs and post-release jobs (Docker build, GitHub Action smoke
-# test, downstream dispatch) that run on `release.published` events fired by
-# semantic-release (see .github/workflows/release.yml). Prereleases from `next`
-# and `feat/**` are skipped for the post-release jobs.
-#
-# The matrix itself is defined once in the reusable .github/workflows/test.yml
-# (workflow_call). This workflow invokes it for PRs + release events; the
-# release pipeline in release.yml invokes it as the gate before publishing.
-# This workflow intentionally does NOT run on push-to-main so we don't
-# duplicate the gating matrix.
+# PR gate: runs the reusable test matrix on pull requests so reviewers see
+# matrix failures before merge. All release-side work (publish, smoke-test
+# staged build, promote to @latest, Docker, downstream dispatch) lives in
+# .github/workflows/release.yml, which has a linear needs-chain that only
+# advances @latest after the smoke test passes.
 
-name: Test (& Publish)
+name: Test
 
 on:
   pull_request:
@@ -19,9 +14,6 @@ on:
       - synchronize
     paths-ignore:
       - 'docs/**'
-  release:
-    types:
-      - published
   workflow_dispatch:
 
 concurrency:
@@ -35,159 +27,8 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
     with:
-      # Only release.published from main (not prereleases) and manual dispatch
-      # count as trusted contexts for Heretto credentials; PR runs (especially
-      # from forks) never get them.
-      include_heretto_secrets: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease) }}
+      include_heretto_secrets: ${{ github.event_name == 'workflow_dispatch' }}
     secrets:
       HERETTO_ORG_ID: ${{ secrets.HERETTO_ORG_ID }}
       HERETTO_USERNAME: ${{ secrets.HERETTO_USERNAME }}
       HERETTO_TOKEN: ${{ secrets.HERETTO_TOKEN }}
-
-  test-github-action:
-    name: Test GitHub Action
-    needs: test
-    if: github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get package version
-        id: get_version
-        shell: bash
-        run: echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
-
-      # The github-action below installs doc-detective via the @latest
-      # dist-tag, so we must wait for @latest to *point to* the just-published
-      # version (not just for the version to exist on npm).
-      - name: Wait for @latest dist-tag to update
-        shell: bash
-        run: |
-          EXPECTED="${{ steps.get_version.outputs.version }}"
-          for i in $(seq 1 12); do
-            PUBLISHED=$(npm view "doc-detective@latest" version 2>/dev/null || echo "")
-            if [ "$PUBLISHED" = "$EXPECTED" ]; then
-              echo "doc-detective@latest now resolves to $PUBLISHED"
-              break
-            fi
-            echo "Attempt $i: @latest is '$PUBLISHED', expected '$EXPECTED'. Waiting 10s..."
-            sleep 10
-          done
-          if [ "$PUBLISHED" != "$EXPECTED" ]; then
-            echo "ERROR: Timed out waiting for doc-detective@latest to become $EXPECTED"
-            exit 1
-          fi
-
-      - uses: doc-detective/github-action@latest
-        id: dd
-        with:
-          config: ./test/artifacts/config.json
-          input: ./test/artifacts/doc-content.md
-          exit_on_fail: "true"
-
-  build-docker-image:
-    name: Build & Push Docker Image (${{ matrix.os }})
-    needs: test
-    if: github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease
-    timeout-minutes: 60
-    strategy:
-      matrix:
-        os:
-          - windows-latest
-          - ubuntu-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Get package version
-        id: get_version
-        shell: bash
-        run: echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Switch Docker to Windows containers
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Write-Host "Switching Docker to Windows containers..."
-          $dockerCli = "$Env:ProgramFiles\Docker\Docker\DockerCli.exe"
-          if (-not (Test-Path $dockerCli)) {
-            throw "DockerCli.exe not found at $dockerCli"
-          }
-          & $dockerCli -SwitchWindowsEngine
-          Start-Sleep -Seconds 10
-          docker version
-          docker info
-
-      - name: Verify Windows container mode
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $os = docker info --format '{{.OSType}}'
-          if ($os -ne 'windows') { throw "Docker is not in Windows mode; OSType=$os" }
-          Write-Host "Docker OSType=$os"
-
-      - name: Wait for npm propagation
-        shell: bash
-        run: |
-          EXPECTED="${{ steps.get_version.outputs.version }}"
-          for i in $(seq 1 12); do
-            PUBLISHED=$(npm view "doc-detective@$EXPECTED" version 2>/dev/null || echo "")
-            if [ "$PUBLISHED" = "$EXPECTED" ]; then
-              echo "Version $PUBLISHED available on npm"
-              break
-            fi
-            echo "Attempt $i: expected $EXPECTED, got '$PUBLISHED'. Waiting 10s..."
-            sleep 10
-          done
-          if [ "$PUBLISHED" != "$EXPECTED" ]; then
-            echo "ERROR: Timed out waiting for doc-detective@$EXPECTED on npm"
-            exit 1
-          fi
-
-      - name: Build Docker Image
-        shell: bash
-        run: npm run container:build -- --version="${{ steps.get_version.outputs.version }}"
-
-      - name: Post-build Test
-        shell: bash
-        env:
-          VERSION: ${{ steps.get_version.outputs.version }}
-        run: npm run container:test
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Push Docker image
-        run: docker push --all-tags docdetective/docdetective
-
-  update-downstream-common:
-    name: Update downstream common packages
-    needs: test
-    if: github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get common package version
-        id: get_version
-        run: |
-          echo "version=$(jq -r '.version' src/common/package.json)" >> $GITHUB_OUTPUT
-
-      - name: Update docs
-        run: |
-          curl --fail-with-body --silent --show-error -X POST -H "Authorization: token ${{ secrets.DD_DEP_UPDATE_TOKEN }}" \
-               -H "Accept: application/vnd.github.everest-preview+json" \
-               "https://api.github.com/repos/doc-detective/doc-detective.github.io/dispatches" \
-               -d '{"event_type": "update-common-package-event", "client_payload": {"version": "${{ steps.get_version.outputs.version }}"} }'

--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -3,9 +3,11 @@
 # semantic-release (see .github/workflows/release.yml). Prereleases from `next`
 # and `feat/**` are skipped for the post-release jobs.
 #
-# Note: the matrix that GATES semantic-release on push to a release branch
-# lives in release.yml, not here. This workflow intentionally does NOT run on
-# push so we don't duplicate that matrix.
+# The matrix itself is defined once in the reusable .github/workflows/test.yml
+# (workflow_call). This workflow invokes it for PRs + release events; the
+# release pipeline in release.yml invokes it as the gate before publishing.
+# This workflow intentionally does NOT run on push-to-main so we don't
+# duplicate the gating matrix.
 
 name: Test (& Publish)
 
@@ -32,7 +34,15 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/test.yml
-    secrets: inherit
+    with:
+      # Only release.published from main (not prereleases) and manual dispatch
+      # count as trusted contexts for Heretto credentials; PR runs (especially
+      # from forks) never get them.
+      include_heretto_secrets: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease) }}
+    secrets:
+      HERETTO_ORG_ID: ${{ secrets.HERETTO_ORG_ID }}
+      HERETTO_USERNAME: ${{ secrets.HERETTO_USERNAME }}
+      HERETTO_TOKEN: ${{ secrets.HERETTO_TOKEN }}
 
   test-github-action:
     name: Test GitHub Action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,12 @@ jobs:
         id: sr
         env:
           GITHUB_TOKEN: ${{ secrets.DD_DEP_UPDATE_TOKEN }}
+          # NPM_TOKEN is consumed by @semantic-release/npm's verifyConditions
+          # (writes a temporary ~/.npmrc); NODE_AUTH_TOKEN is what the npm CLI
+          # reads when setup-node@v4 configured `registry-url`, which is what
+          # our @semantic-release/exec publishCmd relies on.
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
 
   smoke-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,16 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/test.yml
-    secrets: inherit
+    with:
+      # Trust main + manual runs with Heretto credentials. Push to
+      # next/feat/** is still a trusted ref (only maintainers can push),
+      # but the Heretto tests aren't needed there and we prefer to keep
+      # the blast radius minimal.
+      include_heretto_secrets: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+    secrets:
+      HERETTO_ORG_ID: ${{ secrets.HERETTO_ORG_ID }}
+      HERETTO_USERNAME: ${{ secrets.HERETTO_USERNAME }}
+      HERETTO_TOKEN: ${{ secrets.HERETTO_TOKEN }}
 
   release:
     needs: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,40 @@ permissions:
   pull-requests: write
 
 jobs:
+  test:
+    name: Test (${{ matrix.os }}, node ${{ matrix.node }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        node:
+          - 20
+          - 22
+          - 24
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - run: npm install
+      - run: npm run build
+      - run: npm test
+        env:
+          HERETTO_ORG_ID: ${{ secrets.HERETTO_ORG_ID }}
+          HERETTO_USERNAME: ${{ secrets.HERETTO_USERNAME }}
+          HERETTO_TOKEN: ${{ secrets.HERETTO_TOKEN }}
+
   release:
+    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -38,7 +71,6 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npm test
 
       - name: Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,29 @@ jobs:
         env:
           HUSKY: '0'
 
+      - name: Wait for both packages to propagate
+        shell: bash
+        env:
+          NEXT: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          for pkg in doc-detective doc-detective-common; do
+            PUBLISHED=""
+            for i in $(seq 1 12); do
+              PUBLISHED=$(npm view "$pkg@$NEXT" version 2>/dev/null || echo "")
+              if [ "$PUBLISHED" = "$NEXT" ]; then
+                echo "$pkg@$NEXT is resolvable on npm"
+                break
+              fi
+              echo "Attempt $i: $pkg@$NEXT not yet resolvable ('$PUBLISHED'). Waiting 10s..."
+              sleep 10
+            done
+            if [ "$PUBLISHED" != "$NEXT" ]; then
+              echo "ERROR: timed out waiting for $pkg@$NEXT to propagate on npm"
+              exit 1
+            fi
+          done
+
       - name: Verify new version strictly advances @latest
         id: guard
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@
 #        → promote (moves @latest to the new version, guarded by a semver
 #                   regression check so a stale/older release can't clobber a
 #                   newer @latest)
-#        → docker + update-downstream-common (fire only after @latest is stable)
+#        → docker (fires only after @latest is stable)
 #
 # Prerelease branches (`next`, `feat/**`) publish to their own dist-tag and
 # skip smoke/promote/docker — those channels don't feed @latest.
@@ -251,20 +251,3 @@ jobs:
 
       - name: Push Docker image
         run: docker push --all-tags docdetective/docdetective
-
-  update-downstream-common:
-    name: Update downstream common packages
-    needs: [release, promote]
-    if: needs.release.outputs.published == 'true' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch update to docs repo
-        env:
-          DD_DEP_UPDATE_TOKEN: ${{ secrets.DD_DEP_UPDATE_TOKEN }}
-          NEXT: ${{ needs.release.outputs.version }}
-        run: |
-          curl --fail-with-body --silent --show-error -X POST \
-               -H "Authorization: token $DD_DEP_UPDATE_TOKEN" \
-               -H "Accept: application/vnd.github.everest-preview+json" \
-               "https://api.github.com/repos/doc-detective/doc-detective.github.io/dispatches" \
-               -d "{\"event_type\": \"update-common-package-event\", \"client_payload\": {\"version\": \"$NEXT\"}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,13 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/test.yml
-    with:
-      include_heretto_secrets: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
     secrets:
-      HERETTO_ORG_ID: ${{ secrets.HERETTO_ORG_ID }}
-      HERETTO_USERNAME: ${{ secrets.HERETTO_USERNAME }}
-      HERETTO_TOKEN: ${{ secrets.HERETTO_TOKEN }}
+      # Only forward HERETTO_* on trusted refs. On next/feat/** the called
+      # workflow receives empty strings and never has access to the real
+      # values, so the trust boundary is enforced here at the caller.
+      HERETTO_ORG_ID: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && secrets.HERETTO_ORG_ID || '' }}
+      HERETTO_USERNAME: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && secrets.HERETTO_USERNAME || '' }}
+      HERETTO_TOKEN: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && secrets.HERETTO_TOKEN || '' }}
 
   release:
     needs: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,16 @@
+# Release pipeline. Linear needs-chain so @latest is only advanced after an
+# end-to-end smoke test of the newly-published artifact:
+#
+#   test → release (publishes to a unique `staging-<version>` dist-tag for main)
+#        → smoke-test (doc-detective/github-action pointed at the staging tag)
+#        → promote (moves @latest to the new version, guarded by a semver
+#                   regression check so a stale/older release can't clobber a
+#                   newer @latest)
+#        → docker + update-downstream-common (fire only after @latest is stable)
+#
+# Prerelease branches (`next`, `feat/**`) publish to their own dist-tag and
+# skip smoke/promote/docker — those channels don't feed @latest.
+
 name: Release
 
 on:
@@ -23,10 +36,6 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
     with:
-      # Trust main + manual runs with Heretto credentials. Push to
-      # next/feat/** is still a trusted ref (only maintainers can push),
-      # but the Heretto tests aren't needed there and we prefer to keep
-      # the blast radius minimal.
       include_heretto_secrets: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
     secrets:
       HERETTO_ORG_ID: ${{ secrets.HERETTO_ORG_ID }}
@@ -37,6 +46,10 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      version: ${{ steps.sr.outputs.version }}
+      channel: ${{ steps.sr.outputs.channel }}
+      published: ${{ steps.sr.outputs.published }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,7 +67,198 @@ jobs:
       - run: npm run build
 
       - name: Release
+        id: sr
         env:
           GITHUB_TOKEN: ${{ secrets.DD_DEP_UPDATE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
+
+  smoke-test:
+    name: Smoke-test staged release
+    needs: release
+    if: needs.release.outputs.published == 'true' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Wait for staging dist-tag to propagate
+        shell: bash
+        env:
+          STAGING_TAG: staging-${{ needs.release.outputs.version }}
+          EXPECTED: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 12); do
+            PUBLISHED=$(npm view "doc-detective@$STAGING_TAG" version 2>/dev/null || echo "")
+            if [ "$PUBLISHED" = "$EXPECTED" ]; then
+              echo "doc-detective@$STAGING_TAG resolves to $PUBLISHED"
+              break
+            fi
+            echo "Attempt $i: doc-detective@$STAGING_TAG is '$PUBLISHED', expected '$EXPECTED'. Waiting 10s..."
+            sleep 10
+          done
+          if [ "$PUBLISHED" != "$EXPECTED" ]; then
+            echo "ERROR: Timed out waiting for doc-detective@$STAGING_TAG on npm"
+            exit 1
+          fi
+
+      - name: Run github-action against staging
+        uses: doc-detective/github-action@latest
+        with:
+          version: staging-${{ needs.release.outputs.version }}
+          config: ./test/artifacts/config.json
+          input: ./test/artifacts/doc-content.md
+          exit_on_fail: "true"
+
+  promote:
+    name: Promote staging → @latest
+    needs: [release, smoke-test]
+    if: needs.release.outputs.published == 'true' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci --ignore-scripts
+        env:
+          HUSKY: '0'
+
+      - name: Verify new version strictly advances @latest
+        id: guard
+        shell: bash
+        env:
+          NEXT: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          # `npm view` exits non-zero if the package has never been published.
+          CURRENT=$(npm view doc-detective@latest version 2>/dev/null || echo "")
+          if [ -z "$CURRENT" ]; then
+            echo "No @latest published yet; $NEXT will be the first."
+          else
+            echo "Current doc-detective@latest is $CURRENT; candidate is $NEXT."
+            IS_NEWER=$(node -p "require('semver').gt('$NEXT','$CURRENT') ? 'yes' : 'no'")
+            if [ "$IS_NEWER" != "yes" ]; then
+              echo "ERROR: refusing to promote $NEXT over existing @latest $CURRENT."
+              echo "This usually means a newer release already landed; re-run only"
+              echo "if you've verified nothing newer was published by another run."
+              exit 1
+            fi
+          fi
+
+          COMMON_CURRENT=$(npm view doc-detective-common@latest version 2>/dev/null || echo "")
+          if [ -n "$COMMON_CURRENT" ]; then
+            IS_NEWER=$(node -p "require('semver').gt('$NEXT','$COMMON_CURRENT') ? 'yes' : 'no'")
+            if [ "$IS_NEWER" != "yes" ]; then
+              echo "ERROR: refusing to promote doc-detective-common $NEXT over existing @latest $COMMON_CURRENT."
+              exit 1
+            fi
+          fi
+
+      - name: Promote to @latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NEXT: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          npm dist-tag add doc-detective@$NEXT latest
+          npm dist-tag add doc-detective-common@$NEXT latest
+
+      - name: Retire staging dist-tag (best-effort)
+        if: always()
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          STAGING_TAG: staging-${{ needs.release.outputs.version }}
+        run: |
+          npm dist-tag rm doc-detective "$STAGING_TAG" || echo "staging tag already gone on doc-detective"
+          npm dist-tag rm doc-detective-common "$STAGING_TAG" || echo "staging tag already gone on doc-detective-common"
+
+  build-docker-image:
+    name: Build & Push Docker Image (${{ matrix.os }})
+    needs: [release, promote]
+    if: needs.release.outputs.published == 'true' && github.ref == 'refs/heads/main'
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Switch Docker to Windows containers
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Write-Host "Switching Docker to Windows containers..."
+          $dockerCli = "$Env:ProgramFiles\Docker\Docker\DockerCli.exe"
+          if (-not (Test-Path $dockerCli)) {
+            throw "DockerCli.exe not found at $dockerCli"
+          }
+          & $dockerCli -SwitchWindowsEngine
+          Start-Sleep -Seconds 10
+          docker version
+          docker info
+
+      - name: Verify Windows container mode
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $os = docker info --format '{{.OSType}}'
+          if ($os -ne 'windows') { throw "Docker is not in Windows mode; OSType=$os" }
+          Write-Host "Docker OSType=$os"
+
+      - name: Build Docker Image
+        shell: bash
+        run: npm run container:build -- --version="${{ needs.release.outputs.version }}"
+
+      - name: Post-build Test
+        shell: bash
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: npm run container:test
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push Docker image
+        run: docker push --all-tags docdetective/docdetective
+
+  update-downstream-common:
+    name: Update downstream common packages
+    needs: [release, promote]
+    if: needs.release.outputs.published == 'true' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch update to docs repo
+        env:
+          DD_DEP_UPDATE_TOKEN: ${{ secrets.DD_DEP_UPDATE_TOKEN }}
+          NEXT: ${{ needs.release.outputs.version }}
+        run: |
+          curl --fail-with-body --silent --show-error -X POST \
+               -H "Authorization: token $DD_DEP_UPDATE_TOKEN" \
+               -H "Accept: application/vnd.github.everest-preview+json" \
+               "https://api.github.com/repos/doc-detective/doc-detective.github.io/dispatches" \
+               -d "{\"event_type\": \"update-common-package-event\", \"client_payload\": {\"version\": \"$NEXT\"}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,36 +21,8 @@ permissions:
 
 jobs:
   test:
-    name: Test (${{ matrix.os }}, node ${{ matrix.node }})
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
-        node:
-          - 20
-          - 22
-          - 24
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-
-      - run: npm install
-      - run: npm run build
-      - run: npm test
-        env:
-          HERETTO_ORG_ID: ${{ secrets.HERETTO_ORG_ID }}
-          HERETTO_USERNAME: ${{ secrets.HERETTO_USERNAME }}
-          HERETTO_TOKEN: ${{ secrets.HERETTO_TOKEN }}
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
 
   release:
     needs: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,8 @@ jobs:
     if: needs.release.outputs.published == 'true' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -115,7 +117,10 @@ jobs:
           fi
 
       - name: Run github-action against staging
-        uses: doc-detective/github-action@latest
+        # Pinned to the v1.4.1 commit. Update in lockstep when the action
+        # cuts a new release; `@latest` is a moving target and expands
+        # the supply-chain surface area.
+        uses: doc-detective/github-action@a2a4f5ceb1abfa55d567e4f6766223082ece2c18 # v1.4.1
         with:
           version: staging-${{ needs.release.outputs.version }}
           config: ./test/artifacts/config.json
@@ -232,7 +237,11 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        run: npm ci
+        # The docker build scripts don't need browsers or drivers, so skip
+        # the postinstall and husky hooks to cut several minutes off the job.
+        run: npm ci --ignore-scripts
+        env:
+          HUSKY: '0'
 
       - name: Switch Docker to Windows containers
         if: runner.os == 'Windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,21 +1,22 @@
 # Reusable test matrix. Single source of truth for the cross-platform
-# test grid used by both npm-test.yaml (PRs, release events) and
-# release.yml (release branches, as the gate before semantic-release).
+# test grid.
 #
-# Update the matrix here; both callers pick up the change automatically.
+# Callers:
+#   - npm-test.yaml (PR gate on `pull_request` + manual `workflow_dispatch`)
+#   - release.yml   (push to main/next/feat/** as the gate before
+#                    semantic-release publishes)
+#
+# HERETTO_* secrets are only valuable on trusted contexts. The trust
+# decision lives in the caller: callers pass the real secret values on
+# trusted events (main push, manual dispatch, etc.) and pass empty
+# strings everywhere else. This workflow just plumbs whatever the caller
+# hands it into the test env, so an untrusted run never sees real
+# credentials.
 
 name: Test Matrix
 
 on:
   workflow_call:
-    inputs:
-      include_heretto_secrets:
-        description: >
-          Caller opts in to passing HERETTO_* env vars to `npm test`.
-          Must only be `true` for trusted contexts (main, workflow_dispatch)
-          — never for fork PRs.
-        type: boolean
-        default: false
     secrets:
       HERETTO_ORG_ID:
         required: false
@@ -56,6 +57,6 @@ jobs:
       - run: npm run build
       - run: npm test
         env:
-          HERETTO_ORG_ID: ${{ inputs.include_heretto_secrets && secrets.HERETTO_ORG_ID || '' }}
-          HERETTO_USERNAME: ${{ inputs.include_heretto_secrets && secrets.HERETTO_USERNAME || '' }}
-          HERETTO_TOKEN: ${{ inputs.include_heretto_secrets && secrets.HERETTO_TOKEN || '' }}
+          HERETTO_ORG_ID: ${{ secrets.HERETTO_ORG_ID }}
+          HERETTO_USERNAME: ${{ secrets.HERETTO_USERNAME }}
+          HERETTO_TOKEN: ${{ secrets.HERETTO_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ on:
       HERETTO_TOKEN:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (${{ matrix.os }}, node ${{ matrix.node }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,14 @@ name: Test Matrix
 
 on:
   workflow_call:
+    inputs:
+      include_heretto_secrets:
+        description: >
+          Caller opts in to passing HERETTO_* env vars to `npm test`.
+          Must only be `true` for trusted contexts (main, workflow_dispatch)
+          — never for fork PRs.
+        type: boolean
+        default: false
     secrets:
       HERETTO_ORG_ID:
         required: false
@@ -48,6 +56,6 @@ jobs:
       - run: npm run build
       - run: npm test
         env:
-          HERETTO_ORG_ID: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && secrets.HERETTO_ORG_ID || '' }}
-          HERETTO_USERNAME: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && secrets.HERETTO_USERNAME || '' }}
-          HERETTO_TOKEN: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && secrets.HERETTO_TOKEN || '' }}
+          HERETTO_ORG_ID: ${{ inputs.include_heretto_secrets && secrets.HERETTO_ORG_ID || '' }}
+          HERETTO_USERNAME: ${{ inputs.include_heretto_secrets && secrets.HERETTO_USERNAME || '' }}
+          HERETTO_TOKEN: ${{ inputs.include_heretto_secrets && secrets.HERETTO_TOKEN || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+# Reusable test matrix. Single source of truth for the cross-platform
+# test grid used by both npm-test.yaml (PRs, release events) and
+# release.yml (release branches, as the gate before semantic-release).
+#
+# Update the matrix here; both callers pick up the change automatically.
+
+name: Test Matrix
+
+on:
+  workflow_call:
+    secrets:
+      HERETTO_ORG_ID:
+        required: false
+      HERETTO_USERNAME:
+        required: false
+      HERETTO_TOKEN:
+        required: false
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }}, node ${{ matrix.node }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        node:
+          - 20
+          - 22
+          - 24
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+        env:
+          HERETTO_ORG_ID: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && secrets.HERETTO_ORG_ID || '' }}
+          HERETTO_USERNAME: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && secrets.HERETTO_USERNAME || '' }}
+          HERETTO_TOKEN: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && secrets.HERETTO_TOKEN || '' }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -28,11 +28,15 @@
         "prepareCmd": "node scripts/sync-common-version.js ${nextRelease.version}"
       }
     ],
-    "@semantic-release/npm",
+    [
+      "@semantic-release/npm",
+      { "npmPublish": false }
+    ],
     [
       "@semantic-release/exec",
       {
-        "publishCmd": "npm publish --workspace src/common --access public --tag ${nextRelease.channel || 'latest'}"
+        "publishCmd": "npm publish --access public --tag ${nextRelease.channel ? nextRelease.channel : 'staging-' + nextRelease.version} && npm publish --workspace src/common --access public --tag ${nextRelease.channel ? nextRelease.channel : 'staging-' + nextRelease.version}",
+        "successCmd": "echo 'version=${nextRelease.version}' >> \"$GITHUB_OUTPUT\" && echo 'channel=${nextRelease.channel || \"\"}' >> \"$GITHUB_OUTPUT\" && echo 'published=true' >> \"$GITHUB_OUTPUT\""
       }
     ],
     [

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -35,7 +35,7 @@
     [
       "@semantic-release/exec",
       {
-        "publishCmd": "npm publish --access public --tag ${nextRelease.channel ? nextRelease.channel : 'staging-' + nextRelease.version} && npm publish --workspace src/common --access public --tag ${nextRelease.channel ? nextRelease.channel : 'staging-' + nextRelease.version}",
+        "publishCmd": "node scripts/publish-staged-release.js ${nextRelease.version} ${nextRelease.channel ? nextRelease.channel : 'staging-' + nextRelease.version}",
         "successCmd": "echo 'version=${nextRelease.version}' >> \"$GITHUB_OUTPUT\" && echo 'channel=${nextRelease.channel || \"\"}' >> \"$GITHUB_OUTPUT\" && echo 'published=true' >> \"$GITHUB_OUTPUT\""
       }
     ],

--- a/scripts/publish-staged-release.js
+++ b/scripts/publish-staged-release.js
@@ -17,6 +17,7 @@
 // Exits non-zero if either package fails to reach the desired end state.
 
 import { spawnSync } from 'node:child_process';
+import semver from 'semver';
 
 const version = process.argv[2];
 const tag = process.argv[3];
@@ -26,19 +27,25 @@ if (!version || !tag) {
   process.exit(1);
 }
 
-const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
-// npm dist-tags must be valid npm identifiers and must not parse as semver.
-// Allow lowercase alphanumerics, hyphens, underscores, and dots (dots show up
-// in our `staging-<version>` tags). The leading-char constraint and the
-// strict character set together rule out shell metacharacters.
+// Shape check for the tag: lowercase alphanumerics, hyphens, underscores,
+// and dots (dots appear in our `staging-<version>` tags). The leading-char
+// constraint and strict character set rule out shell metacharacters —
+// important because we invoke npm via spawn with `shell: true` on Windows.
 const DIST_TAG = /^[a-z0-9][a-z0-9._-]{0,99}$/;
 
-if (!SEMVER.test(version)) {
+if (!semver.valid(version)) {
   console.error(`Refusing to run: ${JSON.stringify(version)} is not a valid semver version`);
   process.exit(1);
 }
 if (!DIST_TAG.test(tag)) {
   console.error(`Refusing to run: ${JSON.stringify(tag)} is not a valid npm dist-tag`);
+  process.exit(1);
+}
+// npm rejects dist-tags that parse as a valid semver range. Reject early with
+// a clear message instead of letting `npm publish` fail with its own cryptic
+// error later.
+if (semver.valid(tag) || semver.validRange(tag)) {
+  console.error(`Refusing to run: ${JSON.stringify(tag)} parses as a semver value; npm dist-tags must not`);
   process.exit(1);
 }
 

--- a/scripts/publish-staged-release.js
+++ b/scripts/publish-staged-release.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// Publish the root and src/common packages with a dist-tag, idempotently.
+//
+// Non-idempotent npm publishes are a problem for staged releases: if the
+// root publish succeeds but `doc-detective-common` fails (network, registry
+// hiccup), the next semantic-release run computes the same version and
+// fails on `npm publish` for the already-published root — leaving the
+// staging tag in limbo.
+//
+// For each package this script does:
+//   * `npm view` to check if the exact version is already on the registry
+//   * if missing → `npm publish --tag <tag>`
+//   * if present → `npm dist-tag add pkg@version <tag>` (ensures the tag
+//                  points at the intended version even if a prior run set
+//                  it incorrectly)
+//
+// Exits non-zero if either package fails to reach the desired end state.
+
+import { spawnSync } from 'node:child_process';
+
+const version = process.argv[2];
+const tag = process.argv[3];
+
+if (!version || !tag) {
+  console.error('Usage: publish-staged-release.js <version> <tag>');
+  process.exit(1);
+}
+
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+// npm dist-tags must be valid npm identifiers and must not parse as semver.
+// Allow lowercase alphanumerics, hyphens, underscores, and dots (dots show up
+// in our `staging-<version>` tags). The leading-char constraint and the
+// strict character set together rule out shell metacharacters.
+const DIST_TAG = /^[a-z0-9][a-z0-9._-]{0,99}$/;
+
+if (!SEMVER.test(version)) {
+  console.error(`Refusing to run: ${JSON.stringify(version)} is not a valid semver version`);
+  process.exit(1);
+}
+if (!DIST_TAG.test(tag)) {
+  console.error(`Refusing to run: ${JSON.stringify(tag)} is not a valid npm dist-tag`);
+  process.exit(1);
+}
+
+const shell = process.platform === 'win32';
+
+function run(args, opts = {}) {
+  console.log(`$ npm ${args.join(' ')}`);
+  return spawnSync('npm', args, { stdio: 'inherit', shell, ...opts });
+}
+
+function capture(args) {
+  const r = spawnSync('npm', args, { shell });
+  return {
+    ok: r.status === 0,
+    stdout: (r.stdout || '').toString().trim(),
+  };
+}
+
+function isAlreadyPublished(pkg, ver) {
+  const { ok, stdout } = capture(['view', `${pkg}@${ver}`, 'version']);
+  return ok && stdout === ver;
+}
+
+function publishOrTag(pkg, workspaceArgs) {
+  if (isAlreadyPublished(pkg, version)) {
+    console.log(`[${pkg}] ${version} already published; ensuring dist-tag ${tag}`);
+    const r = run(['dist-tag', 'add', `${pkg}@${version}`, tag]);
+    if (r.status !== 0) {
+      console.error(`[${pkg}] dist-tag add failed`);
+      process.exit(r.status ?? 1);
+    }
+    return;
+  }
+
+  console.log(`[${pkg}] publishing ${version} with --tag ${tag}`);
+  const r = run([
+    'publish',
+    ...workspaceArgs,
+    '--access', 'public',
+    '--tag', tag,
+  ]);
+  if (r.status !== 0) {
+    console.error(`[${pkg}] publish failed`);
+    process.exit(r.status ?? 1);
+  }
+}
+
+publishOrTag('doc-detective', []);
+publishOrTag('doc-detective-common', ['--workspace', 'src/common']);

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -194,7 +194,7 @@ Triggered by push to `main`, `next`, or any `feat/**` branch. Steps:
 
 #### Downstream (`.github/workflows/npm-test.yaml`)
 
-Still runs the full matrix (Ubuntu/Windows/macOS × Node 20/22/24) on every push and PR. The post-release jobs — `test-github-action`, `build-docker-image`, `update-downstream-common` — now fire on `release.published && !prerelease`, so Docker Hub and `doc-detective.github.io` only update on stable `main` releases, not `next`/`feat/**` prereleases.
+Runs the reusable test matrix (Ubuntu/Windows/macOS × Node 20/22/24) on pull requests as the PR gate. All release-side jobs (pre-publish matrix, publish, smoke test, promote to `@latest`, Docker build) live in `release.yml`.
 
 #### Commit message enforcement
 
@@ -264,7 +264,7 @@ Use `escapeRegExp()` helper when converting user strings to regex patterns (see 
 **Cut a stable release:**
 - Merge a PR into `main` whose commits include at least one `fix:`, `feat:`, or breaking change (`!`/`BREAKING CHANGE`).
 - `release.yml` runs semantic-release, which bumps both packages, publishes to `@latest`, tags, and cuts a GitHub Release.
-- Triggers Docker build and `doc-detective.github.io` dispatch downstream.
+- Triggers the Docker build downstream once `@latest` has been promoted.
 
 **Cut a prerelease from `next`:**
 - Merge to `next` (or push to `next` directly). Same flow, but publishes to the `next` dist-tag as `X.Y.Z-next.N`.


### PR DESCRIPTION
## Problem

Two gaps in the release pipeline after #259:

1. **Matrix didn't gate the release.** `release.yml` only ran `npm test` on ubuntu-node22 before semantic-release published. The full cross-platform matrix ran in parallel in a separate workflow and had no effect on gating.
2. **`@latest` advanced before any end-to-end check.** Even once the matrix gates publish, there was no test that the *published* artifact actually works with the `doc-detective/github-action` (install-from-npm flow).

## Solution

Linear `needs:` chain, all inside `release.yml`:

```
test (reusable matrix)
  → release        (semantic-release publishes X.Y.Z to `staging-<version>`)
  → smoke-test     (doc-detective/github-action pinned to v1.4.1 SHA,
                    pointed at version: staging-<version>)
  → promote        (propagation wait + semver-guarded `npm dist-tag add @latest`)
  → build-docker-image
```

- **Unique staging tag per release** (`staging-<version>`) — collision-proof if concurrent runs ever slip through the concurrency group.
- **Semver regression guard** on promote — `npm dist-tag add @latest` only runs if `semver.gt(new, current@latest)`, so a stale queued run can't promote an older version over a newer one that landed first.
- **Propagation wait** in promote — polls `npm view <pkg>@<version>` for both packages before `npm dist-tag add`.
- **Idempotent publish** via `scripts/publish-staged-release.js` — if the root publishes but the common package fails, a retry re-asserts the dist-tag instead of double-publishing.
- **Staging tag is retired** after successful promote.
- Prereleases (`next`, `feat/**`) unchanged — they publish directly to their own dist-tag.

## Triggers after this PR merges

| Event | Workflow | Runs |
|---|---|---|
| `push` to `main` / `next` / `feat/**` | `release.yml` | matrix → release → (main only) smoke → promote → docker |
| `pull_request` | `npm-test.yaml` | matrix |
| `workflow_dispatch` on either | as above | |

`npm-test.yaml` **no longer** runs on `release.published` or `push`. The old `update-downstream-common` repository_dispatch job was removed entirely.

## Smaller changes bundled

- Matrix extracted into reusable `.github/workflows/test.yml` (`on: workflow_call`) — single source of truth for grid + node versions
- `npm install` → `npm ci` in the matrix for determinism
- Least-privilege secrets: callers forward `HERETTO_*` only on trusted refs (main + dispatch); called workflow never sees secrets on untrusted runs
- `permissions: contents: read` on the reusable workflow and on `smoke-test`
- `doc-detective/github-action` pinned to a SHA (v1.4.1) to reduce supply-chain surface
- `build-docker-image` uses `npm ci --ignore-scripts` + `HUSKY=0` to skip browser/driver downloads
- Docs: `src/common/AGENTS.md` updated to match the new job layout

## Test plan

- [ ] Merge this PR, then trigger `Release` via `workflow_dispatch` on `main` to cut 4.1.0
- [ ] Verify in Actions UI: matrix → release → smoke → promote → docker run in order; failure at any stage short-circuits the chain and leaves `@latest` untouched
- [ ] Verify `npm view doc-detective dist-tags` shows `latest: 4.1.0` after promote and no dangling `staging-4.1.0`
- [ ] Verify `npm view doc-detective-common dist-tags` mirrors
- [ ] After the release, open a throwaway PR to confirm `npm-test.yaml` still runs matrix on PR events