### PR TITLE
fix(ci): correct repository URL in root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hawkeyexl/doc-detective.git"
+    "url": "git+https://github.com/doc-detective/doc-detective.git"
   },
   "keywords": [
     "documentation",


### PR DESCRIPTION
## Why

After #266 merged, the first push to \`main\` ran the new Release pipeline but semantic-release silently skipped publishing. [Run 24645312606](https://github.com/doc-detective/doc-detective/actions/runs/24645312606) shows the matrix and \`release\` job green, but \`smoke-test\`, \`promote\`, and \`docker\` all skipped. Log from the Release step:

\`\`\`
semantic-release › Run automated release from branch main on
  repository git+https://github.com/hawkeyexl/doc-detective.git
semantic-release › The local branch main is behind the remote one,
  therefore a new version won't be published.
\`\`\`

Root \`package.json\` still had \`repository.url\` pointing at my personal fork (\`hawkeyexl/doc-detective\`). Semantic-release uses that URL for its "is the local branch in sync with the remote?" check — so it compared local \`main\` to the fork's \`main\`, which lagged, and aborted without publishing.

Because the release never happened, \`successCmd\` never wrote \`published=true\` to \`\$GITHUB_OUTPUT\`, so all the downstream jobs' \`if: needs.release.outputs.published == 'true'\` evaluated false and they skipped.

## Fix

Point \`repository.url\` at the canonical repo (\`doc-detective/doc-detective\`), matching what \`src/common/package.json\` already had.

One-line change in \`package.json\`.

## Test plan

- [ ] Merge, then either push a \`feat:\`/\`fix:\` commit to \`main\` or \`workflow_dispatch\` the Release workflow
- [ ] Verify semantic-release actually publishes (no "behind the remote" abort)
- [ ] Verify the smoke-test → promote → docker chain runs
- [ ] Verify \`npm view doc-detective dist-tags\` shows \`latest: 4.1.0\` after promote

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package repository metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->