### PR TITLE
fix(ci): host local test fixtures during release smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,17 @@ jobs:
             exit 1
           fi
 
+      - name: Start local test server
+        # test/artifacts/doc-content.md references http://localhost:8092.
+        # The existing Mocha hooks start a server on that port for the unit
+        # tests, but this job doesn't invoke Mocha — so serve the static
+        # fixtures directly. Pattern copied from PR #252.
+        working-directory: ./test/server/public
+        run: |
+          python3 -m http.server 8092 &
+          curl --fail --silent --retry 10 --retry-delay 1 --retry-connrefused http://localhost:8092 > /dev/null
+          echo "Test server is ready."
+
       - name: Run github-action against staging
         # Pinned to the v1.4.1 commit. Update in lockstep when the action
         # cuts a new release; `@latest` is a moving target and expands

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,8 +130,8 @@ jobs:
         # fixtures directly. Pattern copied from PR #252.
         working-directory: ./test/server/public
         run: |
-          python3 -m http.server 8092 &
-          curl --fail --silent --retry 10 --retry-delay 1 --retry-connrefused http://localhost:8092 > /dev/null
+          python3 -m http.server --bind 127.0.0.1 8092 &
+          curl --fail --silent --retry 10 --retry-delay 1 --retry-connrefused http://127.0.0.1:8092 > /dev/null
           echo "Test server is ready."
 
       - name: Run github-action against staging


### PR DESCRIPTION
## Why

[Run 24671490509](https://github.com/doc-detective/doc-detective/actions/runs/24671490509/job/72145952109) failed at the smoke-test step:

\`\`\`
Error: Invalid or unresolvable URL: http://localhost:8092
Failed Specs:
1. test/artifacts/doc-content.md
\`\`\`

\`test/artifacts/doc-content.md\` (the fixture the smoke test points \`doc-detective/github-action\` at) has a \`goTo\` step targeting \`http://localhost:8092\`. That port is served by \`test/server/index.js\` which Mocha auto-starts during unit tests — but the smoke-test job doesn't invoke Mocha, so nothing was listening and the first \`goTo\` blew up.

Because the smoke test failed, 4.1.0 didn't get promoted to \`@latest\`. It's sitting on the \`staging-4.1.0\` dist-tag on npm.

## Fix

Add the same "start a static server in the background" pattern that [#252](https://github.com/doc-detective/doc-detective/pull/252) applied to the old \`auto-dev-release.yml\` smoke-test job — just a \`python3 -m http.server\` out of \`./test/server/public\` with a curl readiness probe. ubuntu-latest ships python3 so no setup overhead.

\`\`\`yaml
- name: Start local test server
  working-directory: ./test/server/public
  run: |
    python3 -m http.server 8092 &
    curl --fail --silent --retry 10 --retry-delay 1 --retry-connrefused http://localhost:8092 > /dev/null
    echo "Test server is ready."
\`\`\`

## After this merges

4.1.0 is already published to \`staging-4.1.0\` on npm but not \`@latest\`. To recover:
- Trigger the Release workflow manually (\`workflow_dispatch\` on main). Because the publish helper is idempotent (#266) it will see 4.1.0 already on the registry and just re-assert the staging tag, then smoke, then promote.
- Or, if you'd rather not re-run the full pipeline, \`npm dist-tag add doc-detective@4.1.0 latest\` + same for \`doc-detective-common\` does the minimum — but then Docker Hub won't be updated. Re-running is cleaner.

## Test plan

- [ ] Merge
- [ ] Trigger Release on main; verify the smoke-test step now runs the github-action successfully against the staging dist-tag
- [ ] Verify promote → docker completes the chain
- [ ] \`npm view doc-detective dist-tags\` shows \`latest: 4.1.0\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved smoke test workflow with automatic test server initialization and health verification to ensure test environment readiness before running integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->