### PR TITLE
test(core): replace external google.com target with local test server

### DIFF
--- a/test/core-artifacts/checkLink.spec.json
+++ b/test/core-artifacts/checkLink.spec.json
@@ -6,19 +6,21 @@
           "loadVariables": "env"
         },
         {
-          "checkLink": "https://www.google.com"
+          "checkLink": "http://localhost:8092"
         },
         {
           "checkLink": {
-            "url": "https://www.google.com",
+            "url": "http://localhost:8092",
             "statusCodes": "200"
           }
         },
         {
           "checkLink": {
-            "url": "/images",
-            "origin": "https://www.google.com",
-            "statusCodes": [200]
+            "url": "/enhanced-elements.html",
+            "origin": "http://localhost:8092",
+            "statusCodes": [
+              200
+            ]
           }
         },
         {
@@ -26,7 +28,7 @@
         },
         {
           "checkLink": {
-            "url": "/images",
+            "url": "/enhanced-elements.html",
             "origin": "$URL"
           }
         }

--- a/test/core-artifacts/context_chrome.spec.json
+++ b/test/core-artifacts/context_chrome.spec.json
@@ -2,8 +2,17 @@
   "id": "Make sure Chrome is working",
   "contexts": [
     {
-      "app": { "name": "chrome", "options": { "headless": true } },
-      "platforms": ["windows", "mac", "linux"]
+      "app": {
+        "name": "chrome",
+        "options": {
+          "headless": true
+        }
+      },
+      "platforms": [
+        "windows",
+        "mac",
+        "linux"
+      ]
     }
   ],
   "tests": [
@@ -11,7 +20,7 @@
       "steps": [
         {
           "action": "goTo",
-          "url": "https://www.google.com"
+          "url": "http://localhost:8092"
         }
       ]
     }

--- a/test/core-artifacts/context_firefox.spec.json
+++ b/test/core-artifacts/context_firefox.spec.json
@@ -2,8 +2,14 @@
   "id": "Make sure Firefox is working",
   "contexts": [
     {
-      "app": { "name": "firefox" },
-      "platforms": ["windows", "mac", "linux"]
+      "app": {
+        "name": "firefox"
+      },
+      "platforms": [
+        "windows",
+        "mac",
+        "linux"
+      ]
     }
   ],
   "tests": [
@@ -11,7 +17,7 @@
       "steps": [
         {
           "action": "goTo",
-          "url": "https://www.google.com"
+          "url": "http://localhost:8092"
         }
       ]
     }

--- a/test/core-artifacts/context_safari.spec.json
+++ b/test/core-artifacts/context_safari.spec.json
@@ -2,8 +2,12 @@
   "id": "Make sure Safari is working",
   "contexts": [
     {
-      "app": { "name": "safari" },
-      "platforms": ["mac"]
+      "app": {
+        "name": "safari"
+      },
+      "platforms": [
+        "mac"
+      ]
     }
   ],
   "tests": [
@@ -11,7 +15,7 @@
       "steps": [
         {
           "action": "goTo",
-          "url": "https://www.google.com"
+          "url": "http://localhost:8092"
         }
       ]
     }

--- a/test/core-artifacts/env
+++ b/test/core-artifacts/env
@@ -2,4 +2,4 @@ USER="John Doe"
 JOB="Software Engineer"
 SECRET="YOUR_SECRET_KEY"
 WAIT=1
-URL=https://www.google.com
+URL=http://localhost:8092

--- a/test/core-artifacts/goTo.spec.json
+++ b/test/core-artifacts/goTo.spec.json
@@ -6,12 +6,12 @@
           "loadVariables": "env"
         },
         {
-          "goTo": "https://www.google.com"
+          "goTo": "http://localhost:8092"
         },
         {
           "goTo": {
-            "url": "/images",
-            "origin": "https://www.google.com"
+            "url": "/enhanced-elements.html",
+            "origin": "http://localhost:8092"
           }
         },
         {
@@ -19,7 +19,7 @@
         },
         {
           "goTo": {
-            "url": "/images",
+            "url": "/enhanced-elements.html",
             "origin": "$URL"
           }
         }


### PR DESCRIPTION
## Why

[Run 24678512566](https://github.com/doc-detective/doc-detective/actions/runs/24678512566) failed on \`windows-latest / node 24\` with:

\`\`\`
goTo action timed out after 83872ms
  ✓ Document ready
  ✓ Network idle (500ms)
  ✗ DOM stability timeout: DOM stability check failed
\`\`\`

Other eight matrix cells passed. Root cause: the offending spec hits \`https://www.google.com\` and \`https://www.google.com/images\`, which:
- Mutate their DOM continuously (search suggestions, doodles, ads, carousels)
- Throttle bot-shaped traffic

"DOM stability" against a page that never stops changing is a race. The slowest matrix cell trips it first; this time it was Windows + Node 24. The flake will recur every few runs.

## Fix

Swap the fixture to \`http://localhost:8092\` — the Express server that Mocha's \`beforeAll\` already spins up for every unit-test run (\`test/hooks.js\` → \`test/server/index.js\` serving out of \`test/server/public\`). It's deterministic, in-process, and already exercised by dozens of other specs. Subpath steps that used to point at \`/images\` now point at \`/enhanced-elements.html\`, which is a static fixture in \`test/server/public/\`.

## Files touched (all under \`test/core-artifacts/\`)

- \`env\` — \`URL\` env var
- \`goTo.spec.json\` — two literal URL steps + two \`$URL\`-driven steps
- \`checkLink.spec.json\` — same shape as \`goTo\`
- \`context_chrome.spec.json\` / \`context_firefox.spec.json\` / \`context_safari.spec.json\` — browser smoke tests

No production code changes.

## Test plan

- [ ] Push + observe CI: all nine matrix cells should pass without flake
- [ ] Re-trigger Release on main after this lands to finish the 4.1.x release chain