### PR TITLE
feat(postinstall): offer to install agent tools for detected coding agents

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,5 +1,6 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import * as browsers from "@puppeteer/browsers";
 import * as geckodriver from "geckodriver";
 
@@ -8,9 +9,129 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 async function main() {
   await installBrowsers();
   // await installAppiumDepencencies();
+  await maybePromptInstallAgents();
 }
 
 main();
+
+async function maybePromptInstallAgents() {
+  // Don't prompt in non-interactive contexts. npm sets many of these during
+  // automated installs (CI, Docker builds, `npm install --silent`, etc.), and a
+  // blocking prompt there would hang the parent install.
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return;
+  if (process.env.CI) return;
+  if (process.env.DOC_DETECTIVE_SKIP_AGENT_PROMPT) return;
+
+  let listAdapters;
+  try {
+    const registryPath = path.join(__dirname, "..", "dist", "agents", "registry.js");
+    ({ listAdapters } = await import(pathToFileURL(registryPath).href));
+  } catch {
+    // Compiled agents module isn't present (e.g., dev checkout without a build,
+    // or a partial install). Skip silently — postinstall must never fail.
+    return;
+  }
+
+  // NOTE: do NOT chdir() to INIT_CWD here. Adapter detect()/getInstallState()
+  // implementations spawn bare commands (e.g., `claude --version`), and on
+  // Windows CreateProcess searches the cwd before PATH. Running with cwd set
+  // to a (potentially untrusted) user repo would let a hostile `claude.cmd`
+  // or `claude.exe` in that repo execute during `npm install`. The tradeoff
+  // is that project-scope `.claude/`-style files in the consuming repo won't
+  // be seen here — we accept occasional over-prompting in that case. The
+  // child CLI spawn below gets INIT_CWD explicitly since the user has
+  // consented by then and we invoke node with an absolute path.
+  const targetCwd = process.env.INIT_CWD || process.cwd();
+
+  // Hard ceiling on the whole detection phase. Some adapters shell out to
+  // external CLIs that could hang on auth prompts, proxy stalls, etc., and a
+  // hung postinstall would freeze `npm install`. On timeout we treat the
+  // answer as "don't know" and skip prompting.
+  const DETECTION_TIMEOUT_MS = 10_000;
+
+  let needsInstall;
+  try {
+    const adapters = listAdapters();
+    const detection = Promise.all(
+      adapters.map(async (adapter) => {
+        try {
+          const detect = await adapter.detect();
+          if (!detect.present) return null;
+          const scopes = adapter.supportsScopes();
+          const states = await Promise.all(
+            scopes.map((s) =>
+              adapter.getInstallState(s).catch(() => ({ installed: false }))
+            )
+          );
+          if (states.some((s) => s.installed)) return null;
+          return adapter;
+        } catch {
+          return null;
+        }
+      })
+    );
+    const timeout = new Promise((resolve) =>
+      setTimeout(() => resolve("__timeout__"), DETECTION_TIMEOUT_MS).unref()
+    );
+    const result = await Promise.race([detection, timeout]);
+    if (result === "__timeout__") return;
+    needsInstall = result.filter(Boolean);
+  } catch {
+    return;
+  }
+
+  if (needsInstall.length === 0) return;
+
+  let confirm;
+  try {
+    ({ confirm } = await import("@inquirer/prompts"));
+  } catch {
+    return;
+  }
+
+  const names = needsInstall.map((a) => a.displayName).join(", ");
+  console.log(
+    `\nDetected coding agents that may be missing doc-detective tools: ${names}.`
+  );
+  let proceed = false;
+  try {
+    proceed = await confirm({
+      message: "Install doc-detective agent tools now?",
+      default: false,
+    });
+  } catch {
+    // User cancelled (Ctrl+C) or prompt failed — treat as decline.
+    return;
+  }
+  if (!proceed) {
+    console.log(
+      "Skipped. Run `npx doc-detective install-agents` later to install."
+    );
+    return;
+  }
+
+  // Pre-fill --agent so the CLI doesn't re-prompt for the picker. Scope stays
+  // interactive on purpose — project vs global is a per-user decision.
+  const cliPath = path.join(__dirname, "..", "bin", "doc-detective.js");
+  const cliArgs = ["install-agents"];
+  for (const a of needsInstall) {
+    cliArgs.push("--agent", a.id);
+  }
+  const exitCode = await new Promise((resolve) => {
+    const child = spawn(process.execPath, [cliPath, ...cliArgs], {
+      stdio: "inherit",
+      cwd: targetCwd,
+    });
+    child.on("exit", (code) => resolve(code ?? 0));
+    child.on("error", () => resolve(1));
+  });
+  if (exitCode !== 0) {
+    console.log(
+      `\ndoc-detective install-agents exited with code ${exitCode}. ` +
+        "You can retry with `npx doc-detective install-agents`."
+    );
+  }
+}
 
 async function installBrowsers() {
   // Move to package root directory to correctly set browser snapshot directory

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -46,10 +46,22 @@ async function maybePromptInstallAgents() {
   // npm prepends `node_modules/.bin` (and every ancestor's .bin) onto PATH for
   // lifecycle scripts, so a malicious transitive dep declaring `bin: { claude }`
   // could ship a fake `claude` binary that an adapter's bare-command spawn
-  // would pick up. Sanitize PATH for the detection phase only. Restore before
-  // we invoke anything else (notably the child CLI spawn, which legitimately
-  // needs the full PATH so the user's real agent tooling works).
-  const originalPath = process.env.PATH;
+  // would pick up. Sanitize PATH for detection AND pass the sanitized PATH
+  // through to the child CLI spawn — legitimate `claude`/`gh`/etc binaries
+  // always come from system or user-global bin dirs, never from a project's
+  // `node_modules/.bin`, so stripping those entries is safe throughout.
+  //
+  // On Windows the PATH env var can be spelled `Path` or `PATH` depending on
+  // how the parent process populated its environment. Node's process.env is
+  // case-insensitive for reads on Windows, but assigning `process.env.PATH`
+  // when the underlying entry is `Path` creates a second entry — so resolve
+  // the actual key once and use it consistently.
+  const pathKey =
+    process.platform === "win32"
+      ? Object.keys(process.env).find((k) => k.toUpperCase() === "PATH") ||
+        "Path"
+      : "PATH";
+  const originalPath = process.env[pathKey];
   const pathSep = process.platform === "win32" ? ";" : ":";
   const initCwdAbs = process.env.INIT_CWD
     ? path.resolve(process.env.INIT_CWD)
@@ -71,7 +83,7 @@ async function maybePromptInstallAgents() {
       return true;
     })
     .join(pathSep);
-  process.env.PATH = sanitizedPath;
+  process.env[pathKey] = sanitizedPath;
 
   // Hard ceiling on the whole detection phase. Some adapters shell out to
   // external CLIs that could hang on auth prompts, proxy stalls, etc. On
@@ -109,17 +121,17 @@ async function maybePromptInstallAgents() {
     );
     const result = await Promise.race([detection, timeout]);
     if (result === "__timeout__") {
-      process.env.PATH = originalPath;
+      process.env[pathKey] = originalPath;
       // Orphaned adapter children would otherwise keep the event loop alive
       // and freeze `npm install`. See comment above.
       process.exit(0);
     }
     adaptersNeedingInstall = result.filter(Boolean);
   } catch {
-    process.env.PATH = originalPath;
+    process.env[pathKey] = originalPath;
     return;
   }
-  process.env.PATH = originalPath;
+  process.env[pathKey] = originalPath;
 
   if (adaptersNeedingInstall.length === 0) return;
 
@@ -158,10 +170,15 @@ async function maybePromptInstallAgents() {
   for (const a of adaptersNeedingInstall) {
     cliArgs.push("--agent", a.id);
   }
+  // Hand the child the sanitized PATH under the actual key (PATH or Path) so
+  // its adapter spawns can't resolve a fake `claude`/`gh`/etc from
+  // `node_modules/.bin` during the install step either.
+  const childEnv = { ...process.env, [pathKey]: sanitizedPath };
   const { code, signal } = await new Promise((resolve) => {
     const child = spawn(process.execPath, [cliPath, ...cliArgs], {
       stdio: "inherit",
       cwd: targetCwd,
+      env: childEnv,
     });
     // Use `close` (fires after all stdio is flushed) and capture signal so a
     // signal-terminated child (code === null) is treated as failure rather

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -43,13 +43,47 @@ async function maybePromptInstallAgents() {
   // consented by then and we invoke node with an absolute path.
   const targetCwd = process.env.INIT_CWD || process.cwd();
 
+  // npm prepends `node_modules/.bin` (and every ancestor's .bin) onto PATH for
+  // lifecycle scripts, so a malicious transitive dep declaring `bin: { claude }`
+  // could ship a fake `claude` binary that an adapter's bare-command spawn
+  // would pick up. Sanitize PATH for the detection phase only. Restore before
+  // we invoke anything else (notably the child CLI spawn, which legitimately
+  // needs the full PATH so the user's real agent tooling works).
+  const originalPath = process.env.PATH;
+  const pathSep = process.platform === "win32" ? ";" : ":";
+  const initCwdAbs = process.env.INIT_CWD
+    ? path.resolve(process.env.INIT_CWD)
+    : null;
+  const sanitizedPath = (originalPath || "")
+    .split(pathSep)
+    .filter((entry) => {
+      if (!entry || entry === ".") return false;
+      const normalized = entry.split(path.sep).join("/");
+      if (normalized.includes("/node_modules/.bin")) return false;
+      if (initCwdAbs) {
+        const resolved = path.resolve(entry);
+        if (
+          resolved === initCwdAbs ||
+          resolved.startsWith(initCwdAbs + path.sep)
+        )
+          return false;
+      }
+      return true;
+    })
+    .join(pathSep);
+  process.env.PATH = sanitizedPath;
+
   // Hard ceiling on the whole detection phase. Some adapters shell out to
-  // external CLIs that could hang on auth prompts, proxy stalls, etc., and a
-  // hung postinstall would freeze `npm install`. On timeout we treat the
-  // answer as "don't know" and skip prompting.
+  // external CLIs that could hang on auth prompts, proxy stalls, etc. On
+  // timeout we return — but because Promise.race doesn't cancel the detection
+  // promise, any spawned adapter child processes keep the event loop alive
+  // and `npm install` would still hang. Force-exit on timeout to tear them
+  // down. This is safe here: maybePromptInstallAgents is the last step in
+  // main(), the browser installs have already completed, and we're exiting
+  // cleanly with code 0.
   const DETECTION_TIMEOUT_MS = 10_000;
 
-  let needsInstall;
+  let adaptersNeedingInstall;
   try {
     const adapters = listAdapters();
     const detection = Promise.all(
@@ -74,13 +108,20 @@ async function maybePromptInstallAgents() {
       setTimeout(() => resolve("__timeout__"), DETECTION_TIMEOUT_MS).unref()
     );
     const result = await Promise.race([detection, timeout]);
-    if (result === "__timeout__") return;
-    needsInstall = result.filter(Boolean);
+    if (result === "__timeout__") {
+      process.env.PATH = originalPath;
+      // Orphaned adapter children would otherwise keep the event loop alive
+      // and freeze `npm install`. See comment above.
+      process.exit(0);
+    }
+    adaptersNeedingInstall = result.filter(Boolean);
   } catch {
+    process.env.PATH = originalPath;
     return;
   }
+  process.env.PATH = originalPath;
 
-  if (needsInstall.length === 0) return;
+  if (adaptersNeedingInstall.length === 0) return;
 
   let confirm;
   try {
@@ -89,7 +130,7 @@ async function maybePromptInstallAgents() {
     return;
   }
 
-  const names = needsInstall.map((a) => a.displayName).join(", ");
+  const names = adaptersNeedingInstall.map((a) => a.displayName).join(", ");
   console.log(
     `\nDetected coding agents that may be missing doc-detective tools: ${names}.`
   );
@@ -114,20 +155,24 @@ async function maybePromptInstallAgents() {
   // interactive on purpose — project vs global is a per-user decision.
   const cliPath = path.join(__dirname, "..", "bin", "doc-detective.js");
   const cliArgs = ["install-agents"];
-  for (const a of needsInstall) {
+  for (const a of adaptersNeedingInstall) {
     cliArgs.push("--agent", a.id);
   }
-  const exitCode = await new Promise((resolve) => {
+  const { code, signal } = await new Promise((resolve) => {
     const child = spawn(process.execPath, [cliPath, ...cliArgs], {
       stdio: "inherit",
       cwd: targetCwd,
     });
-    child.on("exit", (code) => resolve(code ?? 0));
-    child.on("error", () => resolve(1));
+    // Use `close` (fires after all stdio is flushed) and capture signal so a
+    // signal-terminated child (code === null) is treated as failure rather
+    // than silently succeeding.
+    child.on("close", (c, s) => resolve({ code: c, signal: s }));
+    child.on("error", () => resolve({ code: 1, signal: null }));
   });
-  if (exitCode !== 0) {
+  if (signal || (code !== null && code !== 0)) {
+    const reason = signal ? `due to signal ${signal}` : `with code ${code}`;
     console.log(
-      `\ndoc-detective install-agents exited with code ${exitCode}. ` +
+      `\ndoc-detective install-agents exited ${reason}. ` +
         "You can retry with `npx doc-detective install-agents`."
     );
   }

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -57,8 +57,12 @@ export async function runInstallAgents(
 
   // Install each in order; collect reports. When an adapter doesn't support
   // the requested scope, degrade to its nearest supported scope and attach a
-  // note to the report so callers see the divergence.
+  // note to the report so callers see the divergence. Each install() is
+  // isolated so one adapter's failure doesn't prevent the remaining adapters
+  // from getting a chance — otherwise the user who said "install into these
+  // three" would lose the last two when the first one errors.
   const reports: InstallReport[] = [];
+  const failures: { adapter: AgentAdapter; error: unknown }[] = [];
   for (const adapter of targeted) {
     const effective = effectiveScopeFor(adapter, scope);
     if (effective.degraded) {
@@ -68,23 +72,36 @@ export async function runInstallAgents(
       );
     }
     logger(`\n→ ${adapter.displayName} (${adapter.id}) — scope: ${effective.scope}`, "info");
-    const report = await adapter.install({
-      scope: effective.scope,
-      force: Boolean(argv.force),
-      dryRun,
-      logger,
-    });
-    const finalReport = effective.degraded
-      ? {
-          ...report,
-          notes: [
-            ...(report.notes ?? []),
-            `Requested scope '${scope}' is not supported by ${adapter.displayName}; installed as '${effective.scope}' instead.`,
-          ],
-        }
-      : report;
-    reports.push(finalReport);
-    logger(summarizeReport(finalReport), "info");
+    try {
+      const report = await adapter.install({
+        scope: effective.scope,
+        force: Boolean(argv.force),
+        dryRun,
+        logger,
+      });
+      const finalReport = effective.degraded
+        ? {
+            ...report,
+            notes: [
+              ...(report.notes ?? []),
+              `Requested scope '${scope}' is not supported by ${adapter.displayName}; installed as '${effective.scope}' instead.`,
+            ],
+          }
+        : report;
+      reports.push(finalReport);
+      logger(summarizeReport(finalReport), "info");
+    } catch (err) {
+      failures.push({ adapter, error: err });
+      const message = err instanceof Error ? err.message : String(err);
+      logger(`  failed: ${message}`, "error");
+    }
+  }
+  if (failures.length > 0) {
+    const names = failures.map((f) => f.adapter.displayName).join(", ");
+    // Throw so the CLI exits nonzero and the postinstall prompt's retry hint
+    // fires; earlier adapters that succeeded still completed their side
+    // effects, they just don't show up in the thrown error's message.
+    throw new Error(`Agent install failed for: ${names}.`);
   }
   return reports;
 }

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -933,6 +933,38 @@ describe("runInstallAgents() orchestration", function () {
     assert.equal(both.lastScope, "project");        // respected
   });
 
+  it("one adapter's install failure does not block the remaining adapters", async function () {
+    const failing = makeStubAdapter("failing");
+    failing.install = async function () {
+      this.calls.install++;
+      throw new Error("simulated install failure");
+    };
+    const ok1 = makeStubAdapter("ok-one");
+    const ok2 = makeStubAdapter("ok-two");
+    const logs = [];
+    await assert.rejects(
+      runInstallAgents(
+        {
+          agent: ["failing", "ok-one", "ok-two"],
+          scope: "project",
+          force: false,
+          yes: true,
+          "dry-run": false,
+        },
+        { adapters: [failing, ok1, ok2], isTTY: () => false, logger: (m) => logs.push(m) }
+      ),
+      /failing/i
+    );
+    // Every adapter got its turn — the first one's throw did not abort the loop.
+    assert.equal(failing.calls.install, 1);
+    assert.equal(ok1.calls.install, 1);
+    assert.equal(ok2.calls.install, 1);
+    assert.ok(
+      logs.some((l) => /failed:.*simulated install failure/i.test(l)),
+      `expected a 'failed: ...' log entry; got: ${JSON.stringify(logs)}`
+    );
+  });
+
   it("reports 'no detected agents' cleanly (no throw, empty reports)", async function () {
     const cc = makeStubAdapter("claude", {
       detection: { present: false, onPath: false, configPaths: {} },


### PR DESCRIPTION
## Summary

- Extends the `postinstall` script to detect supported AI coding agents (Claude Code, Copilot CLI, Gemini CLI, Codex, Qwen Code, opencode) via the compiled adapter registry.
- When an agent is present but has **no** doc-detective tools installed in any supported scope, asks the user whether to install them and spawns `doc-detective install-agents --agent <id>` on consent.
- Pre-fills `--agent` so the CLI doesn't re-prompt for the agent picker; scope picker remains interactive.

## Why

Users already have to opt in by running `install-agents` manually to get the MCP / plugin tooling into their coding agent. Discovering the feature was the friction point. This adds a one-time, interactive, opt-in prompt at install time for people who clearly have an agent on the machine.

## Safety / guardrails

This runs inside `npm install`, so it had to be defensive. It:
- Skips unless **both** `stdin` and `stdout` are TTYs (so `npm install --silent`, piped installs, and logged installs never prompt).
- Skips when `CI` or `DOC_DETECTIVE_SKIP_AGENT_PROMPT` is set.
- Wraps the whole detection phase in a 10s `Promise.race` timeout (`setTimeout().unref()`) so a hung agent CLI can never freeze `npm install`.
- Does **not** `chdir()` into `INIT_CWD`. Adapters spawn bare commands like `claude`, and on Windows `CreateProcess` resolves cwd before PATH — running adapter detection with cwd set to an untrusted user repo would let a hostile `claude.cmd`/`claude.exe` there execute during install. Trade-off: project-scope `.claude/`-style files in the consuming repo may not be seen at this stage; the child CLI (invoked via absolute `process.execPath` + absolute cli path, post-consent) does get `cwd: INIT_CWD`.
- Swallows every failure path — postinstall must never fail the parent install.
- Captures the spawned CLI's exit code and prints a retry hint on nonzero instead of silently claiming success.

## Review process

Changes went through an adversarial review pass with Copilot CLI (gpt-5.2). Issues found and fixed in this PR:
- **HIGH** — Windows CWD-precedence RCE via `chdir(INIT_CWD)` + bare-command spawns → `chdir` removed.
- **HIGH** — No timeout around adapter detection → 10s `Promise.race` timeout added.
- **MED** — Child exit code ignored → captured + retry hint on nonzero.
- **MED** — Over-confident "without doc-detective tools" wording given weak detection → softened to "may be missing".
- **LOW** — Double prompting (postinstall + CLI picker) → `--agent` pre-fill.

Out-of-scope adapter-level items (tri-state install status, empty `supportsScopes()` guard, `prompts.ts` TTY-check asymmetry, `getInstallState` network fetch) were not pulled into this change to keep the diff focused; the 10s timeout mitigates the network-fetch concern for this caller.

## Test plan

- [ ] `npm install doc-detective` in a TTY with Claude Code present and no plugin installed → prompt appears; `y` launches scope picker; `n` prints skip hint.
- [ ] Same install with `CI=1` → no prompt, install completes normally.
- [ ] Same install with stdin/stdout piped (e.g., `| cat`) → no prompt, install completes normally.
- [ ] Install inside a malicious test repo with a `claude.cmd` in it on Windows → that binary is **not** executed.
- [ ] With `DOC_DETECTIVE_SKIP_AGENT_PROMPT=1` → no prompt.
- [ ] Dev checkout without a `dist/` build → no prompt, no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive prompt to offer optional agent tools after install
  * Detects missing adapters and skips prompting in CI or non-interactive shells

* **Bug Fixes**
  * Continues installing remaining adapters when one fails and reports aggregated failures

* **Tests**
  * Added test validating per-adapter failure handling and continued install attempts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->