### PR TITLE
fix(postinstall): case-insensitive PATH filtering on Windows + safe undefined restore

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -63,20 +63,26 @@ async function maybePromptInstallAgents() {
       : "PATH";
   const originalPath = process.env[pathKey];
   const pathSep = process.platform === "win32" ? ";" : ":";
+  // Windows paths are case-insensitive, so normalize both sides of every
+  // comparison to lowercase on win32. Otherwise `C:\Proj\NODE_MODULES\.BIN`
+  // would slip past a literal `/node_modules/.bin` check.
+  const isWin = process.platform === "win32";
+  const caseFold = (s) => (isWin ? s.toLowerCase() : s);
   const initCwdAbs = process.env.INIT_CWD
     ? path.resolve(process.env.INIT_CWD)
     : null;
+  const initCwdMatch = initCwdAbs ? caseFold(initCwdAbs) : null;
   const sanitizedPath = (originalPath || "")
     .split(pathSep)
     .filter((entry) => {
       if (!entry || entry === ".") return false;
-      const normalized = entry.split(path.sep).join("/");
+      const normalized = caseFold(entry.split(path.sep).join("/"));
       if (normalized.includes("/node_modules/.bin")) return false;
-      if (initCwdAbs) {
-        const resolved = path.resolve(entry);
+      if (initCwdMatch) {
+        const resolved = caseFold(path.resolve(entry));
         if (
-          resolved === initCwdAbs ||
-          resolved.startsWith(initCwdAbs + path.sep)
+          resolved === initCwdMatch ||
+          resolved.startsWith(initCwdMatch + path.sep)
         )
           return false;
       }
@@ -84,6 +90,14 @@ async function maybePromptInstallAgents() {
     })
     .join(pathSep);
   process.env[pathKey] = sanitizedPath;
+  // Restoring via `process.env[k] = undefined` coerces to the literal string
+  // "undefined" (Node stringifies every env value), leaving the process with
+  // a broken PATH. Delete the key when the original was absent; only assign
+  // when we have a real string.
+  const restorePath = () => {
+    if (originalPath === undefined) delete process.env[pathKey];
+    else process.env[pathKey] = originalPath;
+  };
 
   // Hard ceiling on the whole detection phase. Some adapters shell out to
   // external CLIs that could hang on auth prompts, proxy stalls, etc. On
@@ -121,17 +135,17 @@ async function maybePromptInstallAgents() {
     );
     const result = await Promise.race([detection, timeout]);
     if (result === "__timeout__") {
-      process.env[pathKey] = originalPath;
+      restorePath();
       // Orphaned adapter children would otherwise keep the event loop alive
       // and freeze `npm install`. See comment above.
       process.exit(0);
     }
     adaptersNeedingInstall = result.filter(Boolean);
   } catch {
-    process.env[pathKey] = originalPath;
+    restorePath();
     return;
   }
-  process.env[pathKey] = originalPath;
+  restorePath();
 
   if (adaptersNeedingInstall.length === 0) return;
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -72,6 +72,14 @@ async function maybePromptInstallAgents() {
     ? path.resolve(process.env.INIT_CWD)
     : null;
   const initCwdMatch = initCwdAbs ? caseFold(initCwdAbs) : null;
+  // Guard against INIT_CWD resolving to a root ("/" on POSIX, "C:\" on
+  // Windows): blindly appending path.sep would produce "//" or "C:\\", and
+  // `startsWith` would miss every subpath. When the value already ends with
+  // a separator (root case), use it as-is; otherwise append.
+  const initCwdPrefix =
+    initCwdMatch && !initCwdMatch.endsWith(path.sep)
+      ? initCwdMatch + path.sep
+      : initCwdMatch;
   const sanitizedPath = (originalPath || "")
     .split(pathSep)
     .filter((entry) => {
@@ -80,10 +88,7 @@ async function maybePromptInstallAgents() {
       if (normalized.includes("/node_modules/.bin")) return false;
       if (initCwdMatch) {
         const resolved = caseFold(path.resolve(entry));
-        if (
-          resolved === initCwdMatch ||
-          resolved.startsWith(initCwdMatch + path.sep)
-        )
+        if (resolved === initCwdMatch || resolved.startsWith(initCwdPrefix))
           return false;
       }
       return true;


### PR DESCRIPTION
## Summary

Two follow-up hardening fixes for the `maybePromptInstallAgents()` function added in [#273](https://github.com/doc-detective/doc-detective/pull/273). Both landed as review comments after #273 was merged.

## What

- **Case-insensitive PATH filtering on Windows.** The PATH sanitizer compared path entries literally against `/node_modules/.bin`, so a PATH entry like `C:\Proj\NODE_MODULES\.BIN` slipped past the filter. Normalize both the entry and the `INIT_CWD` prefix to lowercase on `win32` before comparing. POSIX comparisons stay case-sensitive.
- **Safe undefined restore.** `process.env[pathKey] = originalPath` when `originalPath` is `undefined` coerces to the literal string `"undefined"` (Node stringifies every env value), leaving the process with a broken PATH. Added a `restorePath()` helper that deletes the key when the original was absent and only assigns when it was a real string. Used at every restore site (normal, `catch`, and timeout branches).

## Why

Defense-in-depth on the PATH sanitization from #273. Without these, a postinstall running against a Windows consumer repo with an uppercased `NODE_MODULES\.BIN` entry — or an unusual environment where PATH is genuinely absent — could reintroduce the binary-hijacking window that the sanitization was supposed to close.

## Test plan

- [x] Smoke-tested the filter against 7 cases on Windows: `C:/System32` (keep), `C:/Proj/NODE_MODULES/.BIN` (drop), mixed-case `/Project/node_modules/.bin` (drop), path inside `INIT_CWD` (drop), unrelated path (keep), `.` (drop), empty (drop) — all correct.
- [x] `node --check scripts/postinstall.js` passes.
- [ ] Full CI matrix (runs on PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows PATH handling to use case-insensitive comparisons and more robust matching for entries under the initial working directory.
  * Enhanced filtering to better ignore local node_modules binaries during install flows.
  * Fixed PATH restoration to correctly remove unset environment entries instead of assigning incorrect string values on errors or timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->