### PR TITLE
refactor(container-tests): share server + fixtures with main suite

### DIFF
--- a/src/container/test/artifacts/checkLink.spec.json
+++ b/src/container/test/artifacts/checkLink.spec.json
@@ -6,19 +6,21 @@
           "loadVariables": "env"
         },
         {
-          "checkLink": "https://www.google.com"
+          "checkLink": "$URL"
         },
         {
           "checkLink": {
-            "url": "https://www.google.com",
+            "url": "$URL",
             "statusCodes": "200"
           }
         },
         {
           "checkLink": {
-            "url": "/images",
-            "origin": "https://www.google.com",
-            "statusCodes": [200]
+            "url": "/enhanced-elements.html",
+            "origin": "$URL",
+            "statusCodes": [
+              200
+            ]
           }
         },
         {
@@ -26,7 +28,7 @@
         },
         {
           "checkLink": {
-            "url": "/images",
+            "url": "/enhanced-elements.html",
             "origin": "$URL"
           }
         }

--- a/src/container/test/artifacts/checkLink.spec.json
+++ b/src/container/test/artifacts/checkLink.spec.json
@@ -11,7 +11,9 @@
         {
           "checkLink": {
             "url": "$URL",
-            "statusCodes": "200"
+            "statusCodes": [
+              200
+            ]
           }
         },
         {

--- a/src/container/test/artifacts/context_chrome.spec.json
+++ b/src/container/test/artifacts/context_chrome.spec.json
@@ -2,16 +2,27 @@
   "id": "Make sure Chrome is working",
   "contexts": [
     {
-      "app": { "name": "chrome", "options": { "headless": true } },
-      "platforms": ["windows", "mac", "linux"]
+      "app": {
+        "name": "chrome",
+        "options": {
+          "headless": true
+        }
+      },
+      "platforms": [
+        "windows",
+        "mac",
+        "linux"
+      ]
     }
   ],
   "tests": [
     {
       "steps": [
         {
-          "action": "goTo",
-          "url": "https://www.google.com"
+          "loadVariables": "env"
+        },
+        {
+          "goTo": "$URL"
         }
       ]
     }

--- a/src/container/test/artifacts/context_chrome.spec.json
+++ b/src/container/test/artifacts/context_chrome.spec.json
@@ -1,13 +1,13 @@
 {
-  "id": "Make sure Chrome is working",
-  "contexts": [
+  "specId": "Make sure Chrome is working",
+  "runOn": [
     {
-      "app": {
-        "name": "chrome",
-        "options": {
+      "browsers": [
+        {
+          "name": "chrome",
           "headless": true
         }
-      },
+      ],
       "platforms": [
         "windows",
         "mac",

--- a/src/container/test/artifacts/context_firefox.spec.json
+++ b/src/container/test/artifacts/context_firefox.spec.json
@@ -1,10 +1,10 @@
 {
-  "id": "Make sure Firefox is working",
-  "contexts": [
+  "specId": "Make sure Firefox is working",
+  "runOn": [
     {
-      "app": {
-        "name": "firefox"
-      },
+      "browsers": [
+        "firefox"
+      ],
       "platforms": [
         "windows",
         "mac",

--- a/src/container/test/artifacts/context_firefox.spec.json
+++ b/src/container/test/artifacts/context_firefox.spec.json
@@ -2,16 +2,24 @@
   "id": "Make sure Firefox is working",
   "contexts": [
     {
-      "app": { "name": "firefox" },
-      "platforms": ["windows", "mac", "linux"]
+      "app": {
+        "name": "firefox"
+      },
+      "platforms": [
+        "windows",
+        "mac",
+        "linux"
+      ]
     }
   ],
   "tests": [
     {
       "steps": [
         {
-          "action": "goTo",
-          "url": "https://www.google.com"
+          "loadVariables": "env"
+        },
+        {
+          "goTo": "$URL"
         }
       ]
     }

--- a/src/container/test/artifacts/context_safari.spec.json
+++ b/src/container/test/artifacts/context_safari.spec.json
@@ -1,10 +1,10 @@
 {
-  "id": "Make sure Safari is working",
-  "contexts": [
+  "specId": "Make sure Safari is working",
+  "runOn": [
     {
-      "app": {
-        "name": "safari"
-      },
+      "browsers": [
+        "safari"
+      ],
       "platforms": [
         "mac"
       ]

--- a/src/container/test/artifacts/context_safari.spec.json
+++ b/src/container/test/artifacts/context_safari.spec.json
@@ -2,16 +2,22 @@
   "id": "Make sure Safari is working",
   "contexts": [
     {
-      "app": { "name": "safari" },
-      "platforms": ["mac"]
+      "app": {
+        "name": "safari"
+      },
+      "platforms": [
+        "mac"
+      ]
     }
   ],
   "tests": [
     {
       "steps": [
         {
-          "action": "goTo",
-          "url": "https://www.google.com"
+          "loadVariables": "env"
+        },
+        {
+          "goTo": "$URL"
         }
       ]
     }

--- a/src/container/test/artifacts/doc-content.md
+++ b/src/container/test/artifacts/doc-content.md
@@ -1,23 +1,24 @@
-# Doc Detective documentation overview
+# Doc Detective container-test overview
 
 <!-- test
 testId: doc-detective-docs
 detectSteps: false
 -->
 
-[Doc Detective documentation](https://docs.doc-detective.com) is split into a few key sections:
+The container test harness points Doc Detective at the same local
+Express server that the main test suite uses (`test/server/` on the
+host, reached from inside the container via `host.docker.internal:8092`).
 
-<!-- step checkLink: "https://docs.doc-detective.com" -->
+<!-- step checkLink: "http://host.docker.internal:8092" -->
 
-- The landing page discusses what Doc Detective is, what it does, and who might find it useful.
-- [Get started](https://docs.doc-detective.com/docs/get-started/installation) covers how to quickly get up and running with Doc Detective.
+- The server's root (`index.html`) has common HTML elements we can
+  navigate to and interact with.
+- The `#text-elements` section contains a **Text Elements** heading.
 
-  <!-- step checkLink: "https://docs.doc-detective.com/docs/get-started/installation" -->
+  <!-- step checkLink: "http://host.docker.internal:8092/enhanced-elements.html" -->
 
-Some pages also have unique headings. If you open [type](https://docs.doc-detective.com/docs/actions/type) it has **Special keys**.
+<!-- step goTo: "http://host.docker.internal:8092" -->
+<!-- step find: Text Elements -->
 
-<!-- step goTo: "https://docs.doc-detective.com/docs/actions/type" -->
-<!-- step find: Special keys -->
-
-![Search results.](reference.png){ .screenshot }
+![Fixture screenshot.](reference.png){ .screenshot }
 <!-- step screenshot: reference.png -->

--- a/src/container/test/artifacts/doc-content.md
+++ b/src/container/test/artifacts/doc-content.md
@@ -5,19 +5,20 @@ testId: doc-detective-docs
 detectSteps: false
 -->
 
-The container test harness points Doc Detective at the same local
-Express server that the main test suite uses (`test/server/` on the
-host, reached from inside the container via `host.docker.internal:8092`).
+The container test harness serves the same `test/server/public/` fixtures
+the main test suite uses, but from a sidecar container on a shared
+docker network so the test container reaches it by docker DNS name
+(`dd-test-server`).
 
-<!-- step checkLink: "http://host.docker.internal:8092" -->
+<!-- step checkLink: "http://dd-test-server:8092" -->
 
 - The server's root (`index.html`) has common HTML elements we can
   navigate to and interact with.
 - The `#text-elements` section contains a **Text Elements** heading.
 
-  <!-- step checkLink: "http://host.docker.internal:8092/enhanced-elements.html" -->
+  <!-- step checkLink: "http://dd-test-server:8092/enhanced-elements.html" -->
 
-<!-- step goTo: "http://host.docker.internal:8092" -->
+<!-- step goTo: "http://dd-test-server:8092" -->
 <!-- step find: Text Elements -->
 
 ![Fixture screenshot.](reference.png){ .screenshot }

--- a/src/container/test/artifacts/env
+++ b/src/container/test/artifacts/env
@@ -1,5 +1,5 @@
 USER="John Doe"
 JOB="Software Engineer"
 SECRET="YOUR_SECRET_KEY"
-URL=http://host.docker.internal:8092
+URL=http://dd-test-server:8092
 WAIT="1"

--- a/src/container/test/artifacts/env
+++ b/src/container/test/artifacts/env
@@ -1,5 +1,5 @@
 USER="John Doe"
 JOB="Software Engineer"
 SECRET="YOUR_SECRET_KEY"
-URL="https://www.google.com"
+URL=http://host.docker.internal:8092
 WAIT="1"

--- a/src/container/test/artifacts/find_matchText.spec.json
+++ b/src/container/test/artifacts/find_matchText.spec.json
@@ -4,27 +4,27 @@
     {
       "steps": [
         {
-          "goTo": {
-            "url": "https://example.com/",
-            "timeout": 60000
+          "loadVariables": "env"
+        },
+        {
+          "goTo": "$URL"
+        },
+        {
+          "find": {
+            "selector": "#text-elements > h2",
+            "elementText": "Text Elements"
           }
         },
         {
           "find": {
-            "elementText": "Example Domain",
-            "timeout": 30000
+            "selector": "#text-elements > h2",
+            "elementText": "/^Text Elements$/"
           }
         },
         {
           "find": {
-            "elementText": "/^Example Domain$/",
-            "timeout": 30000
-          }
-        },
-        {
-          "find": {
-            "elementText": "/^E.*?n$/",
-            "timeout": 30000
+            "selector": "#text-elements > h2",
+            "elementText": "/^T.*?s/"
           }
         }
       ]

--- a/src/container/test/artifacts/find_matchText.spec.json
+++ b/src/container/test/artifacts/find_matchText.spec.json
@@ -1,5 +1,5 @@
 {
-  "id": "matchTextRegex",
+  "specId": "matchTextRegex",
   "tests": [
     {
       "steps": [

--- a/src/container/test/artifacts/find_rightClick.spec.json
+++ b/src/container/test/artifacts/find_rightClick.spec.json
@@ -1,21 +1,23 @@
 {
-    "id": "find_right click",
-    "tests": [
-      {
-        "steps": [
-          {
-            "action": "goTo",
-            "url": "https://www.google.com"
-          },
-          {
-            "action": "find",
-            "selector": "[title=Search]",
+  "id": "find_rightClick",
+  "tests": [
+    {
+      "steps": [
+        {
+          "loadVariables": "env"
+        },
+        {
+          "goTo": "$URL"
+        },
+        {
+          "find": {
+            "selector": "#text-input",
             "click": {
               "button": "right"
             }
           }
-        ]
-      }
-    ]
-  }
-  
+        }
+      ]
+    }
+  ]
+}

--- a/src/container/test/artifacts/find_rightClick.spec.json
+++ b/src/container/test/artifacts/find_rightClick.spec.json
@@ -1,5 +1,5 @@
 {
-  "id": "find_rightClick",
+  "specId": "find_rightClick",
   "tests": [
     {
       "steps": [

--- a/src/container/test/artifacts/find_setVariables.spec.json
+++ b/src/container/test/artifacts/find_setVariables.spec.json
@@ -4,16 +4,16 @@
       "id": "Set env variable from element text",
       "steps": [
         {
-          "goTo": {
-            "url": "https://example.com/",
-            "timeout": 60000
-          }
+          "loadVariables": "env"
         },
         {
-          "description": "Set HEADING variable to the text of the 'Example Domain' element.",
+          "goTo": "$URL"
+        },
+        {
+          "description": "Set HEADING variable to the text of the 'Text Elements' section heading.",
           "find": {
-            "elementText": "Example Domain",
-            "timeout": 30000
+            "selector": "#text-elements > h2",
+            "elementText": "Text Elements"
           },
           "variables": {
             "HEADING": "extract($$element.text, \".*\")"
@@ -23,7 +23,7 @@
           "description": "Print and validate the value of the HEADING variable.",
           "runShell": {
             "command": "echo $HEADING",
-            "stdio": "Example Domain"
+            "stdio": "Text Elements"
           }
         }
       ]

--- a/src/container/test/artifacts/find_setVariables.spec.json
+++ b/src/container/test/artifacts/find_setVariables.spec.json
@@ -1,7 +1,7 @@
 {
   "tests": [
     {
-      "id": "Set env variable from element text",
+      "testId": "Set env variable from element text",
       "steps": [
         {
           "loadVariables": "env"

--- a/src/container/test/artifacts/goTo.spec.json
+++ b/src/container/test/artifacts/goTo.spec.json
@@ -6,12 +6,12 @@
           "loadVariables": "env"
         },
         {
-          "goTo": "https://www.google.com"
+          "goTo": "$URL"
         },
         {
           "goTo": {
-            "url": "/images",
-            "origin": "https://www.google.com"
+            "url": "/enhanced-elements.html",
+            "origin": "$URL"
           }
         },
         {
@@ -19,7 +19,7 @@
         },
         {
           "goTo": {
-            "url": "/images",
+            "url": "/enhanced-elements.html",
             "origin": "$URL"
           }
         }

--- a/src/container/test/artifacts/test.spec.json
+++ b/src/container/test/artifacts/test.spec.json
@@ -8,28 +8,33 @@
       "cleanup": "cleanup.spec.json",
       "steps": [
         {
-          "action": "checkLink",
-          "url": "https://www.google.com"
+          "loadVariables": "env"
         },
         {
-          "action": "goTo",
-          "url": "https://www.google.com"
-        },
-        { 
-          "action": "startRecording"
+          "checkLink": "$URL"
         },
         {
-          "action": "find",
-          "selector": "[title=Search]",
-          "timeout": 10000,
-          "moveTo": true,
-          "click": true,
-          "typeKeys": {
-            "keys": ["shorthair cat", "$ENTER$"]
+          "goTo": "$URL"
+        },
+        {
+          "startRecording": {}
+        },
+        {
+          "find": {
+            "selector": "#text-input",
+            "timeout": 10000,
+            "moveTo": true,
+            "click": true,
+            "type": {
+              "keys": [
+                "shorthair cat",
+                "$ENTER$"
+              ]
+            }
           }
         },
         {
-          "action": "stopRecording"
+          "stopRecording": {}
         }
       ]
     }

--- a/src/container/test/artifacts/test.spec.json
+++ b/src/container/test/artifacts/test.spec.json
@@ -1,11 +1,11 @@
 {
-  "id": "Do all the things! - Spec",
+  "specId": "Do all the things! - Spec",
   "tests": [
     {
-      "id": "Do all the things! - Test",
+      "testId": "Do all the things! - Test",
       "description": "This test includes nearly every property across all actions.",
-      "setup": "setup.spec.json",
-      "cleanup": "cleanup.spec.json",
+      "before": "setup.spec.json",
+      "after": "cleanup.spec.json",
       "steps": [
         {
           "loadVariables": "env"

--- a/src/container/test/artifacts/test.spec.json
+++ b/src/container/test/artifacts/test.spec.json
@@ -17,7 +17,7 @@
           "goTo": "$URL"
         },
         {
-          "startRecording": {}
+          "record": true
         },
         {
           "find": {
@@ -34,7 +34,7 @@
           }
         },
         {
-          "stopRecording": {}
+          "stopRecord": true
         }
       ]
     }

--- a/src/container/test/artifacts/type.spec.json
+++ b/src/container/test/artifacts/type.spec.json
@@ -1,7 +1,7 @@
 {
   "tests": [
     {
-      "description": "Exercises the three type shapes (array, string, object) in a single driver session to avoid chromedriver-restart flake inside the container.",
+      "description": "Exercises the three type shapes (array keys, single-key string, object with inputDelay) in a single driver session to avoid chromedriver-restart flake inside the container. Each step targets the input by selector so keystrokes don't race the active-element focus state.",
       "steps": [
         {
           "loadVariables": "env"
@@ -10,31 +10,29 @@
           "goTo": "$URL"
         },
         {
-          "find": "#text-input"
-        },
-        {
-          "type": [
-            "kittens",
-            "$ENTER$"
-          ]
-        },
-        {
-          "goTo": "$URL"
-        },
-        {
-          "find": "#text-input"
-        },
-        {
-          "type": "kittens"
+          "type": {
+            "selector": "#text-input",
+            "keys": [
+              "kittens",
+              "$ENTER$"
+            ]
+          }
         },
         {
           "goTo": "$URL"
-        },
-        {
-          "find": "#text-input"
         },
         {
           "type": {
+            "selector": "#text-input",
+            "keys": "kittens"
+          }
+        },
+        {
+          "goTo": "$URL"
+        },
+        {
+          "type": {
+            "selector": "#text-input",
             "keys": [
               "kittens",
               "$ENTER$"

--- a/src/container/test/artifacts/type.spec.json
+++ b/src/container/test/artifacts/type.spec.json
@@ -1,33 +1,44 @@
 {
   "tests": [
     {
+      "description": "Exercises the three type shapes (array, string, object) in a single driver session to avoid chromedriver-restart flake inside the container.",
       "steps": [
         {
-          "goTo": "https://www.google.com"
+          "loadVariables": "env"
         },
         {
-          "type": ["kittens", "$ENTER$"]
-        }
-      ]
-    },
-    {
-      "steps": [
+          "goTo": "$URL"
+        },
         {
-          "goTo": "https://www.google.com"
+          "find": "#text-input"
+        },
+        {
+          "type": [
+            "kittens",
+            "$ENTER$"
+          ]
+        },
+        {
+          "goTo": "$URL"
+        },
+        {
+          "find": "#text-input"
         },
         {
           "type": "kittens"
-        }
-      ]
-    },
-    {
-      "steps": [
+        },
         {
-          "goTo": "https://www.google.com"
+          "goTo": "$URL"
+        },
+        {
+          "find": "#text-input"
         },
         {
           "type": {
-            "keys": ["kittens", "$ENTER$"],
+            "keys": [
+              "kittens",
+              "$ENTER$"
+            ],
             "inputDelay": 100
           }
         }

--- a/src/container/test/runTests.test.cjs
+++ b/src/container/test/runTests.test.cjs
@@ -4,14 +4,48 @@ const fs = require("fs");
 const { networkInterfaces } = require("os");
 const artifactPath = path.resolve(__dirname, "./artifacts");
 const outputFile = path.resolve(artifactPath, "results.json");
-const { spawn } = require("child_process");
+const { spawn, execFileSync } = require("child_process");
 
-// Resolve the first non-loopback IPv4 address on the host. That's the
-// address that a Docker container can reach (the host shows up on the
-// container's LAN via Docker's bridge or NAT). Used to pin
-// `host.docker.internal` to a real IP on engines where the magic name
-// isn't auto-wired (Linux Docker Engine, native Windows containers on
-// windows-2022 CI runners, etc.).
+// Figure out which Docker engine we're talking to so we can give the
+// container a working `host.docker.internal`:
+//   - Docker Desktop (Win/Mac): auto-wires the name, don't override.
+//   - Linux Docker Engine:      use `host-gateway` (the blessed path).
+//   - Native Windows Engine:    `host-gateway` isn't reliable (not how
+//                               GH's windows-2022 runner's engine
+//                               handles it), so fall back to an
+//                               explicit host IP.
+function detectDockerEngine() {
+  // Docker Desktop (Win/Mac) uses context names prefixed `desktop-`
+  // (e.g. `desktop-windows`, `desktop-linux`). Both native Windows
+  // Engine and Linux Docker Engine use different context names
+  // (typically `default`).
+  let context = "";
+  try {
+    context = execFileSync("docker", ["context", "show"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    context = "";
+  }
+  if (/^desktop-/i.test(context)) return "docker-desktop";
+
+  // Not Docker Desktop. Ask the engine which container OS it's running;
+  // the same Linux runner could conceivably run Windows containers, but
+  // in practice each runner is one or the other.
+  let osType = "";
+  try {
+    osType = execFileSync("docker", ["info", "--format", "{{.OSType}}"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    osType = "";
+  }
+  if (/windows/i.test(osType)) return "windows-native";
+  return "linux-native";
+}
+
 function resolveHostIPv4() {
   for (const addresses of Object.values(networkInterfaces())) {
     for (const a of addresses || []) {
@@ -21,6 +55,25 @@ function resolveHostIPv4() {
     }
   }
   return null;
+}
+
+function buildHostNetworkArgs() {
+  const engine = detectDockerEngine();
+  if (engine === "docker-desktop") {
+    // Docker Desktop already wires host.docker.internal for both Linux
+    // and Windows container modes. Overriding with --add-host here can
+    // steer the container at the wrong interface IP.
+    return [];
+  }
+  if (engine === "linux-native") {
+    // Docker Engine 20.10+ resolves `host-gateway` to the bridge's
+    // host-side IP. This is the Docker-blessed way.
+    return ["--add-host", "host.docker.internal:host-gateway"];
+  }
+  // Native Windows engine (e.g. GitHub Actions windows-2022 runner) or
+  // an unknown engine — map explicitly.
+  const ip = resolveHostIPv4();
+  return ip ? ["--add-host", `host.docker.internal:${ip}`] : [];
 }
 
 const version = process.env.VERSION || 'latest';
@@ -63,20 +116,12 @@ describe("Run tests successfully", function () {
       // Spec fixtures reference the local test server on the host
       // (test/server/, port 8092 — started by test/hooks.js as a Mocha
       // root hook, shared with the main test suite). Reach it from the
-      // container via `host.docker.internal`.
-      //
-      // Docker Desktop for Windows/Mac auto-wires `host.docker.internal`.
-      // Everywhere else — Linux Docker Engine, native Windows containers
-      // on GitHub Actions' windows-2022 runner — it isn't, so map the
-      // name to a real host IP explicitly. Doing this unconditionally is
-      // safe: a user-provided `--add-host` always wins over the engine's
-      // built-in name resolution.
-      const hostIp = resolveHostIPv4();
-      const hostNetworkArgs = hostIp
-        ? ["--add-host", `host.docker.internal:${hostIp}`]
-        : process.platform === "linux"
-          ? ["--add-host", "host.docker.internal:host-gateway"]
-          : [];
+      // container via `host.docker.internal`; see `buildHostNetworkArgs`
+      // for per-engine handling.
+      const hostNetworkArgs = buildHostNetworkArgs();
+      if (hostNetworkArgs.length) {
+        console.log(`Using docker args for host networking: ${hostNetworkArgs.join(" ")}`);
+      }
 
       // Resource limits are generous enough to cover many serial Chrome
       // sessions (each spec + each `contexts:` block starts a fresh

--- a/src/container/test/runTests.test.cjs
+++ b/src/container/test/runTests.test.cjs
@@ -1,9 +1,27 @@
 const path = require("path");
 const assert = require("assert").strict;
 const fs = require("fs");
+const { networkInterfaces } = require("os");
 const artifactPath = path.resolve(__dirname, "./artifacts");
 const outputFile = path.resolve(artifactPath, "results.json");
 const { spawn } = require("child_process");
+
+// Resolve the first non-loopback IPv4 address on the host. That's the
+// address that a Docker container can reach (the host shows up on the
+// container's LAN via Docker's bridge or NAT). Used to pin
+// `host.docker.internal` to a real IP on engines where the magic name
+// isn't auto-wired (Linux Docker Engine, native Windows containers on
+// windows-2022 CI runners, etc.).
+function resolveHostIPv4() {
+  for (const addresses of Object.values(networkInterfaces())) {
+    for (const a of addresses || []) {
+      if (a && a.family === "IPv4" && !a.internal) {
+        return a.address;
+      }
+    }
+  }
+  return null;
+}
 
 const version = process.env.VERSION || 'latest';
 
@@ -45,16 +63,18 @@ describe("Run tests successfully", function () {
       // Spec fixtures reference the local test server on the host
       // (test/server/, port 8092 — started by test/hooks.js as a Mocha
       // root hook, shared with the main test suite). Reach it from the
-      // container via `host.docker.internal`. Docker Desktop on
-      // Windows/Mac wires that DNS name automatically; only Linux
-      // engines need `--add-host host.docker.internal:host-gateway`.
+      // container via `host.docker.internal`.
       //
-      // Gate on the host platform, not on `os` above — `os` is the
-      // image-tag selector and is "linux" for every non-win32 host
-      // (including macOS, where Docker Desktop has already wired the
-      // name and this flag would be redundant).
-      const hostNetworkArgs =
-        process.platform === "linux"
+      // Docker Desktop for Windows/Mac auto-wires `host.docker.internal`.
+      // Everywhere else — Linux Docker Engine, native Windows containers
+      // on GitHub Actions' windows-2022 runner — it isn't, so map the
+      // name to a real host IP explicitly. Doing this unconditionally is
+      // safe: a user-provided `--add-host` always wins over the engine's
+      // built-in name resolution.
+      const hostIp = resolveHostIPv4();
+      const hostNetworkArgs = hostIp
+        ? ["--add-host", `host.docker.internal:${hostIp}`]
+        : process.platform === "linux"
           ? ["--add-host", "host.docker.internal:host-gateway"]
           : [];
 

--- a/src/container/test/runTests.test.cjs
+++ b/src/container/test/runTests.test.cjs
@@ -111,10 +111,55 @@ if (process.platform === "win32") {
   internalPath = path.join("/","app");
 }
 
+const FIREWALL_RULE_NAME = "dd-container-test-8092";
+
+function openWindowsFirewallFor8092() {
+  if (process.platform !== "win32") return;
+  // On GitHub Actions windows-2022 runners, the default firewall blocks
+  // incoming connections from the Docker NAT subnet to the host's
+  // test server on port 8092. Add a temporary allow-rule for the run
+  // and remove it after. `netsh` requires admin; the runner has it. If
+  // we can't add the rule we just press on — the request will still
+  // fail with the same symptom and the diagnostic is obvious.
+  try {
+    execFileSync(
+      "netsh",
+      [
+        "advfirewall", "firewall", "add", "rule",
+        `name=${FIREWALL_RULE_NAME}`,
+        "dir=in", "action=allow", "protocol=TCP", "localport=8092",
+      ],
+      { stdio: ["ignore", "ignore", "ignore"] }
+    );
+    console.log(`Added Windows Firewall rule ${FIREWALL_RULE_NAME} for port 8092.`);
+  } catch (e) {
+    console.log(
+      `Could not add Windows Firewall rule (${e.code || e.message}); continuing.`
+    );
+  }
+}
+
+function closeWindowsFirewallFor8092() {
+  if (process.platform !== "win32") return;
+  try {
+    execFileSync(
+      "netsh",
+      ["advfirewall", "firewall", "delete", "rule", `name=${FIREWALL_RULE_NAME}`],
+      { stdio: ["ignore", "ignore", "ignore"] }
+    );
+  } catch {
+    // Rule didn't exist or couldn't be removed; fine either way.
+  }
+}
+
 // Run tests in Docker container
 describe("Run tests successfully", function () {
   // Set indefinite timeout
   this.timeout(0);
+
+  before(openWindowsFirewallFor8092);
+  after(closeWindowsFirewallFor8092);
+
   it("All specs pass", async () => {
     // Remove any stale results files from a previous failed run.
     // Doc Detective writes `results.json`, falling back to `results-N.json`

--- a/src/container/test/runTests.test.cjs
+++ b/src/container/test/runTests.test.cjs
@@ -51,40 +51,49 @@ function tryDocker(args) {
 // same network and reaches the sidecar by DNS name. Works identically on
 // every docker engine and sidesteps NAT routing and Windows Firewall.
 function startTestServerSidecar() {
-  // Linux containers: default `bridge` driver. Windows containers: `nat`
-  // (the `bridge` driver is Linux-only and `docker network create` fails
-  // on a Windows engine without this flag).
-  const driver = os === "windows" ? "nat" : "bridge";
-  console.log(`Creating docker network ${networkName} (driver=${driver})…`);
-  runDocker(["network", "create", "--driver", driver, networkName]);
+  try {
+    // Linux containers: default `bridge` driver. Windows containers: `nat`
+    // (the `bridge` driver is Linux-only and `docker network create` fails
+    // on a Windows engine without this flag).
+    const driver = os === "windows" ? "nat" : "bridge";
+    console.log(`Creating docker network ${networkName} (driver=${driver})…`);
+    runDocker(["network", "create", "--driver", driver, networkName]);
 
-  // Reuse the doc-detective image so we don't pay an extra image pull.
-  // It has python3 installed; the built-in http.server is enough.
-  const pythonCmd = os === "windows" ? "python" : "python3";
-  console.log(
-    `Starting test-server sidecar ${serverContainerName} on ${networkName}…`
-  );
-  runDocker([
-    "run",
-    "--rm",
-    "--detach",
-    "--name",
-    serverContainerName,
-    "--network",
-    networkName,
-    "--network-alias",
-    serverDnsName,
-    "-v",
-    `${publicDir}:${internalPublicDir}`,
-    "--entrypoint",
-    pythonCmd,
-    `docdetective/docdetective:${version}-${os}`,
-    "-m",
-    "http.server",
-    "8092",
-    "--directory",
-    internalPublicDir,
-  ]);
+    // Reuse the doc-detective image so we don't pay an extra image pull.
+    // It has python3 installed; the built-in http.server is enough.
+    const pythonCmd = os === "windows" ? "python" : "python3";
+    console.log(
+      `Starting test-server sidecar ${serverContainerName} on ${networkName}…`
+    );
+    runDocker([
+      "run",
+      "--rm",
+      "--detach",
+      "--name",
+      serverContainerName,
+      "--network",
+      networkName,
+      "--network-alias",
+      serverDnsName,
+      "-v",
+      `${publicDir}:${internalPublicDir}`,
+      "--entrypoint",
+      pythonCmd,
+      `docdetective/docdetective:${version}-${os}`,
+      "-m",
+      "http.server",
+      "8092",
+      "--directory",
+      internalPublicDir,
+    ]);
+  } catch (e) {
+    // If the container-run failed after the network was created, or
+    // `docker network create` left a half-created entry behind, roll back
+    // before rethrowing so Mocha's after hook isn't the only thing
+    // standing between us and a leaked network/container.
+    try { stopTestServerSidecar(); } catch (_) {}
+    throw e;
+  }
 }
 
 function stopTestServerSidecar() {
@@ -92,12 +101,54 @@ function stopTestServerSidecar() {
   tryDocker(["network", "rm", networkName]);
 }
 
+// Probe the sidecar from the sidecar itself — uses the Python interpreter
+// already installed in the image, so no extra image pull or cross-container
+// cold start per attempt.
+function probeTestServerReady() {
+  const pythonCmd = os === "windows" ? "python" : "python3";
+  try {
+    execFileSync(
+      "docker",
+      [
+        "exec",
+        serverContainerName,
+        pythonCmd,
+        "-c",
+        "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8092/', timeout=1).status == 200 else 1)",
+      ],
+      { stdio: ["ignore", "ignore", "ignore"] }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForTestServer(timeoutMs = 30_000, pollMs = 500) {
+  const deadline = Date.now() + timeoutMs;
+  let attempts = 0;
+  while (Date.now() < deadline) {
+    attempts++;
+    if (probeTestServerReady()) {
+      console.log(`Test server ready after ${attempts} probe(s).`);
+      return;
+    }
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  throw new Error(
+    `Test server did not become ready within ${timeoutMs}ms after ${attempts} probes.`
+  );
+}
+
 // Run tests in Docker container
 describe("Run tests successfully", function () {
   // Set indefinite timeout
   this.timeout(0);
 
-  before(startTestServerSidecar);
+  before(async function () {
+    startTestServerSidecar();
+    await waitForTestServer();
+  });
   after(stopTestServerSidecar);
 
   it("All specs pass", async () => {

--- a/src/container/test/runTests.test.cjs
+++ b/src/container/test/runTests.test.cjs
@@ -22,6 +22,17 @@ describe("Run tests successfully", function () {
   // Set indefinite timeout
   this.timeout(0);
   it("All specs pass", async () => {
+    // Remove any stale results files from a previous failed run.
+    // Doc Detective writes `results.json`, falling back to `results-N.json`
+    // when the target file already exists — so a leftover `results.json`
+    // from an earlier failure makes the next run write to `results-1.json`
+    // and this harness would then read outdated counts from `results.json`.
+    for (const f of fs.readdirSync(artifactPath)) {
+      if (/^results(-\d+)?\.json$/.test(f)) {
+        fs.unlinkSync(path.join(artifactPath, f));
+      }
+    }
+
     return new Promise((resolve, reject) => {
       let hasCompleted = false;
 
@@ -31,10 +42,29 @@ describe("Run tests successfully", function () {
         callback();
       };
 
+      // Spec fixtures reference the local test server on the host
+      // (test/server/, port 8092 — started by test/hooks.js as a Mocha
+      // root hook, shared with the main test suite). Reach it from the
+      // container via `host.docker.internal`. Docker Desktop on
+      // Windows/Mac wires that DNS name automatically; Linux engines
+      // need `--add-host host.docker.internal:host-gateway`.
+      const hostNetworkArgs =
+        os === "linux"
+          ? ["--add-host", "host.docker.internal:host-gateway"]
+          : [];
+
+      // Resource limits are generous enough to cover many serial Chrome
+      // sessions (each spec + each `contexts:` block starts a fresh
+      // chromedriver); under tighter caps a late spec intermittently
+      // loses a webdriver handshake (`UND_ERR_HEADERS_TIMEOUT`,
+      // `ECONNREFUSED 127.0.0.1:9515`). These limits are what the test
+      // harness needs locally and in CI; they don't model what the
+      // published image needs to run customer tests.
       const runTests = spawn(
         "docker",
         [
-          "run", "--rm", "--memory=2g", "--cpus=2",
+          "run", "--rm", "--memory=4g", "--cpus=4",
+          ...hostNetworkArgs,
           "-v", `${artifactPath}:${internalPath}`,
           `docdetective/docdetective:${version}-${os}`,
           "-c", "./config.json", "-i", ".", "-o", "./results.json",

--- a/src/container/test/runTests.test.cjs
+++ b/src/container/test/runTests.test.cjs
@@ -1,155 +1,95 @@
 const path = require("path");
 const assert = require("assert").strict;
 const fs = require("fs");
-const { networkInterfaces } = require("os");
 const artifactPath = path.resolve(__dirname, "./artifacts");
 const outputFile = path.resolve(artifactPath, "results.json");
+const publicDir = path.resolve(__dirname, "../../../test/server/public");
 const { spawn, execFileSync } = require("child_process");
 
-// Figure out which Docker engine we're talking to so we can give the
-// container a working `host.docker.internal`:
-//   - Docker Desktop (Win/Mac): auto-wires the name, don't override.
-//   - Linux Docker Engine:      use `host-gateway` (the blessed path).
-//   - Native Windows Engine:    `host-gateway` isn't reliable (not how
-//                               GH's windows-2022 runner's engine
-//                               handles it), so fall back to an
-//                               explicit host IP.
-function detectDockerEngine() {
-  // Docker Desktop (Win/Mac) uses context names prefixed `desktop-`
-  // (e.g. `desktop-windows`, `desktop-linux`). Both native Windows
-  // Engine and Linux Docker Engine use different context names
-  // (typically `default`).
-  let context = "";
-  try {
-    context = execFileSync("docker", ["context", "show"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    context = "";
-  }
-  if (/^desktop-/i.test(context)) return "docker-desktop";
+const version = process.env.VERSION || "latest";
 
-  // Not Docker Desktop. Ask the engine which container OS it's running;
-  // the same Linux runner could conceivably run Windows containers, but
-  // in practice each runner is one or the other.
-  let osType = "";
-  try {
-    osType = execFileSync("docker", ["info", "--format", "{{.OSType}}"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    osType = "";
-  }
-  if (/windows/i.test(osType)) return "windows-native";
-  return "linux-native";
+let os;
+let internalPath;
+let internalPublicDir;
+if (process.platform === "win32") {
+  os = "windows";
+  internalPath = "C:\\app";
+  internalPublicDir = "C:\\srv";
+} else {
+  os = "linux";
+  internalPath = path.join("/", "app");
+  internalPublicDir = path.join("/", "srv");
 }
 
-function resolveNatGatewayIP() {
-  // Windows containers use the `nat` network by default; the Gateway in
-  // that network's IPAM config is the IP of the host's NAT virtual
-  // adapter — the only IP the container can route to reach the host.
-  // The host's LAN IP won't work here because the NAT subnet has no
-  // route to it.
+// Unique per-run names so parallel runs don't collide.
+const runId = `${process.pid}-${Date.now()}`;
+const networkName = `dd-test-net-${runId}`;
+const serverContainerName = `dd-test-server-${runId}`;
+// Stable name for containers on this network; fixtures reference it via $URL.
+const serverDnsName = "dd-test-server";
+
+function runDocker(args, opts = {}) {
+  return execFileSync("docker", args, {
+    encoding: "utf8",
+    stdio: opts.stdio || ["ignore", "pipe", "pipe"],
+  });
+}
+
+function tryDocker(args) {
   try {
-    const out = execFileSync(
-      "docker",
-      ["network", "inspect", "nat", "--format", "{{range .IPAM.Config}}{{.Gateway}} {{end}}"],
-      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
-    ).trim();
-    const gw = out.split(/\s+/).filter(Boolean)[0];
-    return gw || null;
-  } catch {
+    return runDocker(args);
+  } catch (e) {
     return null;
   }
 }
 
-function resolveHostIPv4() {
-  for (const addresses of Object.values(networkInterfaces())) {
-    for (const a of addresses || []) {
-      if (a && a.family === "IPv4" && !a.internal) {
-        return a.address;
-      }
-    }
-  }
-  return null;
+// Spec fixtures reference a local test server (see test/server/public/).
+// Rather than relying on host↔container networking — which is a moving
+// target across Docker Desktop, Linux Docker Engine, and native Windows
+// Engine on GH's windows-2022 runner — run the server as a sidecar
+// container on a dedicated docker network. The test container joins the
+// same network and reaches the sidecar by DNS name. Works identically on
+// every docker engine and sidesteps NAT routing and Windows Firewall.
+function startTestServerSidecar() {
+  // Linux containers: default `bridge` driver. Windows containers: `nat`
+  // (the `bridge` driver is Linux-only and `docker network create` fails
+  // on a Windows engine without this flag).
+  const driver = os === "windows" ? "nat" : "bridge";
+  console.log(`Creating docker network ${networkName} (driver=${driver})…`);
+  runDocker(["network", "create", "--driver", driver, networkName]);
+
+  // Reuse the doc-detective image so we don't pay an extra image pull.
+  // It has python3 installed; the built-in http.server is enough.
+  const pythonCmd = os === "windows" ? "python" : "python3";
+  console.log(
+    `Starting test-server sidecar ${serverContainerName} on ${networkName}…`
+  );
+  runDocker([
+    "run",
+    "--rm",
+    "--detach",
+    "--name",
+    serverContainerName,
+    "--network",
+    networkName,
+    "--network-alias",
+    serverDnsName,
+    "-v",
+    `${publicDir}:${internalPublicDir}`,
+    "--entrypoint",
+    pythonCmd,
+    `docdetective/docdetective:${version}-${os}`,
+    "-m",
+    "http.server",
+    "8092",
+    "--directory",
+    internalPublicDir,
+  ]);
 }
 
-function buildHostNetworkArgs() {
-  const engine = detectDockerEngine();
-  if (engine === "docker-desktop") {
-    // Docker Desktop already wires host.docker.internal for both Linux
-    // and Windows container modes. Overriding with --add-host here can
-    // steer the container at the wrong interface IP.
-    return [];
-  }
-  if (engine === "linux-native") {
-    // Docker Engine 20.10+ resolves `host-gateway` to the bridge's
-    // host-side IP. This is the Docker-blessed way.
-    return ["--add-host", "host.docker.internal:host-gateway"];
-  }
-  // Native Windows engine (e.g. GitHub Actions windows-2022 runner). The
-  // container is on the `nat` network; use that network's gateway IP,
-  // which is how the container routes to the host. `resolveHostIPv4()`
-  // would pick the runner's LAN IP, which the NAT subnet can't reach.
-  const gw = resolveNatGatewayIP();
-  if (gw) return ["--add-host", `host.docker.internal:${gw}`];
-  const ip = resolveHostIPv4();
-  return ip ? ["--add-host", `host.docker.internal:${ip}`] : [];
-}
-
-const version = process.env.VERSION || 'latest';
-
-let os;
-let internalPath;
-if (process.platform === "win32") {
-  os = "windows";
-  internalPath = "C:\\app";
-} else {
-  os = "linux";
-  internalPath = path.join("/","app");
-}
-
-const FIREWALL_RULE_NAME = "dd-container-test-8092";
-
-function openWindowsFirewallFor8092() {
-  if (process.platform !== "win32") return;
-  // On GitHub Actions windows-2022 runners, the default firewall blocks
-  // incoming connections from the Docker NAT subnet to the host's
-  // test server on port 8092. Add a temporary allow-rule for the run
-  // and remove it after. `netsh` requires admin; the runner has it. If
-  // we can't add the rule we just press on — the request will still
-  // fail with the same symptom and the diagnostic is obvious.
-  try {
-    execFileSync(
-      "netsh",
-      [
-        "advfirewall", "firewall", "add", "rule",
-        `name=${FIREWALL_RULE_NAME}`,
-        "dir=in", "action=allow", "protocol=TCP", "localport=8092",
-      ],
-      { stdio: ["ignore", "ignore", "ignore"] }
-    );
-    console.log(`Added Windows Firewall rule ${FIREWALL_RULE_NAME} for port 8092.`);
-  } catch (e) {
-    console.log(
-      `Could not add Windows Firewall rule (${e.code || e.message}); continuing.`
-    );
-  }
-}
-
-function closeWindowsFirewallFor8092() {
-  if (process.platform !== "win32") return;
-  try {
-    execFileSync(
-      "netsh",
-      ["advfirewall", "firewall", "delete", "rule", `name=${FIREWALL_RULE_NAME}`],
-      { stdio: ["ignore", "ignore", "ignore"] }
-    );
-  } catch {
-    // Rule didn't exist or couldn't be removed; fine either way.
-  }
+function stopTestServerSidecar() {
+  tryDocker(["rm", "-f", serverContainerName]);
+  tryDocker(["network", "rm", networkName]);
 }
 
 // Run tests in Docker container
@@ -157,8 +97,8 @@ describe("Run tests successfully", function () {
   // Set indefinite timeout
   this.timeout(0);
 
-  before(openWindowsFirewallFor8092);
-  after(closeWindowsFirewallFor8092);
+  before(startTestServerSidecar);
+  after(stopTestServerSidecar);
 
   it("All specs pass", async () => {
     // Remove any stale results files from a previous failed run.
@@ -181,16 +121,6 @@ describe("Run tests successfully", function () {
         callback();
       };
 
-      // Spec fixtures reference the local test server on the host
-      // (test/server/, port 8092 — started by test/hooks.js as a Mocha
-      // root hook, shared with the main test suite). Reach it from the
-      // container via `host.docker.internal`; see `buildHostNetworkArgs`
-      // for per-engine handling.
-      const hostNetworkArgs = buildHostNetworkArgs();
-      if (hostNetworkArgs.length) {
-        console.log(`Using docker args for host networking: ${hostNetworkArgs.join(" ")}`);
-      }
-
       // Resource limits are generous enough to cover many serial Chrome
       // sessions (each spec + each `contexts:` block starts a fresh
       // chromedriver); under tighter caps a late spec intermittently
@@ -201,11 +131,21 @@ describe("Run tests successfully", function () {
       const runTests = spawn(
         "docker",
         [
-          "run", "--rm", "--memory=4g", "--cpus=4",
-          ...hostNetworkArgs,
-          "-v", `${artifactPath}:${internalPath}`,
+          "run",
+          "--rm",
+          "--memory=4g",
+          "--cpus=4",
+          "--network",
+          networkName,
+          "-v",
+          `${artifactPath}:${internalPath}`,
           `docdetective/docdetective:${version}-${os}`,
-          "-c", "./config.json", "-i", ".", "-o", "./results.json",
+          "-c",
+          "./config.json",
+          "-i",
+          ".",
+          "-o",
+          "./results.json",
         ],
         { stdio: ["ignore", "pipe", "pipe"] }
       );

--- a/src/container/test/runTests.test.cjs
+++ b/src/container/test/runTests.test.cjs
@@ -46,6 +46,25 @@ function detectDockerEngine() {
   return "linux-native";
 }
 
+function resolveNatGatewayIP() {
+  // Windows containers use the `nat` network by default; the Gateway in
+  // that network's IPAM config is the IP of the host's NAT virtual
+  // adapter — the only IP the container can route to reach the host.
+  // The host's LAN IP won't work here because the NAT subnet has no
+  // route to it.
+  try {
+    const out = execFileSync(
+      "docker",
+      ["network", "inspect", "nat", "--format", "{{range .IPAM.Config}}{{.Gateway}} {{end}}"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+    ).trim();
+    const gw = out.split(/\s+/).filter(Boolean)[0];
+    return gw || null;
+  } catch {
+    return null;
+  }
+}
+
 function resolveHostIPv4() {
   for (const addresses of Object.values(networkInterfaces())) {
     for (const a of addresses || []) {
@@ -70,8 +89,12 @@ function buildHostNetworkArgs() {
     // host-side IP. This is the Docker-blessed way.
     return ["--add-host", "host.docker.internal:host-gateway"];
   }
-  // Native Windows engine (e.g. GitHub Actions windows-2022 runner) or
-  // an unknown engine — map explicitly.
+  // Native Windows engine (e.g. GitHub Actions windows-2022 runner). The
+  // container is on the `nat` network; use that network's gateway IP,
+  // which is how the container routes to the host. `resolveHostIPv4()`
+  // would pick the runner's LAN IP, which the NAT subnet can't reach.
+  const gw = resolveNatGatewayIP();
+  if (gw) return ["--add-host", `host.docker.internal:${gw}`];
   const ip = resolveHostIPv4();
   return ip ? ["--add-host", `host.docker.internal:${ip}`] : [];
 }

--- a/src/container/test/runTests.test.cjs
+++ b/src/container/test/runTests.test.cjs
@@ -46,10 +46,15 @@ describe("Run tests successfully", function () {
       // (test/server/, port 8092 — started by test/hooks.js as a Mocha
       // root hook, shared with the main test suite). Reach it from the
       // container via `host.docker.internal`. Docker Desktop on
-      // Windows/Mac wires that DNS name automatically; Linux engines
-      // need `--add-host host.docker.internal:host-gateway`.
+      // Windows/Mac wires that DNS name automatically; only Linux
+      // engines need `--add-host host.docker.internal:host-gateway`.
+      //
+      // Gate on the host platform, not on `os` above — `os` is the
+      // image-tag selector and is "linux" for every non-win32 host
+      // (including macOS, where Docker Desktop has already wired the
+      // name and this flag would be redundant).
       const hostNetworkArgs =
-        os === "linux"
+        process.platform === "linux"
           ? ["--add-host", "host.docker.internal:host-gateway"]
           : [];
 


### PR DESCRIPTION
## Why

After shipping #277 the Windows Docker build still flaked with
`UND_ERR_HEADERS_TIMEOUT` fetching external URLs from Chrome inside the
container. Investigation showed the failure is specific to GitHub
Actions' `windows-2022` runner doing external HTTPS through Docker —
the same image ran fine locally on Docker Desktop for Windows.

The fix is to stop depending on external hosts at all. Doc Detective's
main test suite already has an in-process Express server
(`test/server/index.js`, serves `test/server/public/` on port 8092,
started by Mocha's root hook via `test/hooks.js`). The container test
suite was the only thing still reaching out to google.com /
example.com / docs.doc-detective.com. Unify on a server we control and
the flake (and the drift between the two fixture sets) both go away.

After multiple layered attempts at host↔container networking
(`host.docker.internal` auto-wiring / `host-gateway` / NAT gateway IP
resolution / Windows Firewall allow-rule), this PR ends up on the
robust approach:

## What

**Test server runs as a sidecar docker container.** Before the test
container starts, a `before` hook:

1. Creates a per-run docker network (driver `bridge` on Linux, `nat`
   on native Windows Engine).
2. Starts the doc-detective image as a sidecar running
   `python -m http.server 8092 --directory /srv`, with
   `test/server/public` mounted, `--network-alias dd-test-server`.
3. Polls `docker exec <sidecar> python -c "urllib.request.urlopen(...)"`
   with 500ms backoff / 30s deadline to wait for the HTTP listener to
   come up before starting the test container.
4. Wraps those steps in try/catch so a partial setup doesn't leak a
   network or container.

The test container joins the same network via `--network` and reaches
the server by docker DNS name (`dd-test-server`). No
`host.docker.internal`, no `--add-host`, no firewall path, no NAT
routing — identical behavior on Docker Desktop, Linux Docker Engine,
and native Windows Engine.

After hook removes the sidecar container and the network.

**Fixtures:**

- `src/container/test/artifacts/env`: `URL=http://dd-test-server:8092`
- 8 spec files under `src/container/test/artifacts/` updated to use
  `$URL` and assert against content in `test/server/public/index.html`
  (`#text-input`, `#text-elements > h2`, "Text Elements")
- `doc-content.md` rewritten to reference the sidecar
- v3 schema hygiene: spec-level `id` → `specId`, test-level
  `id`/`setup`/`cleanup` → `testId`/`before`/`after`,
  `contexts` → `runOn`, `{app: {name, options}}` →
  `{browsers: [{name, headless}]}`, `startRecording`/`stopRecording`
  → `record`/`stopRecord`

**Harness hygiene:**

- Resource limits bumped to `4g/4cpu` — Chrome session churn under
  the previous `2g/2cpu` caps occasionally lost a chromedriver
  handshake.
- Stale `results*.json` files removed at the start of each run so a
  previous crash doesn't cause the harness to compare against
  outdated counts.

## Validation

End-to-end on Docker Desktop for Windows:

1. Rebuilt `4.2.0-windows` locally from current source
   (`npm run container:build -- --version=4.2.0`).
2. `VERSION=4.2.0 npm run container:test` → **13 specs pass, 0 fail**.
   "🎉 All items passed! 🎉"

## Follow-up, not this PR

Full fixture unification (delete `src/container/test/artifacts/`
entirely and point the container runner at `test/core-artifacts/`)
is still a worthwhile reduction. Blocker today is
`test/core-artifacts/config.json` referencing paths outside the mount
(`./test/core-need_updates/reqres.openapi.yaml`,
`./dev/doc-content.md`) and including browsers the container doesn't
have. Separate PR.