### PR TITLE
build(container): prebuilt Windows toolchain base image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -108,23 +108,26 @@ jobs:
     # Skip the app build when this workflow was triggered by a push that
     # only touched the windows-base Dockerfile / versions.json, or when
     # the operator explicitly asked for `build_base` via workflow_dispatch.
-    #
-    # Also skip the windows-2022 leg on PRs that touch the base files:
-    # those PRs haven't published the new composite base tag to Docker Hub
-    # yet, so the thin windows.Dockerfile's `FROM` would fail to resolve.
-    # build-windows-base (PR build-only) already proves the base builds in
-    # that case; the ubuntu leg still runs so Linux coverage is retained.
+    # The windows-2022 matrix leg is additionally short-circuited at
+    # step level on base-change PRs — see WINDOWS_APP_BUILD_SKIP below.
     if: >-
       github.event_name != 'push' &&
-      !(github.event_name == 'workflow_dispatch' && inputs.build_base) &&
-      !(
-        github.event_name == 'pull_request' &&
-        matrix.os == 'windows-2022' &&
-        needs.detect-base-change.outputs.base == 'true'
-      )
+      !(github.event_name == 'workflow_dispatch' && inputs.build_base)
     timeout-minutes: 60
     env:
       IMAGE_VERSION: ${{ inputs.version || 'latest' }}
+      # On base-change PRs the thin windows.Dockerfile's FROM points at
+      # a composite base tag that hasn't been published yet, so the
+      # windows-2022 leg of this matrix would fail to resolve. Short-
+      # circuit the expensive steps (Switch Docker, Build, Test) in that
+      # case — build-windows-base (PR build-only) already proves the base
+      # builds, and the ubuntu leg still provides Linux coverage.
+      # Evaluated per-step because `matrix.*` isn't available in the
+      # job-level `if:` context.
+      WINDOWS_APP_BUILD_SKIP: >-
+        ${{ github.event_name == 'pull_request' &&
+            matrix.os == 'windows-2022' &&
+            needs.detect-base-change.outputs.base == 'true' }}
     strategy:
       matrix:
         os:
@@ -152,7 +155,7 @@ jobs:
           HUSKY: '0'
 
       - name: Switch Docker to Windows containers
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && env.WINDOWS_APP_BUILD_SKIP != 'true'
         shell: pwsh
         run: |
           Write-Host "Switching Docker to Windows containers..."
@@ -208,18 +211,24 @@ jobs:
           docker info
 
       - name: Verify Windows container mode
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && env.WINDOWS_APP_BUILD_SKIP != 'true'
         shell: pwsh
         run: |
           $os = docker info --format '{{.OSType}}'
           if ($os -ne 'windows') { throw "Docker is not in Windows mode; OSType=$os" }
           Write-Host "Docker OSType=$os"
 
+      - name: Skip windows-2022 app build (base tag not yet published)
+        if: env.WINDOWS_APP_BUILD_SKIP == 'true'
+        run: echo "Base files changed in this PR; the composite base tag is not yet on Docker Hub. Skipping windows-2022 app build. build-windows-base covers the base; ubuntu leg covers Linux."
+
       - name: Build Docker Image
+        if: env.WINDOWS_APP_BUILD_SKIP != 'true'
         shell: bash
         run: npm run container:build -- --version="$IMAGE_VERSION" ${{ inputs.no_cache && '--no-cache' || '' }}
 
       - name: Post-build Test
+        if: env.WINDOWS_APP_BUILD_SKIP != 'true'
         shell: bash
         env:
           VERSION: ${{ env.IMAGE_VERSION }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -59,9 +59,24 @@ on:
         required: false
         type: boolean
         default: false
+      build_base:
+        description: >
+          Build and push the Windows toolchain base image
+          (docdetective/docdetective-windows-base) instead of the app
+          image. Run this when windows-base.versions.json or
+          windows-base.Dockerfile changes.
+        required: false
+        type: boolean
+        default: false
   pull_request:
     paths:
       - 'src/container/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/container/windows-base.Dockerfile'
+      - 'src/container/windows-base.versions.json'
 
 concurrency:
   group: docker-build-${{ github.head_ref || github.ref }}-${{ inputs.version || 'pr' }}
@@ -72,6 +87,12 @@ permissions:
 
 jobs:
   build:
+    # Skip the app build when this workflow was triggered by a push that
+    # only touched the windows-base Dockerfile / versions.json, or when
+    # the operator explicitly asked for `build_base` via workflow_dispatch.
+    if: >-
+      github.event_name != 'push' &&
+      !(github.event_name == 'workflow_dispatch' && inputs.build_base)
     timeout-minutes: 60
     env:
       IMAGE_VERSION: ${{ inputs.version || 'latest' }}
@@ -221,3 +242,78 @@ jobs:
               exit 1
             fi
           fi
+
+  # Builds and pushes docdetective/docdetective-windows-base, the prebuilt
+  # Windows toolchain base image that windows.Dockerfile's FROM points at.
+  # Triggered automatically when the base Dockerfile or its version pin
+  # file change on main, or manually via workflow_dispatch with
+  # build_base=true. Never runs on PRs — it would push before review.
+  build-windows-base:
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.build_base)
+    timeout-minutes: 90
+    runs-on: windows-2022
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+        env:
+          HUSKY: '0'
+
+      - name: Switch Docker to Windows containers
+        shell: pwsh
+        run: |
+          Write-Host "Switching Docker to Windows containers..."
+          Stop-Service docker -ErrorAction SilentlyContinue
+
+          $attemptedDockerdPaths = @()
+          $dockerd = (Get-Command dockerd -ErrorAction SilentlyContinue).Source
+          if ($dockerd) {
+            $attemptedDockerdPaths += $dockerd
+          } else {
+            $fallbackDockerd = "$Env:ProgramFiles\Docker\dockerd.exe"
+            $attemptedDockerdPaths += $fallbackDockerd
+            $dockerd = $fallbackDockerd
+          }
+
+          if (-not (Test-Path -LiteralPath $dockerd)) {
+            $pathsString = $attemptedDockerdPaths -join ', '
+            throw "Could not find 'dockerd'. Paths attempted: $pathsString"
+          }
+
+          & $dockerd --unregister-service 2>$null
+          & $dockerd --register-service
+          Start-Service docker
+
+          $retries = 0
+          $os = $null
+          while ($retries -lt 12) {
+            Start-Sleep -Seconds 5
+            $retries++
+            $output = docker info --format '{{.OSType}}' 2>&1
+            if ($LASTEXITCODE -eq 0) {
+              $os = ($output | Select-Object -Last 1).ToString().Trim()
+              if ($os -eq 'windows') { break }
+            }
+          }
+          if ($os -ne 'windows') {
+            throw "Docker did not switch to Windows mode; last observed OSType=$os"
+          }
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push base image
+        shell: bash
+        run: npm run container:build:base:push

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -86,6 +86,23 @@ permissions:
   contents: read
 
 jobs:
+  # Lightweight ubuntu job that flags whether the current change touches
+  # the base-image files. Consumed by build-windows-base so that PR runs
+  # only spin up a windows-2022 runner when the base is actually in scope.
+  detect-base-change:
+    runs-on: ubuntu-latest
+    outputs:
+      base: ${{ steps.filter.outputs.base }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            base:
+              - 'src/container/windows-base.Dockerfile'
+              - 'src/container/windows-base.versions.json'
+
   build:
     # Skip the app build when this workflow was triggered by a push that
     # only touched the windows-base Dockerfile / versions.json, or when
@@ -243,15 +260,21 @@ jobs:
             fi
           fi
 
-  # Builds and pushes docdetective/docdetective-windows-base, the prebuilt
-  # Windows toolchain base image that windows.Dockerfile's FROM points at.
-  # Triggered automatically when the base Dockerfile or its version pin
-  # file change on main, or manually via workflow_dispatch with
-  # build_base=true. Never runs on PRs — it would push before review.
+  # Builds docdetective/docdetective-windows-base, the prebuilt Windows
+  # toolchain base image that windows.Dockerfile's FROM points at.
+  #
+  # Triggers:
+  #   - push to main touching the base files      → build + push
+  #   - workflow_dispatch with build_base=true    → build + push
+  #   - pull_request touching the base files      → build only (no push,
+  #                                                  no Docker Hub login)
+  #     so that base-image breakages are caught pre-merge.
   build-windows-base:
+    needs: [detect-base-change]
     if: >-
       github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && inputs.build_base)
+      (github.event_name == 'workflow_dispatch' && inputs.build_base) ||
+      (github.event_name == 'pull_request' && needs.detect-base-change.outputs.base == 'true')
     timeout-minutes: 90
     runs-on: windows-2022
     steps:
@@ -268,10 +291,17 @@ jobs:
         env:
           HUSKY: '0'
 
+      # Body copied verbatim from the `build` job above so the two don't
+      # drift — any change to container-mode switching needs to land in
+      # both steps (or be factored into a composite action).
       - name: Switch Docker to Windows containers
         shell: pwsh
         run: |
           Write-Host "Switching Docker to Windows containers..."
+
+          # GitHub Actions Windows runners ship Docker Engine, not Docker
+          # Desktop, so DockerCli.exe -SwitchWindowsEngine doesn't exist.
+          # Reconfigure the dockerd service to run in Windows-container mode.
           Stop-Service docker -ErrorAction SilentlyContinue
 
           $attemptedDockerdPaths = @()
@@ -289,11 +319,14 @@ jobs:
             throw "Could not find 'dockerd'. Paths attempted: $pathsString"
           }
 
+          Write-Host "Using dockerd at: $dockerd"
+
           & $dockerd --unregister-service 2>$null
           & $dockerd --register-service
           Start-Service docker
 
           $retries = 0
+          $lastDockerInfoError = $null
           $os = $null
           while ($retries -lt 12) {
             Start-Sleep -Seconds 5
@@ -301,19 +334,42 @@ jobs:
             $output = docker info --format '{{.OSType}}' 2>&1
             if ($LASTEXITCODE -eq 0) {
               $os = ($output | Select-Object -Last 1).ToString().Trim()
+              Write-Host "Docker OSType: $os (attempt $retries)"
               if ($os -eq 'windows') { break }
+            } else {
+              $lastDockerInfoError = ($output | Out-String).Trim()
+              Write-Host "Docker not ready yet (attempt $retries): $lastDockerInfoError"
             }
           }
           if ($os -ne 'windows') {
-            throw "Docker did not switch to Windows mode; last observed OSType=$os"
+            if (-not $os) { $os = 'unknown' }
+            $details = if ($lastDockerInfoError) { "; last docker info error=$lastDockerInfoError" } else { "" }
+            throw "Docker did not switch to Windows mode after waiting; last observed OSType=$os$details"
           }
+          docker version
+          docker info
+
+      - name: Verify Windows container mode
+        shell: pwsh
+        run: |
+          $os = docker info --format '{{.OSType}}'
+          if ($os -ne 'windows') { throw "Docker is not in Windows mode; OSType=$os" }
+          Write-Host "Docker OSType=$os"
 
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push base image
+      - name: Build base image (+ push when not a PR)
         shell: bash
-        run: npm run container:build:base:push
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$GH_EVENT_NAME" = "pull_request" ]; then
+            npm run container:build:base
+          else
+            npm run container:build:base:push
+          fi

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -104,12 +104,24 @@ jobs:
               - 'src/container/windows-base.versions.json'
 
   build:
+    needs: [detect-base-change]
     # Skip the app build when this workflow was triggered by a push that
     # only touched the windows-base Dockerfile / versions.json, or when
     # the operator explicitly asked for `build_base` via workflow_dispatch.
+    #
+    # Also skip the windows-2022 leg on PRs that touch the base files:
+    # those PRs haven't published the new composite base tag to Docker Hub
+    # yet, so the thin windows.Dockerfile's `FROM` would fail to resolve.
+    # build-windows-base (PR build-only) already proves the base builds in
+    # that case; the ubuntu leg still runs so Linux coverage is retained.
     if: >-
       github.event_name != 'push' &&
-      !(github.event_name == 'workflow_dispatch' && inputs.build_base)
+      !(github.event_name == 'workflow_dispatch' && inputs.build_base) &&
+      !(
+        github.event_name == 'pull_request' &&
+        matrix.os == 'windows-2022' &&
+        needs.detect-base-change.outputs.base == 'true'
+      )
     timeout-minutes: 60
     env:
       IMAGE_VERSION: ${{ inputs.version || 'latest' }}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "dev": "node ./dev",
     "container:build": "node src/container/scripts/build.cjs",
     "container:rebuild": "node src/container/scripts/build.cjs --no-cache",
+    "container:build:base": "node src/container/scripts/build.cjs --target=base",
+    "container:build:base:push": "node src/container/scripts/build.cjs --target=base --push",
     "container:test": "mocha src/container/test/*.test.cjs --timeout 0"
   },
   "repository": {

--- a/src/container/.dockerignore
+++ b/src/container/.dockerignore
@@ -1,0 +1,5 @@
+scripts/
+test/
+tests/
+*.md
+.dockerignore

--- a/src/container/scripts/build.cjs
+++ b/src/container/scripts/build.cjs
@@ -177,22 +177,27 @@ function buildAppImage() {
   console.log(`Building for OS: ${os}`);
   console.log(`Tags: ${tags}`);
 
-  // For Windows, pre-pull the base image so the developer sees a clean
-  // pull-progress bar instead of a silent fetch mid-build. Also pin the
-  // FROM to the exact versioned tag from windows-base.versions.json.
+  // For Windows, always pin the FROM to the exact versioned tag from
+  // windows-base.versions.json so builds stay deterministic — drifting to
+  // `:latest` would silently pull whatever base was last published.
+  // Optionally pre-pull the base image so the developer sees a clean
+  // pull-progress bar instead of a silent fetch mid-build; --no-pull-base
+  // only skips the pre-pull, not the pinning.
   let extraBuildArgs = [];
-  if (os === "windows" && !skipBasePrePull) {
+  if (os === "windows") {
     const { baseTag } = readBasePins();
     const baseRef = `docdetective/docdetective-windows-base:${baseTag}`;
     extraBuildArgs = ["--build-arg", `BASE_TAG=${baseTag}`];
-    try {
-      console.log(`Pre-pulling base image: ${baseRef}`);
-      execFileSync("docker", ["pull", baseRef], { stdio: "inherit" });
-    } catch (err) {
-      console.warn(
-        `Warning: could not pre-pull ${baseRef} (${err.message}). ` +
-          `Continuing — docker build will attempt the pull itself.`
-      );
+    if (!skipBasePrePull) {
+      try {
+        console.log(`Pre-pulling base image: ${baseRef}`);
+        execFileSync("docker", ["pull", baseRef], { stdio: "inherit" });
+      } catch (err) {
+        console.warn(
+          `Warning: could not pre-pull ${baseRef} (${err.message}). ` +
+            `Continuing — docker build will attempt the pull itself.`
+        );
+      }
     }
   }
 

--- a/src/container/scripts/build.cjs
+++ b/src/container/scripts/build.cjs
@@ -82,7 +82,11 @@ function buildBaseImage() {
     process.exit(1);
   }
   const pins = JSON.parse(fs.readFileSync(versionsPath, "utf8"));
-  const baseTag = `${pins.node}-${pins.python}-${pins.java}-${pins.dita}`;
+  const windowsServerTag = pins.windowsServer || "ltsc2022";
+  // Tag encodes every pin so bumping any one — including the OS base —
+  // produces a distinct tag; the thin windows.Dockerfile pins its FROM
+  // to this exact composite tag via BASE_TAG.
+  const baseTag = `${windowsServerTag}-${pins.node}-${pins.python}-${pins.java}-${pins.dita}`;
   const repo = "docdetective/docdetective-windows-base";
   const tags = [baseTag, "latest"];
   const tagArgs = tags.flatMap((t) => ["-t", `${repo}:${t}`]);
@@ -93,6 +97,8 @@ function buildBaseImage() {
     "-f",
     path.join(containerDir, "windows-base.Dockerfile"),
     ...tagArgs,
+    "--build-arg",
+    `WINDOWS_SERVER_TAG=${windowsServerTag}`,
     "--build-arg",
     `NODE_VERSION=${pins.node}`,
     "--build-arg",
@@ -155,7 +161,8 @@ function buildAppImage() {
     const pinsPath = path.join(containerDir, "windows-base.versions.json");
     if (fs.existsSync(pinsPath)) {
       const pins = JSON.parse(fs.readFileSync(pinsPath, "utf8"));
-      const baseTag = `${pins.node}-${pins.python}-${pins.java}-${pins.dita}`;
+      const windowsServerTag = pins.windowsServer || "ltsc2022";
+      const baseTag = `${windowsServerTag}-${pins.node}-${pins.python}-${pins.java}-${pins.dita}`;
       const baseRef = `docdetective/docdetective-windows-base:${baseTag}`;
       extraBuildArgs = ["--build-arg", `BASE_TAG=${baseTag}`];
       try {

--- a/src/container/scripts/build.cjs
+++ b/src/container/scripts/build.cjs
@@ -67,6 +67,40 @@ try {
 
 const os = dockerOSType === "windows" ? "windows" : "linux";
 
+// Reads and validates windows-base.versions.json, and composes the base
+// image's composite tag. Central so the base-build and app-build paths
+// cannot drift on the tag scheme. Exits non-zero on any missing/invalid
+// field rather than silently composing an "undefined-..." tag.
+function readBasePins() {
+  const versionsPath = path.join(containerDir, "windows-base.versions.json");
+  if (!fs.existsSync(versionsPath)) {
+    console.error(`Missing version pin file: ${versionsPath}`);
+    process.exit(1);
+  }
+  let pins;
+  try {
+    pins = JSON.parse(fs.readFileSync(versionsPath, "utf8"));
+  } catch (err) {
+    console.error(`Failed to parse ${versionsPath}: ${err.message}`);
+    process.exit(1);
+  }
+  const required = ["windowsServer", "node", "python", "java", "dita"];
+  const missing = required.filter(
+    (k) => typeof pins[k] !== "string" || pins[k].length === 0
+  );
+  if (missing.length) {
+    console.error(
+      `${versionsPath} is missing required field(s): ${missing.join(", ")}`
+    );
+    process.exit(1);
+  }
+  // Tag encodes every pin so bumping any one — including the OS base —
+  // produces a distinct tag; the thin windows.Dockerfile pins its FROM
+  // to this exact composite tag via BASE_TAG.
+  const baseTag = `${pins.windowsServer}-${pins.node}-${pins.python}-${pins.java}-${pins.dita}`;
+  return { pins, baseTag };
+}
+
 // ---------- base-image build path ----------
 function buildBaseImage() {
   if (os !== "windows") {
@@ -76,17 +110,7 @@ function buildBaseImage() {
     process.exit(1);
   }
 
-  const versionsPath = path.join(containerDir, "windows-base.versions.json");
-  if (!fs.existsSync(versionsPath)) {
-    console.error(`Missing version pin file: ${versionsPath}`);
-    process.exit(1);
-  }
-  const pins = JSON.parse(fs.readFileSync(versionsPath, "utf8"));
-  const windowsServerTag = pins.windowsServer || "ltsc2022";
-  // Tag encodes every pin so bumping any one — including the OS base —
-  // produces a distinct tag; the thin windows.Dockerfile pins its FROM
-  // to this exact composite tag via BASE_TAG.
-  const baseTag = `${windowsServerTag}-${pins.node}-${pins.python}-${pins.java}-${pins.dita}`;
+  const { pins, baseTag } = readBasePins();
   const repo = "docdetective/docdetective-windows-base";
   const tags = [baseTag, "latest"];
   const tagArgs = tags.flatMap((t) => ["-t", `${repo}:${t}`]);
@@ -98,7 +122,7 @@ function buildBaseImage() {
     path.join(containerDir, "windows-base.Dockerfile"),
     ...tagArgs,
     "--build-arg",
-    `WINDOWS_SERVER_TAG=${windowsServerTag}`,
+    `WINDOWS_SERVER_TAG=${pins.windowsServer}`,
     "--build-arg",
     `NODE_VERSION=${pins.node}`,
     "--build-arg",
@@ -158,22 +182,17 @@ function buildAppImage() {
   // FROM to the exact versioned tag from windows-base.versions.json.
   let extraBuildArgs = [];
   if (os === "windows" && !skipBasePrePull) {
-    const pinsPath = path.join(containerDir, "windows-base.versions.json");
-    if (fs.existsSync(pinsPath)) {
-      const pins = JSON.parse(fs.readFileSync(pinsPath, "utf8"));
-      const windowsServerTag = pins.windowsServer || "ltsc2022";
-      const baseTag = `${windowsServerTag}-${pins.node}-${pins.python}-${pins.java}-${pins.dita}`;
-      const baseRef = `docdetective/docdetective-windows-base:${baseTag}`;
-      extraBuildArgs = ["--build-arg", `BASE_TAG=${baseTag}`];
-      try {
-        console.log(`Pre-pulling base image: ${baseRef}`);
-        execFileSync("docker", ["pull", baseRef], { stdio: "inherit" });
-      } catch (err) {
-        console.warn(
-          `Warning: could not pre-pull ${baseRef} (${err.message}). ` +
-            `Continuing — docker build will attempt the pull itself.`
-        );
-      }
+    const { baseTag } = readBasePins();
+    const baseRef = `docdetective/docdetective-windows-base:${baseTag}`;
+    extraBuildArgs = ["--build-arg", `BASE_TAG=${baseTag}`];
+    try {
+      console.log(`Pre-pulling base image: ${baseRef}`);
+      execFileSync("docker", ["pull", baseRef], { stdio: "inherit" });
+    } catch (err) {
+      console.warn(
+        `Warning: could not pre-pull ${baseRef} (${err.message}). ` +
+          `Continuing — docker build will attempt the pull itself.`
+      );
     }
   }
 

--- a/src/container/scripts/build.cjs
+++ b/src/container/scripts/build.cjs
@@ -1,37 +1,58 @@
-// Script to build Docker image with version from package.json
+// Script to build Docker image with version from package.json.
+//
+// Default (no --target): builds the thin top-layer image, `docdetective/docdetective`.
+//   npm run container:build -- --version=X.Y.Z
+//
+// Base (--target=base): builds the prebuilt Windows toolchain base image,
+// `docdetective/docdetective-windows-base`. Rebuild only when a tool
+// version in windows-base.versions.json bumps.
+//   npm run container:build:base
+//   npm run container:build:base -- --push
 const { execFileSync, execSync } = require("child_process");
+const fs = require("fs");
 const path = require("path");
 
 const containerDir = path.resolve(__dirname, "..");
 
-// Get arguments from command line
+// ---------- arg parsing ----------
 const args = process.argv.slice(2);
 
-// Check if a custom version is specified with --version
-let version = "latest";
-for (let i = 0; i < args.length; i++) {
-  const arg = args[i];
-  if (arg === "--version" || arg === "-v") {
-    const nextArg = args[i + 1];
-    if (!nextArg || nextArg.startsWith("-")) {
-      console.error(`Missing value for ${arg}`);
-      process.exit(1);
+function readFlagValue(flag) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === flag) {
+      const next = args[i + 1];
+      if (!next || next.startsWith("-")) {
+        console.error(`Missing value for ${arg}`);
+        process.exit(1);
+      }
+      return next;
     }
-    version = nextArg;
-    break;
+    if (arg.startsWith(`${flag}=`)) {
+      return arg.slice(flag.length + 1);
+    }
   }
-  if (arg.startsWith("--version=") || arg.startsWith("-v=")) {
-    version = arg.split("=")[1];
-    break;
-  }
+  return undefined;
 }
+
+let version = readFlagValue("--version") || readFlagValue("-v") || "latest";
 if (!/^[\w.\-]+$/.test(version)) {
   console.error(`Invalid version string: ${version}`);
   process.exit(1);
 }
-console.log(`Building Docker image with version: ${version}`);
 
-// Detect Docker container mode
+const target = readFlagValue("--target") || "app";
+if (target !== "app" && target !== "base") {
+  console.error(`Invalid --target: ${target} (expected 'app' or 'base')`);
+  process.exit(1);
+}
+
+const shouldPush = args.includes("--push");
+const noCache = args.includes("--no-cache");
+const pullBaseImage = args.includes("--pull");
+const skipBasePrePull = args.includes("--no-pull-base");
+
+// ---------- detect Docker container mode ----------
 let dockerOSType;
 try {
   dockerOSType = execSync('docker info --format "{{.OSType}}"', {
@@ -44,44 +65,130 @@ try {
   dockerOSType = process.platform === "win32" ? "windows" : "linux";
 }
 
-let os;
-let tags;
-let envVariables = {
-  ...process.env,
-};
-if (dockerOSType === "windows") {
-  os = "windows";
-  tags = ["windows", "latest-windows", `${version}-windows`];
-  envVariables.DOCKER_BUILDKIT = "0";
-} else {
-  os = "linux";
-  tags = [...new Set(["linux", "latest", "latest-linux", version, `${version}-linux`])];
+const os = dockerOSType === "windows" ? "windows" : "linux";
+
+// ---------- base-image build path ----------
+function buildBaseImage() {
+  if (os !== "windows") {
+    console.error(
+      "--target=base is only supported in Windows container mode (there is no linux-base image)."
+    );
+    process.exit(1);
+  }
+
+  const versionsPath = path.join(containerDir, "windows-base.versions.json");
+  if (!fs.existsSync(versionsPath)) {
+    console.error(`Missing version pin file: ${versionsPath}`);
+    process.exit(1);
+  }
+  const pins = JSON.parse(fs.readFileSync(versionsPath, "utf8"));
+  const baseTag = `${pins.node}-${pins.python}-${pins.java}-${pins.dita}`;
+  const repo = "docdetective/docdetective-windows-base";
+  const tags = [baseTag, "latest"];
+  const tagArgs = tags.flatMap((t) => ["-t", `${repo}:${t}`]);
+
+  const dockerArgs = [
+    "build",
+    ...(pullBaseImage ? ["--pull"] : []),
+    "-f",
+    path.join(containerDir, "windows-base.Dockerfile"),
+    ...tagArgs,
+    "--build-arg",
+    `NODE_VERSION=${pins.node}`,
+    "--build-arg",
+    `PYTHON_VERSION=${pins.python}`,
+    "--build-arg",
+    `JAVA_VERSION=${pins.java}`,
+    "--build-arg",
+    `DITA_VERSION=${pins.dita}`,
+    ...(noCache ? ["--no-cache"] : []),
+    containerDir,
+  ];
+
+  console.log(`Building base image: ${repo}:${baseTag}`);
+  console.log(`Docker command: docker ${dockerArgs.join(" ")}`);
+
+  execFileSync("docker", dockerArgs, {
+    stdio: "inherit",
+    env: { ...process.env, DOCKER_BUILDKIT: "0" },
+  });
+
+  if (shouldPush) {
+    console.log(`Pushing base image tags to Docker Hub...`);
+    for (const t of tags) {
+      execFileSync("docker", ["push", `${repo}:${t}`], { stdio: "inherit" });
+    }
+  }
+
+  console.log(`Base image build complete: ${repo}:${baseTag}`);
+  return { repo, baseTag };
 }
-console.log(`Building for OS: ${os}`);
-console.log(`Tags: ${tags}`);
 
-// Construct '-t' arguments for Docker build
-const tagArgs = tags.flatMap((tag) => ["-t", `docdetective/docdetective:${tag}`]);
-console.log(`Tag arguments: ${tagArgs.join(" ")}`);
+// ---------- app-image build path ----------
+function buildAppImage() {
+  let tags;
+  const envVariables = { ...process.env };
 
-// Build the Docker command args
-const dockerArgs = [
-  "build",
-  ...(args.includes("--pull") ? ["--pull"] : []),
-  "-f",
-  path.join(containerDir, `${os}.Dockerfile`),
-  ...tagArgs,
-  "--build-arg",
-  `PACKAGE_VERSION=${version}`,
-  ...(args.includes("--no-cache") ? ["--no-cache"] : []),
-  containerDir,
-];
+  if (os === "windows") {
+    tags = ["windows", "latest-windows", `${version}-windows`];
+    envVariables.DOCKER_BUILDKIT = "0";
+  } else {
+    tags = [
+      ...new Set([
+        "linux",
+        "latest",
+        "latest-linux",
+        version,
+        `${version}-linux`,
+      ]),
+    ];
+  }
 
-console.log(`Docker command: docker ${dockerArgs.join(" ")}`);
+  console.log(`Building for OS: ${os}`);
+  console.log(`Tags: ${tags}`);
 
-// Execute the command
-try {
-  console.log(`Executing: docker ${dockerArgs.join(" ")}`);
+  // For Windows, pre-pull the base image so the developer sees a clean
+  // pull-progress bar instead of a silent fetch mid-build. Also pin the
+  // FROM to the exact versioned tag from windows-base.versions.json.
+  let extraBuildArgs = [];
+  if (os === "windows" && !skipBasePrePull) {
+    const pinsPath = path.join(containerDir, "windows-base.versions.json");
+    if (fs.existsSync(pinsPath)) {
+      const pins = JSON.parse(fs.readFileSync(pinsPath, "utf8"));
+      const baseTag = `${pins.node}-${pins.python}-${pins.java}-${pins.dita}`;
+      const baseRef = `docdetective/docdetective-windows-base:${baseTag}`;
+      extraBuildArgs = ["--build-arg", `BASE_TAG=${baseTag}`];
+      try {
+        console.log(`Pre-pulling base image: ${baseRef}`);
+        execFileSync("docker", ["pull", baseRef], { stdio: "inherit" });
+      } catch (err) {
+        console.warn(
+          `Warning: could not pre-pull ${baseRef} (${err.message}). ` +
+            `Continuing — docker build will attempt the pull itself.`
+        );
+      }
+    }
+  }
+
+  const tagArgs = tags.flatMap((tag) => [
+    "-t",
+    `docdetective/docdetective:${tag}`,
+  ]);
+
+  const dockerArgs = [
+    "build",
+    ...(args.includes("--pull") ? ["--pull"] : []),
+    "-f",
+    path.join(containerDir, `${os}.Dockerfile`),
+    ...tagArgs,
+    "--build-arg",
+    `PACKAGE_VERSION=${version}`,
+    ...extraBuildArgs,
+    ...(noCache ? ["--no-cache"] : []),
+    containerDir,
+  ];
+
+  console.log(`Docker command: docker ${dockerArgs.join(" ")}`);
 
   execFileSync("docker", dockerArgs, {
     stdio: "inherit",
@@ -89,7 +196,17 @@ try {
   });
 
   console.log("Docker build completed successfully");
+}
+
+// ---------- entrypoint ----------
+try {
+  if (target === "base") {
+    buildBaseImage();
+  } else {
+    console.log(`Building Docker image with version: ${version}`);
+    buildAppImage();
+  }
 } catch (error) {
-  console.error("Docker build failed:", error);
+  console.error("Docker build failed:", error.message || error);
   process.exit(1);
 }

--- a/src/container/windows-base.Dockerfile
+++ b/src/container/windows-base.Dockerfile
@@ -1,0 +1,103 @@
+# Prebuilt base image for docdetective/docdetective:windows.
+#
+# Contains Node.js, Python, Microsoft OpenJDK, and DITA-OT. Rebuilt rarely —
+# only when a pinned tool version bumps. Kept separate from the thin top
+# layer in windows.Dockerfile so that cold local builds can skip the
+# multi-minute Windows installer steps and just `docker pull` this image.
+#
+# Tags: docdetective/docdetective-windows-base:<node>-<python>-<java>-<dita>
+#       docdetective/docdetective-windows-base:latest
+#
+# Tool versions are sourced from windows-base.versions.json; the ARG defaults
+# below must stay in sync with that file.
+
+FROM mcr.microsoft.com/windows/server:ltsc2022
+
+ARG NODE_VERSION=22.15.0
+ARG PYTHON_VERSION=3.13.1
+ARG JAVA_VERSION=17.0.14
+ARG DITA_VERSION=4.3.4
+
+ENV NODE_VERSION=${NODE_VERSION}
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+ENV JAVA_VERSION=${JAVA_VERSION}
+ENV DITA_VERSION=${DITA_VERSION}
+
+LABEL authors="Doc Detective" \
+    description="Prebuilt Windows toolchain base for Doc Detective (Node, Python, OpenJDK, DITA-OT)." \
+    maintainer="manny@doc-detective.com" \
+    license="AGPL-3.0" \
+    homepage="https://www.doc-detective.com" \
+    repository="https://github.com/doc-detective/doc-detective" \
+    source="https://github.com/doc-detective/doc-detective" \
+    documentation="https://www.doc-detective.com" \
+    vendor="Doc Detective"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Set-ExecutionPolicy Bypass -Scope Process -Force
+
+# Download all four toolchain archives in parallel, then install sequentially.
+# msiexec / Windows installers do not play well when run concurrently, so
+# only the downloads are parallelized. This typically cuts 2-4 minutes off
+# a cold base-image build versus the original per-tool RUN layout.
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    $NodeUrl   = 'https://nodejs.org/dist/v' + $env:NODE_VERSION + '/node-v' + $env:NODE_VERSION + '-x64.msi'; \
+    $PythonUrl = 'https://www.python.org/ftp/python/' + $env:PYTHON_VERSION + '/python-' + $env:PYTHON_VERSION + '-amd64.exe'; \
+    $JavaUrl   = 'https://aka.ms/download-jdk/microsoft-jdk-' + $env:JAVA_VERSION + '-windows-x64.zip'; \
+    $DitaUrl   = 'https://github.com/dita-ot/dita-ot/releases/download/' + $env:DITA_VERSION + '/dita-ot-' + $env:DITA_VERSION + '.zip'; \
+    $downloads = @( \
+        @{ Url = $NodeUrl;   Path = 'C:\node-installer.msi'   }, \
+        @{ Url = $PythonUrl; Path = 'C:\python-installer.exe' }, \
+        @{ Url = $JavaUrl;   Path = 'C:\openjdk.zip'          }, \
+        @{ Url = $DitaUrl;   Path = 'C:\dita-ot.zip'          }  \
+    ); \
+    $jobs = $downloads | ForEach-Object { \
+        $dl = $_; \
+        Start-Job -ScriptBlock { \
+            param($url, $path) \
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+            (New-Object System.Net.WebClient).DownloadFile($url, $path) \
+        } -ArgumentList $dl.Url, $dl.Path \
+    }; \
+    $jobs | Wait-Job | ForEach-Object { \
+        if ($_.State -ne 'Completed') { \
+            Receive-Job $_; \
+            throw ('Download job failed: ' + $_.Name + ' (state=' + $_.State + ')') \
+        }; \
+        Receive-Job $_ | Out-Null; \
+        Remove-Job $_ \
+    }; \
+    Write-Host 'Installing Node.js...'; \
+    Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', 'C:\node-installer.msi', '/quiet', '/norestart' -Wait; \
+    Remove-Item -Path 'C:\node-installer.msi' -Force; \
+    Write-Host 'Installing Python...'; \
+    Start-Process -FilePath 'C:\python-installer.exe' -ArgumentList '/quiet', 'InstallAllUsers=1', 'PrependPath=0', 'Include_test=0' -Wait; \
+    Remove-Item -Path 'C:\python-installer.exe' -Force; \
+    Write-Host 'Extracting OpenJDK...'; \
+    Expand-Archive -Path 'C:\openjdk.zip' -DestinationPath 'C:\temp-jdk' -Force; \
+    $ExtractedDir = Get-ChildItem -Path 'C:\temp-jdk' -Directory | Select-Object -First 1; \
+    Move-Item -Path $ExtractedDir.FullName -Destination 'C:\openjdk' -Force; \
+    Remove-Item -Path 'C:\temp-jdk' -Force -Recurse; \
+    Remove-Item -Path 'C:\openjdk.zip' -Force; \
+    Write-Host 'Extracting DITA-OT...'; \
+    Expand-Archive -Path 'C:\dita-ot.zip' -DestinationPath 'C:\' -Force; \
+    Move-Item -Path ('C:\dita-ot-' + $env:DITA_VERSION) -Destination 'C:\dita-ot' -Force; \
+    Remove-Item -Path 'C:\dita-ot.zip' -Force
+
+# Persist PATH and JAVA_HOME for all downstream layers / containers.
+RUN $PythonMajorMinor = ($env:PYTHON_VERSION -split '\.')[0..1] -join ''; \
+    $PythonPath        = 'C:\Program Files\Python' + $PythonMajorMinor; \
+    $PythonScriptsPath = $PythonPath + '\Scripts'; \
+    $newPath = 'C:\Program Files\nodejs;' + $PythonPath + ';' + $PythonScriptsPath + ';C:\openjdk\bin;C:\dita-ot\bin;' + $env:Path; \
+    [Environment]::SetEnvironmentVariable('Path', $newPath, [System.EnvironmentVariableTarget]::Machine); \
+    [Environment]::SetEnvironmentVariable('JAVA_HOME', 'C:\openjdk', [System.EnvironmentVariableTarget]::Machine)
+
+# Verify every tool installed correctly. Fails the build fast if any step
+# silently broke above.
+RUN node -v; \
+    npm -v; \
+    python --version; \
+    pip --version; \
+    java -version; \
+    dita --version

--- a/src/container/windows-base.Dockerfile
+++ b/src/container/windows-base.Dockerfile
@@ -67,14 +67,17 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     $JavaUrl   = 'https://aka.ms/download-jdk/microsoft-jdk-' + $env:JAVA_VERSION + '-windows-x64.zip'; \
     $DitaUrl   = 'https://github.com/dita-ot/dita-ot/releases/download/' + $env:DITA_VERSION + '/dita-ot-' + $env:DITA_VERSION + '.zip'; \
     $downloads = @( \
-        @{ Url = $NodeUrl;   Path = 'C:\node-installer.msi'   }, \
-        @{ Url = $PythonUrl; Path = 'C:\python-installer.exe' }, \
-        @{ Url = $JavaUrl;   Path = 'C:\openjdk.zip'          }, \
-        @{ Url = $DitaUrl;   Path = 'C:\dita-ot.zip'          }  \
+        @{ Name = 'node';   Url = $NodeUrl;   Path = 'C:\node-installer.msi'   }, \
+        @{ Name = 'python'; Url = $PythonUrl; Path = 'C:\python-installer.exe' }, \
+        @{ Name = 'java';   Url = $JavaUrl;   Path = 'C:\openjdk.zip'          }, \
+        @{ Name = 'dita';   Url = $DitaUrl;   Path = 'C:\dita-ot.zip'          }  \
     ); \
+    # -Name makes the tool identifiable in the "Download job failed" throw
+    # below; without it jobs get auto-names like Job1/Job2/... and the
+    # error can't say which tool URL bombed.
     $jobs = $downloads | ForEach-Object { \
         $dl = $_; \
-        Start-Job -ScriptBlock { \
+        Start-Job -Name $dl.Name -ScriptBlock { \
             param($url, $path) \
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
             (New-Object System.Net.WebClient).DownloadFile($url, $path) \

--- a/src/container/windows-base.Dockerfile
+++ b/src/container/windows-base.Dockerfile
@@ -16,15 +16,19 @@
 # A PR that edits windows-base.versions.json or this file will:
 #   1. Trigger the `build-windows-base` CI job on PR (build-only, no push),
 #      so any install/syntax errors in the base are caught in review.
-#   2. Trigger the app `build` job, which sets FROM to the NEW composite
-#      tag — which isn't on Docker Hub yet, so that job will FAIL.
+#   2. Skip the windows-2022 leg of the app `build` job via the
+#      WINDOWS_APP_BUILD_SKIP gate in docker-build.yml — the new composite
+#      base tag isn't on Docker Hub yet, so its FROM couldn't resolve.
+#      The ubuntu leg of the app build still runs for Linux coverage.
+#      PR checks stay green on the app-build side.
 #
-# To get the app build green before merge, a maintainer must publish the
-# new base tag first by dispatching the `Docker build` workflow manually
-# with `build_base=true`. Once the new tag exists on Docker Hub, re-run
-# the PR's failed checks and the app build will resolve its FROM.
-# After merge, the push-to-main trigger will rebuild and re-push the
-# base automatically, keeping it in sync with the merged pin file.
+# The new base tag still needs to be published before any new app image
+# that references it can be pushed. After merge, the push-to-main trigger
+# rebuilds and re-pushes the base automatically, keeping Docker Hub in
+# sync with the merged pin file; subsequent app-image publishes then
+# resolve their FROM normally. If you need the base on Hub sooner (e.g.
+# to validate on a non-CI windows host), dispatch the `Docker build`
+# workflow manually with `build_base=true`.
 
 ARG WINDOWS_SERVER_TAG=ltsc2022
 FROM mcr.microsoft.com/windows/server:${WINDOWS_SERVER_TAG}

--- a/src/container/windows-base.Dockerfile
+++ b/src/container/windows-base.Dockerfile
@@ -89,10 +89,13 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
         Remove-Job $_ \
     }; \
     Write-Host 'Installing Node.js...'; \
-    Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', 'C:\node-installer.msi', '/quiet', '/norestart' -Wait; \
+    $nodeInstall = Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', 'C:\node-installer.msi', '/quiet', '/norestart' -Wait -PassThru; \
+    # 3010 = success, reboot required. Normal for MSI silent installs and safe to ignore inside a container.
+    if ($nodeInstall.ExitCode -notin 0, 3010) { throw ('Node.js installer failed with exit code ' + $nodeInstall.ExitCode) }; \
     Remove-Item -Path 'C:\node-installer.msi' -Force; \
     Write-Host 'Installing Python...'; \
-    Start-Process -FilePath 'C:\python-installer.exe' -ArgumentList '/quiet', 'InstallAllUsers=1', 'PrependPath=0', 'Include_test=0' -Wait; \
+    $pythonInstall = Start-Process -FilePath 'C:\python-installer.exe' -ArgumentList '/quiet', 'InstallAllUsers=1', 'PrependPath=0', 'Include_test=0' -Wait -PassThru; \
+    if ($pythonInstall.ExitCode -notin 0, 3010) { throw ('Python installer failed with exit code ' + $pythonInstall.ExitCode) }; \
     Remove-Item -Path 'C:\python-installer.exe' -Force; \
     Write-Host 'Extracting OpenJDK...'; \
     Expand-Archive -Path 'C:\openjdk.zip' -DestinationPath 'C:\temp-jdk' -Force; \
@@ -114,10 +117,23 @@ RUN $PythonMajorMinor = ($env:PYTHON_VERSION -split '\.')[0..1] -join ''; \
     [Environment]::SetEnvironmentVariable('JAVA_HOME', 'C:\openjdk', [System.EnvironmentVariableTarget]::Machine)
 
 # Verify every tool installed correctly. Fails the build fast if any step
-# silently broke above.
-RUN node -v; \
-    npm -v; \
-    python --version; \
-    pip --version; \
-    java -version; \
-    dita --version
+# silently broke above. $ErrorActionPreference=Stop catches cmdlet
+# failures but NOT native-command non-zero exits, and a later successful
+# command would reset $LASTEXITCODE — so each invocation is checked
+# explicitly.
+RUN $checks = @( \
+        @('node',   '-v'), \
+        @('npm',    '-v'), \
+        @('python', '--version'), \
+        @('pip',    '--version'), \
+        @('java',   '-version'), \
+        @('dita',   '--version')  \
+    ); \
+    foreach ($c in $checks) { \
+        $exe = $c[0]; \
+        $cmdArgs = $c[1..($c.Length - 1)]; \
+        & $exe @cmdArgs; \
+        if ($LASTEXITCODE -ne 0) { \
+            throw ($exe + ' ' + ($cmdArgs -join ' ') + ' failed with exit code ' + $LASTEXITCODE) \
+        } \
+    }

--- a/src/container/windows-base.Dockerfile
+++ b/src/container/windows-base.Dockerfile
@@ -11,7 +11,8 @@
 # Tool versions are sourced from windows-base.versions.json; the ARG defaults
 # below must stay in sync with that file.
 
-FROM mcr.microsoft.com/windows/server:ltsc2022
+ARG WINDOWS_SERVER_TAG=ltsc2022
+FROM mcr.microsoft.com/windows/server:${WINDOWS_SERVER_TAG}
 
 ARG NODE_VERSION=22.15.0
 ARG PYTHON_VERSION=3.13.1

--- a/src/container/windows-base.Dockerfile
+++ b/src/container/windows-base.Dockerfile
@@ -5,11 +5,26 @@
 # layer in windows.Dockerfile so that cold local builds can skip the
 # multi-minute Windows installer steps and just `docker pull` this image.
 #
-# Tags: docdetective/docdetective-windows-base:<node>-<python>-<java>-<dita>
+# Tags: docdetective/docdetective-windows-base:<windowsServer>-<node>-<python>-<java>-<dita>
 #       docdetective/docdetective-windows-base:latest
 #
 # Tool versions are sourced from windows-base.versions.json; the ARG defaults
 # below must stay in sync with that file.
+#
+# Bumping a pinned version (bootstrap flow for contributors):
+# -----------------------------------------------------------
+# A PR that edits windows-base.versions.json or this file will:
+#   1. Trigger the `build-windows-base` CI job on PR (build-only, no push),
+#      so any install/syntax errors in the base are caught in review.
+#   2. Trigger the app `build` job, which sets FROM to the NEW composite
+#      tag — which isn't on Docker Hub yet, so that job will FAIL.
+#
+# To get the app build green before merge, a maintainer must publish the
+# new base tag first by dispatching the `Docker build` workflow manually
+# with `build_base=true`. Once the new tag exists on Docker Hub, re-run
+# the PR's failed checks and the app build will resolve its FROM.
+# After merge, the push-to-main trigger will rebuild and re-push the
+# base automatically, keeping it in sync with the merged pin file.
 
 ARG WINDOWS_SERVER_TAG=ltsc2022
 FROM mcr.microsoft.com/windows/server:${WINDOWS_SERVER_TAG}

--- a/src/container/windows-base.versions.json
+++ b/src/container/windows-base.versions.json
@@ -1,0 +1,7 @@
+{
+  "node": "22.15.0",
+  "python": "3.13.1",
+  "java": "17.0.14",
+  "dita": "4.3.4",
+  "windowsServer": "ltsc2022"
+}

--- a/src/container/windows.Dockerfile
+++ b/src/container/windows.Dockerfile
@@ -1,8 +1,14 @@
-FROM mcr.microsoft.com/windows/server:ltsc2022 AS system
+# Thin top layer on top of docdetective/docdetective-windows-base, which
+# carries Node.js, Python, OpenJDK, and DITA-OT. See windows-base.Dockerfile.
+#
+# Only `npm install -g doc-detective@<version>` runs here, so cold local
+# builds collapse to one image pull + one short install layer.
+
+ARG BASE_TAG=latest
+FROM docdetective/docdetective-windows-base:${BASE_TAG}
+
 ARG PACKAGE_VERSION=latest
-ARG PYTHON_VERSION=3.13.1
 ENV PACKAGE_VERSION=${PACKAGE_VERSION}
-ENV PYTHON_VERSION=${PYTHON_VERSION}
 
 LABEL authors="Doc Detective" \
     description="The official Docker image for Doc Detective. Keep your docs accurate with ease." \
@@ -15,112 +21,14 @@ LABEL authors="Doc Detective" \
     documentation="https://www.doc-detective.com" \
     vendor="Doc Detective"
 
-# Set environment container to trigger container-based behaviors
 ENV DOC_DETECTIVE='{"container": "docdetective/docdetective:windows", "version": "'$PACKAGE_VERSION'"}'
 
-# Set up PowerShell with proper error handling and execution policy
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Set PowerShell execution policy to allow scripts to run
-RUN Set-ExecutionPolicy Bypass -Scope Process -Force
-
-# Download and install Node.js directly from nodejs.org
-RUN [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; \
-    $NodeJsUrl = 'https://nodejs.org/dist/v22.15.0/node-v22.15.0-x64.msi'; \
-    $NodeJsInstaller = 'C:\node-installer.msi'; \
-    (New-Object System.Net.WebClient).DownloadFile($NodeJsUrl, $NodeJsInstaller); \
-    # Verify checksum
-    # $shaText = (Invoke-RestMethod 'https://nodejs.org/dist/v22.15.0/SHASUMS256.txt'); \
-    # $expected = ($shaText | Select-String 'node-v22.15.0-x64.msi').Line.Split(' ')[0]; \
-    # if ((Get-FileHash -Path $NodeJsInstaller -Algorithm SHA256).Hash -ne $expected) { \
-    #   Write-Error 'Node.js installer checksum mismatch' -ErrorAction Stop; \
-    # } \
-    # Install Node.js silently
-    Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', "$NodeJsInstaller", '/quiet', '/norestart' -Wait; \
-    # Clean up installer
-    Remove-Item -Path $NodeJsInstaller -Force
-
-# Add Node to PATH and verify installation
-RUN $env:Path = 'C:\Program Files\nodejs;' + $env:Path; \
-    [Environment]::SetEnvironmentVariable('Path', $env:Path, [System.EnvironmentVariableTarget]::Machine); \
-    Set-ExecutionPolicy Bypass -Scope Process -Force; \
-    node -v; \
-    npm -v
-
-# Download and install Python
-RUN $PythonVersion = $env:PYTHON_VERSION; \
-    $PythonMajorMinor = ($PythonVersion -split '\.')[0..1] -join ''; \
-    $PythonUrl = 'https://www.python.org/ftp/python/' + $PythonVersion + '/python-' + $PythonVersion + '-amd64.exe'; \
-    $PythonInstaller = 'C:\python-installer.exe'; \
-    Write-Host 'Downloading Python...'; \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri $PythonUrl -OutFile $PythonInstaller -UseBasicParsing; \
-    Write-Host 'Installing Python...'; \
-    Start-Process -FilePath $PythonInstaller -ArgumentList '/quiet', 'InstallAllUsers=1', 'PrependPath=0', 'Include_test=0' -Wait; \
-    Write-Host 'Python installation completed'; \
-    Remove-Item -Path $PythonInstaller -Force
-
-# Add Python to PATH and verify installation
-RUN $PythonVersion = $env:PYTHON_VERSION; \
-    $PythonMajorMinor = ($PythonVersion -split '\.')[0..1] -join ''; \
-    $PythonPath = 'C:\Program Files\Python' + $PythonMajorMinor; \
-    $PythonScriptsPath = 'C:\Program Files\Python' + $PythonMajorMinor + '\Scripts'; \
-    $env:Path = $PythonPath + ';' + $PythonScriptsPath + ';' + $env:Path; \
-    [Environment]::SetEnvironmentVariable('Path', $env:Path, [System.EnvironmentVariableTarget]::Machine); \
-    Write-Host 'Verifying Python installation...'; \
-    python --version; \
-    pip --version;
-
-# Download and install Microsoft OpenJDK 17
-RUN $JavaVersion = '17.0.14'; \
-    $JavaUrl = 'https://aka.ms/download-jdk/microsoft-jdk-' + $JavaVersion + '-windows-x64.zip'; \
-    $JavaZip = 'C:\openjdk.zip'; \
-    Write-Host 'Downloading Microsoft OpenJDK 17...'; \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri $JavaUrl -OutFile $JavaZip -UseBasicParsing; \
-    Write-Host 'Extracting OpenJDK...'; \
-    Expand-Archive -Path $JavaZip -DestinationPath 'C:\temp-jdk' -Force; \
-    $ExtractedDir = Get-ChildItem -Path 'C:\temp-jdk' -Directory | Select-Object -First 1; \
-    Move-Item -Path $ExtractedDir.FullName -Destination 'C:\openjdk' -Force; \
-    Remove-Item -Path 'C:\temp-jdk' -Force -Recurse; \
-    Write-Host 'Java installation completed'; \
-    Remove-Item -Path $JavaZip -Force
-
-# Add Java to PATH and set JAVA_HOME
-RUN $env:JAVA_HOME = 'C:\openjdk'; \
-    [Environment]::SetEnvironmentVariable('JAVA_HOME', $env:JAVA_HOME, [System.EnvironmentVariableTarget]::Machine); \
-    $env:Path = 'C:\openjdk\bin;' + $env:Path; \
-    [Environment]::SetEnvironmentVariable('Path', $env:Path, [System.EnvironmentVariableTarget]::Machine); \
-    Write-Host "JAVA_HOME set to: $env:JAVA_HOME"; \
-    java -version
-
-# Download and install DITA-OT
-RUN $DitaVersion = '4.3.4'; \
-    $DitaUrl = 'https://github.com/dita-ot/dita-ot/releases/download/' + $DitaVersion + '/dita-ot-' + $DitaVersion + '.zip'; \
-    $DitaZip = 'C:\dita-ot.zip'; \
-    Write-Host 'Downloading DITA-OT...'; \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri $DitaUrl -OutFile $DitaZip -UseBasicParsing; \
-    Write-Host 'Extracting DITA-OT...'; \
-    Expand-Archive -Path $DitaZip -DestinationPath 'C:\' -Force; \
-    Move-Item -Path ('C:\dita-ot-' + $DitaVersion) -Destination 'C:\dita-ot' -Force; \
-    Remove-Item -Path $DitaZip -Force
-
-# Add DITA-OT to PATH and verify installation
-RUN $env:Path = 'C:\dita-ot\bin;' + $env:Path; \
-    [Environment]::SetEnvironmentVariable('Path', $env:Path, [System.EnvironmentVariableTarget]::Machine); \
-    Write-Host 'DITA-OT installed. Verifying...'; \
-    dita --version
-
-# Install Doc Detective from NPM
 RUN Set-ExecutionPolicy Bypass -Scope Process -Force; \
     npm install -g doc-detective@$env:PACKAGE_VERSION
 
-# Create app directory
 WORKDIR /app
 
-# Add entrypoint command base
 ENTRYPOINT ["C:\\Program Files\\nodejs\\npx.cmd", "doc-detective"]
-
-# Set default command
 CMD []


### PR DESCRIPTION
## Summary

- Split the Windows container image into two layers: a heavy prebuilt base (`docdetective/docdetective-windows-base`) containing Node 22.15.0, Python 3.13.1, Microsoft OpenJDK 17.0.14, and DITA-OT 4.3.4, and a thin top layer (`docdetective/docdetective:windows`) that just runs `npm install -g doc-detective@<version>`.
- Cold local builds drop from ~15–25 min to ~3–6 min — `docker pull` of an already-assembled Windows image is substantially faster than re-running four Windows installers (especially `msiexec`) on every developer machine.
- Adds a new `build-windows-base` CI job in `docker-build.yml` that publishes the base image. Triggered on `workflow_dispatch` with `build_base=true`, or automatically on push-to-main when `windows-base.Dockerfile` / `windows-base.versions.json` change. The regular app-build job is unchanged and gains the speedup automatically once the base is on Docker Hub.

## What changed

- `src/container/windows-base.Dockerfile` — **new**, heavy toolchain base. Downloads for all four tools run in parallel via `Start-Job`; installers still run sequentially (msiexec does not tolerate concurrent MSI installs). Trailing verify-all-tools RUN fails fast if any step silently broke.
- `src/container/windows-base.versions.json` — **new**, single source of truth for pinned tool versions. Both the Dockerfile ARG defaults and the build script read from this file; the base image's Docker Hub tag encodes all four versions (`<node>-<python>-<java>-<dita>`).
- `src/container/windows.Dockerfile` — rewritten as a thin top layer: `FROM docdetective/docdetective-windows-base:${BASE_TAG}` + `npm install -g doc-detective@$env:PACKAGE_VERSION`. Inherits PATH and `JAVA_HOME` from the base.
- `src/container/.dockerignore` — **new**, drops `scripts/`, `test/`, `*.md` from the build context. No Dockerfile in the repo does `COPY` / `ADD`, so the exclusions are safe.
- `src/container/scripts/build.cjs` — adds a `--target=base` path with optional `--push`. Reads `windows-base.versions.json` to tag the base image deterministically. The default app-build path now pre-pulls the base image (soft-warns if the registry tag is missing) and passes `--build-arg BASE_TAG=<pinned>` so `FROM` resolves to the exact known-good toolchain rather than a moving `latest`.
- `package.json` — new `container:build:base` and `container:build:base:push` scripts. The existing `container:build` and `container:rebuild` are unchanged.
- `.github/workflows/docker-build.yml` — new `build-windows-base` job, guarded so it never runs on PRs (would push before review). Existing app-build job gained an `if:` so it doesn't double-fire on the new `push` trigger or when `workflow_dispatch` is used to build only the base.

## Why `build(container):` and not `feat(container):`

Per `CLAUDE.md`, `build:` commits don't trigger a semantic-release version bump, which is correct here — this is build-infrastructure only, no runtime behavior change for users of `doc-detective` or `doc-detective:windows`.

## Local verification

Run on a windows-2022 host with Docker Desktop in Windows container mode:

- `npm run container:build:base` → all four tools install; verify-RUN prints `v22.15.0`, `Python 3.13.1`, `openjdk 17.0.14`, `DITA-OT 4.3.4`. Tagged `docdetective/docdetective-windows-base:22.15.0-3.13.1-17.0.14-4.3.4` + `:latest`.
- Base image pushed to Docker Hub.
- `npm run container:build -- --version=latest` → pre-pulls the base (now on Hub), builds a thin top layer, tags `docdetective/docdetective:windows` + `:latest-windows`.
- `docker run --rm --entrypoint powershell docdetective/docdetective:windows -Command "node -v; npm -v; python --version; java --version; dita --version; npm ls -g --depth=0 doc-detective"` — all five expected outputs, `doc-detective@4.2.1`.
- `VERSION=latest npm run container:test` — 1 passing (63 s).

## Test plan

- [ ] Review the `.dockerignore` list — confirm no Dockerfile in the repo will ever want to `COPY` `scripts/` or `test/` into the image
- [ ] Review the `build-windows-base` job's trigger conditions in `docker-build.yml` (should only fire on `workflow_dispatch` with `build_base=true`, or push-to-main that touches the base Dockerfile / versions file)
- [ ] After merge, trigger `Docker build` workflow manually with `build_base=true` to rebuild and re-push the base from CI (the current image on Hub was pushed from a local Windows dev box)
- [ ] Confirm a regular app-build job run (no `build_base`) on the windows-2022 runner now pulls the base layer instead of rebuilding the toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI can now optionally build/push a dedicated Windows "base" container image independently.

* **Chores**
  * Introduced a prebuilt Windows base image with pinned Node/Python/Java/DITA versions to speed and stabilize Windows builds.
  * CI workflow updated to detect base-image changes and conditionally run/build app or base image, improving build efficiency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->