### PR TITLE
fix(ci): prevent late webdriver rejection from killing mocha on win32+node24

### DIFF
--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -429,6 +429,9 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
       windowsHide: true,
       cwd: path.join(__dirname, "../.."),
     });
+    appium.on("error", (err: any) => {
+      log(config, "warn", `Appium process error: ${err.message}`);
+    });
     appium.stdout.on("data", (data: any) => {
       // console.log(`stdout: ${data}`);
     });
@@ -809,6 +812,10 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     } catch {
       // Process may already be terminated
     }
+    // Let in-flight WebDriver HTTP response rejections hit the microtask
+    // queue while the test harness unhandledRejection handler is still
+    // attached. Without this, Node 24 on Windows can race and exit 1.
+    await new Promise((r) => setTimeout(r, 250));
   }
 
   // Upload changed files back to source integrations (best-effort)

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -430,7 +430,7 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
       cwd: path.join(__dirname, "../.."),
     });
     appium.on("error", (err: any) => {
-      log(config, "warn", `Appium process error: ${err.message}`);
+      log(config, "warning", `Appium process error: ${err?.stack ?? err?.message ?? String(err)}`);
     });
     appium.stdout.on("data", (data: any) => {
       // console.log(`stdout: ${data}`);
@@ -812,10 +812,6 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     } catch {
       // Process may already be terminated
     }
-    // Let in-flight WebDriver HTTP response rejections hit the microtask
-    // queue while the test harness unhandledRejection handler is still
-    // attached. Without this, Node 24 on Windows can race and exit 1.
-    await new Promise((r) => setTimeout(r, 250));
   }
 
   // Upload changed files back to source integrations (best-effort)

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -19,14 +19,46 @@ const apiServer = createServer({
 // the mocha process with exit 1 before the reporter flushes. Observed on
 // Windows + Node 24; microtask-scheduling differences make the other
 // matrix legs settle the rejection inside the suppressed try/catch.
-// Log the stack so a real bug stays visible but don't re-throw.
+//
+// Handlers below are narrowly scoped: only suppress rejections shaped
+// like a WebDriver/Appium teardown race. For every other unhandled
+// rejection or uncaught exception we still log the stack AND set
+// process.exitCode = 1, so mocha flushes its reporter but the run
+// still fails — nothing masked.
+function isWebDriverTeardownError(reason) {
+  if (!reason) return false;
+  const text = [reason.name, reason.message, reason.stack]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    /WebDriver(Error|RequestError)/.test(text) ||
+    (/webdriver/i.test(text) &&
+      /(ECONNREFUSED|ECONNRESET|socket hang up)/.test(text))
+  );
+}
+
 function onUnhandledRejection(reason) {
   const stack = reason && reason.stack ? reason.stack : String(reason);
-  console.error(`[test/hooks] unhandledRejection (non-fatal):\n${stack}`);
+  if (isWebDriverTeardownError(reason)) {
+    console.error(
+      `[test/hooks] WebDriver teardown rejection (non-fatal):\n${stack}`
+    );
+    return;
+  }
+  console.error(`[test/hooks] unhandledRejection (failing run):\n${stack}`);
+  process.exitCode = 1;
 }
+
 function onUncaughtException(err) {
   const stack = err && err.stack ? err.stack : String(err);
-  console.error(`[test/hooks] uncaughtException (non-fatal):\n${stack}`);
+  if (isWebDriverTeardownError(err)) {
+    console.error(
+      `[test/hooks] WebDriver teardown exception (non-fatal):\n${stack}`
+    );
+    return;
+  }
+  console.error(`[test/hooks] uncaughtException (failing run):\n${stack}`);
+  process.exitCode = 1;
 }
 
 export const mochaHooks = {

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -13,8 +13,26 @@ const apiServer = createServer({
   staticDir: "./test/server/public",
 });
 
+// Late unhandled rejections from WebdriverIO's HTTP client (fired after
+// deleteSession's try/catch has resolved, when in-flight requests lose
+// their socket as kill(appium.pid) tears down the Appium tree) can kill
+// the mocha process with exit 1 before the reporter flushes. Observed on
+// Windows + Node 24; microtask-scheduling differences make the other
+// matrix legs settle the rejection inside the suppressed try/catch.
+// Log the stack so a real bug stays visible but don't re-throw.
+function onUnhandledRejection(reason) {
+  const stack = reason && reason.stack ? reason.stack : String(reason);
+  console.error(`[test/hooks] unhandledRejection (non-fatal):\n${stack}`);
+}
+function onUncaughtException(err) {
+  const stack = err && err.stack ? err.stack : String(err);
+  console.error(`[test/hooks] uncaughtException (non-fatal):\n${stack}`);
+}
+
 export const mochaHooks = {
   async beforeAll() {
+    process.on("unhandledRejection", onUnhandledRejection);
+    process.on("uncaughtException", onUncaughtException);
     for (const [name, s] of [["main", server], ["API", apiServer]]) {
       try {
         await s.start();
@@ -35,5 +53,7 @@ export const mochaHooks = {
         console.error(`Failed to stop test server: ${error.message}`);
       }
     }
+    process.off("unhandledRejection", onUnhandledRejection);
+    process.off("uncaughtException", onUncaughtException);
   },
 };


### PR DESCRIPTION
## Summary

- Only the `Test (windows-latest, node 24)` matrix leg of run [24743366722](https://github.com/doc-detective/doc-detective/actions/runs/24743366722/attempts/1) failed. mocha died mid-suite in [test/core-screenshot.test.js](test/core-screenshot.test.js), right after the 2nd test of the `"Screenshot with URL `path` (remote reference)"` describe block — no failure report, no summary, 9s of silence, then exit 1. Post-job cleanup terminated orphan `firefox`, `geckodriver`, `crashhelper`, `node`, `cmd`.
- Root cause: a late `unhandledRejection` from WebdriverIO's HTTP client fires after `driver.deleteSession()`'s try/catch has resolved, triggered by in-flight requests losing their socket when `kill(appium.pid)` tears down the Appium tree. Node treats unhandled rejections as fatal (exit 1, no mocha output). The repo has no process-level rejection handlers. Windows + Node 24 surfaces the race reliably; microtask-scheduling differences let Node 20/22 and POSIX settle the rejection inside the suppressed try/catch.

## Changes

1. **[test/hooks.js](../blob/claude/hungry-leakey-dce99d/test/hooks.js)** — `mochaHooks.beforeAll` registers non-fatal `unhandledRejection`/`uncaughtException` handlers that log the full stack with a `[test/hooks]` prefix; `afterAll` removes them. mocha surfaces its own assertion failures via the `Runner` event path (not `process.on`), so tests that legitimately throw still fail normally.
2. **[src/core/tests.ts](../blob/claude/hungry-leakey-dce99d/src/core/tests.ts)** — attach `appium.on("error", ...)` immediately after the `spawn("npx", ["appium"], ...)` call. Prevents `ENOENT`/`EPERM` from the spawn becoming an unhandled `'error'` emission on Windows.
3. **[src/core/tests.ts](../blob/claude/hungry-leakey-dce99d/src/core/tests.ts)** — await a 250ms settle after `kill(appium.pid)` so in-flight WebDriver HTTP response rejections hit the microtask queue while the harness's handler is still attached.

## Why not an alternative

- `NODE_OPTIONS=--unhandled-rejections=warn` in the workflow: fixes only CI (not local `npm test`), globally downgrades Node 24's default for the whole run, and leaves no visible hook for contributors.
- Skip the suite on `win32 && node 24`: hides legitimate screenshot coverage on a release-gate matrix leg.
- Replace `tree-kill` with graceful WebdriverIO teardown: correct long-term fix but touches browser lifecycle broadly; deferred to a focused PR.

## Test plan

- [ ] `Test (ubuntu-latest, node 20/22/24)` green
- [ ] `Test (macos-latest, node 20/22/24)` green
- [ ] `Test (windows-latest, node 20/22)` green (no regression)
- [ ] `Test (windows-latest, node 24)` green — the original failing leg
- [ ] mocha prints the `X passing / Y failing` summary on all legs
- [ ] Any `[test/hooks] unhandledRejection (non-fatal):` lines in the log are non-fatal and don't suppress real failures
- [ ] Re-run the matrix 2–3× via `gh workflow run` to confirm stability (root race is still present; fix makes it non-fatal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error logging and handling during test execution to capture and report process-level errors more reliably.
  * Enhanced shutdown behavior to ensure in-flight requests complete before test harness termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->