### PR TITLE
fix(ci): close Appium port-bind race on Windows + Node 24

### DIFF
--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -975,19 +975,28 @@ async function runStep({
 async function waitForPortFree(port: number, timeoutMs: number = 30000) {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    const free = await new Promise<boolean>((resolve) => {
+    const result = await new Promise<"free" | "busy" | Error>((resolve) => {
       const server = net.createServer();
-      server.once("error", () => resolve(false));
+      server.once("error", (err: NodeJS.ErrnoException) => {
+        // Only EADDRINUSE means "keep polling". Any other bind failure
+        // (EACCES, invalid host, etc.) is a real problem and must surface.
+        if (err && err.code === "EADDRINUSE") resolve("busy");
+        else resolve(err instanceof Error ? err : new Error(String(err)));
+      });
       server.once("listening", () => {
-        server.close(() => resolve(true));
+        server.close(() => resolve("free"));
       });
       server.listen(port, "127.0.0.1");
     });
-    if (free) return;
+    if (result === "free") return;
+    if (result instanceof Error) throw result;
     await new Promise((r) => setTimeout(r, 250));
   }
-  // Timeout: the port is still bound but we let Appium try anyway -- its own
-  // spawn will fail with a clearer error than a silent wdio ECONNREFUSED.
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for 127.0.0.1:${port} to become free. ` +
+      `A prior Appium instance is still bound to the port; the next session create ` +
+      `would race the teardown and fail with an opaque ECONNREFUSED.`
+  );
 }
 // Delay execution until Appium server is available.
 async function appiumIsReady(timeoutMs: number = 120000) {
@@ -1007,13 +1016,13 @@ async function appiumIsReady(timeoutMs: number = 120000) {
 }
 
 // Start the Appium driver specified in `capabilities`.
-async function driverStart(capabilities: any, retries: number = 3) {
+async function driverStart(capabilities: any, maxAttempts: number = 4) {
   // POST /session can race a just-spawned-or-still-dying Appium on Windows:
   // /status may already return 200 from the outgoing process while /session
   // is no longer accepting. Retry with linear backoff ONLY on ECONNREFUSED --
   // any other error is a real session-creation failure and propagates.
   let lastError: any;
-  for (let attempt = 0; attempt <= retries; attempt++) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       const driver: any = await wdio.remote({
         protocol: "http",
@@ -1030,8 +1039,8 @@ async function driverStart(capabilities: any, retries: number = 3) {
     } catch (err: any) {
       lastError = err;
       if (!/ECONNREFUSED/.test(String(err && err.message))) throw err;
-      if (attempt < retries) {
-        await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
+      if (attempt < maxAttempts) {
+        await new Promise((r) => setTimeout(r, 500 * attempt));
       }
     }
   }

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -28,6 +28,7 @@ import { resolveExpression } from "./expressions.js";
 import { getEnvironment, getAvailableApps } from "./config.js";
 import { uploadChangedFiles } from "./integrations/index.js";
 import http from "node:http";
+import net from "node:net";
 import https from "node:https";
 import { fileURLToPath } from "node:url";
 
@@ -423,6 +424,9 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   if (appiumRequired) {
     // Set Appium home directory
     setAppiumHome();
+    // Ensure the Appium port is not still bound by a zombie from a prior
+    // runTests() call in this process before spawning a fresh one.
+    await waitForPortFree(4723);
     // Start Appium server
     appium = spawn("npx", ["appium"], {
       shell: true,
@@ -962,6 +966,29 @@ async function runStep({
   return actionResult;
 }
 
+// Wait until the given TCP port is not bound by anything on 127.0.0.1.
+// Between per-test runTests() calls, a prior Appium on port 4723 can still
+// be tearing down while the new one is about to spawn. On Windows + Node 24
+// the teardown window is wide enough for the new Appium's spawn to race the
+// old one's exit and confuse wdio's POST /session. Blocking until the port
+// is free makes the handoff deterministic.
+async function waitForPortFree(port: number, timeoutMs: number = 30000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const free = await new Promise<boolean>((resolve) => {
+      const server = net.createServer();
+      server.once("error", () => resolve(false));
+      server.once("listening", () => {
+        server.close(() => resolve(true));
+      });
+      server.listen(port, "127.0.0.1");
+    });
+    if (free) return;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  // Timeout: the port is still bound but we let Appium try anyway -- its own
+  // spawn will fail with a clearer error than a silent wdio ECONNREFUSED.
+}
 // Delay execution until Appium server is available.
 async function appiumIsReady(timeoutMs: number = 120000) {
   let isReady = false;
@@ -980,19 +1007,35 @@ async function appiumIsReady(timeoutMs: number = 120000) {
 }
 
 // Start the Appium driver specified in `capabilities`.
-async function driverStart(capabilities: any) {
-  const driver: any = await wdio.remote({
-    protocol: "http",
-    hostname: "127.0.0.1",
-    port: 4723,
-    path: "/",
-    logLevel: "error",
-    capabilities,
-    connectionRetryTimeout: 120000, // 2 minutes
-    waitforTimeout: 120000, // 2 minutes
-  });
-  driver.state = { url: "", x: null, y: null };
-  return driver;
+async function driverStart(capabilities: any, retries: number = 3) {
+  // POST /session can race a just-spawned-or-still-dying Appium on Windows:
+  // /status may already return 200 from the outgoing process while /session
+  // is no longer accepting. Retry with linear backoff ONLY on ECONNREFUSED --
+  // any other error is a real session-creation failure and propagates.
+  let lastError: any;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const driver: any = await wdio.remote({
+        protocol: "http",
+        hostname: "127.0.0.1",
+        port: 4723,
+        path: "/",
+        logLevel: "error",
+        capabilities,
+        connectionRetryTimeout: 120000, // 2 minutes
+        waitforTimeout: 120000, // 2 minutes
+      });
+      driver.state = { url: "", x: null, y: null };
+      return driver;
+    } catch (err: any) {
+      lastError = err;
+      if (!/ECONNREFUSED/.test(String(err && err.message))) throw err;
+      if (attempt < retries) {
+        await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
+      }
+    }
+  }
+  throw lastError;
 }
 
 /**

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -32,11 +32,15 @@ function isWebDriverTeardownError(reason) {
     .join(" ");
   if (!/WebDriver(Error|RequestError)/.test(text)) return false;
   if (!/(ECONNREFUSED|ECONNRESET|socket hang up)/.test(text)) return false;
-  // Session CREATION (POST /session) is NOT teardown — a ECONNREFUSED here
-  // means the new Appium isn't ready yet, and the test genuinely cannot
-  // proceed. Let that propagate as a real failure rather than swallowing
-  // it silently and leaving the caller with a truncated result object.
-  if (/method[:\s"']+POST/i.test(text)) return false;
+  // Session CREATION is NOT teardown — an ECONNREFUSED on POST /session means
+  // the new Appium isn't ready yet, and the test genuinely cannot proceed.
+  // Match both forms WebdriverIO uses in practice: the structured
+  // `method: "POST"` form and the bare `POST /session` form. Let those
+  // propagate as real failures rather than swallowing them silently and
+  // leaving the caller with a truncated result object.
+  const mentionsPost =
+    /method[:=\s"']+POST\b/i.test(text) || /\bPOST\b[^"\n]*\/session\b/i.test(text);
+  if (mentionsPost) return false;
   return true;
 }
 

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -30,11 +30,14 @@ function isWebDriverTeardownError(reason) {
   const text = [reason.name, reason.message, reason.stack]
     .filter(Boolean)
     .join(" ");
-  return (
-    /WebDriver(Error|RequestError)/.test(text) ||
-    (/webdriver/i.test(text) &&
-      /(ECONNREFUSED|ECONNRESET|socket hang up)/.test(text))
-  );
+  if (!/WebDriver(Error|RequestError)/.test(text)) return false;
+  if (!/(ECONNREFUSED|ECONNRESET|socket hang up)/.test(text)) return false;
+  // Session CREATION (POST /session) is NOT teardown — a ECONNREFUSED here
+  // means the new Appium isn't ready yet, and the test genuinely cannot
+  // proceed. Let that propagate as a real failure rather than swallowing
+  // it silently and leaving the caller with a truncated result object.
+  if (/method[:\s"']+POST/i.test(text)) return false;
+  return true;
 }
 
 function onUnhandledRejection(reason) {


### PR DESCRIPTION
## Summary

Post-merge release of [#281](https://github.com/doc-detective/doc-detective/pull/281) surfaced a **second** Windows + Node 24 failure pattern, distinct from the original bug that #281 fixed. This PR closes the underlying race and tightens #281's safety net so real infrastructure problems can't hide behind a TypeError.

## The race

Between two sequential per-test `runTests()` calls in [test/core-screenshot.test.js](test/core-screenshot.test.js), the prior test's Appium is killed on port 4723 while the next test's Appium spawns. On Windows + Node 24 the teardown window is wide:

1. `appiumIsReady()`'s `GET /status` gets 200 from the dying prior Appium — looks ready.
2. `driverStart()`'s `POST /session` arrives on the dying process that has already stopped accepting sessions → `ECONNREFUSED`.
3. #281's `isWebDriverTeardownError()` predicate was broad enough to swallow that rejection as a "teardown" race, so `runTests()` returned a truncated result whose `steps[1]` was `undefined`.
4. The test assertion at [core-screenshot.test.js:534](test/core-screenshot.test.js:534) failed with an opaque `TypeError: Cannot read properties of undefined (reading 'result')` — masking the real problem.

Reproduced on [run 24748437330 attempt 2](https://github.com/doc-detective/doc-detective/actions/runs/24748437330/job/72425801217):

```
01:21:25  ✔ leaves `step.screenshot.overwrite` unchanged    ← Appium on 4723 killed here
01:21:30  ERROR webdriver: ECONNREFUSED POST /session       ← next test's session create
01:21:31  ERROR webdriver: ECONNREFUSED POST /session       ← retry also fails
01:21:32  1) ignores overwrite=true for URL paths
         TypeError: Cannot read properties of undefined (reading 'result')
```

## Changes

### 1. [src/core/tests.ts](src/core/tests.ts) — `waitForPortFree()` before Appium spawn

New helper that tries to bind `127.0.0.1:4723` itself; if the port is still held, polls every 250ms for up to 30s. Called right before `spawn("npx", ["appium"], …)`. Deterministic handoff, no blind sleeps.

### 2. [src/core/tests.ts](src/core/tests.ts) — `driverStart()` retries ONLY on ECONNREFUSED

Up to 3 attempts, linear backoff (500/1000/1500ms). Any other error propagates immediately, so real session-creation failures still surface.

### 3. [test/hooks.js](test/hooks.js) — narrow `isWebDriverTeardownError()` predicate

No longer suppresses rejections whose message includes `method: "POST"` — those are session *creations*, not teardowns, and masking them hides infrastructure problems. Teardowns (`DELETE /session/<id>`, `GET "title"` post-cleanup) stay suppressed as #281 intended.

### Predicate behavior verification

Ran a small local script against the regex:

| Error | Expected | Actual |
|---|---|---|
| `DELETE /session/<id>` teardown ECONNREFUSED | suppress | ✅ suppress |
| `GET "title"` post-teardown ECONNREFUSED | suppress | ✅ suppress |
| `POST /session` create ECONNREFUSED | propagate | ✅ propagate |
| Unrelated `TypeError` | propagate | ✅ propagate |

## Follow-up note

There was also a separate silent-exit pattern during Core test suite on the first attempt ([job 72405801394](https://github.com/doc-detective/doc-detective/actions/runs/24748437330/job/72405801394) attempt 1) — process killed at 4 min with no mocha output and no handler fire. That one did not reproduce on re-run and is native-level (not caught by this PR). If it recurs, it's worth a separate investigation focused on Firefox Nightly / geckodriver / Windows runner env.

## Test plan

- [ ] `Test (ubuntu-latest, node 20/22/24)` green
- [ ] `Test (macos-latest, node 20/22/24)` green
- [ ] `Test (windows-latest, node 20/22)` green (no regression)
- [ ] `Test (windows-latest, node 24)` green — the problematic leg
- [ ] No `[test/hooks] WebDriver teardown rejection` lines for `POST /session` ECONNREFUSED (those should now fail loudly)
- [ ] Re-run the matrix 2–3× via `gh workflow run` to confirm stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry logic now only retries on connection-refused errors and fails fast for other errors.
  * Error classification refined to avoid suppressing genuine session-creation failures during teardown races.

* **Tests**
  * Test startup now waits for the server port to become available before launching.
  * Driver initialization uses bounded retries with linear backoff to improve connection resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->