### PR TITLE
feat(cli): add --test and --spec filters for narrowing test runs

### DIFF
--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -62,19 +62,21 @@
       ]
     },
     "specFilter": {
-      "description": "Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI.",
+      "description": "Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI. Each entry must contain at least one non-whitespace character.",
       "type": "array",
       "items": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "pattern": "\\S"
       }
     },
     "testFilter": {
-      "description": "Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI.",
+      "description": "Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI. Each entry must contain at least one non-whitespace character.",
       "type": "array",
       "items": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "pattern": "\\S"
       }
     },
     "recursive": {

--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -61,6 +61,22 @@
         "json"
       ]
     },
+    "specFilter": {
+      "description": "Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "testFilter": {
+      "description": "Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
     "recursive": {
       "description": "If `true` searches `input`, `setup`, and `cleanup` paths recursively for test specifications and source files.",
       "type": "boolean",
@@ -17724,6 +17740,15 @@
           }
         ]
       }
+    },
+    {
+      "testFilter": [
+        "smoke",
+        "login"
+      ],
+      "specFilter": [
+        "auth"
+      ]
     }
   ]
 }

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -75,19 +75,21 @@
           ]
         },
         "specFilter": {
-          "description": "Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI.",
+          "description": "Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI. Each entry must contain at least one non-whitespace character.",
           "type": "array",
           "items": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "\\S"
           }
         },
         "testFilter": {
-          "description": "Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI.",
+          "description": "Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI. Each entry must contain at least one non-whitespace character.",
           "type": "array",
           "items": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "\\S"
           }
         },
         "recursive": {

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -74,6 +74,22 @@
             "json"
           ]
         },
+        "specFilter": {
+          "description": "Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "testFilter": {
+          "description": "Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
         "recursive": {
           "description": "If `true` searches `input`, `setup`, and `cleanup` paths recursively for test specifications and source files.",
           "type": "boolean",
@@ -17737,6 +17753,15 @@
               }
             ]
           }
+        },
+        {
+          "testFilter": [
+            "smoke",
+            "login"
+          ],
+          "specFilter": [
+            "auth"
+          ]
         }
       ]
     },

--- a/src/common/src/schemas/src_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/config_v3.schema.json
@@ -47,6 +47,22 @@
       },
       "default": ["terminal", "json"]
     },
+    "specFilter": {
+      "description": "Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "testFilter": {
+      "description": "Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
     "recursive": {
       "description": "If `true` searches `input`, `setup`, and `cleanup` paths recursively for test specifications and source files.",
       "type": "boolean",
@@ -652,6 +668,10 @@
           }
         ]
       }
+    },
+    {
+      "testFilter": ["smoke", "login"],
+      "specFilter": ["auth"]
     }
   ]
 }

--- a/src/common/src/schemas/src_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/config_v3.schema.json
@@ -48,19 +48,21 @@
       "default": ["terminal", "json"]
     },
     "specFilter": {
-      "description": "Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI.",
+      "description": "Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI. Each entry must contain at least one non-whitespace character.",
       "type": "array",
       "items": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "pattern": "\\S"
       }
     },
     "testFilter": {
-      "description": "Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI.",
+      "description": "Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI. Each entry must contain at least one non-whitespace character.",
       "type": "array",
       "items": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "pattern": "\\S"
       }
     },
     "recursive": {

--- a/src/common/src/types/generated/config_v3.ts
+++ b/src/common/src/types/generated/config_v3.ts
@@ -64,6 +64,14 @@ export interface Config {
    */
   reporters?: string[];
   /**
+   * Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI.
+   */
+  specFilter?: string[];
+  /**
+   * Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI.
+   */
+  testFilter?: string[];
+  /**
    * If `true` searches `input`, `setup`, and `cleanup` paths recursively for test specifications and source files.
    */
   recursive?: boolean;

--- a/src/common/src/types/generated/config_v3.ts
+++ b/src/common/src/types/generated/config_v3.ts
@@ -64,11 +64,11 @@ export interface Config {
    */
   reporters?: string[];
   /**
-   * Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI.
+   * Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI. Each entry must contain at least one non-whitespace character.
    */
   specFilter?: string[];
   /**
-   * Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI.
+   * Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI. Each entry must contain at least one non-whitespace character.
    */
   testFilter?: string[];
   /**

--- a/src/common/src/types/generated/resolvedTests_v3.ts
+++ b/src/common/src/types/generated/resolvedTests_v3.ts
@@ -101,6 +101,14 @@ export interface Config {
    */
   reporters?: string[];
   /**
+   * Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI.
+   */
+  specFilter?: string[];
+  /**
+   * Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI.
+   */
+  testFilter?: string[];
+  /**
    * If `true` searches `input`, `setup`, and `cleanup` paths recursively for test specifications and source files.
    */
   recursive?: boolean;

--- a/src/common/src/types/generated/resolvedTests_v3.ts
+++ b/src/common/src/types/generated/resolvedTests_v3.ts
@@ -101,11 +101,11 @@ export interface Config {
    */
   reporters?: string[];
   /**
-   * Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI.
+   * Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI. Each entry must contain at least one non-whitespace character.
    */
   specFilter?: string[];
   /**
-   * Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI.
+   * Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI. Each entry must contain at least one non-whitespace character.
    */
   testFilter?: string[];
   /**

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -69,6 +69,32 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.equal("");
       });
 
+      it("should validate a config_v3 object with testFilter and specFilter as arrays of strings", function () {
+        const result = validate({
+          schemaKey: "config_v3",
+          object: {
+            testFilter: ["smoke", "login"],
+            specFilter: ["auth"],
+          },
+        });
+
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+        expect(result.object.testFilter).to.deep.equal(["smoke", "login"]);
+        expect(result.object.specFilter).to.deep.equal(["auth"]);
+      });
+
+      it("should reject a config_v3 object whose testFilter is a bare string", function () {
+        const result = validate({
+          schemaKey: "config_v3",
+          object: { testFilter: "smoke" },
+        });
+
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+        expect(result.errors).to.include("testFilter");
+      });
+
       it("should add default values when addDefaults=true", function () {
         const result = validate({
           schemaKey: "step_v3",

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -95,6 +95,30 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.include("testFilter");
       });
 
+      it("should reject a config_v3 object whose testFilter contains a whitespace-only entry", function () {
+        // A whitespace-only pattern would compile to a regex that matches
+        // almost anything containing whitespace — never the user's intent.
+        // Rejecting at validation time is clearer than silently dropping it
+        // at runtime (which compileFilter also does as defense-in-depth).
+        const result = validate({
+          schemaKey: "config_v3",
+          object: { testFilter: ["   "] },
+        });
+
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+
+      it("should reject a config_v3 object whose specFilter contains a whitespace-only entry", function () {
+        const result = validate({
+          schemaKey: "config_v3",
+          object: { specFilter: ["\t\n"] },
+        });
+
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+
       it("should add default values when addDefaults=true", function () {
         const result = validate({
           schemaKey: "step_v3",

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -414,6 +414,20 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
       "warning",
       "No specs or tests matched the configured filters. Nothing was run."
     );
+    // Short-circuit: skip environment / app discovery and the spec-iteration
+    // loop entirely. Without this, a fully-filtered run still spins up
+    // getAvailableApps and friends — wasted work, plus an avoidable error
+    // path if discovery fails on the host. Mirrors the runViaApi early
+    // return so both run paths behave the same way.
+    return {
+      summary: {
+        specs: { pass: 0, fail: 0, warning: 0, skipped: 0 },
+        tests: { pass: 0, fail: 0, warning: 0, skipped: 0 },
+        contexts: { pass: 0, fail: 0, warning: 0, skipped: 0 },
+        steps: { pass: 0, fail: 0, warning: 0, skipped: 0 },
+      },
+      specs: [],
+    };
   }
 
   // Get runner details

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -246,6 +246,34 @@ async function allowUnsafeSteps({ config }: { config: any }) {
 
 // Run specifications via API.
 async function runViaApi({ resolvedTests, apiKey, config = {} }: { resolvedTests: any; apiKey: any; config?: any }): Promise<any> {
+  // Apply specFilter / testFilter before sending. Without this the API run
+  // path silently ignores --test / --spec, since the orchestration server
+  // sees the full unfiltered payload.
+  const runConfig = resolvedTests?.config ?? config;
+  const filtersActive =
+    (Array.isArray(runConfig?.specFilter) && runConfig.specFilter.length > 0) ||
+    (Array.isArray(runConfig?.testFilter) && runConfig.testFilter.length > 0);
+  if (filtersActive) {
+    const filteredSpecs = selectSpecsForRun(resolvedTests?.specs ?? [], runConfig);
+    if (filteredSpecs.length === 0) {
+      log(
+        runConfig,
+        "warning",
+        "No specs or tests matched the configured filters. Nothing was sent to the Doc Detective API."
+      );
+      return {
+        summary: {
+          specs: { pass: 0, fail: 0, warning: 0, skipped: 0 },
+          tests: { pass: 0, fail: 0, warning: 0, skipped: 0 },
+          contexts: { pass: 0, fail: 0, warning: 0, skipped: 0 },
+          steps: { pass: 0, fail: 0, warning: 0, skipped: 0 },
+        },
+        specs: [],
+      };
+    }
+    resolvedTests = { ...resolvedTests, specs: filteredSpecs };
+  }
+
   const baseUrl =
     process.env.DOC_DETECTIVE_API_URL || "https://api.doc-detective.com";
   // Make an API request to create a test run

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -1,7 +1,7 @@
 import kill from "tree-kill";
 import * as wdio from "webdriverio";
 import os from "node:os";
-import { log, replaceEnvs } from "./utils.js";
+import { log, replaceEnvs, selectSpecsForRun } from "./utils.js";
 import axios from "axios";
 import { instantiateCursor } from "./tests/moveTo.js";
 import { goTo } from "./tests/goTo.js";
@@ -373,7 +373,20 @@ async function runViaApi({ resolvedTests, apiKey, config = {} }: { resolvedTests
  */
 async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   const config: any = resolvedTests.config;
-  const specs = resolvedTests.specs;
+  // Narrow the spec set to what specFilter / testFilter allow before running.
+  // Filtered-out specs / tests do not appear in the report (true filter, not
+  // skip). Pass-through when neither filter is set.
+  const filtersActive =
+    (Array.isArray(config?.specFilter) && config.specFilter.length > 0) ||
+    (Array.isArray(config?.testFilter) && config.testFilter.length > 0);
+  const specs = selectSpecsForRun(resolvedTests.specs, config);
+  if (filtersActive && specs.length === 0) {
+    log(
+      config,
+      "warning",
+      "No specs or tests matched the configured filters. Nothing was run."
+    );
+  }
 
   // Get runner details
   const runnerDetails = {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -24,7 +24,44 @@ export {
   redactUrlForOutput,
   assertUrlHostIsPublic,
   sanitizeFilesystemName,
+  compileFilter,
+  matchesFilter,
+  selectSpecsForRun,
 };
+
+function compileFilter(patterns?: string[] | unknown): RegExp[] {
+  if (!Array.isArray(patterns) || patterns.length === 0) return [];
+  return patterns
+    .filter((s): s is string => typeof s === "string" && s.length > 0)
+    .map((s) => new RegExp(s, "i"));
+}
+
+function matchesFilter(id: string | undefined, filters: RegExp[]): boolean {
+  if (!Array.isArray(filters) || filters.length === 0) return true;
+  if (typeof id !== "string") return false;
+  return filters.some((re) => re.test(id));
+}
+
+// Apply config.specFilter / config.testFilter to a specs[] array. Returns a
+// new array with non-matching specs removed and each matching spec's tests
+// narrowed to those that pass the test filter. Specs with zero remaining
+// tests are dropped. Input is not mutated. If neither filter is configured,
+// the input is returned as-is for cheap pass-through.
+function selectSpecsForRun(specs: any[], config: any): any[] {
+  const specFilters = compileFilter(config?.specFilter);
+  const testFilters = compileFilter(config?.testFilter);
+  if (specFilters.length === 0 && testFilters.length === 0) return specs;
+  const out: any[] = [];
+  for (const spec of specs || []) {
+    if (!matchesFilter(spec?.specId, specFilters)) continue;
+    const filteredTests = (spec?.tests || []).filter((t: any) =>
+      matchesFilter(t?.testId, testFilters)
+    );
+    if (filteredTests.length === 0) continue;
+    out.push({ ...spec, tests: filteredTests });
+  }
+  return out;
+}
 
 function isRelativeUrl(url: string) {
   try {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -31,8 +31,15 @@ export {
 
 function compileFilter(patterns?: string[] | unknown): RegExp[] {
   if (!Array.isArray(patterns) || patterns.length === 0) return [];
+  // Trim each pattern before compiling so config / env / CLI inputs all
+  // produce the same regex (the CLI splits on `,` and trims; config files
+  // and DOC_DETECTIVE_CONFIG do not). Whitespace-only entries are dropped —
+  // a bare "   " would otherwise compile to /   /i and match anything that
+  // happens to contain whitespace, which is never the user's intent.
   return patterns
-    .filter((s): s is string => typeof s === "string" && s.length > 0)
+    .filter((s): s is string => typeof s === "string")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
     .map((s) => new RegExp(s, "i"));
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -400,12 +400,9 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
       bold: "\x1b[1m",
     };
 
-    // Check if we have the new results format with summary
-    if (!results) {
-      // No results means the runner bailed before producing a report (e.g.
-      // no input matched, no tests detected upstream). Surface that as a
-      // warning rather than the prior bare "No results available." line —
-      // the run still exits 0, but it is empty, not a clean success.
+    // Single source of truth for the "No tests were run" warning so the
+    // null-results path and the totalTests===0 path can't drift apart.
+    const printNoTestsWarning = () => {
       const specFilterActive =
         Array.isArray(config?.specFilter) && config.specFilter.length > 0;
       const testFilterActive =
@@ -426,6 +423,15 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
           `${colors.yellow}Check that the input paths contain testable content.${colors.reset}`
         );
       }
+    };
+
+    // Check if we have the new results format with summary
+    if (!results) {
+      // No results means the runner bailed before producing a report (e.g.
+      // no input matched, no tests detected upstream). Surface that as a
+      // warning rather than the prior bare "No results available." line —
+      // the run still exits 0, but it is empty, not a clean success.
+      printNoTestsWarning();
       return;
     }
 
@@ -571,26 +577,7 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
       // rather than letting the green "Passed: 0" line read like success.
       // The run still exits 0 — this is an empty run, not a failure.
       if (totalTests === 0) {
-        const specFilterActive =
-          Array.isArray(config?.specFilter) && config.specFilter.length > 0;
-        const testFilterActive =
-          Array.isArray(config?.testFilter) && config.testFilter.length > 0;
-        console.log(
-          `\n${colors.yellow}⚠️  No tests were run. ⚠️${colors.reset}`
-        );
-        if (specFilterActive || testFilterActive) {
-          console.log(
-            `${colors.yellow}This may be because the configured filters excluded every spec/test. Filters: specFilter=${JSON.stringify(
-              config?.specFilter ?? null
-            )}, testFilter=${JSON.stringify(
-              config?.testFilter ?? null
-            )}.${colors.reset}`
-          );
-        } else {
-          console.log(
-            `${colors.yellow}Check that the input paths contain testable content.${colors.reset}`
-          );
-        }
+        printNoTestsWarning();
       }
 
       // If we have specs with failures, display them

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -811,8 +811,10 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
             );
           });
         }
-      } else if (!hasFailures && !allSpecsSkipped) {
-        // Celebration when all tests pass
+      } else if (!hasFailures && !allSpecsSkipped && totalTests > 0) {
+        // Celebration when all tests pass. Gated on totalTests > 0 so an
+        // empty run (no input matched, all filtered out) doesn't print the
+        // success banner alongside the "No tests were run" warning above.
         console.log(`\n${colors.green}🎉 All items passed! 🎉${colors.reset}`);
       }
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,6 +83,18 @@ function buildYargs(args: any): any {
       type: "string",
       array: true,
     })
+    .option("test", {
+      alias: "t",
+      description:
+        "Run only tests whose testId matches the given regex (case-insensitive). Comma-separate multiple patterns; a test passes if any pattern matches.",
+      type: "string",
+    })
+    .option("spec", {
+      alias: "s",
+      description:
+        "Run only specs whose specId matches the given regex (case-insensitive). Comma-separate multiple patterns; a spec passes if any pattern matches.",
+      type: "string",
+    })
     .version(require("../package.json").version)
     .help()
     .alias("help", "h");
@@ -288,6 +300,20 @@ async function setConfig({ configPath, args }: { configPath?: any; args: any }) 
       config.reporters = reporterList.map((r: any) => String(r));
     }
   }
+  if (typeof args.test === "string" && args.test.length > 0) {
+    const list = args.test
+      .split(",")
+      .map((s: string) => s.trim())
+      .filter((s: string) => s.length > 0);
+    if (list.length > 0) config.testFilter = list;
+  }
+  if (typeof args.spec === "string" && args.spec.length > 0) {
+    const list = args.spec
+      .split(",")
+      .map((s: string) => s.trim())
+      .filter((s: string) => s.length > 0);
+    if (list.length > 0) config.specFilter = list;
+  }
   // Resolve paths
   config = await resolvePaths({
     config: config,
@@ -376,7 +402,30 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
 
     // Check if we have the new results format with summary
     if (!results) {
-      console.log("No results available.");
+      // No results means the runner bailed before producing a report (e.g.
+      // no input matched, no tests detected upstream). Surface that as a
+      // warning rather than the prior bare "No results available." line —
+      // the run still exits 0, but it is empty, not a clean success.
+      const specFilterActive =
+        Array.isArray(config?.specFilter) && config.specFilter.length > 0;
+      const testFilterActive =
+        Array.isArray(config?.testFilter) && config.testFilter.length > 0;
+      console.log(
+        `\n${colors.yellow}⚠️  No tests were run. ⚠️${colors.reset}`
+      );
+      if (specFilterActive || testFilterActive) {
+        console.log(
+          `${colors.yellow}This may be because the configured filters excluded every spec/test. Filters: specFilter=${JSON.stringify(
+            config?.specFilter ?? null
+          )}, testFilter=${JSON.stringify(
+            config?.testFilter ?? null
+          )}.${colors.reset}`
+        );
+      } else {
+        console.log(
+          `${colors.yellow}Check that the input paths contain testable content.${colors.reset}`
+        );
+      }
       return;
     }
 
@@ -515,6 +564,33 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
         console.log(
           `\n${colors.yellow}⚠️  All items were skipped. No specs passed or failed. ⚠️${colors.reset}`
         );
+      }
+
+      // If zero tests ran for any reason (filters excluded everything, no
+      // input matched, no tests detected, etc.), surface that as a warning
+      // rather than letting the green "Passed: 0" line read like success.
+      // The run still exits 0 — this is an empty run, not a failure.
+      if (totalTests === 0) {
+        const specFilterActive =
+          Array.isArray(config?.specFilter) && config.specFilter.length > 0;
+        const testFilterActive =
+          Array.isArray(config?.testFilter) && config.testFilter.length > 0;
+        console.log(
+          `\n${colors.yellow}⚠️  No tests were run. ⚠️${colors.reset}`
+        );
+        if (specFilterActive || testFilterActive) {
+          console.log(
+            `${colors.yellow}This may be because the configured filters excluded every spec/test. Filters: specFilter=${JSON.stringify(
+              config?.specFilter ?? null
+            )}, testFilter=${JSON.stringify(
+              config?.testFilter ?? null
+            )}.${colors.reset}`
+          );
+        } else {
+          console.log(
+            `${colors.yellow}Check that the input paths contain testable content.${colors.reset}`
+          );
+        }
       }
 
       // If we have specs with failures, display them

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -939,6 +939,47 @@ describe("terminalReporter zero-tests-ran warning", function () {
     expect(joined).to.include("No tests were run");
     expect(joined).to.include("Check that the input paths contain testable content");
   });
+
+  it("does NOT print the success celebration on zero-test runs", async function () {
+    // Regression: the reporter previously printed both "No tests were run"
+    // and the green "🎉 All items passed!" banner for empty runs because the
+    // success branch only checked !hasFailures && !allSpecsSkipped. Both are
+    // true for an empty run, so it would fall through. Gate on totalTests>0.
+    const results = makeResults({ pass: 0, fail: 0, warning: 0, skipped: 0 });
+    const captured = await runReporter({}, results);
+    const joined = captured.join("\n");
+    expect(joined).to.include("No tests were run");
+    expect(joined).to.not.include("All items passed");
+  });
+});
+
+describe("runViaApi filter short-circuit", function () {
+  // Avoid spinning up axios. When the filter excludes every spec, runViaApi
+  // must NOT make an HTTP request — it must return the empty-summary shape
+  // so the rest of the pipeline (reporter, telemetry) treats it as a clean
+  // empty run. This test only exercises the short-circuit path; the cross-
+  // wire to selectSpecsForRun is covered by that helper's own tests.
+  let runViaApi;
+  before(async function () {
+    ({ runViaApi } = await import("../dist/core/tests.js"));
+  });
+
+  it("returns an empty summary without making any HTTP request when filters exclude every spec", async function () {
+    const resolvedTests = {
+      config: { testFilter: ["nope"] },
+      specs: [
+        {
+          specId: "s1",
+          tests: [{ testId: "t1" }],
+        },
+      ],
+    };
+    const result = await runViaApi({ resolvedTests, apiKey: "fake-key" });
+    expect(result).to.exist;
+    expect(result.specs).to.deep.equal([]);
+    expect(result.summary.tests.pass).to.equal(0);
+    expect(result.summary.tests.fail).to.equal(0);
+  });
 });
 
 describe("selectSpecsForRun", function () {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1115,6 +1115,24 @@ describe("filter helper", function () {
       expect(out[0].source).to.equal("foo");
       expect(out[1].source).to.equal("bar");
     });
+
+    it("trims surrounding whitespace from each pattern", function () {
+      // Config / env-var paths skip the CLI trim, so a value like " foo "
+      // would otherwise compile into a regex that requires literal spaces.
+      // Keep behavior consistent with the CLI's comma-split-and-trim.
+      const out = compileFilter(["  foo  ", "\tbar\n"]);
+      expect(out).to.have.length(2);
+      expect(out[0].source).to.equal("foo");
+      expect(out[1].source).to.equal("bar");
+    });
+
+    it("drops whitespace-only entries entirely", function () {
+      // A bare "   " would otherwise compile to /   /i and match almost
+      // anything containing whitespace — not a useful filter.
+      const out = compileFilter(["foo", "   ", "\t\n"]);
+      expect(out).to.have.length(1);
+      expect(out[0].source).to.equal("foo");
+    });
   });
 
   describe("matchesFilter", function () {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -953,6 +953,38 @@ describe("terminalReporter zero-tests-ran warning", function () {
   });
 });
 
+describe("runSpecs filter short-circuit", function () {
+  // When filters exclude every spec, runSpecs should return the empty-
+  // summary shape promptly, without entering the spec-iteration loop or
+  // doing any per-context driver work. Mirrors the runViaApi short-circuit
+  // — both run paths must behave the same way on a fully-filtered run.
+  let runSpecs;
+  before(async function () {
+    ({ runSpecs } = await import("../dist/core/tests.js"));
+  });
+
+  it("returns an empty summary when filters exclude every spec", async function () {
+    this.timeout(5000);
+    const resolvedTests = {
+      config: { testFilter: ["nope"], logLevel: "silent" },
+      specs: [
+        {
+          specId: "s1",
+          tests: [{ testId: "t1", contexts: [] }],
+        },
+      ],
+    };
+    const result = await runSpecs({ resolvedTests });
+    expect(result).to.exist;
+    expect(result.specs).to.deep.equal([]);
+    expect(result.summary.tests.pass).to.equal(0);
+    expect(result.summary.tests.fail).to.equal(0);
+    expect(result.summary.tests.warning).to.equal(0);
+    expect(result.summary.tests.skipped).to.equal(0);
+    expect(result.summary.specs.pass).to.equal(0);
+  });
+});
+
 describe("runViaApi filter short-circuit", function () {
   // Avoid spinning up axios. When the filter excludes every spec, runViaApi
   // must NOT make an HTTP request — it must return the empty-summary shape

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,10 @@
-import { setArgs, setConfig, outputResults } from "../dist/utils.js";
-import { appendQueryParams } from "../dist/core/utils.js";
+import { setArgs, setConfig, outputResults, reporters } from "../dist/utils.js";
+import {
+  appendQueryParams,
+  compileFilter,
+  matchesFilter,
+  selectSpecsForRun,
+} from "../dist/core/utils.js";
 import path from "node:path";
 import fs from "node:fs";
 import { createRequire } from "node:module";
@@ -83,6 +88,22 @@ describe("Util tests", function () {
     });
   });
 
+  it("Yargs parses --test and --spec arguments correctly", function () {
+    const test = setArgs(["node", "runTests.js", "--test", "foo,bar"]);
+    expect(test.test).to.equal("foo,bar");
+    expect(test.t).to.equal("foo,bar");
+
+    const spec = setArgs(["node", "runTests.js", "--spec", "baz"]);
+    expect(spec.spec).to.equal("baz");
+    expect(spec.s).to.equal("baz");
+
+    const aliasedTest = setArgs(["node", "runTests.js", "-t", "abc"]);
+    expect(aliasedTest.test).to.equal("abc");
+
+    const aliasedSpec = setArgs(["node", "runTests.js", "-s", "xyz"]);
+    expect(aliasedSpec.spec).to.equal("xyz");
+  });
+
   it("Yargs parses --reporters argument correctly", function () {
     const single = setArgs([
       "node", "runTests.js", "--reporters", "html",
@@ -135,6 +156,28 @@ describe("Util tests", function () {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  it("setConfig stores --test and --spec args on config.testFilter / config.specFilter", async function () {
+    this.timeout(5000);
+    const args1 = setArgs(["node", "runTests.js", "--test", "foo"]);
+    const config1 = await setConfig({ configPath: null, args: args1 });
+    expect(config1.testFilter).to.deep.equal(["foo"]);
+    expect(config1.specFilter).to.equal(undefined);
+
+    const args2 = setArgs(["node", "runTests.js", "--spec", "x,y"]);
+    const config2 = await setConfig({ configPath: null, args: args2 });
+    expect(config2.specFilter).to.deep.equal(["x", "y"]);
+    expect(config2.testFilter).to.equal(undefined);
+
+    const args3 = setArgs(["node", "runTests.js", "--test", "foo, bar , baz"]);
+    const config3 = await setConfig({ configPath: null, args: args3 });
+    expect(config3.testFilter).to.deep.equal(["foo", "bar", "baz"]);
+
+    const args4 = setArgs(["node", "runTests.js", "--input", "."]);
+    const config4 = await setConfig({ configPath: null, args: args4 });
+    expect(config4.testFilter).to.equal(undefined);
+    expect(config4.specFilter).to.equal(undefined);
   });
 
   it("setConfig stores --reporters arg on config.reporters", async function () {
@@ -832,6 +875,199 @@ describe("appendQueryParams", function () {
     expect(qs.get("keep")).to.equal("yes");
     expect(qs.has("drop1")).to.equal(false);
     expect(qs.has("drop2")).to.equal(false);
+  });
+});
+
+describe("terminalReporter zero-tests-ran warning", function () {
+  // Capture console.log into a buffer for assertions.
+  async function runReporter(config, results) {
+    const captured = [];
+    const original = console.log;
+    console.log = (...args) => {
+      captured.push(args.map(String).join(" "));
+    };
+    try {
+      await reporters.terminalReporter(config, ".", results, {});
+    } finally {
+      console.log = original;
+    }
+    return captured;
+  }
+
+  function makeResults(testCounts, options = {}) {
+    return {
+      reportId: "no-tests-test",
+      summary: {
+        specs: options.specs ?? { pass: 0, fail: 0, warning: 0, skipped: 0 },
+        tests: testCounts,
+        contexts: { pass: 0, fail: 0, warning: 0, skipped: 0 },
+        steps: { pass: 0, fail: 0, warning: 0, skipped: 0 },
+      },
+      specs: [],
+    };
+  }
+
+  it("prints a yellow 'No tests were run' warning when totalTests === 0", async function () {
+    const results = makeResults({ pass: 0, fail: 0, warning: 0, skipped: 0 });
+    const captured = await runReporter({}, results);
+    const joined = captured.join("\n");
+    expect(joined).to.include("No tests were run");
+    // The warning line carries the yellow ANSI escape.
+    const warningLine = captured.find((l) => l.includes("No tests were run"));
+    expect(warningLine).to.match(/\x1b\[33m/);
+  });
+
+  it("includes a filter hint when config has filters and totalTests === 0", async function () {
+    const results = makeResults({ pass: 0, fail: 0, warning: 0, skipped: 0 });
+    const captured = await runReporter({ testFilter: ["foo"] }, results);
+    const joined = captured.join("\n");
+    expect(joined).to.include("No tests were run");
+    expect(joined).to.include("filters");
+    expect(joined).to.include('"foo"');
+  });
+
+  it("does NOT print the no-tests warning when at least one test ran", async function () {
+    const results = makeResults({ pass: 1, fail: 0, warning: 0, skipped: 0 });
+    const captured = await runReporter({}, results);
+    const joined = captured.join("\n");
+    expect(joined).to.not.include("No tests were run");
+  });
+
+  it("prints the no-tests warning when results is null (early-bail path)", async function () {
+    const captured = await runReporter({}, null);
+    const joined = captured.join("\n");
+    expect(joined).to.include("No tests were run");
+    expect(joined).to.include("Check that the input paths contain testable content");
+  });
+});
+
+describe("selectSpecsForRun", function () {
+  function fixture() {
+    return [
+      {
+        specId: "auth-spec",
+        description: "Auth flows",
+        tests: [
+          { testId: "login-smoke", description: "Login" },
+          { testId: "logout", description: "Logout" },
+        ],
+      },
+      {
+        specId: "billing-spec",
+        description: "Billing",
+        tests: [
+          { testId: "invoice-smoke", description: "Invoice" },
+          { testId: "refund", description: "Refund" },
+        ],
+      },
+    ];
+  }
+
+  it("returns the input unchanged when no filters are configured", function () {
+    const specs = fixture();
+    const out = selectSpecsForRun(specs, {});
+    expect(out).to.equal(specs);
+  });
+
+  it("keeps only specs whose specId matches specFilter", function () {
+    const out = selectSpecsForRun(fixture(), { specFilter: ["^auth"] });
+    expect(out).to.have.length(1);
+    expect(out[0].specId).to.equal("auth-spec");
+    // All tests of the matching spec are preserved.
+    expect(out[0].tests.map((t) => t.testId)).to.deep.equal(["login-smoke", "logout"]);
+  });
+
+  it("keeps only tests whose testId matches testFilter", function () {
+    const out = selectSpecsForRun(fixture(), { testFilter: ["smoke"] });
+    expect(out).to.have.length(2);
+    expect(out[0].tests.map((t) => t.testId)).to.deep.equal(["login-smoke"]);
+    expect(out[1].tests.map((t) => t.testId)).to.deep.equal(["invoice-smoke"]);
+  });
+
+  it("drops specs with zero matching tests", function () {
+    const out = selectSpecsForRun(fixture(), { testFilter: ["login"] });
+    expect(out).to.have.length(1);
+    expect(out[0].specId).to.equal("auth-spec");
+    expect(out[0].tests.map((t) => t.testId)).to.deep.equal(["login-smoke"]);
+  });
+
+  it("applies specFilter and testFilter together (AND)", function () {
+    const out = selectSpecsForRun(fixture(), {
+      specFilter: ["billing"],
+      testFilter: ["refund"],
+    });
+    expect(out).to.have.length(1);
+    expect(out[0].specId).to.equal("billing-spec");
+    expect(out[0].tests.map((t) => t.testId)).to.deep.equal(["refund"]);
+  });
+
+  it("returns an empty array when filters exclude everything", function () {
+    const out = selectSpecsForRun(fixture(), { testFilter: ["nope"] });
+    expect(out).to.deep.equal([]);
+  });
+
+  it("does not mutate the input specs", function () {
+    const specs = fixture();
+    const snapshot = JSON.parse(JSON.stringify(specs));
+    selectSpecsForRun(specs, { testFilter: ["login"] });
+    expect(specs).to.deep.equal(snapshot);
+  });
+});
+
+describe("filter helper", function () {
+  describe("compileFilter", function () {
+    it("returns [] for undefined", function () {
+      expect(compileFilter(undefined)).to.deep.equal([]);
+    });
+
+    it("returns [] for an empty array", function () {
+      expect(compileFilter([])).to.deep.equal([]);
+    });
+
+    it("returns [] for a non-array (defensive)", function () {
+      expect(compileFilter("foo")).to.deep.equal([]);
+    });
+
+    it("compiles a single pattern into a case-insensitive regex", function () {
+      const out = compileFilter(["foo"]);
+      expect(out).to.have.length(1);
+      expect(out[0]).to.be.instanceOf(RegExp);
+      expect(out[0].flags).to.include("i");
+      expect(out[0].source).to.equal("foo");
+    });
+
+    it("drops empty / non-string entries while keeping the rest", function () {
+      const out = compileFilter(["foo", "", "bar"]);
+      expect(out).to.have.length(2);
+      expect(out[0].source).to.equal("foo");
+      expect(out[1].source).to.equal("bar");
+    });
+  });
+
+  describe("matchesFilter", function () {
+    it("returns true when no filters are configured", function () {
+      expect(matchesFilter("anything", [])).to.equal(true);
+    });
+
+    it("returns true on a literal id substring match", function () {
+      expect(matchesFilter("login-test", compileFilter(["login"]))).to.equal(true);
+    });
+
+    it("matches case-insensitively", function () {
+      expect(matchesFilter("LOGIN-test", compileFilter(["login"]))).to.equal(true);
+    });
+
+    it("returns false when no entry matches", function () {
+      expect(matchesFilter("xyz", compileFilter(["abc"]))).to.equal(false);
+    });
+
+    it("returns false when the id is undefined and a filter is active", function () {
+      expect(matchesFilter(undefined, compileFilter(["abc"]))).to.equal(false);
+    });
+
+    it("returns true when any entry of a multi-pattern filter matches", function () {
+      expect(matchesFilter("smoke-1", compileFilter(["nope", "smoke"]))).to.equal(true);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `--test` / `-t` and `--spec` / `-s` CLI flags (and matching `testFilter` / `specFilter` config fields) so a run can be narrowed to a subset of tests by regex against `testId` / `specId`. Each flag takes a comma-separated list of case-insensitive patterns; CLI values override config-file values.
- When zero tests run for any reason — filters excluded everything, no input matched, or detection found nothing — the terminal reporter now emits a yellow `⚠️ No tests were run ⚠️` warning instead of a misleading green `Passed: 0`. Includes a filter-specific hint when filters were active. Exit code stays 0.
- New schema fields in `config_v3` are typed as `string[]` (CLI parses the comma-separated string into an array inside `setConfig`, mirroring `--input`).

## Why

There was no way to focus a Doc Detective run on a single spec / test without editing files or whittling the input set down. This adds the equivalent of mocha `--grep` / jest `-t`, reachable from the CLI, config files, and the `DOC_DETECTIVE_CONFIG` env var.

## Implementation notes

- Filter decision lives in a pure helper, `selectSpecsForRun(specs, config)` in `src/core/utils.ts`, so it's unit-testable without spinning up Appium / a browser. `runSpecs` calls it once before the iteration loop.
- Match surface is **id only** (`testId` / `specId`) — description is intentionally not part of the match surface, per spec.
- Bad regex propagates as a startup error from `new RegExp(pattern, "i")` rather than silently no-matching.
- `config_v3.schema.json` gains `testFilter` / `specFilter` as optional `array<string>` properties with a new example so the auto-driven schema test in `src/common/test/schema.test.js` exercises them.

## TDD cycles (red → green)

| # | What | Where |
|---|---|---|
| C1 | `compileFilter` / `matchesFilter` | `src/core/utils.ts` ↔ `test/utils.test.js` |
| C2 | yargs `--test` / `--spec` parsing | `src/utils.ts` ↔ `test/utils.test.js` |
| C3 | `setConfig` writes args into config arrays | `src/utils.ts` ↔ `test/utils.test.js` |
| C4 | Schema accepts `array<string>`, rejects bare string | `src/common/src/schemas/...` ↔ `src/common/test/validate.test.js` |
| C5 | `terminalReporter` warns when zero tests ran | `src/utils.ts` ↔ `test/utils.test.js` |
| C6 | `selectSpecsForRun` + `runSpecs` integration | `src/core/utils.ts` + `src/core/tests.ts` ↔ `test/utils.test.js` |

## Test plan

- [x] `npx mocha --exit test/utils.test.js` — 49 passing
- [x] `npm run --workspace=doc-detective-common test` — 581 passing
- [x] Manual smoke: `node bin/doc-detective.js --input ./empty-dir` → yellow "No tests were run" + exit 0
- [x] Manual smoke: filter-via-config + CLI override (`--test "smoke"` overrides `testFilter: ["does-not-exist"]` from `.doc-detective.json`)
- [x] `node bin/doc-detective.js --help` — both flags listed with descriptions

## Out of scope / pre-existing

- 15 root-suite failures in `core-screenshot.test.js` / runner tests are pre-existing infrastructure failures (Appium / browser dependent) and unaffected by this change — verified by stash-and-rerun.
- `src/common` coverage ratchet baseline (`100%`) currently mismatches actual (`99.65%` lines, uncovered in `detectTests.ts:640-644,709`). The drop is pre-existing; nothing in this PR touches `detectTests.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add spec/test filtering: run only matching specs/tests via config arrays or new CLI flags (--spec/-s, --test/-t) using case-insensitive patterns.
* **Improvements**
  * Terminal reporting now warns when filters result in no tests and suppresses the success banner for zero-test runs; warning may note active filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->