### PR TITLE
docs: document --test / --spec filters and testFilter / specFilter config

### DIFF
--- a/docs/fern/pages/docs/get-started/sample-tests.mdx
+++ b/docs/fern/pages/docs/get-started/sample-tests.mdx
@@ -115,6 +115,79 @@ docker run -v .:/app docdetective/docdetective --config /app/.doc-detective.json
   </Tab>
 </Tabs>
 
+### Run a subset of tests
+
+When you only want to run specific tests or specs (for example, while iterating on a single doc page or debugging one failure), use `--test` and `--spec` to filter by `testId` and `specId`. Each flag accepts one or more case-insensitive regex patterns, comma-separated.
+
+To run only tests whose `testId` matches a pattern, use `--test`:
+
+<Tabs>
+  <Tab title="NPX" language="npx">
+
+```bash
+npx doc-detective --test smoke
+```
+
+  </Tab>
+  <Tab title="Docker" language="docker">
+
+```bash
+docker run -v .:/app docdetective/docdetective --test smoke
+```
+
+  </Tab>
+</Tabs>
+
+To run only specs whose `specId` matches a pattern, use `--spec`:
+
+<Tabs>
+  <Tab title="NPX" language="npx">
+
+```bash
+npx doc-detective --spec auth
+```
+
+  </Tab>
+  <Tab title="Docker" language="docker">
+
+```bash
+docker run -v .:/app docdetective/docdetective --spec auth
+```
+
+  </Tab>
+</Tabs>
+
+Comma-separate multiple patterns. A test or spec is included if it matches **any** pattern. The two flags can be combined: `--spec` narrows which specs are considered, then `--test` narrows which tests inside those specs run.
+
+<Tabs>
+  <Tab title="NPX" language="npx">
+
+```bash
+npx doc-detective --spec billing --test "refund,invoice"
+```
+
+  </Tab>
+  <Tab title="Docker" language="docker">
+
+```bash
+docker run -v .:/app docdetective/docdetective --spec billing --test "refund,invoice"
+```
+
+  </Tab>
+</Tabs>
+
+You can also persist filters in your `.doc-detective.json` config as the `testFilter` and `specFilter` fields. Both expect an array of patterns. CLI flags override the config when both are set.
+
+```json
+{
+  "input": ".",
+  "testFilter": ["smoke", "login"],
+  "specFilter": ["auth"]
+}
+```
+
+If your filters exclude every test, Doc Detective prints a yellow `No tests were run` warning, lists the active filters, and exits with code `0` (an empty run, not a failure). Filtered-out specs and tests are excluded from the report entirely — they don't appear as skipped.
+
 ### Remotely hosted tests
 
 You can run tests hosted remotely by specifying the URL of the test file with the `--input` argument. For example, to run tests from a file hosted at `https://doc-detective.com/sample.spec.json`, run the following command:

--- a/docs/fern/pages/reference/schemas/config.md
+++ b/docs/fern/pages/reference/schemas/config.md
@@ -22,6 +22,8 @@ afterAll | one of:<br/>- string<br/>- array of string | Optional. Path(s) to tes
 detectSteps | boolean | Optional. Whether or not to detect steps in input files based on defined markup. | `true`
 allowUnsafeSteps | boolean | Optional. Whether or not to run potentially unsafe steps, such as those that might modify files or system state. | 
 crawl | boolean | Optional. If `true`, crawls sitemap.xml files specified by URL to find additional files to test. | `false`
+specFilter | array of string | Optional. Regex patterns (case-insensitive) applied to each spec's `specId`. If set, only specs whose `specId` matches at least one pattern are run. Equivalent to `--spec` on the CLI. Each entry must contain at least one non-whitespace character. | 
+testFilter | array of string | Optional. Regex patterns (case-insensitive) applied to each test's `testId`. If set, only tests whose `testId` matches at least one pattern are run. Equivalent to `--test` on the CLI. Each entry must contain at least one non-whitespace character. | 
 processDitaMaps | boolean | Optional. If `true`, processes DITA maps and includes generated files as inputs. | `true`
 logLevel | string | Optional. Amount of detail to output when performing an operation.<br/><br/>Accepted values: `silent`, `error`, `warning`, `info`, `debug` | `info`
 runOn | array of object([context](/reference/schemas/context)) | Optional. Contexts to run the test in. Overrides contexts defined at the config and spec levels. | 
@@ -173,5 +175,12 @@ debug | one of:<br/>- boolean<br/>- string | Optional. Enable debugging mode. `t
 ```json
 {
   "crawl": true
+}
+```
+
+```json
+{
+  "testFilter": ["smoke", "login"],
+  "specFilter": ["auth"]
 }
 ```


### PR DESCRIPTION
## Summary

User-facing docs for the spec/test filter feature in [#286](https://github.com/doc-detective/doc-detective/pull/286).

- New **"Run a subset of tests"** section in [Explore sample tests](docs/fern/pages/docs/get-started/sample-tests.mdx), with NPX + Docker examples for `--test`, `--spec`, and the combined form. Calls out the comma-separated multi-pattern form, the CLI-overrides-config precedence, and the empty-run behavior (yellow warning, exit 0).
- Two new rows in the [config schema reference](docs/fern/pages/reference/schemas/config.md) (`specFilter`, `testFilter`) plus a JSON example showing the array form.

## Why

Without this, readers can only discover the flags via `--help` and have to find out the case-insensitive-regex / comma-separated semantics by trial and error. The schema reference was also missing the new fields entirely.

## Notes for reviewer

- Pairs with [#286](https://github.com/doc-detective/doc-detective/pull/286) — should land **after** that PR releases so users running the published `doc-detective` see the documented behavior.
- The schema reference page (`config.md`) appears to be hand-maintained from the JSON Schema in `src/common`; a few existing fields (e.g. `reporters`) are already missing from the table. I only added the two new rows and one example for this feature — broader sync is out of scope.
- No `.spec.json` test changes needed; the existing `sample.spec.json` for the get-started flow doesn't exercise the filter flags.

## Test plan

- [ ] `cd docs && npm i && npm start` — preview locally, confirm the new section renders cleanly under `Explore sample tests`.
- [ ] Confirm code blocks copy-paste correctly (NPX + Docker both shown).
- [ ] `cd docs && npm test` — runs `doc-detective` against the docs (existing passing flow shouldn't regress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for filtering tests and specs using `--test` and `--spec` CLI flags with regex patterns
  * Documented new configuration options to persist test and spec filters in config files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->