### PR TITLE
test(checkLink): add integration regression for 429 in statusCodes

### DIFF
--- a/test/artifacts/checkLink-statusCodes.spec.json
+++ b/test/artifacts/checkLink-statusCodes.spec.json
@@ -1,0 +1,34 @@
+{
+  "specId": "checkLink-statusCodes",
+  "tests": [
+    {
+      "testId": "checkLink accepts 429 when explicitly specified",
+      "description": "Regression: a user reported that checkLink failed against a 429 even when 429 was in statusCodes. Verify singleton array, singleton integer, and multi-value array forms.",
+      "steps": [
+        {
+          "checkLink": {
+            "url": "http://localhost:8092/status/429",
+            "statusCodes": [
+              429
+            ]
+          }
+        },
+        {
+          "checkLink": {
+            "url": "http://localhost:8092/status/429",
+            "statusCodes": 429
+          }
+        },
+        {
+          "checkLink": {
+            "url": "http://localhost:8092/status/429",
+            "statusCodes": [
+              200,
+              429
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/runTests-checkLink-statusCodes.test.js
+++ b/test/runTests-checkLink-statusCodes.test.js
@@ -1,0 +1,49 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnCommand } from "../dist/utils.js";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const artifactPath = path.resolve(__dirname, "./artifacts");
+const specFile = path.resolve(artifactPath, "checkLink-statusCodes.spec.json");
+const outputFile = path.resolve(
+  artifactPath,
+  "checkLink-statusCodes.results.json"
+);
+
+describe("checkLink with explicitly accepted status code (regression)", function () {
+  this.timeout(120000);
+  it("treats a 429 as PASS when 429 is in statusCodes", async () => {
+    if (fs.existsSync(outputFile)) fs.unlinkSync(outputFile);
+    await spawnCommand(
+      `node ./bin/doc-detective.js -c ${artifactPath}/config.json -i ${specFile} -o ${outputFile}`
+    );
+    let waitCount = 0;
+    while (!fs.existsSync(outputFile) && waitCount < 120) {
+      await new Promise((r) => setTimeout(r, 1000));
+      waitCount++;
+    }
+    assert.ok(fs.existsSync(outputFile), "Output file not written");
+    const result = JSON.parse(fs.readFileSync(outputFile, "utf8"));
+    fs.unlinkSync(outputFile);
+
+    assert.equal(result.summary.specs.fail, 0, "Spec failed");
+    assert.equal(result.summary.steps.fail, 0, "At least one step failed");
+    assert.ok(
+      result.summary.steps.pass >= 3,
+      "Expected all three checkLink steps to pass"
+    );
+
+    const steps = result.specs[0].tests[0].contexts[0].steps;
+    assert.equal(steps.length, 3, "Expected 3 steps in the spec");
+    for (const step of steps) {
+      assert.equal(
+        step.result,
+        "PASS",
+        `Step failed: ${step.resultDescription}`
+      );
+      assert.match(step.resultDescription, /429/);
+    }
+  });
+});

--- a/test/runTests-checkLink-statusCodes.test.js
+++ b/test/runTests-checkLink-statusCodes.test.js
@@ -16,14 +16,19 @@ describe("checkLink with explicitly accepted status code (regression)", function
   this.timeout(120000);
   it("treats a 429 as PASS when 429 is in statusCodes", async () => {
     if (fs.existsSync(outputFile)) fs.unlinkSync(outputFile);
-    await spawnCommand(
-      `node ./bin/doc-detective.js -c ${artifactPath}/config.json -i ${specFile} -o ${outputFile}`
-    );
-    let waitCount = 0;
-    while (!fs.existsSync(outputFile) && waitCount < 120) {
-      await new Promise((r) => setTimeout(r, 1000));
-      waitCount++;
-    }
+    // Pass argv as an array so paths containing spaces survive (otherwise
+    // spawnCommand splits a single string on spaces and breaks the args).
+    await spawnCommand("node", [
+      "./bin/doc-detective.js",
+      "-c",
+      path.join(artifactPath, "config.json"),
+      "-i",
+      specFile,
+      "-o",
+      outputFile,
+    ]);
+    // spawnCommand awaits the child's "close" event after draining stdout/stderr,
+    // so by here the output file is fully written -- no need to poll.
     assert.ok(fs.existsSync(outputFile), "Output file not written");
     const result = JSON.parse(fs.readFileSync(outputFile, "utf8"));
     fs.unlinkSync(outputFile);

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -29,6 +29,17 @@ function createServer(options = {}) {
     app.use(express.static(staticDir));
   }
 
+  // Status-code fixture: returns the requested numeric status with a tiny JSON
+  // body. Lets integration tests assert checkLink (and similar) behavior
+  // against deterministic HTTP responses without setting up a per-test server.
+  app.all("/status/:code", (req, res) => {
+    const code = parseInt(req.params.code, 10);
+    if (!Number.isInteger(code) || code < 100 || code > 599) {
+      return res.status(400).json({ error: "Invalid status code" });
+    }
+    res.status(code).json({ status: code });
+  });
+
   // Endpoint for testing DOC_DETECTIVE_API - returns resolved tests
   // IMPORTANT: Must be registered before the catch-all /api/:path route
   app.get("/api/resolved-tests", (req, res) => {

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -32,9 +32,14 @@ function createServer(options = {}) {
   // Status-code fixture: returns the requested numeric status with a tiny JSON
   // body. Lets integration tests assert checkLink (and similar) behavior
   // against deterministic HTTP responses without setting up a per-test server.
+  // Strict /^\d+$/ guard so trailing garbage (e.g. "/status/429abc") is rejected
+  // rather than silently parsed as 429 by parseInt.
   app.all("/status/:code", (req, res) => {
+    if (!/^\d+$/.test(req.params.code)) {
+      return res.status(400).json({ error: "Invalid status code" });
+    }
     const code = parseInt(req.params.code, 10);
-    if (!Number.isInteger(code) || code < 100 || code > 599) {
+    if (code < 100 || code > 599) {
       return res.status(400).json({ error: "Invalid status code" });
     }
     res.status(code).json({ status: code });


### PR DESCRIPTION
## Summary

Adds integration-level coverage for `checkLink` accepting an HTTP 429 response when `429` is explicitly listed in `statusCodes`. A user reported failures in this scenario; the existing unit test ([test/checkLink.test.js:110](https://github.com/doc-detective/doc-detective/blob/main/test/checkLink.test.js#L110)) covers the action in isolation, but the full CLI → spec resolve → `runSpecs` → `checkLink` path was never exercised end-to-end for this case.

## What changed

- **`test/server/index.js`** — added a parameterized `/status/:code` route on the shared test server (port 8092) that returns the requested numeric status. Reusable for any future status-code regression test, mirroring the dynamic-status pattern already used by the inline server in [test/checkLink.test.js](https://github.com/doc-detective/doc-detective/blob/main/test/checkLink.test.js).
- **`test/artifacts/checkLink-statusCodes.spec.json`** — new Doc Detective spec (v3 format) with three `checkLink` steps targeting `http://localhost:8092/status/429`, exercising every schema-supported shape of `statusCodes`:
  - singleton array `[429]`
  - singleton integer `429`
  - multi-value array `[200, 429]` (the realistic shape a user would write — distinct from a one-element array because `anyOf` + `coerceTypes` interactions in AJV can behave differently)
- **`test/runTests-checkLink-statusCodes.test.js`** — focused mocha test that spawns the CLI on just this spec and asserts each step is reported as `PASS` with `resultDescription` matching `/429/`. The same spec also rides along inside the existing `test/runTests.test.js` end-to-end sweep, so any future regression fails CI in two places.

## Reviewer notes

- **No source code under `src/` is modified** — this is purely additional regression coverage. All three forms currently report `PASS` through the full pipeline on `main`, so the reported user failure does not reproduce here. Likely an older version or a config-specific edge case outside this path; new coverage closes the gap regardless.
- The `/status/:code` route is registered before the existing `/api/:path` catch-all (matches the comment about ordering at the existing `/api/resolved-tests` route).
- Repo is at v4.2.3, satisfying the user's "≥ v4.2.2" floor.

## Test plan

- [x] `npx mocha test/runTests-checkLink-statusCodes.test.js` — passes (2.3s)
- [x] `npx mocha test/runTests.test.js test/runTests-checkLink-statusCodes.test.js` — both pass; new spec rides along in the full sweep without regression
- [x] `npm test` — 382 passing in main, 578 passing in `src/common`, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)