### PR TITLE
chore: exclude docs/** from CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,7 @@ reviews:
   path_filters:
     - "!src/common/src/schemas/output_schemas/**"
     - "!src/common/src/schemas/schemas.json"
+    - "!docs/**"
   tools:
     github-checks:
       enabled: true


### PR DESCRIPTION
## Summary

- Append `- "!docs/**"` to `reviews.path_filters` in [.coderabbit.yaml](.coderabbit.yaml) so CodeRabbit skips the user-facing documentation directory.
- Doc-only changes don't benefit from CodeRabbit's code-review heuristics — excluding them cuts review noise without losing signal.

## Why this commit type

`chore:` rather than `docs:` because the change is to tooling/CI configuration, not to documentation content. Per [CLAUDE.md](CLAUDE.md), `chore` is non-releasing — appropriate here since there is no shipped behavior change.

## Notes for reviewers

- Scoped to the root [.coderabbit.yaml](.coderabbit.yaml) only. The submodule config at `src/common/.coderabbit.yaml` was intentionally left alone — it governs the `doc-detective-common` package and has no `docs/` of its own.
- Path glob style (`docs/**`, no leading slash) matches the existing entries in the same array.

## Test plan

- [ ] Verify YAML parses cleanly (no indentation/quoting drift).
- [ ] On the next PR that touches a file under `docs/`, confirm CodeRabbit either lists it under filtered paths or skips reviewing it entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)