### PR TITLE
feat(cli): add --dry-run flag to resolve tests without executing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,6 +90,13 @@ async function runTestsHandler(args: any) {
     ? await runTests(config, { resolvedTests })
     : await runTests(config);
 
+  // Dry-run already emitted the resolved-tests JSON inside runTests().
+  // Skip both reporters (which assume executed-result shape) and the
+  // orchestration-API report-back path.
+  if (config.dryRun) {
+    return;
+  }
+
   if (apiConfig) {
     await reportResults({ apiConfig, results });
   } else {

--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -9419,6 +9419,11 @@
         }
       ],
       "default": false
+    },
+    "dryRun": {
+      "description": "If `true`, fully resolve tests (file/env config merge, schema validation, file detection, inline-test extraction) and emit the resolved test plan as JSON, but do not execute any steps. Equivalent to `--dry-run` on the CLI.",
+      "type": "boolean",
+      "default": false
     }
   },
   "components": {

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -9432,6 +9432,11 @@
             }
           ],
           "default": false
+        },
+        "dryRun": {
+          "description": "If `true`, fully resolve tests (file/env config merge, schema validation, file detection, inline-test extraction) and emit the resolved test plan as JSON, but do not execute any steps. Equivalent to `--dry-run` on the CLI.",
+          "type": "boolean",
+          "default": false
         }
       },
       "components": {

--- a/src/common/src/schemas/src_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/config_v3.schema.json
@@ -396,6 +396,11 @@
         }
       ],
       "default": false
+    },
+    "dryRun": {
+      "description": "If `true`, fully resolve tests (file/env config merge, schema validation, file detection, inline-test extraction) and emit the resolved test plan as JSON, but do not execute any steps. Equivalent to `--dry-run` on the CLI.",
+      "type": "boolean",
+      "default": false
     }
   },
   "components": {

--- a/src/common/src/types/generated/config_v3.ts
+++ b/src/common/src/types/generated/config_v3.ts
@@ -140,6 +140,10 @@ export interface Config {
    * Enable debugging mode. `true` allows pausing on breakpoints, waiting for user input before continuing. `stepThrough` pauses at every step, waiting for user input before continuing. `false` disables all debugging.
    */
   debug?: boolean | "stepThrough";
+  /**
+   * If `true`, fully resolve tests (file/env config merge, schema validation, file detection, inline-test extraction) and emit the resolved test plan as JSON, but do not execute any steps. Equivalent to `--dry-run` on the CLI.
+   */
+  dryRun?: boolean;
 }
 /**
  * A context in which to perform tests. If no contexts are specified but a context is required by one or more tests, Doc Detective attempts to identify a supported context in the current environment and run tests against it. For example, if a browser isn't specified but is required by steps in the test, Doc Detective will search for and use a supported browser available in the current environment.

--- a/src/common/src/types/generated/resolvedTests_v3.ts
+++ b/src/common/src/types/generated/resolvedTests_v3.ts
@@ -177,6 +177,10 @@ export interface Config {
    * Enable debugging mode. `true` allows pausing on breakpoints, waiting for user input before continuing. `stepThrough` pauses at every step, waiting for user input before continuing. `false` disables all debugging.
    */
   debug?: boolean | "stepThrough";
+  /**
+   * If `true`, fully resolve tests (file/env config merge, schema validation, file detection, inline-test extraction) and emit the resolved test plan as JSON, but do not execute any steps. Equivalent to `--dry-run` on the CLI.
+   */
+  dryRun?: boolean;
 }
 /**
  * A context in which to perform tests. If no contexts are specified but a context is required by one or more tests, Doc Detective attempts to identify a supported context in the current environment and run tests against it. For example, if a browser isn't specified but is required by steps in the test, Doc Detective will search for and use a supported browser available in the current environment.

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -119,6 +119,28 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.be.a("string");
       });
 
+      it("should validate a config_v3 object with dryRun set", function () {
+        const result = validate({
+          schemaKey: "config_v3",
+          object: { dryRun: true },
+        });
+
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+        expect(result.object.dryRun).to.equal(true);
+      });
+
+      it("should reject a config_v3 object whose dryRun is not a boolean", function () {
+        const result = validate({
+          schemaKey: "config_v3",
+          object: { dryRun: "yes" },
+        });
+
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+        expect(result.errors).to.include("dryRun");
+      });
+
       it("should add default values when addDefaults=true", function () {
         const result = validate({
           schemaKey: "step_v3",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -57,6 +57,18 @@ async function runTests(config: any, options: any = {}) {
     }
   }
 
+  // Use console.log (not log()) so dry-run output survives --logLevel silent —
+  // the whole point of --dry-run is the printed plan.
+  if (config.dryRun) {
+    console.log(JSON.stringify(resolvedTests, null, 2));
+    cleanTemp();
+    sendTelemetry(config, "runTests:dryRun", {
+      specs: resolvedTests.specs.length,
+    });
+    log(config, "info", supportMessage);
+    return resolvedTests;
+  }
+
   // If config.integrations.docDetectiveApi.apiKey is set, run tests via API instead of locally
   if (!process.env.DOC_DETECTIVE_API && config.integrations && config.integrations.docDetectiveApi && config.integrations.docDetectiveApi.apiKey) {
     // Run test specs via API

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -43,11 +43,25 @@ async function runTests(config: any, options: any = {}) {
 
   if (options.resolvedTests) {
     resolvedTests = options.resolvedTests;
-    config = resolvedTests.config;
+    // Caller-provided config wins over the embedded resolved-tests config
+    // so CLI overrides like --dry-run / --logLevel are preserved when tests
+    // come pre-resolved (DOC_DETECTIVE_API path). Without this merge, a
+    // user running `--dry-run` against an orchestration-supplied resolved
+    // payload would silently execute tests.
+    config = { ...(resolvedTests.config || {}), ...(config || {}) };
+    resolvedTests.config = config;
   }
 
-  // Telemetry notice
-  telemetryNotice(config);
+  // Dry-run requires clean stdout so the JSON dump can be piped through
+  // `jq` / `JSON.parse`. Force silent log level (which gates info logs from
+  // detectAndResolveTests below) and skip the telemetry notice — both would
+  // otherwise corrupt stdout at the default logLevel.
+  if (config.dryRun) {
+    config.logLevel = "silent";
+    if (resolvedTests) resolvedTests.config = config;
+  } else {
+    telemetryNotice(config);
+  }
 
   if (!resolvedTests) {
     resolvedTests = await detectAndResolveTests({ config });
@@ -57,15 +71,12 @@ async function runTests(config: any, options: any = {}) {
     }
   }
 
-  // Use console.log (not log()) so dry-run output survives --logLevel silent —
-  // the whole point of --dry-run is the printed plan.
   if (config.dryRun) {
     console.log(JSON.stringify(resolvedTests, null, 2));
     cleanTemp();
     sendTelemetry(config, "runTests:dryRun", {
       specs: resolvedTests.specs.length,
     });
-    log(config, "info", supportMessage);
     return resolvedTests;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,6 +76,11 @@ function buildYargs(args: any): any {
       description: "Allow execution of potentially unsafe tests",
       type: "boolean",
     })
+    .option("dry-run", {
+      description:
+        "Resolve tests fully (file detection, inline-test extraction, config merge) and emit the resolved test plan as JSON, but do not execute any steps.",
+      type: "boolean",
+    })
     .option("reporters", {
       alias: "r",
       description:
@@ -291,6 +296,9 @@ async function setConfig({ configPath, args }: { configPath?: any; args: any }) 
   }
   if (typeof args.allowUnsafe === "boolean") {
     config.allowUnsafeSteps = args.allowUnsafe;
+  }
+  if (typeof args.dryRun === "boolean") {
+    config.dryRun = args.dryRun;
   }
   if (args.reporters != null) {
     const reporterList = Array.isArray(args.reporters)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,6 +77,7 @@ function buildYargs(args: any): any {
       type: "boolean",
     })
     .option("dry-run", {
+      alias: "n",
       description:
         "Resolve tests fully (file detection, inline-test extraction, config merge) and emit the resolved test plan as JSON, but do not execute any steps.",
       type: "boolean",

--- a/test/dryRun.test.js
+++ b/test/dryRun.test.js
@@ -1,0 +1,96 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { runTests } from "../dist/core/index.js";
+
+describe("--dry-run short-circuits before execution", function () {
+  this.timeout(30000);
+
+  before(async function () {
+    const { expect } = await import("chai");
+    global.expect = expect;
+  });
+
+  let tmpDir;
+  let specPath;
+  let originalLog;
+  let captured;
+
+  beforeEach(function () {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dd-dry-run-"));
+    specPath = path.join(tmpDir, "test.spec.json");
+    fs.writeFileSync(
+      specPath,
+      JSON.stringify(
+        {
+          tests: [
+            {
+              steps: [{ goTo: "https://example.com" }],
+            },
+          ],
+        },
+        null,
+        2
+      )
+    );
+
+    captured = [];
+    originalLog = console.log;
+    console.log = (...args) => {
+      captured.push(args.join(" "));
+    };
+  });
+
+  afterEach(function () {
+    console.log = originalLog;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns the resolved-tests shape and prints it as JSON", async function () {
+    const result = await runTests({
+      input: [specPath],
+      output: tmpDir,
+      logLevel: "silent",
+      dryRun: true,
+      telemetry: { send: false },
+    });
+
+    // Resolved-tests shape (NOT a results shape):
+    // - has `resolvedTestsId` and `specs`
+    // - has `tests[].contexts[].steps[]` (resolution expands a step into contexts)
+    // - has NO `summary` or `reportId` (those exist only on executed results)
+    expect(result).to.be.an("object");
+    expect(result).to.have.property("resolvedTestsId");
+    expect(result).to.have.property("specs").that.is.an("array").with.lengthOf(1);
+    expect(result).to.not.have.property("summary");
+    expect(result).to.not.have.property("reportId");
+
+    const step = result.specs[0].tests[0].contexts[0].steps[0];
+    expect(step).to.have.property("goTo");
+
+    // JSON was emitted to stdout and round-trips with the same shape.
+    const stdoutDump = captured.join("\n");
+    const parsed = JSON.parse(stdoutDump);
+    expect(parsed).to.have.property("resolvedTestsId", result.resolvedTestsId);
+    expect(parsed).to.not.have.property("summary");
+    expect(parsed.specs).to.have.lengthOf(1);
+  });
+
+  it("without dryRun, runTests returns an executed-results shape", async function () {
+    // Sanity control: the same spec, run normally, returns an object with
+    // `summary` and `specs[].tests[].contexts[].steps[]` carrying step
+    // results (a `result` field). This proves the dry-run case above is
+    // returning a *different* shape, not just an empty execution.
+    const result = await runTests({
+      input: [specPath],
+      output: tmpDir,
+      logLevel: "silent",
+      telemetry: { send: false },
+      reporters: [],
+    });
+
+    expect(result).to.be.an("object");
+    expect(result).to.have.property("summary");
+    expect(result).to.not.have.property("resolvedTestsId");
+  });
+});

--- a/test/dryRun.test.js
+++ b/test/dryRun.test.js
@@ -93,4 +93,54 @@ describe("--dry-run short-circuits before execution", function () {
     expect(result).to.have.property("summary");
     expect(result).to.not.have.property("resolvedTestsId");
   });
+
+  it("honors caller dryRun even when options.resolvedTests carries a non-dry-run config", async function () {
+    // Regression for #292: when DOC_DETECTIVE_API supplies a pre-resolved
+    // tests payload, the embedded resolvedTests.config must NOT clobber
+    // CLI-level overrides like dryRun. Caller config wins.
+    const seed = await runTests({
+      input: [specPath],
+      output: tmpDir,
+      logLevel: "silent",
+      dryRun: true,
+      telemetry: { send: false },
+    });
+    captured.length = 0; // discard the seed run's stdout dump
+
+    // Mutate the seed's embedded config so dryRun is FALSE there. If the
+    // merge regresses, runTests would proceed to execute tests.
+    const tampered = JSON.parse(JSON.stringify(seed));
+    tampered.config.dryRun = false;
+    tampered.config.logLevel = "silent";
+
+    const result = await runTests(
+      { dryRun: true, telemetry: { send: false }, logLevel: "silent" },
+      { resolvedTests: tampered }
+    );
+
+    expect(result).to.have.property("resolvedTestsId");
+    expect(result).to.not.have.property("summary");
+
+    // stdout received the JSON dump (one entry from this re-run).
+    const parsed = JSON.parse(captured.join("\n"));
+    expect(parsed).to.have.property("resolvedTestsId");
+  });
+
+  it("emits clean JSON to stdout at default logLevel (no telemetry/support pollution)", async function () {
+    // Regression for #292: telemetryNotice and the support-message log
+    // both wrote to stdout at the default info logLevel and broke
+    // `JSON.parse` of the output. Confirm nothing extra leaks.
+    await runTests({
+      input: [specPath],
+      output: tmpDir,
+      // logLevel intentionally omitted to exercise the default ("info")
+      dryRun: true,
+      telemetry: { send: false },
+    });
+
+    const stdoutDump = captured.join("\n").trim();
+    // The whole stdout must round-trip as a single JSON document.
+    const parsed = JSON.parse(stdoutDump);
+    expect(parsed).to.have.property("resolvedTestsId");
+  });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -104,6 +104,17 @@ describe("Util tests", function () {
     expect(aliasedSpec.spec).to.equal("xyz");
   });
 
+  it("Yargs parses --dry-run as a boolean", function () {
+    const on = setArgs(["node", "runTests.js", "--dry-run"]);
+    expect(on.dryRun).to.equal(true);
+
+    const off = setArgs(["node", "runTests.js", "--no-dry-run"]);
+    expect(off.dryRun).to.equal(false);
+
+    const absent = setArgs(["node", "runTests.js", "--input", "."]);
+    expect(absent.dryRun).to.equal(undefined);
+  });
+
   it("Yargs parses --reporters argument correctly", function () {
     const single = setArgs([
       "node", "runTests.js", "--reporters", "html",
@@ -178,6 +189,23 @@ describe("Util tests", function () {
     const config4 = await setConfig({ configPath: null, args: args4 });
     expect(config4.testFilter).to.equal(undefined);
     expect(config4.specFilter).to.equal(undefined);
+  });
+
+  it("setConfig stores --dry-run on config.dryRun and applies schema default when absent", async function () {
+    this.timeout(5000);
+    const argsOn = setArgs(["node", "runTests.js", "--dry-run"]);
+    const configOn = await setConfig({ configPath: null, args: argsOn });
+    expect(configOn.dryRun).to.equal(true);
+
+    const argsOff = setArgs(["node", "runTests.js", "--no-dry-run"]);
+    const configOff = await setConfig({ configPath: null, args: argsOff });
+    expect(configOff.dryRun).to.equal(false);
+
+    // Schema default is false; absent flag yields false (AJV useDefaults).
+    const argsAbsent = setArgs(["node", "runTests.js", "--input", "."]);
+    expect(argsAbsent.dryRun).to.equal(undefined);
+    const configAbsent = await setConfig({ configPath: null, args: argsAbsent });
+    expect(configAbsent.dryRun).to.equal(false);
   });
 
   it("setConfig stores --reporters arg on config.reporters", async function () {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -113,6 +113,11 @@ describe("Util tests", function () {
 
     const absent = setArgs(["node", "runTests.js", "--input", "."]);
     expect(absent.dryRun).to.equal(undefined);
+
+    // -n alias
+    const aliased = setArgs(["node", "runTests.js", "-n"]);
+    expect(aliased.dryRun).to.equal(true);
+    expect(aliased.n).to.equal(true);
   });
 
   it("Yargs parses --reporters argument correctly", function () {


### PR DESCRIPTION
## Summary
- Add a `--dry-run` CLI flag (and matching `dryRun` config field) that fully resolves the test plan — file detection, inline-test extraction from markdown, config merge, AJV validation — and emits the resolved tests as pretty-printed JSON to stdout, then exits **before** any browser launch, HTTP request, or shell step.
- Wired through the documented CLI-flag-to-config pattern in [CLAUDE.md](CLAUDE.md): schema field with `default: false`, yargs `.option()`, single boolean override block in `setConfig()`, runtime read from `config.dryRun`. The override block sits next to `allowUnsafe` (the canonical boolean precedent).
- Short-circuit lives in [`runTests()` in src/core/index.ts](src/core/index.ts), placed between the resolution chain (`detectAndResolveTests`) and both execution branches (local `runSpecs` and the orchestration-API `runViaApi`). The CLI handler in [src/cli.ts](src/cli.ts) skips both `outputResults()` and `reportResults()` when dry-run is active, since both assume an executed-results shape.
- Uses raw `console.log` (not the `log()` helper) so the JSON dump survives `--logLevel silent` — gating it on log level would defeat the purpose.

## Why
Today the only way to know what Doc Detective resolved from your docs/config is to run the suite. `--dry-run` closes the loop between authoring and verification: you can inspect the merged config, the discovered files, and the expanded inline tests without paying for an actual run.

## Tests
- Schema: positive + negative cases in [`src/common/test/validate.test.js`](src/common/test/validate.test.js).
- Yargs parse + `setConfig` override in [`test/utils.test.js`](test/utils.test.js), mirroring the `--test`/`--spec` precedent in #286.
- Integration test [`test/dryRun.test.js`](test/dryRun.test.js) asserting the return shape (`resolvedTestsId`, no `summary`), JSON-parseability of stdout, and a sanity control showing the *executed-results* shape on a normal run (different shape = different code path).

## Test plan
- [x] `npm run build:common` — schema regenerated and 585 common tests pass
- [x] `npm test` — 391 passing, 15 pre-existing env-dependent failures (browser/Appium/screenshot, all unchanged from `main` baseline)
- [x] CLI smoke: `node ./bin/doc-detective.js runTests --input test/artifacts/setup.spec.json --dry-run --logLevel silent` produces valid `JSON.parse`-able output
- [x] `--no-dry-run` correctly turns it off; absent flag yields `false` via the schema default
- [x] `commitlint --from HEAD~1 --to HEAD --verbose` clean

## Notes for reviewer
- Per [CLAUDE.md](CLAUDE.md), the `feat:` commit type triggers a minor version bump on merge.
- The dry-run output bypasses reporters intentionally — adding a `dryRun` reporter would be over-engineering for a one-line `JSON.stringify`.
- The short-circuit fires *after* `telemetryNotice` and emits a `runTests:dryRun` telemetry event so usage of the flag is observable.
- See the planning artifact at `.claude/plans/add-a-dry-run-cli-fuzzy-zebra.md` for the design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` CLI flag and `dryRun` config option (boolean, default false) to output the fully resolved test plan as JSON and skip test execution and reporting.
  * Dry-run silences runtime notices so the output is a clean JSON payload.

* **Tests**
  * Added validation and integration tests covering CLI parsing, config validation, and dry-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->