### PR TITLE
feat(appium): use dynamic port to avoid conflicts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,9 @@ npx commitlint --from HEAD~1 --to HEAD --verbose
 Running tests is time-intensive. Instead of running a test multiple times to check for different behaviors (such as looking at tail for output verification), save output to a file and inspect that file:
 
 ```bash
-# Run a test and save output to a file
-npm test -- --test "my test name" > output.txt
+# Run a test and save both stdout and stderr to a file (mocha and node write
+# diagnostics, including failures, to stderr — `2>&1` captures both).
+npm test -- --test "my test name" > output.txt 2>&1
 # Inspect the output file
 cat output.txt
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,17 @@ GITHUB_TOKEN=... npx semantic-release --dry-run --no-ci
 npx commitlint --from HEAD~1 --to HEAD --verbose
 ```
 
+## Testing behavior
+
+Running tests is time-intensive. Instead of running a test multiple times to check for different behaviors (such as looking at tail for output verification), save output to a file and inspect that file:
+
+```bash
+# Run a test and save output to a file
+npm test -- --test "my test name" > output.txt
+# Inspect the output file
+cat output.txt
+```
+
 ## CLI flags ↔ config (required pattern)
 
 Every user-facing knob flows through the merged `config` object. CLI flags do **not** bypass it — they override it. Runtime code (runner, reporters, integrations) reads from `config` only, never from `args`. This is what lets config files and `DOC_DETECTIVE_CONFIG` reach the same code paths the CLI does.

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -1030,7 +1030,9 @@ async function appiumIsReady(port: number, timeoutMs: number = 120000) {
   const start = Date.now();
   while (!isReady) {
     if (Date.now() - start > timeoutMs) {
-      throw new Error(`Appium server failed to start within ${timeoutMs / 1000} seconds`);
+      throw new Error(
+        `Appium server on port ${port} failed to start within ${timeoutMs / 1000} seconds`
+      );
     }
     await new Promise((resolve) => setTimeout(resolve, 1000));
     try {
@@ -1130,6 +1132,12 @@ async function getRunner(options: any = {}) {
     shell: true,
     windowsHide: true,
     cwd: path.join(__dirname, "../.."),
+  });
+  // Without a listener an "error" event from spawn (e.g. ENOENT, EACCES)
+  // would crash the process before appiumIsReady's timeout could surface
+  // a meaningful failure.
+  appium.on("error", (err: any) => {
+    log(config, "warning", `Appium process error: ${err?.stack ?? err?.message ?? String(err)}`);
   });
 
   // Wait for Appium to be ready

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -1,7 +1,7 @@
 import kill from "tree-kill";
 import * as wdio from "webdriverio";
 import os from "node:os";
-import { log, replaceEnvs, selectSpecsForRun } from "./utils.js";
+import { log, replaceEnvs, selectSpecsForRun, findFreePort } from "./utils.js";
 import axios from "axios";
 import { instantiateCursor } from "./tests/moveTo.js";
 import { goTo } from "./tests/goTo.js";
@@ -28,7 +28,6 @@ import { resolveExpression } from "./expressions.js";
 import { getEnvironment, getAvailableApps } from "./config.js";
 import { uploadChangedFiles } from "./integrations/index.js";
 import http from "node:http";
-import net from "node:net";
 import https from "node:https";
 import { fileURLToPath } from "node:url";
 
@@ -476,14 +475,12 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   const appiumRequired = isAppiumRequired(specs);
 
   // Warm up Appium
+  let appiumPort: number | undefined;
   if (appiumRequired) {
-    // Set Appium home directory
     setAppiumHome();
-    // Ensure the Appium port is not still bound by a zombie from a prior
-    // runTests() call in this process before spawning a fresh one.
-    await waitForPortFree(4723);
-    // Start Appium server
-    appium = spawn("npx", ["appium"], {
+    appiumPort = await findFreePort();
+    log(config, "debug", `Starting Appium on port ${appiumPort}`);
+    appium = spawn("npx", ["appium", "-p", String(appiumPort)], {
       shell: true,
       windowsHide: true,
       cwd: path.join(__dirname, "../.."),
@@ -497,7 +494,7 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     appium.stderr.on("data", (data: any) => {
       // console.error(`stderr: ${data}`);
     });
-    await appiumIsReady();
+    await appiumIsReady(appiumPort);
     log(config, "debug", "Appium is ready.");
   }
 
@@ -609,7 +606,7 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
 
           // Instantiate driver
           try {
-            driver = await driverStart(caps);
+            driver = await driverStart(caps, appiumPort!);
           } catch (error: any) {
             try {
               // If driver fails to start, try again as headless
@@ -628,7 +625,7 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
                   headless: context.browser?.headless !== false,
                 },
               });
-              driver = await driverStart(caps);
+              driver = await driverStart(caps, appiumPort!);
             } catch (error: any) {
               let errorMessage = `Failed to start context '${context.browser?.name}' on '${platform}'.`;
               if (context.browser?.name === "safari")
@@ -1021,40 +1018,8 @@ async function runStep({
   return actionResult;
 }
 
-// Wait until the given TCP port is not bound by anything on 127.0.0.1.
-// Between per-test runTests() calls, a prior Appium on port 4723 can still
-// be tearing down while the new one is about to spawn. On Windows + Node 24
-// the teardown window is wide enough for the new Appium's spawn to race the
-// old one's exit and confuse wdio's POST /session. Blocking until the port
-// is free makes the handoff deterministic.
-async function waitForPortFree(port: number, timeoutMs: number = 30000) {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    const result = await new Promise<"free" | "busy" | Error>((resolve) => {
-      const server = net.createServer();
-      server.once("error", (err: NodeJS.ErrnoException) => {
-        // Only EADDRINUSE means "keep polling". Any other bind failure
-        // (EACCES, invalid host, etc.) is a real problem and must surface.
-        if (err && err.code === "EADDRINUSE") resolve("busy");
-        else resolve(err instanceof Error ? err : new Error(String(err)));
-      });
-      server.once("listening", () => {
-        server.close(() => resolve("free"));
-      });
-      server.listen(port, "127.0.0.1");
-    });
-    if (result === "free") return;
-    if (result instanceof Error) throw result;
-    await new Promise((r) => setTimeout(r, 250));
-  }
-  throw new Error(
-    `Timed out after ${timeoutMs}ms waiting for 127.0.0.1:${port} to become free. ` +
-      `A prior Appium instance is still bound to the port; the next session create ` +
-      `would race the teardown and fail with an opaque ECONNREFUSED.`
-  );
-}
 // Delay execution until Appium server is available.
-async function appiumIsReady(timeoutMs: number = 120000) {
+async function appiumIsReady(port: number, timeoutMs: number = 120000) {
   let isReady = false;
   const start = Date.now();
   while (!isReady) {
@@ -1063,7 +1028,7 @@ async function appiumIsReady(timeoutMs: number = 120000) {
     }
     await new Promise((resolve) => setTimeout(resolve, 1000));
     try {
-      let resp = await axios.get("http://127.0.0.1:4723/status");
+      let resp = await axios.get(`http://127.0.0.1:${port}/status`);
       if (resp.status === 200) isReady = true;
     } catch {}
   }
@@ -1071,7 +1036,7 @@ async function appiumIsReady(timeoutMs: number = 120000) {
 }
 
 // Start the Appium driver specified in `capabilities`.
-async function driverStart(capabilities: any, maxAttempts: number = 4) {
+async function driverStart(capabilities: any, port: number, maxAttempts: number = 4) {
   // POST /session can race a just-spawned-or-still-dying Appium on Windows:
   // /status may already return 200 from the outgoing process while /session
   // is no longer accepting. Retry with linear backoff ONLY on ECONNREFUSED --
@@ -1082,7 +1047,7 @@ async function driverStart(capabilities: any, maxAttempts: number = 4) {
       const driver: any = await wdio.remote({
         protocol: "http",
         hostname: "127.0.0.1",
-        port: 4723,
+        port,
         path: "/",
         logLevel: "error",
         capabilities,
@@ -1153,16 +1118,17 @@ async function getRunner(options: any = {}) {
   // Set Appium home directory
   setAppiumHome();
 
-  // Start Appium server
-  const appium = spawn("npx", ["appium"], {
+  // Start Appium server on a free ephemeral port
+  const appiumPort = await findFreePort();
+  const appium = spawn("npx", ["appium", "-p", String(appiumPort)], {
     shell: true,
     windowsHide: true,
     cwd: path.join(__dirname, "../.."),
   });
 
   // Wait for Appium to be ready
-  await appiumIsReady();
-  log(config, "debug", "Appium is ready for external driver.");
+  await appiumIsReady(appiumPort);
+  log(config, "debug", `Appium is ready for external driver on port ${appiumPort}.`);
 
   // Get Chrome driver capabilities
   const caps: any = getDriverCapabilities({
@@ -1178,7 +1144,7 @@ async function getRunner(options: any = {}) {
   // Start the runner
   let runner: any;
   try {
-    runner = await driverStart(caps);
+    runner = await driverStart(caps, appiumPort);
   } catch (error: any) {
     // If runner fails, attempt to set headless and retry
     try {
@@ -1188,7 +1154,7 @@ async function getRunner(options: any = {}) {
         "Failed to start Chrome runner. Retrying as headless."
       );
       caps["goog:chromeOptions"].args.push("--headless", "--disable-gpu");
-      runner = await driverStart(caps);
+      runner = await driverStart(caps, appiumPort);
     } catch (error: any) {
       // If runner fails, clean up Appium and rethrow
       kill(appium.pid!);

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -604,9 +604,15 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
           log(config, "debug", "CAPABILITIES:");
           log(config, "debug", caps);
 
+          if (appiumPort === undefined) {
+            throw new Error(
+              "Driver requested but Appium was not started. " +
+                "isAppiumRequired(specs) and isDriverRequired(context) disagreed; this is a bug."
+            );
+          }
           // Instantiate driver
           try {
-            driver = await driverStart(caps, appiumPort!);
+            driver = await driverStart(caps, appiumPort);
           } catch (error: any) {
             try {
               // If driver fails to start, try again as headless
@@ -625,7 +631,7 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
                   headless: context.browser?.headless !== false,
                 },
               });
-              driver = await driverStart(caps, appiumPort!);
+              driver = await driverStart(caps, appiumPort);
             } catch (error: any) {
               let errorMessage = `Failed to start context '${context.browser?.name}' on '${platform}'.`;
               if (context.browser?.name === "safari")

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -480,7 +480,7 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     setAppiumHome();
     appiumPort = await findFreePort();
     log(config, "debug", `Starting Appium on port ${appiumPort}`);
-    appium = spawn("npx", ["appium", "-p", String(appiumPort)], {
+    appium = spawn("npx", ["appium", "-a", "127.0.0.1", "-p", String(appiumPort)], {
       shell: true,
       windowsHide: true,
       cwd: path.join(__dirname, "../.."),
@@ -1128,7 +1128,7 @@ async function getRunner(options: any = {}) {
 
   // Start Appium server on a free ephemeral port
   const appiumPort = await findFreePort();
-  const appium = spawn("npx", ["appium", "-p", String(appiumPort)], {
+  const appium = spawn("npx", ["appium", "-a", "127.0.0.1", "-p", String(appiumPort)], {
     shell: true,
     windowsHide: true,
     cwd: path.join(__dirname, "../.."),

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -31,9 +31,9 @@ export {
 };
 
 // Bind a temp listener to port 0, capture the OS-assigned port, and release
-// it. There is a tiny TOCTOU window between close and the caller's bind, but
-// in practice the port stays in TIME_WAIT-free state and the caller is the
-// only thing racing for it. driverStart's ECONNREFUSED retry absorbs any race.
+// it. There is a small close-to-rebind window where another process could
+// grab the port before the caller binds it. driverStart's ECONNREFUSED retry
+// absorbs that race when the caller is Appium.
 async function findFreePort(): Promise<number> {
   return new Promise<number>((resolve, reject) => {
     const server = net.createServer();

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -27,7 +27,24 @@ export {
   compileFilter,
   matchesFilter,
   selectSpecsForRun,
+  findFreePort,
 };
+
+async function findFreePort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        server.close(() => reject(new Error("Failed to obtain ephemeral port")));
+        return;
+      }
+      const port = addr.port;
+      server.close(() => resolve(port));
+    });
+  });
+}
 
 function compileFilter(patterns?: string[] | unknown): RegExp[] {
   if (!Array.isArray(patterns) || patterns.length === 0) return [];

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -30,6 +30,10 @@ export {
   findFreePort,
 };
 
+// Bind a temp listener to port 0, capture the OS-assigned port, and release
+// it. There is a tiny TOCTOU window between close and the caller's bind, but
+// in practice the port stays in TIME_WAIT-free state and the caller is the
+// only thing racing for it. driverStart's ECONNREFUSED retry absorbs any race.
 async function findFreePort(): Promise<number> {
   return new Promise<number>((resolve, reject) => {
     const server = net.createServer();

--- a/test/appium-port-conflict.test.js
+++ b/test/appium-port-conflict.test.js
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { runTests } from "../dist/core/index.js";
+
+const artifactPath = path.resolve("./test/core-artifacts");
+const config_base = JSON.parse(fs.readFileSync(`${artifactPath}/config.json`, "utf8"));
+const driverSpec = path.join(artifactPath, "wait-with-driver.spec.json");
+
+function makeConfig() {
+  const config = JSON.parse(JSON.stringify(config_base));
+  config.runTests.input = driverSpec;
+  return config;
+}
+
+describe("Dynamic Appium port", function () {
+  // Appium boot ~10s + driver session ~5s; allow generous headroom.
+  this.timeout(600000);
+
+  describe("port 4723 is held by another process", function () {
+    let blocker;
+
+    before(async function () {
+      blocker = net.createServer();
+      await new Promise((resolve, reject) => {
+        blocker.once("error", reject);
+        blocker.listen(4723, "127.0.0.1", resolve);
+      });
+    });
+
+    after(async function () {
+      if (blocker) await new Promise((r) => blocker.close(r));
+    });
+
+    it("runTests still succeeds for a driver-required spec", async function () {
+      const result = await runTests(makeConfig());
+      assert.ok(result, "Expected non-null result");
+      assert.equal(
+        result.summary.specs.fail,
+        0,
+        `Expected 0 failed specs, got ${result.summary.specs.fail}`
+      );
+    });
+  });
+
+  describe("two parallel runTests with 4723 held by another process", function () {
+    let blocker;
+
+    before(async function () {
+      blocker = net.createServer();
+      await new Promise((resolve, reject) => {
+        blocker.once("error", reject);
+        blocker.listen(4723, "127.0.0.1", resolve);
+      });
+    });
+
+    after(async function () {
+      if (blocker) await new Promise((r) => blocker.close(r));
+    });
+
+    it("both succeed without port collision", async function () {
+      const [a, b] = await Promise.all([
+        runTests(makeConfig()),
+        runTests(makeConfig()),
+      ]);
+      assert.ok(a && b, "Expected both results to be non-null");
+      assert.equal(a.summary.specs.fail, 0, "First run had failed specs");
+      assert.equal(b.summary.specs.fail, 0, "Second run had failed specs");
+    });
+  });
+});

--- a/test/appium-port-conflict.test.js
+++ b/test/appium-port-conflict.test.js
@@ -22,11 +22,22 @@ describe("Dynamic Appium port", function () {
     let blocker;
 
     before(async function () {
+      // If 4723 is already held (e.g. by a developer's Appium), the port-held
+      // condition is satisfied externally — proceed without our own blocker.
+      // Any error other than EADDRINUSE is a real bind failure and surfaces.
       blocker = net.createServer();
-      await new Promise((resolve, reject) => {
-        blocker.once("error", reject);
-        blocker.listen(4723, "127.0.0.1", resolve);
-      });
+      try {
+        await new Promise((resolve, reject) => {
+          blocker.once("error", reject);
+          blocker.listen(4723, "127.0.0.1", resolve);
+        });
+      } catch (err) {
+        if (err && err.code === "EADDRINUSE") {
+          blocker = null;
+        } else {
+          throw err;
+        }
+      }
     });
 
     after(async function () {
@@ -48,11 +59,22 @@ describe("Dynamic Appium port", function () {
     let blocker;
 
     before(async function () {
+      // If 4723 is already held (e.g. by a developer's Appium), the port-held
+      // condition is satisfied externally — proceed without our own blocker.
+      // Any error other than EADDRINUSE is a real bind failure and surfaces.
       blocker = net.createServer();
-      await new Promise((resolve, reject) => {
-        blocker.once("error", reject);
-        blocker.listen(4723, "127.0.0.1", resolve);
-      });
+      try {
+        await new Promise((resolve, reject) => {
+          blocker.once("error", reject);
+          blocker.listen(4723, "127.0.0.1", resolve);
+        });
+      } catch (err) {
+        if (err && err.code === "EADDRINUSE") {
+          blocker = null;
+        } else {
+          throw err;
+        }
+      }
     });
 
     after(async function () {

--- a/test/appium-port-conflict.test.js
+++ b/test/appium-port-conflict.test.js
@@ -14,35 +14,36 @@ function makeConfig() {
   return config;
 }
 
+// Bind 127.0.0.1:4723 to satisfy the "port is held" precondition. If the
+// port is already held externally (e.g. a developer's local Appium), the
+// precondition is already satisfied and we return null so the after-hook
+// knows there is nothing to close. Any other bind error propagates.
+async function holdPort4723() {
+  const blocker = net.createServer();
+  try {
+    await new Promise((resolve, reject) => {
+      blocker.once("error", reject);
+      blocker.listen(4723, "127.0.0.1", resolve);
+    });
+    return blocker;
+  } catch (err) {
+    if (err && err.code === "EADDRINUSE") return null;
+    throw err;
+  }
+}
+
+async function releasePort(blocker) {
+  if (blocker) await new Promise((r) => blocker.close(r));
+}
+
 describe("Dynamic Appium port", function () {
   // Appium boot ~10s + driver session ~5s; allow generous headroom.
   this.timeout(600000);
 
   describe("port 4723 is held by another process", function () {
     let blocker;
-
-    before(async function () {
-      // If 4723 is already held (e.g. by a developer's Appium), the port-held
-      // condition is satisfied externally — proceed without our own blocker.
-      // Any error other than EADDRINUSE is a real bind failure and surfaces.
-      blocker = net.createServer();
-      try {
-        await new Promise((resolve, reject) => {
-          blocker.once("error", reject);
-          blocker.listen(4723, "127.0.0.1", resolve);
-        });
-      } catch (err) {
-        if (err && err.code === "EADDRINUSE") {
-          blocker = null;
-        } else {
-          throw err;
-        }
-      }
-    });
-
-    after(async function () {
-      if (blocker) await new Promise((r) => blocker.close(r));
-    });
+    before(async function () { blocker = await holdPort4723(); });
+    after(async function () { await releasePort(blocker); });
 
     it("runTests still succeeds for a driver-required spec", async function () {
       const result = await runTests(makeConfig());
@@ -57,29 +58,8 @@ describe("Dynamic Appium port", function () {
 
   describe("two parallel runTests with 4723 held by another process", function () {
     let blocker;
-
-    before(async function () {
-      // If 4723 is already held (e.g. by a developer's Appium), the port-held
-      // condition is satisfied externally — proceed without our own blocker.
-      // Any error other than EADDRINUSE is a real bind failure and surfaces.
-      blocker = net.createServer();
-      try {
-        await new Promise((resolve, reject) => {
-          blocker.once("error", reject);
-          blocker.listen(4723, "127.0.0.1", resolve);
-        });
-      } catch (err) {
-        if (err && err.code === "EADDRINUSE") {
-          blocker = null;
-        } else {
-          throw err;
-        }
-      }
-    });
-
-    after(async function () {
-      if (blocker) await new Promise((r) => blocker.close(r));
-    });
+    before(async function () { blocker = await holdPort4723(); });
+    after(async function () { await releasePort(blocker); });
 
     it("both succeed without port collision", async function () {
       const [a, b] = await Promise.all([

--- a/test/findFreePort.test.js
+++ b/test/findFreePort.test.js
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import net from "node:net";
+import { findFreePort } from "../dist/core/utils.js";
+
+describe("findFreePort", () => {
+  it("returns a port in the IANA dynamic range", async () => {
+    const port = await findFreePort();
+    assert.equal(typeof port, "number");
+    assert.ok(port >= 1024 && port <= 65535, `out of range: ${port}`);
+  });
+
+  it("returns a port that is immediately bindable on 127.0.0.1", async () => {
+    const port = await findFreePort();
+    await new Promise((resolve, reject) => {
+      const s = net.createServer();
+      s.once("error", reject);
+      s.listen(port, "127.0.0.1", () => s.close(resolve));
+    });
+  });
+
+  it("does not return a port currently bound by another listener", async () => {
+    const taken = net.createServer();
+    await new Promise((r) => taken.listen(0, "127.0.0.1", r));
+    const takenPort = taken.address().port;
+    try {
+      for (let i = 0; i < 5; i++) {
+        const port = await findFreePort();
+        assert.notEqual(port, takenPort);
+      }
+    } finally {
+      await new Promise((r) => taken.close(r));
+    }
+  });
+});

--- a/test/findFreePort.test.js
+++ b/test/findFreePort.test.js
@@ -3,7 +3,7 @@ import net from "node:net";
 import { findFreePort } from "../dist/core/utils.js";
 
 describe("findFreePort", () => {
-  it("returns a port in the IANA dynamic range", async () => {
+  it("returns a port in the non-privileged TCP range", async () => {
     const port = await findFreePort();
     assert.equal(typeof port, "number");
     assert.ok(port >= 1024 && port <= 65535, `out of range: ${port}`);


### PR DESCRIPTION
## Summary

- Replace the hardcoded Appium port `4723` with an OS-assigned ephemeral port discovered at runtime via `net.createServer().listen(0)`.
- Thread the port through the Appium spawn (`-p <port>`), the readiness probe (`appiumIsReady`), and the WebdriverIO remote config (`driverStart`). Both `runSpecs()` and `getRunner()` paths get their own port per invocation.
- Delete `waitForPortFree()` — its only role was to serialize back-to-back runs against a shared `4723`. With per-spawn ports there is nothing left to wait for.

## Motivation

Two failure modes the old hardcoded port surfaced:

1. **Foreign service holds `4723`** — Appium fails to start, surfacing as an opaque ECONNREFUSED at session create.
2. **Two `runTests()` / `getRunner()` invocations in flight at the same time** — the second collides on the port, since `waitForPortFree`'s 30s timeout only buys time for a *prior doc-detective Appium* to finish tearing down, not for a foreign owner.

Per-spawn ephemeral ports fix both.

## What changed

- `src/core/utils.ts` — new `findFreePort()` helper.
- `src/core/tests.ts` — both Appium spawn sites add `-p <port>`; `appiumIsReady(port)` and `driverStart(caps, port)` take the port; `waitForPortFree` deleted; unused `net` import removed.
- `test/findFreePort.test.js` — three unit tests (range, bindable, distinct from a held port).
- `test/appium-port-conflict.test.js` — two integration regressions: single run with `4723` held, and two parallel runs with `4723` held. Both fail on `main` (timeout in `waitForPortFree`); both pass after this change.
- `CLAUDE.md` — small note (separate commit) on capturing test output to a file rather than re-running tests.

## Test plan

- [x] `npx mocha test/findFreePort.test.js` — 3/3 pass
- [x] `npx mocha test/appium-port-conflict.test.js` — 2/2 pass (both failed before the wiring change, confirming red→green)
- [x] `npx mocha test/core-core.test.js` — 15/15 pass (2 intentionally pending). `getRunner()` test logs show the ephemeral port (`35539` in one run) actually in use end-to-end.
- [x] `rg 4723 src/` — no matches
- [ ] CI matrix run

## Reviewer notes

- **No config / CLI / schema knob added** — this is auto-discover only, per the design discussion. If anyone needs a deterministic port for firewalls or debugging, that can be added later as an `appium.port` config field following the project's CLI-flag pattern.
- **`appiumIsReady` and `driverStart` are now port-required.** Both have `port: number` as a required positional arg (no default). `driverStart`'s `maxAttempts` shifted to position 3, but no caller passes it, so the signature change is internal.
- **The `CLAUDE.md` change is unrelated to the Appium work** — kept as a separate `docs:` commit so reviewers can see the scope cleanly. Happy to drop it if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Appium now automatically selects a free TCP port instead of using a fixed default, preventing port conflicts when the standard port is already in use.

* **Tests**
  * Added integration tests verifying successful test execution even when the default port is occupied.
  * Added unit tests for port selection functionality.

* **Documentation**
  * Updated contributor guidelines for test execution procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->