### PR TITLE
feat(platform): add doc-detective.com runner entrypoint

### DIFF
--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -346,8 +346,6 @@ async function provisionWorkspace(source, workspaceDir = WORKSPACE_DIR) {
 	// script (e.g. a runner-internal restart) would otherwise inherit
 	// stale clones.
 	await rm(workspaceDir, { recursive: true, force: true });
-	await mkdir(workspaceDir, { recursive: true });
-	await mkdir(path.join(workspaceDir, OUTPUT_SUBDIR), { recursive: true });
 
 	if (source.type === 'github') {
 		// Required-field guards so a regression in the platform's spec
@@ -383,11 +381,19 @@ async function provisionWorkspace(source, workspaceDir = WORKSPACE_DIR) {
 		// Shallow public clone. Auth-required GitHub repos are out of
 		// scope here — the platform UI requires the user to point at a
 		// public repo or commit secrets via the project secrets layer.
+		// The destination must NOT exist or must be empty for git clone
+		// to succeed; we only `rm` above and let git create the
+		// directory itself, then create the output subdir post-clone.
+		// Pre-creating workspaceDir + output/ would cause clone to
+		// fail with "destination path already exists and is not an
+		// empty directory."
+		const parent = path.dirname(workspaceDir);
+		await mkdir(parent, { recursive: true });
 		const repoUrl = `https://github.com/${source.repo}.git`;
 		const args = ['clone', '--depth=1', '--branch', source.ref, '--', repoUrl, workspaceDir];
 		const code = await new Promise((resolve, reject) => {
 			const child = spawn('git', args, {
-				cwd: '/',
+				cwd: parent,
 				env: process.env,
 				stdio: ['ignore', 'inherit', 'inherit']
 			});
@@ -397,10 +403,13 @@ async function provisionWorkspace(source, workspaceDir = WORKSPACE_DIR) {
 		if (code !== 0) {
 			throw new Error(`git clone failed (exit ${code}) for ${source.repo}@${source.ref}`);
 		}
+		await mkdir(path.join(workspaceDir, OUTPUT_SUBDIR), { recursive: true });
 		return cwd;
 	}
 
 	if (source.type === 'inline') {
+		await mkdir(workspaceDir, { recursive: true });
+		await mkdir(path.join(workspaceDir, OUTPUT_SUBDIR), { recursive: true });
 		const specsDir = path.join(workspaceDir, SPECS_SUBDIR);
 		await mkdir(specsDir, { recursive: true });
 		const specs = Array.isArray(source.specs) ? source.specs : [];

--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -213,7 +213,15 @@ function runChild(cmd, args, opts, onLine) {
 			process.off('SIGTERM', forwardTerm);
 			reject(err);
 		});
-		child.on('exit', (code, signal) => {
+		// `'close'`, not `'exit'`: 'exit' fires as soon as the child
+		// process terminates, but stdout/stderr's 'end' events come
+		// later. The trailing-line flush in attach() runs from those
+		// 'end' handlers, so resolving on 'exit' could let runChild's
+		// caller proceed before onLine had been invoked for the
+		// residual buffer of a child that wrote a partial last line.
+		// 'close' fires only after both the process has exited AND
+		// the stdio streams have closed.
+		child.on('close', (code, signal) => {
 			process.off('SIGTERM', forwardTerm);
 			// Node's exit-code conventions: when terminated by signal, code
 			// is null and the canonical exit is 128 + signal-number. We
@@ -385,16 +393,21 @@ function makeLogShipper(apiBase, runId, token) {
  *     sources we leave the user's `input` alone so their committed
  *     paths resolve from the cloned repo cwd)
  */
-function buildEffectiveConfig(configSnapshot, source) {
+function buildEffectiveConfig(configSnapshot, source, workspaceDir = WORKSPACE_DIR) {
 	const effective = { ...(configSnapshot ?? {}) };
 	// posix.join: these paths land inside DOC_DETECTIVE_CONFIG and are
 	// interpreted by the doc-detective CLI inside the Linux container.
 	// Plain path.join would emit backslashes on Windows test runners
 	// and break the equality assertions, even though no Windows
 	// runtime ever sees this string.
-	effective.output = path.posix.join(WORKSPACE_DIR, OUTPUT_SUBDIR);
+	//
+	// `workspaceDir` matches the path provisionWorkspace materialized
+	// to. main() resolves it once from DD_WORKSPACE_DIR and threads
+	// it through both functions so the CLI's view of the filesystem
+	// can't drift from where the runner actually wrote specs/output.
+	effective.output = path.posix.join(workspaceDir, OUTPUT_SUBDIR);
 	if (source.type === 'inline') {
-		effective.input = path.posix.join(WORKSPACE_DIR, SPECS_SUBDIR);
+		effective.input = path.posix.join(workspaceDir, SPECS_SUBDIR);
 	}
 	return effective;
 }
@@ -584,8 +597,16 @@ async function main() {
 		return 0;
 	}
 
+	// `DD_WORKSPACE_DIR` is a test/ops seam — defaults to /workspace
+	// (the in-container path). Tests redirect this to a tmpdir so
+	// they don't touch the real /workspace; an operator could
+	// redirect to a per-machine spool dir. Resolved once and
+	// threaded through provisionWorkspace + buildEffectiveConfig so
+	// the CLI's view can't drift from where we materialized files.
+	const workspaceDir = process.env.DD_WORKSPACE_DIR || WORKSPACE_DIR;
+
 	const source = spec.source_snapshot ?? { type: 'inline', specs: [] };
-	const config = buildEffectiveConfig(spec.config_snapshot, source);
+	const config = buildEffectiveConfig(spec.config_snapshot, source, workspaceDir);
 	const secrets = spec.secrets ?? {};
 
 	// The spec is the source of truth for everything else (config,
@@ -606,16 +627,9 @@ async function main() {
 
 	const shipper = makeLogShipper(apiBase, runId, token);
 
-	// `DD_WORKSPACE_DIR` is a test/ops seam — defaults to /workspace
-	// (the in-container path). Tests redirect this to a tmpdir so
-	// they don't touch the real /workspace.
-	const workspaceDir = process.env.DD_WORKSPACE_DIR || undefined;
-
 	let cwd;
 	try {
-		cwd = workspaceDir
-			? await provisionWorkspace(source, workspaceDir)
-			: await provisionWorkspace(source);
+		cwd = await provisionWorkspace(source, workspaceDir);
 	} catch (e) {
 		localLog('error', 'workspace provision failed', { err: String(e) });
 		shipper.add('stderr', `workspace provision failed: ${String(e)}`);

--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -42,6 +42,30 @@ import process from 'node:process';
 const WORKSPACE_DIR = '/workspace';
 const SPECS_SUBDIR = 'specs';
 const OUTPUT_SUBDIR = 'output';
+
+/**
+ * Project-secret keys that would clobber container-level env or
+ * fundamentally alter how Node / the doc-detective CLI executes if
+ * the platform let them through. The platform's secret-key validator
+ * only constrains key shape (`/^[A-Za-z_][A-Za-z0-9_]*$/`), so a user
+ * could create a secret named `PATH` or `NODE_OPTIONS` and have it
+ * override the container's value once we spread `secrets` into
+ * `childEnv`. Defense in depth: filter here at injection time and log
+ * the rejection so the run's logs make the source of the discrepancy
+ * obvious. The platform should also reject these names server-side;
+ * this list is the runner-side backstop.
+ */
+const SECRET_DENYLIST = new Set([
+	'PATH',
+	'HOME',
+	'NODE_OPTIONS',
+	'NODE_PATH',
+	'LD_PRELOAD',
+	'LD_LIBRARY_PATH',
+	'DOC_DETECTIVE_CONFIG',
+	'DOC_DETECTIVE_API',
+	'DOC_DETECTIVE_META'
+]);
 const LOG_BATCH_SIZE = 100;
 const LOG_FLUSH_INTERVAL_MS = 1000;
 // Per-line UTF-8 byte cap aligned with the platform's 64 KB validator.
@@ -251,7 +275,14 @@ function makeLogShipper(apiBase, runId, token) {
 		if (timer) return;
 		timer = setTimeout(() => {
 			timer = null;
-			flushNow();
+			// Errors are swallowed inside fireBatch and flushNow uses
+			// allSettled, so no rejection should escape today; the
+			// .catch is a belt-and-suspenders against future changes
+			// that might let one through and silently terminate the
+			// process with an unhandledRejection.
+			flushNow().catch((e) =>
+				localLog('warn', 'scheduled flush rejected', { err: String(e) })
+			);
 		}, LOG_FLUSH_INTERVAL_MS);
 	}
 
@@ -291,9 +322,14 @@ function makeLogShipper(apiBase, runId, token) {
  */
 function buildEffectiveConfig(configSnapshot, source) {
 	const effective = { ...(configSnapshot ?? {}) };
-	effective.output = path.join(WORKSPACE_DIR, OUTPUT_SUBDIR);
+	// posix.join: these paths land inside DOC_DETECTIVE_CONFIG and are
+	// interpreted by the doc-detective CLI inside the Linux container.
+	// Plain path.join would emit backslashes on Windows test runners
+	// and break the equality assertions, even though no Windows
+	// runtime ever sees this string.
+	effective.output = path.posix.join(WORKSPACE_DIR, OUTPUT_SUBDIR);
 	if (source.type === 'inline') {
-		effective.input = path.join(WORKSPACE_DIR, SPECS_SUBDIR);
+		effective.input = path.posix.join(WORKSPACE_DIR, SPECS_SUBDIR);
 	}
 	return effective;
 }
@@ -314,6 +350,16 @@ async function provisionWorkspace(source, workspaceDir = WORKSPACE_DIR) {
 	await mkdir(path.join(workspaceDir, OUTPUT_SUBDIR), { recursive: true });
 
 	if (source.type === 'github') {
+		// Required-field guards so a regression in the platform's spec
+		// shape surfaces as a clear error in run logs instead of an
+		// inscrutable `git clone --branch undefined` failure.
+		if (typeof source.repo !== 'string' || source.repo.length === 0) {
+			throw new Error('github source missing required field: repo');
+		}
+		if (typeof source.ref !== 'string' || source.ref.length === 0) {
+			throw new Error('github source missing required field: ref');
+		}
+
 		// Validate path_prefix *before* the clone so a malformed value
 		// fails fast without burning a network round-trip. Defense in
 		// depth: the platform-side validator already constrains
@@ -369,6 +415,24 @@ async function provisionWorkspace(source, workspaceDir = WORKSPACE_DIR) {
 }
 
 /**
+ * Drop project secrets whose key collides with a container-controlled
+ * env var. `onReject` is invoked once per dropped key — callers use it
+ * to surface the rejection in the run logs so the user can correct
+ * their project secrets.
+ */
+function filterSecrets(secrets, onReject) {
+	const out = {};
+	for (const [k, v] of Object.entries(secrets)) {
+		if (SECRET_DENYLIST.has(k)) {
+			if (onReject) onReject(k);
+			continue;
+		}
+		out[k] = v;
+	}
+	return out;
+}
+
+/**
  * POST /finalize. Best-effort — the caller decides whether a failure
  * here propagates to the process exit code.
  */
@@ -404,10 +468,27 @@ async function main() {
 	selfKill.unref();
 
 	let canceledBySignal = false;
-	process.on('SIGTERM', () => {
+	let childRunning = false;
+	const onPreSpawnSigterm = async () => {
 		canceledBySignal = true;
-		localLog('info', 'SIGTERM received');
-	});
+		localLog('info', 'SIGTERM received before child spawn; posting advisory cancel');
+		// Best-effort early-cancel finalize. The platform watchdog +
+		// cancel handler are still source of truth — this just helps
+		// the row land at `canceled` faster when SIGTERM arrives
+		// during fetchSpec / provisionWorkspace, before the child has
+		// even started. Once the child is running, runChild's own
+		// SIGTERM handler takes over and the post-spawn cleanup path
+		// covers finalize.
+		if (!childRunning) {
+			await postFinalize(apiBase, runId, token, {
+				status: 'canceled',
+				exit_code: 143,
+				summary: { reason: 'sigterm_pre_spawn' }
+			});
+			process.exit(143);
+		}
+	};
+	process.on('SIGTERM', onPreSpawnSigterm);
 
 	// Step 1: fetch spec.
 	const { canceled, spec } = await fetchSpec(apiBase, runId, token);
@@ -439,14 +520,24 @@ async function main() {
 	}
 
 	// Step 2: spawn doc-detective.
+	const safeSecrets = filterSecrets(secrets, (key) =>
+		shipper.add('stderr', `runner: dropping reserved env var "${key}" from project secrets`)
+	);
 	const childEnv = {
 		...process.env,
-		...secrets,
+		...safeSecrets,
 		DOC_DETECTIVE_CONFIG: JSON.stringify(config)
 	};
 	// Don't leak our bearer token into the child's env — the runner
 	// owns the platform conversation, not the test job.
 	delete childEnv.DD_RUN_TOKEN;
+
+	// Hand off SIGTERM ownership to runChild — its forwarder kills the
+	// child process; the post-spawn finalize logic below handles the
+	// advisory POST. Without removing the pre-spawn handler, both
+	// would fire and we'd race two finalize POSTs.
+	process.off('SIGTERM', onPreSpawnSigterm);
+	childRunning = true;
 
 	let exitCode;
 	try {
@@ -510,10 +601,12 @@ export {
 	apiCall,
 	buildEffectiveConfig,
 	fetchSpec,
+	filterSecrets,
 	main,
 	makeLogShipper,
 	postFinalize,
 	provisionWorkspace,
 	readRequiredEnv,
+	SECRET_DENYLIST,
 	sliceLogLine
 };

--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -479,14 +479,19 @@ async function main() {
 		// even started. Once the child is running, runChild's own
 		// SIGTERM handler takes over and the post-spawn cleanup path
 		// covers finalize.
-		if (!childRunning) {
-			await postFinalize(apiBase, runId, token, {
-				status: 'canceled',
-				exit_code: 143,
-				summary: { reason: 'sigterm_pre_spawn' }
-			});
-			process.exit(143);
-		}
+		if (childRunning) return;
+		await postFinalize(apiBase, runId, token, {
+			status: 'canceled',
+			exit_code: 143,
+			summary: { reason: 'sigterm_pre_spawn' }
+		});
+		// Re-check after the await: main() may have raced past the
+		// process.off + childRunning=true sequence while we were on
+		// the network. Calling process.exit(143) at that point would
+		// orphan the just-spawned child. Yield to runChild's
+		// forwardTerm + post-spawn finalize instead.
+		if (childRunning) return;
+		process.exit(143);
 	};
 	process.on('SIGTERM', onPreSpawnSigterm);
 
@@ -529,7 +534,10 @@ async function main() {
 		DOC_DETECTIVE_CONFIG: JSON.stringify(config)
 	};
 	// Don't leak our bearer token into the child's env — the runner
-	// owns the platform conversation, not the test job.
+	// owns the platform conversation, not the test job. DD_RUN_ID and
+	// DD_API_BASE stay in the child's env intentionally: they're
+	// non-sensitive identifiers and a future doc-detective release
+	// may want them for diagnostics or reporter hooks.
 	delete childEnv.DD_RUN_TOKEN;
 
 	// Hand off SIGTERM ownership to runChild — its forwarder kills the

--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -1,0 +1,492 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Doc Detective platform runner entrypoint.
+ *
+ * The doc-detective.com platform launches Fly.io machines that boot
+ * this script as PID 1. The script orchestrates a single run end-to-end:
+ *
+ *   1. read DD_RUN_TOKEN / DD_API_BASE / DD_RUN_ID from env
+ *   2. GET  {api}/api/runs/{id}/spec  → fetch config + source + secrets
+ *   3. provision /workspace from the source_snapshot (github clone or
+ *      inline-spec write-out)
+ *   4. spawn the local `doc-detective` CLI with the merged config in
+ *      DOC_DETECTIVE_CONFIG and project secrets in env
+ *   5. tee child stdout/stderr to the platform via batched
+ *      POST /api/runs/{id}/logs
+ *   6. POST /api/runs/{id}/finalize { status, exit_code, summary }
+ *
+ * Belt-and-suspenders: a process-level setTimeout fires
+ * `process.exit(124)` at DD_TIMEOUT_SECONDS so a runner that loses
+ * connectivity to the API still self-terminates. The platform watchdog
+ * is the authoritative timeout — this is just a local guard.
+ *
+ * SIGTERM (Fly destroy on user-cancel or watchdog stop): best-effort
+ * POST a `canceled` finalize, then exit. The server is the source of
+ * truth — finalize on SIGTERM is advisory.
+ *
+ * Artifact upload (saveScreenshot, recordVideo, html report, …) is
+ * deliberately out of scope for this iteration; the entrypoint
+ * finalizes with an empty artifacts list. A follow-up will walk
+ * config.output and POST signed-upload requests.
+ *
+ * No third-party deps — only Node built-ins. The image already ships
+ * doc-detective globally; we don't add to its install footprint.
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const WORKSPACE_DIR = '/workspace';
+const SPECS_SUBDIR = 'specs';
+const OUTPUT_SUBDIR = 'output';
+const LOG_BATCH_SIZE = 100;
+const LOG_FLUSH_INTERVAL_MS = 1000;
+// Per-line UTF-8 byte cap aligned with the platform's 64 KB validator.
+// Anything longer is sliced into 60 KB chunks (4 KB headroom for
+// non-ASCII expansion when the slice falls mid-codepoint).
+const LOG_LINE_BYTE_LIMIT = 60 * 1024;
+
+/**
+ * Tiny structured logger — writes a JSON line to the *real* stderr so
+ * it lands in Fly's machine logs even when our own log forwarder is
+ * down. Distinct from the captured-and-forwarded child stdout/stderr.
+ */
+function localLog(level, msg, extra) {
+	const line = { ts: new Date().toISOString(), level, msg, ...(extra ?? {}) };
+	process.stderr.write(JSON.stringify(line) + '\n');
+}
+
+function readRequiredEnv(name) {
+	const v = process.env[name];
+	if (!v || v.length === 0) {
+		throw new Error(`Missing required env var: ${name}`);
+	}
+	return v;
+}
+
+/**
+ * Authenticated fetch against the platform API. Throws on non-2xx
+ * (other than the explicitly-allowed status codes); returns the raw
+ * Response so callers can choose to read JSON or treat as fire-and-forget.
+ */
+async function apiCall(method, url, token, body, allowedStatuses = []) {
+	const headers = { authorization: `Bearer ${token}` };
+	if (body !== undefined) headers['content-type'] = 'application/json';
+	const res = await fetch(url, {
+		method,
+		headers,
+		body: body === undefined ? undefined : JSON.stringify(body)
+	});
+	if (!res.ok && !allowedStatuses.includes(res.status)) {
+		const text = await res.text().catch(() => '');
+		throw new Error(`${method} ${url} failed: ${res.status} ${res.statusText} ${text}`);
+	}
+	return res;
+}
+
+/**
+ * Fetch the spec from the platform. The handler returns 410 Gone if
+ * the run was canceled before the runner first connected — we treat
+ * that as a clean no-op exit. Anything else 4xx/5xx is fatal.
+ */
+async function fetchSpec(apiBase, runId, token) {
+	const url = `${apiBase}/api/runs/${encodeURIComponent(runId)}/spec`;
+	const res = await apiCall('GET', url, token, undefined, [410]);
+	if (res.status === 410) {
+		return { canceled: true };
+	}
+	const spec = await res.json();
+	return { canceled: false, spec };
+}
+
+/**
+ * Run a child process to completion, returning its exit code. Stdout
+ * and stderr are streamed to `onLine(stream, payload)`.
+ */
+function runChild(cmd, args, opts, onLine) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(cmd, args, {
+			cwd: opts.cwd,
+			env: opts.env,
+			// Parent receives stdout/stderr as pipes so we can intercept;
+			// stdin is /dev/null since doc-detective doesn't read from it.
+			stdio: ['ignore', 'pipe', 'pipe']
+		});
+
+		// Track a SIGTERM handler that forwards the signal so cancel
+		// propagates to the child instead of orphaning it.
+		const forwardTerm = () => {
+			try {
+				child.kill('SIGTERM');
+			} catch {
+				// child may have already exited
+			}
+		};
+		process.on('SIGTERM', forwardTerm);
+
+		const lineBuffer = { stdout: '', stderr: '' };
+		function attach(stream, name) {
+			stream.setEncoding('utf8');
+			stream.on('data', (chunk) => {
+				lineBuffer[name] += chunk;
+				let idx;
+				while ((idx = lineBuffer[name].indexOf('\n')) !== -1) {
+					const line = lineBuffer[name].slice(0, idx);
+					lineBuffer[name] = lineBuffer[name].slice(idx + 1);
+					if (line.length > 0) onLine(name, line);
+				}
+			});
+			stream.on('end', () => {
+				if (lineBuffer[name].length > 0) {
+					onLine(name, lineBuffer[name]);
+					lineBuffer[name] = '';
+				}
+			});
+		}
+		attach(child.stdout, 'stdout');
+		attach(child.stderr, 'stderr');
+
+		child.on('error', (err) => {
+			process.off('SIGTERM', forwardTerm);
+			reject(err);
+		});
+		child.on('exit', (code, signal) => {
+			process.off('SIGTERM', forwardTerm);
+			// Node's exit-code conventions: when terminated by signal, code
+			// is null and the canonical exit is 128 + signal-number. We
+			// don't map every signal — SIGTERM (15) is the one we forward.
+			if (code !== null) resolve(code);
+			else if (signal === 'SIGTERM') resolve(143);
+			else resolve(1);
+		});
+	});
+}
+
+/**
+ * Slice an oversize line into chunks at LOG_LINE_BYTE_LIMIT bytes so
+ * the platform's 64 KB-per-line cap doesn't bounce the whole batch.
+ */
+function sliceLogLine(payload) {
+	const enc = new TextEncoder();
+	const dec = new TextDecoder('utf-8');
+	const bytes = enc.encode(payload);
+	if (bytes.byteLength <= LOG_LINE_BYTE_LIMIT) return [payload];
+	const out = [];
+	for (let i = 0; i < bytes.byteLength; i += LOG_LINE_BYTE_LIMIT) {
+		// Slice on byte boundaries; mid-codepoint fragments are stitched
+		// back together at the next slice. TextDecoder's stream:false
+		// behavior replaces orphan bytes with U+FFFD — acceptable for
+		// log preservation since the platform already accepts the data
+		// as opaque text and the next slice will start clean.
+		const slice = bytes.subarray(i, Math.min(i + LOG_LINE_BYTE_LIMIT, bytes.byteLength));
+		out.push(dec.decode(slice));
+	}
+	return out;
+}
+
+/**
+ * Buffered log shipper. Lines accumulate in memory; we flush when the
+ * batch hits LOG_BATCH_SIZE or LOG_FLUSH_INTERVAL_MS elapses, whichever
+ * comes first.
+ *
+ * `add()` is synchronous (callers don't await per-line work); when a
+ * batch trips LOG_BATCH_SIZE the POST fires-and-forgets but the
+ * promise lands in the `pending` set so `flush()` is a true
+ * "everything is posted" gate. Without that, callers awaiting
+ * `flush()` after an auto-flush could see an empty buffer and resolve
+ * before the in-flight POST completed — losing logs at finalize time.
+ */
+function makeLogShipper(apiBase, runId, token) {
+	const buffer = [];
+	const pending = new Set();
+	let timer = null;
+
+	function fireBatch(lines) {
+		const p = (async () => {
+			try {
+				await apiCall(
+					'POST',
+					`${apiBase}/api/runs/${encodeURIComponent(runId)}/logs`,
+					token,
+					{ lines }
+				);
+			} catch (e) {
+				// Don't fail the run for transient log-ship failures. The
+				// run remains correct from the user's perspective; logs may
+				// be incomplete. Surface to the local stderr so the Fly
+				// machine log captures the drop.
+				localLog('warn', 'log ship failed', { err: String(e) });
+			} finally {
+				pending.delete(p);
+			}
+		})();
+		pending.add(p);
+		return p;
+	}
+
+	async function flushNow() {
+		if (timer) {
+			clearTimeout(timer);
+			timer = null;
+		}
+		if (buffer.length > 0) {
+			fireBatch(buffer.splice(0, buffer.length));
+		}
+		// Wait for *all* in-flight POSTs (this batch's plus any that were
+		// fired by an earlier auto-flush). allSettled because individual
+		// failures are already swallowed inside fireBatch — no rejection
+		// can escape — but allSettled is the principled choice if that
+		// ever changes.
+		if (pending.size > 0) {
+			await Promise.allSettled(Array.from(pending));
+		}
+	}
+
+	function schedule() {
+		if (timer) return;
+		timer = setTimeout(() => {
+			timer = null;
+			flushNow();
+		}, LOG_FLUSH_INTERVAL_MS);
+	}
+
+	return {
+		add(stream, payload) {
+			const ts = new Date().toISOString();
+			for (const slice of sliceLogLine(payload)) {
+				buffer.push({ ts, stream, payload: slice });
+				if (buffer.length >= LOG_BATCH_SIZE) {
+					fireBatch(buffer.splice(0, buffer.length));
+					return;
+				}
+			}
+			schedule();
+		},
+		flush: flushNow
+	};
+}
+
+/**
+ * Build the effective config_v3 to pass via DOC_DETECTIVE_CONFIG.
+ *
+ * Platform-controlled overrides (clobber whatever the user committed):
+ *   * `output` → /workspace/output (predictable artifact root for the
+ *     planned upload step + keeps the user's relative paths from
+ *     escaping the workspace)
+ *   * `input`  → /workspace/specs (only for inline specs; for github
+ *     sources we leave the user's `input` alone so their committed
+ *     paths resolve from the cloned repo cwd)
+ */
+function buildEffectiveConfig(configSnapshot, source) {
+	const effective = { ...(configSnapshot ?? {}) };
+	effective.output = path.join(WORKSPACE_DIR, OUTPUT_SUBDIR);
+	if (source.type === 'inline') {
+		effective.input = path.join(WORKSPACE_DIR, SPECS_SUBDIR);
+	}
+	return effective;
+}
+
+/**
+ * Provision the workspace dir based on source_snapshot. Returns the
+ * cwd the doc-detective CLI should run from.
+ *
+ * `workspaceDir` defaults to /workspace (the in-container path). Tests
+ * pass a tmpdir so they don't touch the real /workspace.
+ */
+async function provisionWorkspace(source, workspaceDir = WORKSPACE_DIR) {
+	// Wipe any prior state — the machine is fresh, but a retry of this
+	// script (e.g. a runner-internal restart) would otherwise inherit
+	// stale clones.
+	await rm(workspaceDir, { recursive: true, force: true });
+	await mkdir(workspaceDir, { recursive: true });
+	await mkdir(path.join(workspaceDir, OUTPUT_SUBDIR), { recursive: true });
+
+	if (source.type === 'github') {
+		// Shallow public clone. Auth-required GitHub repos are out of
+		// scope here — the platform UI requires the user to point at a
+		// public repo or commit secrets via the project secrets layer.
+		const repoUrl = `https://github.com/${source.repo}.git`;
+		const args = ['clone', '--depth=1', '--branch', source.ref, '--', repoUrl, workspaceDir];
+		const code = await new Promise((resolve, reject) => {
+			const child = spawn('git', args, {
+				cwd: '/',
+				env: process.env,
+				stdio: ['ignore', 'inherit', 'inherit']
+			});
+			child.on('error', reject);
+			child.on('exit', (c) => resolve(c ?? 1));
+		});
+		if (code !== 0) {
+			throw new Error(`git clone failed (exit ${code}) for ${source.repo}@${source.ref}`);
+		}
+		const cwd =
+			source.path_prefix && source.path_prefix.length > 0
+				? path.join(workspaceDir, source.path_prefix)
+				: workspaceDir;
+		return cwd;
+	}
+
+	if (source.type === 'inline') {
+		const specsDir = path.join(workspaceDir, SPECS_SUBDIR);
+		await mkdir(specsDir, { recursive: true });
+		const specs = Array.isArray(source.specs) ? source.specs : [];
+		for (let i = 0; i < specs.length; i++) {
+			const file = path.join(specsDir, `spec-${String(i).padStart(4, '0')}.json`);
+			await writeFile(file, JSON.stringify(specs[i], null, 2), 'utf8');
+		}
+		return workspaceDir;
+	}
+
+	throw new Error(`Unsupported source type: ${String(/** @type {any} */ (source).type)}`);
+}
+
+/**
+ * POST /finalize. Best-effort — the caller decides whether a failure
+ * here propagates to the process exit code.
+ */
+async function postFinalize(apiBase, runId, token, body) {
+	try {
+		await apiCall('POST', `${apiBase}/api/runs/${encodeURIComponent(runId)}/finalize`, token, body);
+		return true;
+	} catch (e) {
+		localLog('warn', 'finalize failed', { err: String(e) });
+		return false;
+	}
+}
+
+async function main() {
+	const apiBase = readRequiredEnv('DD_API_BASE').replace(/\/+$/, '');
+	const runId = readRequiredEnv('DD_RUN_ID');
+	const token = readRequiredEnv('DD_RUN_TOKEN');
+	const timeoutSeconds = Number(process.env.DD_TIMEOUT_SECONDS ?? '1800');
+
+	// Belt-and-suspenders self-kill. Authoritative timeout is the
+	// platform watchdog; this just guarantees a runner that has lost
+	// API connectivity stops burning compute eventually.
+	const selfKill = setTimeout(
+		() => {
+			localLog('warn', 'self-kill timeout exceeded', { timeoutSeconds });
+			process.exit(124);
+		},
+		Math.max(1, timeoutSeconds) * 1000
+	);
+	// .unref() — the timer alone shouldn't keep the event loop alive.
+	selfKill.unref();
+
+	let canceledBySignal = false;
+	process.on('SIGTERM', () => {
+		canceledBySignal = true;
+		localLog('info', 'SIGTERM received');
+	});
+
+	// Step 1: fetch spec.
+	const { canceled, spec } = await fetchSpec(apiBase, runId, token);
+	if (canceled) {
+		localLog('info', 'run canceled before spec fetch (410); exiting cleanly');
+		// Nothing to finalize — the row is already terminal on the server.
+		return 0;
+	}
+
+	const source = spec.source_snapshot ?? { type: 'inline', specs: [] };
+	const config = buildEffectiveConfig(spec.config_snapshot, source);
+	const secrets = spec.secrets ?? {};
+
+	const shipper = makeLogShipper(apiBase, runId, token);
+
+	let cwd;
+	try {
+		cwd = await provisionWorkspace(source);
+	} catch (e) {
+		localLog('error', 'workspace provision failed', { err: String(e) });
+		shipper.add('stderr', `workspace provision failed: ${String(e)}`);
+		await shipper.flush();
+		await postFinalize(apiBase, runId, token, {
+			status: 'failed',
+			exit_code: 1,
+			summary: { reason: 'workspace_provision_failed', error: String(e) }
+		});
+		return 1;
+	}
+
+	// Step 2: spawn doc-detective.
+	const childEnv = {
+		...process.env,
+		...secrets,
+		DOC_DETECTIVE_CONFIG: JSON.stringify(config)
+	};
+	// Don't leak our bearer token into the child's env — the runner
+	// owns the platform conversation, not the test job.
+	delete childEnv.DD_RUN_TOKEN;
+
+	let exitCode;
+	try {
+		exitCode = await runChild('doc-detective', [], { cwd, env: childEnv }, (stream, line) =>
+			shipper.add(stream, line)
+		);
+	} catch (e) {
+		localLog('error', 'child spawn failed', { err: String(e) });
+		shipper.add('stderr', `failed to spawn doc-detective: ${String(e)}`);
+		await shipper.flush();
+		await postFinalize(apiBase, runId, token, {
+			status: 'failed',
+			exit_code: 1,
+			summary: { reason: 'spawn_failed', error: String(e) }
+		});
+		return 1;
+	}
+
+	// Drain any buffered logs before finalizing — the finalize handler
+	// deletes the run_token, so a late /logs POST after finalize 401s.
+	await shipper.flush();
+
+	// Map exit code → finalize status. SIGTERM (143) signals cancel;
+	// the watchdog or cancel handler is the source of truth, but our
+	// best-effort POST helps the row land at `canceled` faster.
+	let finalizeBody;
+	if (canceledBySignal || exitCode === 143) {
+		finalizeBody = {
+			status: 'canceled',
+			exit_code: exitCode,
+			summary: { reason: 'sigterm' }
+		};
+	} else if (exitCode === 0) {
+		finalizeBody = { status: 'succeeded', exit_code: 0, summary: {} };
+	} else {
+		finalizeBody = {
+			status: 'failed',
+			exit_code: exitCode,
+			summary: { reason: 'nonzero_exit' }
+		};
+	}
+	await postFinalize(apiBase, runId, token, finalizeBody);
+	return exitCode;
+}
+
+// Module-import guard so the test file can `import` from this module
+// without triggering main(). Node's `import.meta.url === ...` idiom
+// for "am I the entrypoint?" — works under both `node` and `tsx` and
+// doesn't require require.main.
+const isEntry = import.meta.url === `file://${process.argv[1]}`;
+if (isEntry) {
+	main()
+		.then((code) => process.exit(code))
+		.catch((err) => {
+			localLog('fatal', 'entrypoint crashed', { err: String(err?.stack ?? err) });
+			process.exit(1);
+		});
+}
+
+export {
+	apiCall,
+	buildEffectiveConfig,
+	fetchSpec,
+	main,
+	makeLogShipper,
+	postFinalize,
+	provisionWorkspace,
+	readRequiredEnv,
+	sliceLogLine
+};

--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -176,11 +176,13 @@ function sliceLogLine(payload) {
 	if (bytes.byteLength <= LOG_LINE_BYTE_LIMIT) return [payload];
 	const out = [];
 	for (let i = 0; i < bytes.byteLength; i += LOG_LINE_BYTE_LIMIT) {
-		// Slice on byte boundaries; mid-codepoint fragments are stitched
-		// back together at the next slice. TextDecoder's stream:false
-		// behavior replaces orphan bytes with U+FFFD — acceptable for
-		// log preservation since the platform already accepts the data
-		// as opaque text and the next slice will start clean.
+		// Slice on byte boundaries. TextDecoder's default `stream: false`
+		// replaces incomplete multi-byte sequences at the slice edge
+		// with U+FFFD — the fragment is *not* stitched back together
+		// from the next slice. Acceptable for log preservation: the
+		// platform accepts the data as opaque text, and rare
+		// multi-byte boundaries on a 60 KB cliff are noise compared
+		// to the value of preserving the rest of the line.
 		const slice = bytes.subarray(i, Math.min(i + LOG_LINE_BYTE_LIMIT, bytes.byteLength));
 		out.push(dec.decode(slice));
 	}
@@ -259,11 +261,18 @@ function makeLogShipper(apiBase, runId, token) {
 			for (const slice of sliceLogLine(payload)) {
 				buffer.push({ ts, stream, payload: slice });
 				if (buffer.length >= LOG_BATCH_SIZE) {
+					// Auto-flush — but keep iterating: an oversize line that
+					// produced N slices must still get its remaining N-1
+					// slices into the next batch. An earlier draft of this
+					// function `return`ed here and silently dropped the
+					// tail.
 					fireBatch(buffer.splice(0, buffer.length));
-					return;
 				}
 			}
-			schedule();
+			// Only schedule a timed flush if there's actually something
+			// to flush — guards against a wasted setTimeout cycle when
+			// the loop's last slice was the one that auto-flushed.
+			if (buffer.length > 0) schedule();
 		},
 		flush: flushNow
 	};
@@ -305,6 +314,26 @@ async function provisionWorkspace(source, workspaceDir = WORKSPACE_DIR) {
 	await mkdir(path.join(workspaceDir, OUTPUT_SUBDIR), { recursive: true });
 
 	if (source.type === 'github') {
+		// Validate path_prefix *before* the clone so a malformed value
+		// fails fast without burning a network round-trip. Defense in
+		// depth: the platform-side validator already constrains
+		// path_prefix at project-create time, but a `../etc` would
+		// still traverse out via path.join. path.resolve normalizes
+		// ".." segments and treats absolute path_prefix as an
+		// override; we reject anything that lands outside workspaceDir
+		// (or equals it, which is the no-prefix base case).
+		let cwd = workspaceDir;
+		if (source.path_prefix && source.path_prefix.length > 0) {
+			const resolved = path.resolve(workspaceDir, source.path_prefix);
+			const wsWithSep = workspaceDir.endsWith(path.sep)
+				? workspaceDir
+				: workspaceDir + path.sep;
+			if (resolved !== workspaceDir && !resolved.startsWith(wsWithSep)) {
+				throw new Error(`path_prefix escapes workspace: ${source.path_prefix}`);
+			}
+			cwd = resolved;
+		}
+
 		// Shallow public clone. Auth-required GitHub repos are out of
 		// scope here — the platform UI requires the user to point at a
 		// public repo or commit secrets via the project secrets layer.
@@ -322,10 +351,6 @@ async function provisionWorkspace(source, workspaceDir = WORKSPACE_DIR) {
 		if (code !== 0) {
 			throw new Error(`git clone failed (exit ${code}) for ${source.repo}@${source.ref}`);
 		}
-		const cwd =
-			source.path_prefix && source.path_prefix.length > 0
-				? path.join(workspaceDir, source.path_prefix)
-				: workspaceDir;
 		return cwd;
 	}
 
@@ -361,18 +386,20 @@ async function main() {
 	const apiBase = readRequiredEnv('DD_API_BASE').replace(/\/+$/, '');
 	const runId = readRequiredEnv('DD_RUN_ID');
 	const token = readRequiredEnv('DD_RUN_TOKEN');
-	const timeoutSeconds = Number(process.env.DD_TIMEOUT_SECONDS ?? '1800');
+	// Reject NaN / non-finite / non-positive values so a bad
+	// DD_TIMEOUT_SECONDS env (e.g. an unset-but-quoted-empty-string,
+	// or a typo) doesn't fire setTimeout(NaN) — which fires
+	// immediately and self-kills the runner before /spec lands.
+	const rawTimeout = Number(process.env.DD_TIMEOUT_SECONDS);
+	const timeoutSeconds = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 1800;
 
 	// Belt-and-suspenders self-kill. Authoritative timeout is the
 	// platform watchdog; this just guarantees a runner that has lost
 	// API connectivity stops burning compute eventually.
-	const selfKill = setTimeout(
-		() => {
-			localLog('warn', 'self-kill timeout exceeded', { timeoutSeconds });
-			process.exit(124);
-		},
-		Math.max(1, timeoutSeconds) * 1000
-	);
+	const selfKill = setTimeout(() => {
+		localLog('warn', 'self-kill timeout exceeded', { timeoutSeconds });
+		process.exit(124);
+	}, timeoutSeconds * 1000);
 	// .unref() — the timer alone shouldn't keep the event loop alive.
 	selfKill.unref();
 

--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -419,6 +419,32 @@ function buildEffectiveConfig(configSnapshot, source, workspaceDir = WORKSPACE_D
  * `workspaceDir` defaults to /workspace (the in-container path). Tests
  * pass a tmpdir so they don't touch the real /workspace.
  */
+/**
+ * Resolve `pathPrefix` against `workspaceDir` and reject values that
+ * traverse out of the workspace (e.g. "../etc"). Pure — no fs / spawn
+ * — so it's directly unit-testable without invoking git.
+ *
+ * Defense in depth: the platform-side validator already constrains
+ * path_prefix at project-create time, but a `../etc` would still
+ * traverse via path.join. path.resolve normalizes ".." segments and
+ * treats absolute path_prefix as an override; we reject anything
+ * that lands outside workspaceDir (or equals it, which is the
+ * no-prefix base case).
+ *
+ * Returns the resolved path on success; throws on traversal.
+ */
+function resolvePathPrefix(workspaceDir, pathPrefix) {
+	if (!pathPrefix || pathPrefix.length === 0) return workspaceDir;
+	const resolved = path.resolve(workspaceDir, pathPrefix);
+	const wsWithSep = workspaceDir.endsWith(path.sep)
+		? workspaceDir
+		: workspaceDir + path.sep;
+	if (resolved !== workspaceDir && !resolved.startsWith(wsWithSep)) {
+		throw new Error(`path_prefix escapes workspace: ${pathPrefix}`);
+	}
+	return resolved;
+}
+
 async function provisionWorkspace(source, workspaceDir = WORKSPACE_DIR) {
 	// Wipe any prior state — the machine is fresh, but a retry of this
 	// script (e.g. a runner-internal restart) would otherwise inherit
@@ -437,24 +463,8 @@ async function provisionWorkspace(source, workspaceDir = WORKSPACE_DIR) {
 		}
 
 		// Validate path_prefix *before* the clone so a malformed value
-		// fails fast without burning a network round-trip. Defense in
-		// depth: the platform-side validator already constrains
-		// path_prefix at project-create time, but a `../etc` would
-		// still traverse out via path.join. path.resolve normalizes
-		// ".." segments and treats absolute path_prefix as an
-		// override; we reject anything that lands outside workspaceDir
-		// (or equals it, which is the no-prefix base case).
-		let cwd = workspaceDir;
-		if (source.path_prefix && source.path_prefix.length > 0) {
-			const resolved = path.resolve(workspaceDir, source.path_prefix);
-			const wsWithSep = workspaceDir.endsWith(path.sep)
-				? workspaceDir
-				: workspaceDir + path.sep;
-			if (resolved !== workspaceDir && !resolved.startsWith(wsWithSep)) {
-				throw new Error(`path_prefix escapes workspace: ${source.path_prefix}`);
-			}
-			cwd = resolved;
-		}
+		// fails fast without burning a network round-trip.
+		const cwd = resolvePathPrefix(workspaceDir, source.path_prefix);
 
 		// Shallow public clone. Auth-required GitHub repos are out of
 		// scope here — the platform UI requires the user to point at a
@@ -740,6 +750,7 @@ export {
 	postFinalize,
 	provisionWorkspace,
 	readRequiredEnv,
+	resolvePathPrefix,
 	runChild,
 	SECRET_DENYLIST,
 	sliceLogLine

--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -413,13 +413,6 @@ function buildEffectiveConfig(configSnapshot, source, workspaceDir = WORKSPACE_D
 }
 
 /**
- * Provision the workspace dir based on source_snapshot. Returns the
- * cwd the doc-detective CLI should run from.
- *
- * `workspaceDir` defaults to /workspace (the in-container path). Tests
- * pass a tmpdir so they don't touch the real /workspace.
- */
-/**
  * Resolve `pathPrefix` against `workspaceDir` and reject values that
  * traverse out of the workspace (e.g. "../etc"). Pure — no fs / spawn
  * — so it's directly unit-testable without invoking git.
@@ -445,6 +438,13 @@ function resolvePathPrefix(workspaceDir, pathPrefix) {
 	return resolved;
 }
 
+/**
+ * Provision the workspace dir based on source_snapshot. Returns the
+ * cwd the doc-detective CLI should run from.
+ *
+ * `workspaceDir` defaults to /workspace (the in-container path). Tests
+ * pass a tmpdir so they don't touch the real /workspace.
+ */
 async function provisionWorkspace(source, workspaceDir = WORKSPACE_DIR) {
 	// Wipe any prior state — the machine is fresh, but a retry of this
 	// script (e.g. a runner-internal restart) would otherwise inherit

--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -72,6 +72,16 @@ const LOG_FLUSH_INTERVAL_MS = 1000;
 // Anything longer is sliced into 60 KB chunks (4 KB headroom for
 // non-ASCII expansion when the slice falls mid-codepoint).
 const LOG_LINE_BYTE_LIMIT = 60 * 1024;
+// Cap on concurrently-pending /logs POSTs. With LOG_BATCH_SIZE=100 and
+// LOG_LINE_BYTE_LIMIT=60 KB, each pending batch retains ~6 MB. 8
+// pending = ~48 MB worst case — bounded enough to stay well under
+// any realistic Fly machine memory cap even when the platform API
+// stalls. Past the cap we load-shed: drop the new batch with a warn
+// log rather than backpressure (which would block the synchronous
+// `add()` callers — the child process's stdout/stderr `data`
+// handlers — and surface as a runaway memory accumulation in the
+// stream's internal buffer instead).
+const LOG_MAX_PENDING_BATCHES = 8;
 
 /**
  * Tiny structured logger — writes a JSON line to the *real* stderr so
@@ -91,19 +101,45 @@ function readRequiredEnv(name) {
 	return v;
 }
 
+/** Default per-call fetch budget. The platform watchdog is the
+ * authoritative timeout for the run as a whole; this just keeps a
+ * single hung request from holding everything else hostage. */
+const API_CALL_TIMEOUT_MS = 30_000;
+/** Slightly longer budget for /finalize so it has a chance to land
+ * even when the platform is under load — finalize is the
+ * acknowledgment that lets the row leave its terminal-but-stuck
+ * state on time, so it gets priority over /logs. */
+const API_FINALIZE_TIMEOUT_MS = 60_000;
+
 /**
  * Authenticated fetch against the platform API. Throws on non-2xx
  * (other than the explicitly-allowed status codes); returns the raw
  * Response so callers can choose to read JSON or treat as fire-and-forget.
+ *
+ * `timeoutMs` aborts the request if the platform blackholes (TCP
+ * accept, no response). Without it a hung POST holds the runner open
+ * until the global self-kill fires (default 30 minutes). Defaults to
+ * 30s; finalize callers pass a longer budget.
  */
-async function apiCall(method, url, token, body, allowedStatuses = []) {
+async function apiCall(method, url, token, body, allowedStatuses = [], timeoutMs = API_CALL_TIMEOUT_MS) {
 	const headers = { authorization: `Bearer ${token}` };
 	if (body !== undefined) headers['content-type'] = 'application/json';
-	const res = await fetch(url, {
-		method,
-		headers,
-		body: body === undefined ? undefined : JSON.stringify(body)
-	});
+	let res;
+	try {
+		res = await fetch(url, {
+			method,
+			headers,
+			body: body === undefined ? undefined : JSON.stringify(body),
+			signal: AbortSignal.timeout(timeoutMs)
+		});
+	} catch (e) {
+		// AbortSignal.timeout fires a TimeoutError; surface that with the
+		// URL + budget so logs make the cause obvious.
+		if (e && e.name === 'TimeoutError') {
+			throw new Error(`${method} ${url} timed out after ${timeoutMs}ms`);
+		}
+		throw e;
+	}
 	if (!res.ok && !allowedStatuses.includes(res.status)) {
 		const text = await res.text().catch(() => '');
 		throw new Error(`${method} ${url} failed: ${res.status} ${res.statusText} ${text}`);
@@ -228,9 +264,38 @@ function sliceLogLine(payload) {
 function makeLogShipper(apiBase, runId, token) {
 	const buffer = [];
 	const pending = new Set();
+	let dropped = 0;
 	let timer = null;
 
 	function fireBatch(lines) {
+		// Load-shed: if too many POSTs are already in flight (platform
+		// API blackholing, slow network), drop the new batch and bump
+		// a counter. Without this cap, `add()` continues to enqueue
+		// indefinitely and pending grows unbounded — each retained
+		// batch holds ~6 MB so a sustained outage OOM-kills the
+		// machine. The lost log lines are noted in localLog (Fly
+		// machine log) and a single summary stderr breadcrumb so the
+		// run's own log stream tells the user something went missing.
+		if (pending.size >= LOG_MAX_PENDING_BATCHES) {
+			if (dropped === 0) {
+				// First-drop breadcrumb. Subsequent drops are silent on
+				// stderr (lest we DOS the run's own log stream), but
+				// each one bumps the counter for finalize-time visibility.
+				try {
+					process.stderr.write(
+						`runner: /logs backlog at cap (${LOG_MAX_PENDING_BATCHES} pending); dropping batches until pressure clears\n`
+					);
+				} catch {
+					// stderr write can throw if the stream is gone; harmless.
+				}
+			}
+			dropped += lines.length;
+			localLog('warn', 'log batch shed under backpressure', {
+				pending: pending.size,
+				droppedSoFar: dropped
+			});
+			return Promise.resolve();
+		}
 		const p = (async () => {
 			try {
 				await apiCall(
@@ -447,7 +512,14 @@ function filterSecrets(secrets, onReject) {
  */
 async function postFinalize(apiBase, runId, token, body) {
 	try {
-		await apiCall('POST', `${apiBase}/api/runs/${encodeURIComponent(runId)}/finalize`, token, body);
+		await apiCall(
+			'POST',
+			`${apiBase}/api/runs/${encodeURIComponent(runId)}/finalize`,
+			token,
+			body,
+			[],
+			API_FINALIZE_TIMEOUT_MS
+		);
 		return true;
 	} catch (e) {
 		localLog('warn', 'finalize failed', { err: String(e) });
@@ -516,11 +588,34 @@ async function main() {
 	const config = buildEffectiveConfig(spec.config_snapshot, source);
 	const secrets = spec.secrets ?? {};
 
+	// The spec is the source of truth for everything else (config,
+	// source, secrets) — it should win for timeout too. Prefer the
+	// spec value, fall back to the env timeout we already set up
+	// (kept as a bootstrap so the pre-spec self-kill is non-NaN).
+	// Reset the self-kill timer to the spec's value so a project that
+	// asked for 60s isn't held open until the 1800s default fires.
+	const specTimeout = Number(spec.timeout_seconds);
+	if (Number.isFinite(specTimeout) && specTimeout > 0 && specTimeout !== timeoutSeconds) {
+		clearTimeout(selfKill);
+		const respec = setTimeout(() => {
+			localLog('warn', 'self-kill timeout exceeded', { timeoutSeconds: specTimeout });
+			process.exit(124);
+		}, specTimeout * 1000);
+		respec.unref();
+	}
+
 	const shipper = makeLogShipper(apiBase, runId, token);
+
+	// `DD_WORKSPACE_DIR` is a test/ops seam — defaults to /workspace
+	// (the in-container path). Tests redirect this to a tmpdir so
+	// they don't touch the real /workspace.
+	const workspaceDir = process.env.DD_WORKSPACE_DIR || undefined;
 
 	let cwd;
 	try {
-		cwd = await provisionWorkspace(source);
+		cwd = workspaceDir
+			? await provisionWorkspace(source, workspaceDir)
+			: await provisionWorkspace(source);
 	} catch (e) {
 		localLog('error', 'workspace provision failed', { err: String(e) });
 		shipper.add('stderr', `workspace provision failed: ${String(e)}`);
@@ -549,6 +644,13 @@ async function main() {
 	// may want them for diagnostics or reporter hooks.
 	delete childEnv.DD_RUN_TOKEN;
 
+	// `DD_RUNNER_CMD` is a test/ops seam — defaults to the canonical
+	// `doc-detective` binary, but tests override it to a fixture
+	// script and a future ops scenario could point it at a different
+	// CLI installation path. Not advertised; the runner's contract
+	// with users is `doc-detective`.
+	const runnerCmd = process.env.DD_RUNNER_CMD || 'doc-detective';
+
 	// Hand off SIGTERM ownership to runChild — its forwarder kills the
 	// child process; the post-spawn finalize logic below handles the
 	// advisory POST. Without removing the pre-spawn handler, both
@@ -558,7 +660,7 @@ async function main() {
 
 	let exitCode;
 	try {
-		exitCode = await runChild('doc-detective', [], { cwd, env: childEnv }, (stream, line) =>
+		exitCode = await runChild(runnerCmd, [], { cwd, env: childEnv }, (stream, line) =>
 			shipper.add(stream, line)
 		);
 	} catch (e) {
@@ -624,6 +726,7 @@ export {
 	postFinalize,
 	provisionWorkspace,
 	readRequiredEnv,
+	runChild,
 	SECRET_DENYLIST,
 	sliceLogLine
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "src/common"
   ],
   "bin": {
-    "doc-detective": "bin/doc-detective.js"
+    "doc-detective": "bin/doc-detective.js",
+    "doc-detective-runner": "bin/runner-entrypoint.js"
   },
   "type": "module",
   "files": [

--- a/src/container/linux.Dockerfile
+++ b/src/container/linux.Dockerfile
@@ -56,7 +56,11 @@ RUN node -v \
 # Create app directory
 WORKDIR /app
 
-# Add entrypoint command base
+# Default entrypoint runs the doc-detective CLI directly so `docker run`
+# users get the existing behavior. The doc-detective.com platform
+# overrides this to `doc-detective-runner` (also installed by
+# `npm install -g doc-detective`, see package.json `bin`) via the Fly
+# Machine `init.entrypoint` field.
 ENTRYPOINT [ "npx", "doc-detective" ]
 
 # Set default command

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -13,6 +13,7 @@ import {
   postFinalize,
   provisionWorkspace,
   readRequiredEnv,
+  resolvePathPrefix,
   runChild,
   SECRET_DENYLIST,
   sliceLogLine,
@@ -362,36 +363,47 @@ describe("runner-entrypoint: provisionWorkspace", () => {
     );
   });
 
-  it("rejects path_prefix that escapes the workspace via traversal", async () => {
-    // Defense-in-depth: even though the platform's project validator
-    // already constrains path_prefix, a regression that admitted "../"
-    // would let a malicious project root the runner's cwd outside
-    // /workspace. The guard rejects up-front.
-    //
-    // We can't actually exercise the github branch (no real clone in
-    // unit tests), but the guard sits inside the github branch — so we
-    // verify it indirectly by feeding a github-shaped source. The
-    // guard fires before git is invoked.
-    await assert.rejects(
-      provisionWorkspace(
-        { type: "github", repo: "x/y", ref: "main", path_prefix: "../etc" },
-        path.join(tmp, "ws-traverse")
-      ),
+  // Note: path_prefix validation is now covered by the
+  // `resolvePathPrefix` describe block below — pure-helper tests
+  // that don't have to invoke git. The previous version of this
+  // suite reached the guard via provisionWorkspace's github branch,
+  // which forced one test to make a live `git clone` call to assert
+  // the guard wasn't over-eager. The pure-helper extraction lets us
+  // assert traversal/no-traversal directly.
+});
+
+describe("runner-entrypoint: resolvePathPrefix", () => {
+  it("returns workspaceDir unchanged when path_prefix is absent", () => {
+    assert.equal(resolvePathPrefix("/workspace"), "/workspace");
+    assert.equal(resolvePathPrefix("/workspace", ""), "/workspace");
+    assert.equal(resolvePathPrefix("/workspace", undefined), "/workspace");
+  });
+
+  it("joins a normal in-workspace prefix", () => {
+    assert.equal(resolvePathPrefix("/workspace", "docs"), "/workspace/docs");
+    assert.equal(
+      resolvePathPrefix("/workspace", "subdir/nested"),
+      "/workspace/subdir/nested"
+    );
+  });
+
+  it("rejects a traversal that escapes the workspace via ..", () => {
+    assert.throws(
+      () => resolvePathPrefix("/workspace", "../etc"),
+      /escapes workspace/
+    );
+    assert.throws(
+      () => resolvePathPrefix("/workspace", "subdir/../../escape"),
       /escapes workspace/
     );
   });
 
-  it("accepts an in-workspace path_prefix on github sources", async () => {
-    // Confirms the guard isn't over-eager: a normal subdirectory
-    // path_prefix should pass. We can't run git clone, so the guard
-    // resolves first, then the test fails at the actual `git` call.
-    // We assert the failure is the git-clone failure, not the guard.
-    await assert.rejects(
-      provisionWorkspace(
-        { type: "github", repo: "x/y", ref: "main", path_prefix: "docs" },
-        path.join(tmp, "ws-ok-prefix")
-      ),
-      /git clone failed/
+  it("rejects an absolute prefix that path.resolve would otherwise honor as an override", () => {
+    // path.resolve('/workspace', '/etc') === '/etc' — without the
+    // guard this would silently let the user point cwd at /etc.
+    assert.throws(
+      () => resolvePathPrefix("/workspace", "/etc/passwd"),
+      /escapes workspace/
     );
   });
 });

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -7,10 +7,12 @@ import {
   apiCall,
   buildEffectiveConfig,
   fetchSpec,
+  filterSecrets,
   makeLogShipper,
   postFinalize,
   provisionWorkspace,
   readRequiredEnv,
+  SECRET_DENYLIST,
   sliceLogLine,
 } from "../bin/runner-entrypoint.js";
 
@@ -231,6 +233,40 @@ describe("runner-entrypoint: buildEffectiveConfig", () => {
   });
 });
 
+describe("runner-entrypoint: filterSecrets", () => {
+  it("passes through non-reserved keys unchanged", () => {
+    const out = filterSecrets({ STRIPE_KEY: "sk_xxx", AWS_REGION: "us-east-1" });
+    assert.deepEqual(out, { STRIPE_KEY: "sk_xxx", AWS_REGION: "us-east-1" });
+  });
+
+  it("drops every key in the denylist and reports each via onReject", () => {
+    const dropped = [];
+    const out = filterSecrets(
+      { PATH: "/evil", HOME: "/tmp/x", FOO: "ok", NODE_OPTIONS: "--inspect" },
+      (k) => dropped.push(k)
+    );
+    assert.deepEqual(out, { FOO: "ok" });
+    assert.deepEqual(dropped.sort(), ["HOME", "NODE_OPTIONS", "PATH"]);
+  });
+
+  it("includes every container-shadowing key the implementation cares about", () => {
+    // Lock the denylist contents so a future trim doesn't accidentally
+    // re-open a footgun.
+    const expected = [
+      "DOC_DETECTIVE_API",
+      "DOC_DETECTIVE_CONFIG",
+      "DOC_DETECTIVE_META",
+      "HOME",
+      "LD_LIBRARY_PATH",
+      "LD_PRELOAD",
+      "NODE_OPTIONS",
+      "NODE_PATH",
+      "PATH",
+    ];
+    assert.deepEqual([...SECRET_DENYLIST].sort(), expected);
+  });
+});
+
 describe("runner-entrypoint: provisionWorkspace", () => {
   let tmp;
   beforeEach(async () => {
@@ -284,6 +320,27 @@ describe("runner-entrypoint: provisionWorkspace", () => {
     await assert.rejects(
       provisionWorkspace({ type: "nope" }, path.join(tmp, "ws-bad")),
       /Unsupported source type/
+    );
+  });
+
+  it("rejects github sources missing repo or ref before invoking git", async () => {
+    // Up-front field guards make a server-side spec-shape regression
+    // surface as a clear error instead of an inscrutable
+    // `git clone --branch undefined ...` failure. We assert the error
+    // message names the missing field so logs are diagnostic.
+    await assert.rejects(
+      provisionWorkspace(
+        { type: "github", ref: "main" },
+        path.join(tmp, "ws-no-repo")
+      ),
+      /missing required field: repo/
+    );
+    await assert.rejects(
+      provisionWorkspace(
+        { type: "github", repo: "x/y" },
+        path.join(tmp, "ws-no-ref")
+      ),
+      /missing required field: ref/
     );
   });
 

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -760,6 +760,10 @@ describe("runner-entrypoint: main()", () => {
   beforeEach(async () => {
     if (isWindows) return;
     tmpDir = await mkdtemp(path.join(os.tmpdir(), "dd-main-"));
+    // Reset across tests so a stale path from an earlier test (which
+    // called writeRunnerFixture) can't leak into a later test that
+    // didn't. envForRun() picks up whatever's in this var.
+    runnerScriptPath = undefined;
   });
   afterEach(async () => {
     if (isWindows) return;
@@ -857,6 +861,28 @@ describe("runner-entrypoint: main()", () => {
     assert.equal(code, 1);
     assert.equal(observed.finalize.status, "failed");
     assert.equal(observed.finalize.summary.reason, "spawn_failed");
+  });
+
+  it("re-arms self-kill from spec.timeout_seconds when it differs from the env value", async function () {
+    if (isWindows) this.skip();
+    // Child runs to completion quickly so we don't actually wait for
+    // the self-kill — we just need to confirm the run still finalizes
+    // succeeded after main() processes the divergent spec timeout
+    // (regression-checks that the re-arm path doesn't throw or hang).
+    await writeRunnerFixture("process.exit(0);\n");
+    await setupSpec({
+      run_id: "run-main-1",
+      // Diverges from DD_TIMEOUT_SECONDS=60 set in envForRun() so the
+      // `specTimeout !== timeoutSeconds` branch fires.
+      timeout_seconds: 1234,
+      config_snapshot: {},
+      source_snapshot: { type: "inline", specs: [] },
+      secrets: {},
+    });
+    envForRun();
+    const code = await main();
+    assert.equal(code, 0);
+    assert.equal(observed.finalize.status, "succeeded");
   });
 
   it("posts failed finalize with workspace_provision_failed for unsupported source", async function () {

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -8,10 +8,12 @@ import {
   buildEffectiveConfig,
   fetchSpec,
   filterSecrets,
+  main,
   makeLogShipper,
   postFinalize,
   provisionWorkspace,
   readRequiredEnv,
+  runChild,
   SECRET_DENYLIST,
   sliceLogLine,
 } from "../bin/runner-entrypoint.js";
@@ -520,5 +522,356 @@ describe("runner-entrypoint: postFinalize", () => {
       status: "failed",
     });
     assert.equal(ok, false);
+  });
+});
+
+describe("runner-entrypoint: apiCall timeout", () => {
+  it("aborts and throws TimeoutError-shaped message when the server stalls past the budget", async () => {
+    // Server accepts the connection but never writes a response, so
+    // only the AbortSignal.timeout can rescue the call. 50ms budget
+    // is well under any real server latency on CI.
+    const sockets = [];
+    const server = await new Promise((resolve) => {
+      const s = http.createServer((req) => {
+        // Hold the request open. We track the socket so afterEach can
+        // force-close it; otherwise server.close() blocks forever.
+        sockets.push(req.socket);
+      });
+      s.listen(0, "127.0.0.1", () => resolve(s));
+    });
+    const { port } = server.address();
+    try {
+      await assert.rejects(
+        apiCall("GET", `http://127.0.0.1:${port}/stall`, "tok", undefined, [], 50),
+        /timed out after 50ms/
+      );
+    } finally {
+      for (const sock of sockets) sock.destroy();
+      await new Promise((r) => server.close(r));
+    }
+  });
+});
+
+describe("runner-entrypoint: runChild", () => {
+  // Fixtures that exercise each behavior we care about. node -e is
+  // self-contained — no test file scaffolding to manage.
+  const NODE = process.execPath;
+  const echo = (script) => [NODE, ["-e", script]];
+
+  it("delivers each stdout/stderr line to onLine in order", async () => {
+    const lines = [];
+    const exit = await runChild(
+      ...echo(
+        "process.stdout.write('a\\nb\\n'); process.stderr.write('e1\\n'); process.exit(0);"
+      ),
+      { cwd: process.cwd(), env: process.env },
+      (stream, payload) => lines.push([stream, payload])
+    );
+    assert.equal(exit, 0);
+    assert.deepEqual(lines, [
+      ["stdout", "a"],
+      ["stdout", "b"],
+      ["stderr", "e1"],
+    ]);
+  });
+
+  it("re-assembles a line split across two write() chunks", async () => {
+    // Force a chunk boundary mid-line by writing two halves with a
+    // delay. The line buffer accumulates the partial chunk; only on
+    // the newline does onLine fire.
+    const lines = [];
+    const exit = await runChild(
+      ...echo(
+        "process.stdout.write('hel'); setTimeout(() => { process.stdout.write('lo\\n'); process.exit(0); }, 50);"
+      ),
+      { cwd: process.cwd(), env: process.env },
+      (stream, payload) => lines.push([stream, payload])
+    );
+    assert.equal(exit, 0);
+    assert.deepEqual(lines, [["stdout", "hello"]]);
+  });
+
+  it("flushes a trailing line that the child never terminated with \\n", async () => {
+    // The child writes 'tail' with no newline then exits. The 'end'
+    // handler must flush the residual buffer or the line is lost.
+    const lines = [];
+    const exit = await runChild(
+      ...echo("process.stdout.write('tail'); process.exit(0);"),
+      { cwd: process.cwd(), env: process.env },
+      (stream, payload) => lines.push([stream, payload])
+    );
+    assert.equal(exit, 0);
+    assert.deepEqual(lines, [["stdout", "tail"]]);
+  });
+
+  it("propagates the child's non-zero exit code", async () => {
+    const exit = await runChild(
+      ...echo("process.exit(7);"),
+      { cwd: process.cwd(), env: process.env },
+      () => undefined
+    );
+    assert.equal(exit, 7);
+  });
+
+  it("maps signal-terminated child to 143 when SIGTERM is forwarded", async function () {
+    // Child has no SIGTERM handler so Node's default kills it with
+    // (code: null, signal: 'SIGTERM') — runChild's mapper resolves
+    // that to 143. The setInterval keeps the event loop alive until
+    // the signal arrives.
+    this.timeout(5000);
+    const exitPromise = runChild(
+      ...echo("setInterval(() => {}, 1000);"),
+      { cwd: process.cwd(), env: process.env },
+      () => undefined
+    );
+    // Let the child reach setInterval, then drive the parent
+    // process's SIGTERM listener — which is exactly the
+    // `forwardTerm` handler installed by runChild. It SIGTERMs the
+    // child, which Node defaults to terminate.
+    await new Promise((r) => setTimeout(r, 200));
+    process.emit("SIGTERM");
+    const exit = await exitPromise;
+    assert.equal(exit, 143);
+  });
+
+  it("rejects if the child cannot be spawned (ENOENT)", async () => {
+    await assert.rejects(
+      runChild("definitely-not-a-real-binary-xyz", [], {
+        cwd: process.cwd(),
+        env: process.env,
+      }, () => undefined),
+      /ENOENT|spawn|not found/i
+    );
+  });
+
+  it("removes its SIGTERM listener on exit so successive runs don't accumulate handlers", async () => {
+    const before = process.listenerCount("SIGTERM");
+    await runChild(
+      ...echo("process.exit(0);"),
+      { cwd: process.cwd(), env: process.env },
+      () => undefined
+    );
+    const after = process.listenerCount("SIGTERM");
+    assert.equal(after, before, "runChild leaked a SIGTERM listener");
+  });
+});
+
+describe("runner-entrypoint: makeLogShipper backpressure", () => {
+  it("load-sheds new batches when pending hits the cap", async () => {
+    // Make the API server hold every POST open so pending grows.
+    // Tracking the held requests lets afterEach drain them.
+    const heldResponses = [];
+    const released = [];
+    const api = await makeApiServer((req, res, body) => {
+      heldResponses.push(res);
+      released.push(JSON.parse(body));
+      // intentionally never end — the test releases at teardown
+    });
+    try {
+      const shipper = makeLogShipper(api.base, "run", "tok");
+      // Saturate pending to LOG_MAX_PENDING_BATCHES (8). Each batch
+      // is LOG_BATCH_SIZE=100 lines. Need to push at least 8*100 lines
+      // so each fireBatch fires before pending fills, then push more
+      // to exercise the load-shed branch.
+      for (let i = 0; i < 100 * 9; i++) shipper.add("stdout", `l-${i}`);
+      // Yield to let the queued POSTs land on the server. We can't
+      // await flush() because that'd hang on the held responses; we
+      // assert on the server's seen-batch count instead.
+      await new Promise((r) => setTimeout(r, 50));
+      // 8 batches should have been accepted (cap = LOG_MAX_PENDING_BATCHES).
+      // The 9th batch was dropped on the floor.
+      assert.ok(
+        released.length === 8,
+        `expected exactly 8 in-flight batches, saw ${released.length}`
+      );
+    } finally {
+      for (const res of heldResponses) {
+        try { res.writeHead(204); res.end(); } catch {}
+      }
+      await closeServer(api.server);
+    }
+  });
+});
+
+describe("runner-entrypoint: main()", () => {
+  // End-to-end against a loopback server. Uses DD_RUNNER_CMD to
+  // override the spawn target with a node fixture so we can drive
+  // exit codes / stdout deterministically without depending on the
+  // doc-detective binary being installed.
+  const NODE = process.execPath;
+
+  function makeFakeRunner(script) {
+    // Returns a value usable as DD_RUNNER_CMD: we point at node
+    // itself and pass the script via DD_RUNNER_SCRIPT_PATH? Simpler:
+    // write a tmp .mjs and point DD_RUNNER_CMD at a tiny shim. But
+    // DD_RUNNER_CMD is just argv[0] — we can't pass extra args via
+    // the env seam. So we write a shell-less tmp script that node
+    // can execute directly via shebang on POSIX.
+    //
+    // Actually simpler: spawn `node` with no args wouldn't run
+    // anything. The cleanest path is to keep it portable: use
+    // DD_RUNNER_CMD = path to a tmp .js file that node can run via
+    // its shebang on POSIX or that we explicitly invoke. Since CI
+    // is POSIX (linux/macos), and Windows skips this suite, a
+    // shebang-prefixed file with chmod +x works.
+    return script;
+  }
+
+  // Skip on Windows: the fake-runner approach uses #!/usr/bin/env node
+  // which Windows doesn't honor for spawn(). The intra-runner branches
+  // are exercised on Linux/macOS coverage; Windows-specific runtime
+  // shape is not part of this PR's scope.
+  const isWindows = process.platform === "win32";
+
+  let tmpDir;
+  let api;
+  let observed;
+  let runnerScriptPath;
+
+  async function setupSpec(spec) {
+    observed = { logs: [], finalize: null, specReturned: false };
+    api = await makeApiServer((req, res, body) => {
+      const url = req.url;
+      if (req.method === "GET" && url.endsWith("/spec")) {
+        observed.specReturned = true;
+        if (spec === 410) {
+          res.writeHead(410);
+          res.end();
+          return;
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(spec));
+        return;
+      }
+      if (req.method === "POST" && url.endsWith("/logs")) {
+        observed.logs.push(JSON.parse(body));
+        res.writeHead(204); res.end();
+        return;
+      }
+      if (req.method === "POST" && url.endsWith("/finalize")) {
+        observed.finalize = JSON.parse(body);
+        res.writeHead(204); res.end();
+        return;
+      }
+      res.writeHead(404); res.end();
+    });
+  }
+
+  beforeEach(async () => {
+    if (isWindows) return;
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "dd-main-"));
+  });
+  afterEach(async () => {
+    if (isWindows) return;
+    if (api) await closeServer(api.server);
+    api = null;
+    if (tmpDir) await rm(tmpDir, { recursive: true, force: true });
+    delete process.env.DD_API_BASE;
+    delete process.env.DD_RUN_ID;
+    delete process.env.DD_RUN_TOKEN;
+    delete process.env.DD_RUNNER_CMD;
+    delete process.env.DD_TIMEOUT_SECONDS;
+    delete process.env.DD_WORKSPACE_DIR;
+  });
+
+  async function writeRunnerFixture(jsBody) {
+    runnerScriptPath = path.join(tmpDir, "fake-runner.mjs");
+    const { writeFile, chmod } = await import("node:fs/promises");
+    // Point the shebang at the absolute node path so PATH
+    // misconfiguration in CI doesn't bite us.
+    const shebang = `#!${NODE}\n`;
+    await writeFile(runnerScriptPath, shebang + jsBody, "utf8");
+    await chmod(runnerScriptPath, 0o755);
+  }
+
+  function envForRun() {
+    process.env.DD_API_BASE = api.base;
+    process.env.DD_RUN_ID = "run-main-1";
+    process.env.DD_RUN_TOKEN = "tok-main-1";
+    if (runnerScriptPath) process.env.DD_RUNNER_CMD = runnerScriptPath;
+    process.env.DD_TIMEOUT_SECONDS = "60";
+    process.env.DD_WORKSPACE_DIR = path.join(tmpDir, "workspace");
+  }
+
+  it("returns 0 without finalize when /spec returns 410 (canceled-before-spawn)", async function () {
+    if (isWindows) this.skip();
+    await setupSpec(410);
+    envForRun();
+    const code = await main();
+    assert.equal(code, 0);
+    assert.equal(observed.finalize, null, "no finalize POST expected on 410");
+  });
+
+  it("posts succeeded finalize when child exits 0", async function () {
+    if (isWindows) this.skip();
+    await writeRunnerFixture(
+      "process.stdout.write('hello\\n'); process.exit(0);\n"
+    );
+    await setupSpec({
+      run_id: "run-main-1",
+      timeout_seconds: 60,
+      config_snapshot: {},
+      source_snapshot: { type: "inline", specs: [] },
+      secrets: {},
+    });
+    envForRun();
+    const code = await main();
+    assert.equal(code, 0);
+    assert.equal(observed.finalize.status, "succeeded");
+    assert.equal(observed.finalize.exit_code, 0);
+    // At least one /logs POST should have carried the 'hello' line.
+    const allLines = observed.logs.flatMap((b) => b.lines);
+    assert.ok(allLines.some((l) => l.payload === "hello"));
+  });
+
+  it("posts failed finalize with nonzero_exit reason when child exits non-zero", async function () {
+    if (isWindows) this.skip();
+    await writeRunnerFixture("process.exit(7);\n");
+    await setupSpec({
+      run_id: "run-main-1",
+      timeout_seconds: 60,
+      config_snapshot: {},
+      source_snapshot: { type: "inline", specs: [] },
+      secrets: {},
+    });
+    envForRun();
+    const code = await main();
+    assert.equal(code, 7);
+    assert.equal(observed.finalize.status, "failed");
+    assert.equal(observed.finalize.exit_code, 7);
+    assert.equal(observed.finalize.summary.reason, "nonzero_exit");
+  });
+
+  it("posts failed finalize with spawn_failed reason when DD_RUNNER_CMD is bogus", async function () {
+    if (isWindows) this.skip();
+    await setupSpec({
+      run_id: "run-main-1",
+      timeout_seconds: 60,
+      config_snapshot: {},
+      source_snapshot: { type: "inline", specs: [] },
+      secrets: {},
+    });
+    envForRun();
+    process.env.DD_RUNNER_CMD = "/nonexistent/path/to/runner-xyz";
+    const code = await main();
+    assert.equal(code, 1);
+    assert.equal(observed.finalize.status, "failed");
+    assert.equal(observed.finalize.summary.reason, "spawn_failed");
+  });
+
+  it("posts failed finalize with workspace_provision_failed for unsupported source", async function () {
+    if (isWindows) this.skip();
+    await setupSpec({
+      run_id: "run-main-1",
+      timeout_seconds: 60,
+      config_snapshot: {},
+      source_snapshot: { type: "totally-bogus" },
+      secrets: {},
+    });
+    envForRun();
+    const code = await main();
+    assert.equal(code, 1);
+    assert.equal(observed.finalize.status, "failed");
+    assert.equal(observed.finalize.summary.reason, "workspace_provision_failed");
   });
 });

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -233,6 +233,22 @@ describe("runner-entrypoint: buildEffectiveConfig", () => {
     assert.equal(cfg.input, "/workspace/specs");
     assert.equal(cfg.output, "/workspace/output");
   });
+
+  it("threads a custom workspaceDir through input/output so it stays in sync with provisionWorkspace", () => {
+    // Regression: an earlier draft hardcoded WORKSPACE_DIR here, so
+    // an operator pointing DD_WORKSPACE_DIR at /var/dd/ws would have
+    // gotten the workspace materialized at /var/dd/ws but the CLI
+    // told to read/write at /workspace/* — a silent mismatch that
+    // looked fine in unit tests because the fake-runner ignores
+    // DOC_DETECTIVE_CONFIG.
+    const cfg = buildEffectiveConfig(
+      {},
+      { type: "inline", specs: [] },
+      "/var/dd/ws"
+    );
+    assert.equal(cfg.output, "/var/dd/ws/output");
+    assert.equal(cfg.input, "/var/dd/ws/specs");
+  });
 });
 
 describe("runner-entrypoint: filterSecrets", () => {

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -630,6 +630,14 @@ describe("runner-entrypoint: runChild", () => {
   });
 
   it("maps signal-terminated child to 143 when SIGTERM is forwarded", async function () {
+    // POSIX-only: Windows doesn't have real signals — child.kill('SIGTERM')
+    // there maps to TerminateProcess and Node reports (code: 1,
+    // signal: null) rather than (code: null, signal: 'SIGTERM'), so
+    // the 143 contract this test asserts only holds on Linux/macOS.
+    // The runner only ever runs in the Linux container in
+    // production; the Windows test runner is for cross-platform
+    // safety on the rest of the file.
+    if (process.platform === "win32") this.skip();
     // Child has no SIGTERM handler so Node's default kills it with
     // (code: null, signal: 'SIGTERM') — runChild's mapper resolves
     // that to 143. The setInterval keeps the event loop alive until

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -373,36 +373,47 @@ describe("runner-entrypoint: provisionWorkspace", () => {
 });
 
 describe("runner-entrypoint: resolvePathPrefix", () => {
+  // Use os.tmpdir() as the workspace base so paths are truly absolute
+  // on every platform — Windows treats `/workspace` as drive-relative
+  // and path.resolve normalizes it to `C:\workspace`, which would
+  // break exact-string assertions. We don't actually create anything
+  // in the tmpdir; the helper is pure.
+  const ws = os.tmpdir();
+
   it("returns workspaceDir unchanged when path_prefix is absent", () => {
-    assert.equal(resolvePathPrefix("/workspace"), "/workspace");
-    assert.equal(resolvePathPrefix("/workspace", ""), "/workspace");
-    assert.equal(resolvePathPrefix("/workspace", undefined), "/workspace");
+    assert.equal(resolvePathPrefix(ws), ws);
+    assert.equal(resolvePathPrefix(ws, ""), ws);
+    assert.equal(resolvePathPrefix(ws, undefined), ws);
   });
 
   it("joins a normal in-workspace prefix", () => {
-    assert.equal(resolvePathPrefix("/workspace", "docs"), "/workspace/docs");
+    assert.equal(resolvePathPrefix(ws, "docs"), path.join(ws, "docs"));
     assert.equal(
-      resolvePathPrefix("/workspace", "subdir/nested"),
-      "/workspace/subdir/nested"
+      resolvePathPrefix(ws, "subdir/nested"),
+      path.join(ws, "subdir", "nested")
     );
   });
 
   it("rejects a traversal that escapes the workspace via ..", () => {
     assert.throws(
-      () => resolvePathPrefix("/workspace", "../etc"),
+      () => resolvePathPrefix(ws, "../etc"),
       /escapes workspace/
     );
     assert.throws(
-      () => resolvePathPrefix("/workspace", "subdir/../../escape"),
+      () => resolvePathPrefix(ws, "subdir/../../escape"),
       /escapes workspace/
     );
   });
 
   it("rejects an absolute prefix that path.resolve would otherwise honor as an override", () => {
-    // path.resolve('/workspace', '/etc') === '/etc' — without the
-    // guard this would silently let the user point cwd at /etc.
+    // path.resolve(ws, '<absolute-other-path>') replaces ws entirely
+    // — without the guard this would silently let the user point cwd
+    // at an arbitrary path. Use a sibling tmpdir-rooted path so the
+    // assertion is platform-agnostic; on Linux this is `/etc/passwd`,
+    // on Windows it's `C:\some\other\absolute\path`.
+    const otherAbs = path.resolve(os.tmpdir(), "..", "definitely-not-the-workspace");
     assert.throws(
-      () => resolvePathPrefix("/workspace", "/etc/passwd"),
+      () => resolvePathPrefix(ws, otherAbs),
       /escapes workspace/
     );
   });

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -724,23 +724,6 @@ describe("runner-entrypoint: main()", () => {
   // doc-detective binary being installed.
   const NODE = process.execPath;
 
-  function makeFakeRunner(script) {
-    // Returns a value usable as DD_RUNNER_CMD: we point at node
-    // itself and pass the script via DD_RUNNER_SCRIPT_PATH? Simpler:
-    // write a tmp .mjs and point DD_RUNNER_CMD at a tiny shim. But
-    // DD_RUNNER_CMD is just argv[0] — we can't pass extra args via
-    // the env seam. So we write a shell-less tmp script that node
-    // can execute directly via shebang on POSIX.
-    //
-    // Actually simpler: spawn `node` with no args wouldn't run
-    // anything. The cleanest path is to keep it portable: use
-    // DD_RUNNER_CMD = path to a tmp .js file that node can run via
-    // its shebang on POSIX or that we explicitly invoke. Since CI
-    // is POSIX (linux/macos), and Windows skips this suite, a
-    // shebang-prefixed file with chmod +x works.
-    return script;
-  }
-
   // Skip on Windows: the fake-runner approach uses #!/usr/bin/env node
   // which Windows doesn't honor for spawn(). The intra-runner branches
   // are exercised on Linux/macOS coverage; Windows-specific runtime

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -74,16 +74,19 @@ describe("runner-entrypoint: sliceLogLine", () => {
     assert.deepEqual(out, ["hello"]);
   });
 
-  it("slices oversize lines so each chunk fits the platform's 64 KB cap", () => {
-    // 200 KB of ASCII → ~3 chunks at 60 KB each
+  it("slices oversize lines so each chunk fits the runner's 60 KB internal cap", () => {
+    // 200 KB of ASCII → ~4 chunks at 60 KB each. Implementation cap is
+    // 60 KB (4 KB headroom under the platform's 64 KB-per-line cap);
+    // we assert against the implementation cap, not the platform cap,
+    // so a regression that grew slices to 61 KB would surface here.
     const big = "a".repeat(200 * 1024);
     const slices = sliceLogLine(big);
     assert.ok(slices.length >= 3, `expected ≥3 slices, got ${slices.length}`);
     const enc = new TextEncoder();
     for (const s of slices) {
       assert.ok(
-        enc.encode(s).byteLength <= 64 * 1024,
-        `slice exceeded 64 KB byte cap`
+        enc.encode(s).byteLength <= 60 * 1024,
+        `slice exceeded 60 KB byte cap`
       );
     }
     // Reassembly preserves total content length (modulo lossy mid-codepoint
@@ -283,6 +286,39 @@ describe("runner-entrypoint: provisionWorkspace", () => {
       /Unsupported source type/
     );
   });
+
+  it("rejects path_prefix that escapes the workspace via traversal", async () => {
+    // Defense-in-depth: even though the platform's project validator
+    // already constrains path_prefix, a regression that admitted "../"
+    // would let a malicious project root the runner's cwd outside
+    // /workspace. The guard rejects up-front.
+    //
+    // We can't actually exercise the github branch (no real clone in
+    // unit tests), but the guard sits inside the github branch — so we
+    // verify it indirectly by feeding a github-shaped source. The
+    // guard fires before git is invoked.
+    await assert.rejects(
+      provisionWorkspace(
+        { type: "github", repo: "x/y", ref: "main", path_prefix: "../etc" },
+        path.join(tmp, "ws-traverse")
+      ),
+      /escapes workspace/
+    );
+  });
+
+  it("accepts an in-workspace path_prefix on github sources", async () => {
+    // Confirms the guard isn't over-eager: a normal subdirectory
+    // path_prefix should pass. We can't run git clone, so the guard
+    // resolves first, then the test fails at the actual `git` call.
+    // We assert the failure is the git-clone failure, not the guard.
+    await assert.rejects(
+      provisionWorkspace(
+        { type: "github", repo: "x/y", ref: "main", path_prefix: "docs" },
+        path.join(tmp, "ws-ok-prefix")
+      ),
+      /git clone failed/
+    );
+  });
 });
 
 describe("runner-entrypoint: makeLogShipper", () => {
@@ -338,6 +374,33 @@ describe("runner-entrypoint: makeLogShipper", () => {
       const shipper = makeLogShipper(api.base, "run", "tok");
       await shipper.flush();
       assert.equal(calls, 0);
+    } finally {
+      await closeServer(api.server);
+    }
+  });
+
+  it("preserves all slices of an oversize line that auto-flushes mid-iteration", async () => {
+    // Regression test for a bug where add() returned after the first
+    // slice triggered the auto-flush, silently dropping subsequent
+    // slices of the same oversize line.
+    const seen = [];
+    const api = await makeApiServer((req, res, body) => {
+      seen.push(JSON.parse(body));
+      res.writeHead(204);
+      res.end();
+    });
+    try {
+      const shipper = makeLogShipper(api.base, "run", "tok");
+      // Pre-fill buffer so the first slice of the oversize line
+      // immediately trips LOG_BATCH_SIZE.
+      for (let i = 0; i < 99; i++) shipper.add("stdout", `pad-${i}`);
+      // 180 KB → 3 slices at 60 KB each.
+      const oversize = "x".repeat(180 * 1024);
+      shipper.add("stdout", oversize);
+      await shipper.flush();
+      // Total expected line count: 99 padding + 3 slices = 102.
+      const total = seen.reduce((acc, batch) => acc + batch.lines.length, 0);
+      assert.equal(total, 102, `expected 102 lines across batches, got ${total}`);
     } finally {
       await closeServer(api.server);
     }

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -1,0 +1,404 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import {
+  apiCall,
+  buildEffectiveConfig,
+  fetchSpec,
+  makeLogShipper,
+  postFinalize,
+  provisionWorkspace,
+  readRequiredEnv,
+  sliceLogLine,
+} from "../bin/runner-entrypoint.js";
+
+/**
+ * Unit tests for the platform runner entrypoint. Real HTTP — a tiny
+ * loopback server stands in for the platform API so we exercise the
+ * fetch/auth/header path end-to-end without mocks. File-system tests
+ * use a per-test tmpdir so we don't touch /workspace on the dev box.
+ */
+
+function makeApiServer(handler) {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      // Drain body for handler convenience.
+      const chunks = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => {
+        const body = chunks.length ? Buffer.concat(chunks).toString("utf8") : "";
+        handler(req, res, body);
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({ server, base: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+async function closeServer(s) {
+  await new Promise((r) => s.close(r));
+}
+
+describe("runner-entrypoint: readRequiredEnv", () => {
+  it("returns the value when set", () => {
+    process.env.__DD_TEST_VAR = "hello";
+    try {
+      assert.equal(readRequiredEnv("__DD_TEST_VAR"), "hello");
+    } finally {
+      delete process.env.__DD_TEST_VAR;
+    }
+  });
+
+  it("throws when the var is missing", () => {
+    delete process.env.__DD_TEST_MISSING;
+    assert.throws(() => readRequiredEnv("__DD_TEST_MISSING"), /Missing required env var/);
+  });
+
+  it("throws when the var is empty string", () => {
+    process.env.__DD_TEST_EMPTY = "";
+    try {
+      assert.throws(() => readRequiredEnv("__DD_TEST_EMPTY"), /Missing required env var/);
+    } finally {
+      delete process.env.__DD_TEST_EMPTY;
+    }
+  });
+});
+
+describe("runner-entrypoint: sliceLogLine", () => {
+  it("returns the line as-is when under the byte limit", () => {
+    const out = sliceLogLine("hello");
+    assert.deepEqual(out, ["hello"]);
+  });
+
+  it("slices oversize lines so each chunk fits the platform's 64 KB cap", () => {
+    // 200 KB of ASCII → ~3 chunks at 60 KB each
+    const big = "a".repeat(200 * 1024);
+    const slices = sliceLogLine(big);
+    assert.ok(slices.length >= 3, `expected ≥3 slices, got ${slices.length}`);
+    const enc = new TextEncoder();
+    for (const s of slices) {
+      assert.ok(
+        enc.encode(s).byteLength <= 64 * 1024,
+        `slice exceeded 64 KB byte cap`
+      );
+    }
+    // Reassembly preserves total content length (modulo lossy mid-codepoint
+    // boundaries — for ASCII the count is exact).
+    const reassembled = slices.join("");
+    assert.equal(reassembled.length, big.length);
+  });
+});
+
+describe("runner-entrypoint: apiCall", () => {
+  let api;
+  beforeEach(async () => {
+    api = await makeApiServer((req, res, body) => {
+      res.setHeader("x-saw-auth", req.headers.authorization || "");
+      res.setHeader("x-saw-method", req.method);
+      res.setHeader("x-saw-content-type", req.headers["content-type"] || "");
+      if (req.url === "/echo") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ method: req.method, body, url: req.url }));
+        return;
+      }
+      if (req.url === "/410") {
+        res.writeHead(410);
+        res.end("gone");
+        return;
+      }
+      if (req.url === "/500") {
+        res.writeHead(500);
+        res.end("nope");
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+  });
+  afterEach(() => closeServer(api.server));
+
+  it("attaches the bearer token and content-type for JSON bodies", async () => {
+    const res = await apiCall("POST", `${api.base}/echo`, "tok-1", { x: 1 });
+    assert.equal(res.headers.get("x-saw-auth"), "Bearer tok-1");
+    assert.equal(res.headers.get("x-saw-content-type"), "application/json");
+    const json = await res.json();
+    assert.equal(json.method, "POST");
+    assert.equal(json.body, JSON.stringify({ x: 1 }));
+  });
+
+  it("omits content-type when no body is sent", async () => {
+    const res = await apiCall("GET", `${api.base}/echo`, "tok-2");
+    assert.equal(res.headers.get("x-saw-content-type"), "");
+  });
+
+  it("throws on non-2xx by default", async () => {
+    await assert.rejects(apiCall("GET", `${api.base}/500`, "tok-x"), /500/);
+  });
+
+  it("does not throw when the status is in allowedStatuses", async () => {
+    const res = await apiCall("GET", `${api.base}/410`, "tok-x", undefined, [410]);
+    assert.equal(res.status, 410);
+  });
+});
+
+describe("runner-entrypoint: fetchSpec", () => {
+  it("returns canceled=true on 410 Gone", async () => {
+    const api = await makeApiServer((req, res) => {
+      if (req.url === "/api/runs/run-1/spec") {
+        res.writeHead(410);
+        res.end();
+      }
+    });
+    try {
+      const out = await fetchSpec(api.base, "run-1", "tok");
+      assert.equal(out.canceled, true);
+      assert.equal(out.spec, undefined);
+    } finally {
+      await closeServer(api.server);
+    }
+  });
+
+  it("returns the parsed spec on 200", async () => {
+    const api = await makeApiServer((req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          run_id: "run-1",
+          timeout_seconds: 120,
+          config_snapshot: {},
+          source_snapshot: { type: "inline", specs: [] },
+          secrets: {},
+        })
+      );
+    });
+    try {
+      const out = await fetchSpec(api.base, "run-1", "tok");
+      assert.equal(out.canceled, false);
+      assert.equal(out.spec.run_id, "run-1");
+      assert.equal(out.spec.timeout_seconds, 120);
+    } finally {
+      await closeServer(api.server);
+    }
+  });
+
+  it("URL-encodes the run id in the path", async () => {
+    let observed = "";
+    const api = await makeApiServer((req, res) => {
+      observed = req.url;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{}");
+    });
+    try {
+      await fetchSpec(api.base, "weird id/with slash", "tok");
+      assert.equal(observed, "/api/runs/weird%20id%2Fwith%20slash/spec");
+    } finally {
+      await closeServer(api.server);
+    }
+  });
+});
+
+describe("runner-entrypoint: buildEffectiveConfig", () => {
+  it("forces output to /workspace/output for github sources", () => {
+    const cfg = buildEffectiveConfig(
+      { input: "docs/", output: "user-output", reporters: ["json"] },
+      { type: "github", repo: "x/y", ref: "main" }
+    );
+    assert.equal(cfg.output, "/workspace/output");
+    assert.equal(cfg.input, "docs/"); // user's input preserved for github sources
+    assert.deepEqual(cfg.reporters, ["json"]);
+  });
+
+  it("forces both input and output for inline sources", () => {
+    const cfg = buildEffectiveConfig(
+      { input: "ignored-by-platform", output: "user-output" },
+      { type: "inline", specs: [] }
+    );
+    assert.equal(cfg.input, "/workspace/specs");
+    assert.equal(cfg.output, "/workspace/output");
+  });
+
+  it("returns a usable config when configSnapshot is missing/empty", () => {
+    const cfg = buildEffectiveConfig(undefined, { type: "inline", specs: [] });
+    assert.equal(cfg.input, "/workspace/specs");
+    assert.equal(cfg.output, "/workspace/output");
+  });
+});
+
+describe("runner-entrypoint: provisionWorkspace", () => {
+  let tmp;
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(os.tmpdir(), "dd-runner-"));
+  });
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it("writes each inline spec to a deterministic, zero-padded filename", async () => {
+    const wsRoot = path.join(tmp, "ws");
+    const cwd = await provisionWorkspace(
+      {
+        type: "inline",
+        specs: [
+          { id: "s1", tests: [] },
+          { id: "s2", tests: [{ steps: [] }] },
+        ],
+      },
+      wsRoot
+    );
+    assert.equal(cwd, wsRoot);
+    const specsDir = path.join(wsRoot, "specs");
+    const entries = (await readdir(specsDir)).sort();
+    assert.deepEqual(entries, ["spec-0000.json", "spec-0001.json"]);
+    const first = JSON.parse(await readFile(path.join(specsDir, "spec-0000.json"), "utf8"));
+    assert.equal(first.id, "s1");
+  });
+
+  it("returns the workspaceDir as cwd when no path_prefix is set on github sources", async () => {
+    // We can't actually clone in unit tests, but the path-prefix logic
+    // is reachable independently — exercise inline to confirm the
+    // workspaceDir override is honored. The github branch is covered
+    // implicitly by the path-prefix join shape above.
+    const wsRoot = path.join(tmp, "ws-github-shape");
+    const cwd = await provisionWorkspace(
+      { type: "inline", specs: [] },
+      wsRoot
+    );
+    assert.equal(cwd, wsRoot);
+  });
+
+  it("creates an output subdir for the platform-controlled artifact root", async () => {
+    const wsRoot = path.join(tmp, "ws-output");
+    await provisionWorkspace({ type: "inline", specs: [] }, wsRoot);
+    const entries = await readdir(wsRoot);
+    assert.ok(entries.includes("output"), `expected 'output' subdir, got ${entries.join(",")}`);
+  });
+
+  it("rejects unsupported source types", async () => {
+    await assert.rejects(
+      provisionWorkspace({ type: "nope" }, path.join(tmp, "ws-bad")),
+      /Unsupported source type/
+    );
+  });
+});
+
+describe("runner-entrypoint: makeLogShipper", () => {
+  it("ships a flush'd batch with the bearer token", async () => {
+    const seen = [];
+    const api = await makeApiServer((req, res, body) => {
+      seen.push({ url: req.url, auth: req.headers.authorization, body });
+      res.writeHead(204);
+      res.end();
+    });
+    try {
+      const shipper = makeLogShipper(api.base, "run-X", "tok-Y");
+      shipper.add("stdout", "hello");
+      shipper.add("stderr", "world");
+      await shipper.flush();
+      assert.equal(seen.length, 1);
+      assert.equal(seen[0].url, "/api/runs/run-X/logs");
+      assert.equal(seen[0].auth, "Bearer tok-Y");
+      const parsed = JSON.parse(seen[0].body);
+      assert.equal(parsed.lines.length, 2);
+      assert.equal(parsed.lines[0].stream, "stdout");
+      assert.equal(parsed.lines[0].payload, "hello");
+      assert.equal(parsed.lines[1].stream, "stderr");
+      assert.equal(parsed.lines[1].payload, "world");
+    } finally {
+      await closeServer(api.server);
+    }
+  });
+
+  it("swallows transport errors so a bad /logs response doesn't fail the run", async () => {
+    const api = await makeApiServer((req, res) => {
+      res.writeHead(500);
+      res.end();
+    });
+    try {
+      const shipper = makeLogShipper(api.base, "run-Z", "tok");
+      shipper.add("stdout", "line");
+      // Should resolve, not reject.
+      await shipper.flush();
+    } finally {
+      await closeServer(api.server);
+    }
+  });
+
+  it("does not POST when the buffer is empty", async () => {
+    let calls = 0;
+    const api = await makeApiServer((req, res) => {
+      calls++;
+      res.writeHead(204);
+      res.end();
+    });
+    try {
+      const shipper = makeLogShipper(api.base, "run", "tok");
+      await shipper.flush();
+      assert.equal(calls, 0);
+    } finally {
+      await closeServer(api.server);
+    }
+  });
+
+  it("auto-flushes when the batch hits LOG_BATCH_SIZE", async () => {
+    const seen = [];
+    const api = await makeApiServer((req, res, body) => {
+      seen.push(JSON.parse(body));
+      res.writeHead(204);
+      res.end();
+    });
+    try {
+      const shipper = makeLogShipper(api.base, "run", "tok");
+      // Fire 100 lines — the cap. Should flush exactly once without
+      // waiting for the interval timer.
+      for (let i = 0; i < 100; i++) shipper.add("stdout", `line-${i}`);
+      // Give the queued flush microtask a chance to land.
+      await new Promise((r) => setImmediate(r));
+      // Drain the post-flush state in case the implementation queues
+      // a follow-up flush; an extra empty drain is harmless.
+      await shipper.flush();
+      assert.equal(seen.length, 1, `expected 1 batch, got ${seen.length}`);
+      assert.equal(seen[0].lines.length, 100);
+    } finally {
+      await closeServer(api.server);
+    }
+  });
+});
+
+describe("runner-entrypoint: postFinalize", () => {
+  it("returns true on 204", async () => {
+    const seen = [];
+    const api = await makeApiServer((req, res, body) => {
+      seen.push({ url: req.url, body });
+      res.writeHead(204);
+      res.end();
+    });
+    try {
+      const ok = await postFinalize(api.base, "run-F", "tok", {
+        status: "succeeded",
+        exit_code: 0,
+        summary: {},
+      });
+      assert.equal(ok, true);
+      assert.equal(seen[0].url, "/api/runs/run-F/finalize");
+      assert.deepEqual(JSON.parse(seen[0].body), {
+        status: "succeeded",
+        exit_code: 0,
+        summary: {},
+      });
+    } finally {
+      await closeServer(api.server);
+    }
+  });
+
+  it("returns false on transport failure (does not throw)", async () => {
+    // Point at a non-listening port so fetch fails with ECONNREFUSED.
+    const ok = await postFinalize("http://127.0.0.1:1", "run", "tok", {
+      status: "failed",
+    });
+    assert.equal(ok, false);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 5 of the [doc-detective.com platform integration](https://github.com/doc-detective/online/blob/main/plans/doc-detective-platform-integration.md). Adds the runner-side entrypoint that turns this image into a self-driving Fly.io machine for the platform.

The platform launches a Fly machine per run with `DD_RUN_TOKEN` / `DD_API_BASE` / `DD_RUN_ID` injected as env. The machine's job is to authenticate back, fetch its config + source + project secrets, run the test job, stream logs, and finalize. Previously that orchestration didn't exist anywhere — `bin/runner-entrypoint.js` is it.

## What's in the box

- **`bin/runner-entrypoint.js`** — the orchestration script. End-to-end:
  1. read `DD_RUN_TOKEN` / `DD_API_BASE` / `DD_RUN_ID` from env
  2. `GET /api/runs/:id/spec` → fetch `config_snapshot`, `source_snapshot`, decrypted secrets (handles `410 Gone` as a clean cancel before start)
  3. provision `/workspace` from the source: `git clone --depth=1` for `type:'github'` (with optional `path_prefix` cd), or write `source_snapshot.specs[]` to `/workspace/specs/*.json` for `type:'inline'`
  4. spawn `doc-detective` (no subcommand) with the merged config in `DOC_DETECTIVE_CONFIG` and project secrets in env
  5. tee child stdout/stderr to the platform via batched `POST /api/runs/:id/logs` (100 lines or 1s, whichever first; oversize lines sliced to fit the platform's 64 KB byte cap)
  6. `POST /api/runs/:id/finalize` with the mapped status (`succeeded` / `failed` / `canceled`) + exit code
- **`package.json`** — registers it as a second `bin` (`doc-detective-runner`) so `npm install -g doc-detective` puts it on `PATH` automatically. The Dockerfile's `npm install -g doc-detective@$PACKAGE_VERSION` step picks it up for free.
- **`linux.Dockerfile`** — comment-only update. The default `ENTRYPOINT` is unchanged (`docker run` users still get the CLI). The platform overrides `init.entrypoint` to `doc-detective-runner` via Fly Machine config — that wiring lives in a follow-up online-repo PR.
- **`test/runner-entrypoint.test.js`** — 25 unit tests against a real loopback HTTP server (no mocks): spec fetch (200 + 410), `apiCall` auth/headers/error handling, log shipping (auth, error swallowing, batch auto-flush gate), oversize-line slicing, finalize POST shape, and inline workspace write-out.

## Belt-and-suspenders

- Process-level `setTimeout(() => process.exit(124), DD_TIMEOUT_SECONDS * 1000)` self-kill so a runner that loses API connectivity eventually shuts itself down. The platform watchdog (Sweep B) remains authoritative.
- `SIGTERM` handler forwards to the spawned doc-detective child and best-effort posts a `canceled` finalize so the row lands at `canceled` faster — the server is still source of truth.
- Log shipper tracks in-flight POSTs so `await flush()` is a true "everything is posted" gate; without that, an auto-flushed batch could outlive the finalize call and 401.

## Out of scope (deliberate)

Artifact upload — `saveScreenshot`, `recordVideo`, html report, etc. The entrypoint finalizes with an empty artifacts list. A follow-up will walk `config.output` and POST `/api/runs/:id/artifacts/sign` for each file.

## Test plan

- [x] `npm run build && npx mocha --exit test/runner-entrypoint.test.js` — 25/25 ✓
- [x] `npx mocha --exit test/runner-entrypoint.test.js test/findFreePort.test.js test/checkLink.test.js` — 52/52 ✓ (no regressions in unrelated suites)
- [ ] Follow-up online PR: set `init.entrypoint = ['doc-detective-runner']` in `runner-host-fly.ts`'s machine spec and verify a real run end-to-end.

https://claude.ai/code/session_01Ncx411jEevDgGyvoEeBJVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ncx411jEevDgGyvoEeBJVs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new runner command to execute Doc Detective runs with workspace provisioning, batched real-time log streaming, and final status reporting.

* **Tests**
  * Added comprehensive tests covering env handling, config resolution, spec fetching, workspace provisioning, log shipping, and finalization behaviors.

* **Documentation**
  * Clarified container entrypoint behavior and platform integration in container docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->