### PR TITLE
fix(runtime): skip app detection in dry-run runs (windows+node22 flake)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -508,7 +508,13 @@ async function setConfig({ config }: any) {
 
   // Detect current environment.
   config.environment = getEnvironment();
-  config.environment.apps = await getAvailableApps({ config });
+  // Dry runs return the resolved-tests preview without ever executing, and
+  // `environment.apps` is only consumed by the runner paths in tests.ts (which
+  // re-detect themselves). Skipping the detection avoids the @puppeteer/browsers
+  // load, the browser-cache scan, and the unbounded `appium driver list` spawn —
+  // the work that pushes dryRun.test.js past its mocha timeout on a starved
+  // windows+node22 runner. No effect on resolved output.
+  config.environment.apps = config.dryRun ? [] : await getAvailableApps({ config });
 
   // Resolve concurrent runners configuration
   config.concurrentRunners = resolveConcurrentRunners(config);

--- a/test/dryRun.test.js
+++ b/test/dryRun.test.js
@@ -68,6 +68,11 @@ describe("--dry-run short-circuits before execution", function () {
     const step = result.specs[0].tests[0].contexts[0].steps[0];
     expect(step).to.have.property("goTo");
 
+    // Dry runs must NOT probe the environment for apps (no @puppeteer/browsers
+    // load, no `appium driver list` spawn) — that work is what flaked the
+    // windows+node22 mocha timeout. Resolution never reads environment.apps.
+    expect(result.config.environment.apps).to.deep.equal([]);
+
     // JSON was emitted to stdout and round-trips with the same shape.
     const stdoutDump = captured.join("\n");
     const parsed = JSON.parse(stdoutDump);


### PR DESCRIPTION
## Problem

CI flakes only on the **`windows-latest` + `node 22`** matrix cell. ubuntu/macOS (node 22 & 24) and windows + node 24 are reliably green. On the flaky cell the mocha suite runs ~28 min instead of ~10–13 min and 1–2 tests exceed their 30 000 ms timeout — the repeat offender being `test/dryRun.test.js` (*"--dry-run short-circuits before execution"*). It passes on every retry, so it's a timeout/resource-starvation flake, not a correctness bug.

## Root cause

`runTests` (`src/core/index.ts`) only short-circuits for dry-run **after** `detectAndResolveTests` → `setConfig` has already run. Inside `setConfig`, `src/core/config.ts` unconditionally calls `getAvailableApps({ config })`, which:

- lazy-loads `@puppeteer/browsers` (heavy module),
- scans the browser cache on disk (`getInstalledBrowsers`), and
- spawns an **unbounded** `appium driver list` child process (~17 s normally, no timeout).

On a resource-starved Windows runner this work balloons past the 30 s mocha timeout for the dry-run test.

## Fix

Skip app detection when `config.dryRun` is set:

```ts
config.environment.apps = config.dryRun ? [] : await getAvailableApps({ config });
```

This is safe because `config.environment.apps` is consumed **only** by the execution/runner paths in `src/core/tests.ts` (which call `getAvailableApps()` themselves) and is **never** read by `resolveTests`/`detectTests`. A dry run returns the resolved-tests preview and never executes, so detection is pure wasted work there — skipping it leaves the resolved output unchanged. Bonus: `--dry-run` is now faster for all users.

Adds a regression assertion that a dry run leaves `environment.apps` empty.

## Verification

Built and ran locally on **node 22 (Windows)** — the affected matrix cell:

- `npx mocha --exit test/dryRun.test.js` → **4 passing**, dry-run case down to ~0.7 s (was at risk of >30 s under load).
- The non-dry control case still runs the full `setConfig` → `getAvailableApps` path and passes, confirming the execution path is unchanged.

## Out of scope

No spawn hang-guard and no mocha timeout bumps. The other occasionally-observed offender — the execution test *"Run tests successfully"* (already on 10–30 min timeouts) — is collateral of a near-dead runner and isn't addressable via per-test timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized dry-run mode to skip expensive app detection logic, resulting in faster execution times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->