### PR TITLE
fix(core): lazy-load webdriverio Key in typeKeys so lean installs run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# [4.6.0-typekeys-lazy-webdriverio.1](https://github.com/doc-detective/doc-detective/compare/v4.5.0...v4.6.0-typekeys-lazy-webdriverio.1) (2026-06-04)
+
+
+### Bug Fixes
+
+* **core:** fail-soft on key-map load error and add subtract alias ([5901f0b](https://github.com/doc-detective/doc-detective/commit/5901f0b4691739b49df68c4939983151c7ddc1f1))
+* **core:** lazy-load webdriverio Key in typeKeys so lean installs run ([bdc93b0](https://github.com/doc-detective/doc-detective/commit/bdc93b0cbe4d607ae6deb40ae29b982c84f1fd94)), closes [#312](https://github.com/doc-detective/doc-detective/issues/312)
+* declare node >=22.12.0 engine requirement ([999378e](https://github.com/doc-detective/doc-detective/commit/999378e6d3af1ffe9105e6be259ffb9b6884debe))
+* **install:** stop heavy deps installing (and warning) on npm i ([#308](https://github.com/doc-detective/doc-detective/issues/308)) ([17a8579](https://github.com/doc-detective/doc-detective/commit/17a85793981ecb8f3255d1db530670f7b98d1ee4))
+* re-cut next prerelease after npm publish token failure ([197232b](https://github.com/doc-detective/doc-detective/commit/197232b6feb5795e1b134f1b5fbdb39c940c3a43))
+* **release:** apply publish manifest transform before npm reads it ([#312](https://github.com/doc-detective/doc-detective/issues/312)) ([ef86d51](https://github.com/doc-detective/doc-detective/commit/ef86d510d5bea0e251eb68e7bb51c351c6febb90))
+* **runtime:** bump @puppeteer/browsers to v3 for node 24 support ([#309](https://github.com/doc-detective/doc-detective/issues/309)) ([21603dd](https://github.com/doc-detective/doc-detective/commit/21603dd653749c71855c004154984fab200ec74c))
+* **runtime:** skip app detection in dry-run runs ([#311](https://github.com/doc-detective/doc-detective/issues/311)) ([82aa6d5](https://github.com/doc-detective/doc-detective/commit/82aa6d58a2e2bd93ec3cf08aed7d1e81b55b42ac))
+
+
+### Features
+
+* **install:** lazy-install heavy deps and browsers via runtime cache ([#305](https://github.com/doc-detective/doc-detective/issues/305)) ([e7e1623](https://github.com/doc-detective/doc-detective/commit/e7e162364e3b1d6fbd637b5453ba1190f8772de2)), closes [#60](https://github.com/doc-detective/doc-detective/issues/60) [#60](https://github.com/doc-detective/doc-detective/issues/60)
+
 # [4.6.0-next.6](https://github.com/doc-detective/doc-detective/compare/v4.6.0-next.5...v4.6.0-next.6) (2026-06-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.6.0-typekeys-lazy-webdriverio.2](https://github.com/doc-detective/doc-detective/compare/v4.6.0-typekeys-lazy-webdriverio.1...v4.6.0-typekeys-lazy-webdriverio.2) (2026-06-04)
+
+
+### Bug Fixes
+
+* **core:** only load webdriverio for typeKeys when a special token is present ([ae8faf8](https://github.com/doc-detective/doc-detective/commit/ae8faf84706efa06b1184261305b2d6912825f38))
+
 # [4.6.0-typekeys-lazy-webdriverio.1](https://github.com/doc-detective/doc-detective/compare/v4.5.0...v4.6.0-typekeys-lazy-webdriverio.1) (2026-06-04)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective",
-  "version": "4.6.0-typekeys-lazy-webdriverio.1",
+  "version": "4.6.0-typekeys-lazy-webdriverio.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective",
-      "version": "4.6.0-typekeys-lazy-webdriverio.1",
+      "version": "4.6.0-typekeys-lazy-webdriverio.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [
@@ -26118,7 +26118,7 @@
     },
     "src/common": {
       "name": "doc-detective-common",
-      "version": "4.6.0-typekeys-lazy-webdriverio.1",
+      "version": "4.6.0-typekeys-lazy-webdriverio.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective",
-  "version": "4.6.0-next.6",
+  "version": "4.6.0-typekeys-lazy-webdriverio.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective",
-      "version": "4.6.0-next.6",
+      "version": "4.6.0-typekeys-lazy-webdriverio.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [
@@ -26118,7 +26118,7 @@
     },
     "src/common": {
       "name": "doc-detective-common",
-      "version": "4.6.0-next.6",
+      "version": "4.6.0-typekeys-lazy-webdriverio.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective",
-  "version": "4.6.0-next.6",
+  "version": "4.6.0-typekeys-lazy-webdriverio.1",
   "description": "Treat doc content as testable assertions to validate doc accuracy and product UX.",
   "workspaces": [
     "src/common"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective",
-  "version": "4.6.0-typekeys-lazy-webdriverio.1",
+  "version": "4.6.0-typekeys-lazy-webdriverio.2",
   "description": "Treat doc content as testable assertions to validate doc accuracy and product UX.",
   "workspaces": [
     "src/common"

--- a/src/common/package-lock.json
+++ b/src/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "4.6.0-typekeys-lazy-webdriverio.1",
+  "version": "4.6.0-typekeys-lazy-webdriverio.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "4.6.0-typekeys-lazy-webdriverio.1",
+      "version": "4.6.0-typekeys-lazy-webdriverio.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/src/common/package-lock.json
+++ b/src/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "4.6.0-next.6",
+  "version": "4.6.0-typekeys-lazy-webdriverio.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "4.6.0-next.6",
+      "version": "4.6.0-typekeys-lazy-webdriverio.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/src/common/package.json
+++ b/src/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "4.6.0-next.6",
+  "version": "4.6.0-typekeys-lazy-webdriverio.1",
   "description": "Shared components for Doc Detective projects.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/common/package.json
+++ b/src/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "4.6.0-typekeys-lazy-webdriverio.1",
+  "version": "4.6.0-typekeys-lazy-webdriverio.2",
   "description": "Shared components for Doc Detective projects.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/core/tests/typeKeys.ts
+++ b/src/core/tests/typeKeys.ts
@@ -64,7 +64,10 @@ async function getSpecialKeyMap(
     $MULTIPLY$: Key.Multiply,
     $ADD$: Key.Add,
     $SEPARATOR$: Key.Separator,
+    // `$SUBSTRACT$` is a long-standing misspelling kept for backwards
+    // compatibility; `$SUBTRACT$` is the correctly-spelled alias.
     $SUBSTRACT$: Key.Subtract,
+    $SUBTRACT$: Key.Subtract,
     $DECIMAL$: Key.Decimal,
     $DIVIDE$: Key.Divide,
     $F1$: Key.F1,
@@ -181,7 +184,17 @@ async function typeKeys({ config, step, driver }: { config: any; step: any; driv
   // Substitute special keys
   // 1. For each key, identify if it following the escape pattern of `$...$`.
   // 2. If it does, replace it with the corresponding `Key` object from `specialKeyMap`.
-  const specialKeyMap = await getSpecialKeyMap({ cacheDir: config?.cacheDir });
+  // Loading webdriverio can throw (e.g. the runtime dep isn't installed yet).
+  // Return a step-level FAIL rather than letting it abort the whole run, matching
+  // how other heavy-dep-backed steps behave.
+  let specialKeyMap: Record<string, string>;
+  try {
+    specialKeyMap = await getSpecialKeyMap({ cacheDir: config?.cacheDir });
+  } catch (error: any) {
+    result.status = "FAIL";
+    result.description = `Couldn't load key definitions: ${error.message}`;
+    return result;
+  }
   step.type.keys = step.type.keys.map((key: any) => {
     if (key.startsWith("$") && key.endsWith("$") && specialKeyMap[key]) {
       return specialKeyMap[key];

--- a/src/core/tests/typeKeys.ts
+++ b/src/core/tests/typeKeys.ts
@@ -1,70 +1,89 @@
 import { validate } from "../../common/src/validate.js";
-import { Key } from "webdriverio";
 import {
   findElementByCriteria,
 } from "./findStrategies.js";
+import { loadHeavyDep } from "../../runtime/loader.js";
 
 export { typeKeys };
 
-const specialKeyMap: Record<string, string> = {
-  $CTRL$: Key.Ctrl,
-  $NULL$: Key.NULL,
-  $CANCEL$: Key.Cancel,
-  $HELP$: Key.Help,
-  $BACKSPACE$: Key.Backspace,
-  $TAB$: Key.Tab,
-  $CLEAR$: Key.Clear,
-  $RETURN$: Key.Return,
-  $ENTER$: Key.Enter,
-  $SHIFT$: Key.Shift,
-  $CONTROL$: Key.Control,
-  $ALT$: Key.Alt,
-  $PAUSE$: Key.Pause,
-  $ESCAPE$: Key.Escape,
-  $SPACE$: Key.Space,
-  $PAGE_UP$: Key.PageUp,
-  $PAGE_DOWN$: Key.PageDown,
-  $END$: Key.End,
-  $HOME$: Key.Home,
-  $ARROW_LEFT$: Key.ArrowLeft,
-  $ARROW_UP$: Key.ArrowUp,
-  $ARROW_RIGHT$: Key.ArrowRight,
-  $ARROW_DOWN$: Key.ArrowDown,
-  $INSERT$: Key.Insert,
-  $DELETE$: Key.Delete,
-  $SEMICOLON$: Key.Semicolon,
-  $EQUALS$: Key.Equals,
-  $NUMPAD_0$: Key.Numpad0,
-  $NUMPAD_1$: Key.Numpad1,
-  $NUMPAD_2$: Key.Numpad2,
-  $NUMPAD_3$: Key.Numpad3,
-  $NUMPAD_4$: Key.Numpad4,
-  $NUMPAD_5$: Key.Numpad5,
-  $NUMPAD_6$: Key.Numpad6,
-  $NUMPAD_7$: Key.Numpad7,
-  $NUMPAD_8$: Key.Numpad8,
-  $NUMPAD_9$: Key.Numpad9,
-  $MULTIPLY$: Key.Multiply,
-  $ADD$: Key.Add,
-  $SEPARATOR$: Key.Separator,
-  $SUBSTRACT$: Key.Subtract,
-  $DECIMAL$: Key.Decimal,
-  $DIVIDE$: Key.Divide,
-  $F1$: Key.F1,
-  $F2$: Key.F2,
-  $F3$: Key.F3,
-  $F4$: Key.F4,
-  $F5$: Key.F5,
-  $F6$: Key.F6,
-  $F7$: Key.F7,
-  $F8$: Key.F8,
-  $F9$: Key.F9,
-  $F10$: Key.F10,
-  $F11$: Key.F11,
-  $F12$: Key.F12,
-  $COMMAND$: Key.Command,
-  $ZANKAKU_HANDKAKU$: Key.ZenkakuHankaku,
-};
+// webdriverio is a heavy runtime dep that a lean install does not ship (it is
+// lazy-installed on first browser use). Importing `Key` statically would drag
+// webdriverio into the module graph at load time, breaking even `--version` on
+// a lean install. So lazy-load it the first time a typeKeys step runs, mirroring
+// saveScreenshot.ts. The modifier entries (Ctrl/Command/…) are webdriverio
+// sentinels that driver.keys() interprets per-platform — we must use the real
+// export, not hardcoded WebDriver code points.
+type WdioModule = typeof import("webdriverio");
+
+let _specialKeyMap: Record<string, string> | null = null;
+
+async function getSpecialKeyMap(
+  ctx: { cacheDir?: string } = {}
+): Promise<Record<string, string>> {
+  if (_specialKeyMap) return _specialKeyMap;
+  const wdio = await loadHeavyDep<WdioModule>("webdriverio", { ctx });
+  const { Key } = wdio;
+  _specialKeyMap = {
+    $CTRL$: Key.Ctrl,
+    $NULL$: Key.NULL,
+    $CANCEL$: Key.Cancel,
+    $HELP$: Key.Help,
+    $BACKSPACE$: Key.Backspace,
+    $TAB$: Key.Tab,
+    $CLEAR$: Key.Clear,
+    $RETURN$: Key.Return,
+    $ENTER$: Key.Enter,
+    $SHIFT$: Key.Shift,
+    $CONTROL$: Key.Control,
+    $ALT$: Key.Alt,
+    $PAUSE$: Key.Pause,
+    $ESCAPE$: Key.Escape,
+    $SPACE$: Key.Space,
+    $PAGE_UP$: Key.PageUp,
+    $PAGE_DOWN$: Key.PageDown,
+    $END$: Key.End,
+    $HOME$: Key.Home,
+    $ARROW_LEFT$: Key.ArrowLeft,
+    $ARROW_UP$: Key.ArrowUp,
+    $ARROW_RIGHT$: Key.ArrowRight,
+    $ARROW_DOWN$: Key.ArrowDown,
+    $INSERT$: Key.Insert,
+    $DELETE$: Key.Delete,
+    $SEMICOLON$: Key.Semicolon,
+    $EQUALS$: Key.Equals,
+    $NUMPAD_0$: Key.Numpad0,
+    $NUMPAD_1$: Key.Numpad1,
+    $NUMPAD_2$: Key.Numpad2,
+    $NUMPAD_3$: Key.Numpad3,
+    $NUMPAD_4$: Key.Numpad4,
+    $NUMPAD_5$: Key.Numpad5,
+    $NUMPAD_6$: Key.Numpad6,
+    $NUMPAD_7$: Key.Numpad7,
+    $NUMPAD_8$: Key.Numpad8,
+    $NUMPAD_9$: Key.Numpad9,
+    $MULTIPLY$: Key.Multiply,
+    $ADD$: Key.Add,
+    $SEPARATOR$: Key.Separator,
+    $SUBSTRACT$: Key.Subtract,
+    $DECIMAL$: Key.Decimal,
+    $DIVIDE$: Key.Divide,
+    $F1$: Key.F1,
+    $F2$: Key.F2,
+    $F3$: Key.F3,
+    $F4$: Key.F4,
+    $F5$: Key.F5,
+    $F6$: Key.F6,
+    $F7$: Key.F7,
+    $F8$: Key.F8,
+    $F9$: Key.F9,
+    $F10$: Key.F10,
+    $F11$: Key.F11,
+    $F12$: Key.F12,
+    $COMMAND$: Key.Command,
+    $ZANKAKU_HANDKAKU$: Key.ZenkakuHankaku,
+  };
+  return _specialKeyMap;
+}
 
 // Type a sequence of keys in the active element.
 async function typeKeys({ config, step, driver }: { config: any; step: any; driver: any }) {
@@ -162,6 +181,7 @@ async function typeKeys({ config, step, driver }: { config: any; step: any; driv
   // Substitute special keys
   // 1. For each key, identify if it following the escape pattern of `$...$`.
   // 2. If it does, replace it with the corresponding `Key` object from `specialKeyMap`.
+  const specialKeyMap = await getSpecialKeyMap({ cacheDir: config?.cacheDir });
   step.type.keys = step.type.keys.map((key: any) => {
     if (key.startsWith("$") && key.endsWith("$") && specialKeyMap[key]) {
       return specialKeyMap[key];

--- a/src/core/tests/typeKeys.ts
+++ b/src/core/tests/typeKeys.ts
@@ -182,25 +182,32 @@ async function typeKeys({ config, step, driver }: { config: any; step: any; driv
   }
 
   // Substitute special keys
-  // 1. For each key, identify if it following the escape pattern of `$...$`.
-  // 2. If it does, replace it with the corresponding `Key` object from `specialKeyMap`.
-  // Loading webdriverio can throw (e.g. the runtime dep isn't installed yet).
-  // Return a step-level FAIL rather than letting it abort the whole run, matching
-  // how other heavy-dep-backed steps behave.
-  let specialKeyMap: Record<string, string>;
-  try {
-    specialKeyMap = await getSpecialKeyMap({ cacheDir: config?.cacheDir });
-  } catch (error: any) {
-    result.status = "FAIL";
-    result.description = `Couldn't load key definitions: ${error.message}`;
-    return result;
-  }
-  step.type.keys = step.type.keys.map((key: any) => {
-    if (key.startsWith("$") && key.endsWith("$") && specialKeyMap[key]) {
-      return specialKeyMap[key];
+  // 1. For each key, identify if it follows the escape pattern of `$...$`.
+  // 2. If it does, replace it with the corresponding `Key` value from `specialKeyMap`.
+  // Only load the map (and thus webdriverio) when a sentinel token is actually
+  // present — plain-text typing must not pull in the heavy dep or risk a
+  // load-time FAIL. Loading webdriverio can throw (e.g. the runtime dep isn't
+  // installed yet); return a step-level FAIL rather than aborting the whole run,
+  // matching how other heavy-dep-backed steps behave.
+  const hasSpecialTokens = step.type.keys.some(
+    (key: any) => key.startsWith("$") && key.endsWith("$")
+  );
+  if (hasSpecialTokens) {
+    let specialKeyMap: Record<string, string>;
+    try {
+      specialKeyMap = await getSpecialKeyMap({ cacheDir: config?.cacheDir });
+    } catch (error: any) {
+      result.status = "FAIL";
+      result.description = `Couldn't load key definitions: ${error.message}`;
+      return result;
     }
-    return key;
-  });
+    step.type.keys = step.type.keys.map((key: any) => {
+      if (key.startsWith("$") && key.endsWith("$") && specialKeyMap[key]) {
+        return specialKeyMap[key];
+      }
+      return key;
+    });
+  }
 
   // Run action
   try {


### PR DESCRIPTION
## Problem

After the publish-manifest fix (#312) made `npm i -g doc-detective@next` actually lean (no `webdriverio`/`appium`/etc.), the CLI fails to even start:

```
$ doc-detective --version
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'webdriverio' imported from
  .../dist/core/tests/typeKeys.js
```

`src/core/tests/typeKeys.ts` statically imported `{ Key }` from `webdriverio` at module-load time to build its special-key map. `typeKeys.js` is in the CLI startup module graph, so loading *any* command (even `--version`/`--help`) eagerly resolved `webdriverio` — which a lean install no longer ships. It only ever worked because the pre-#312 install always (incorrectly) dragged in the heavy tree.

## Fix

Lazy-load `webdriverio` via the existing `loadHeavyDep` runtime loader the first time a `typeKeys` step actually runs, mirroring `saveScreenshot.ts` (sharp/pngjs/pixelmatch). The special-key map is built on first use and memoized.

The modifier entries (`Key.Ctrl`, `Key.Command`, …) are webdriverio sentinels that `driver.keys()` interprets per-platform, so the real `Key` export is kept rather than hardcoding WebDriver code points.

`typeKeys` was the **only** module in the build with a static heavy-dep import (verified by scanning `dist/` for static `import`/`require` of every heavy dep).

## Verification

In an environment with `webdriverio` absent from `node_modules` (the lean scenario):
- `dist/core/tests/typeKeys.js` imports cleanly (no `ERR_MODULE_NOT_FOUND`)
- `doc-detective --version` and `--help` work
- No static heavy-dep import remains anywhere in `dist/`

The lazy path is unchanged behaviorally: when a `typeKeys` step runs during a real browser test, `loadHeavyDep` provides the same `webdriverio` module (already loaded by `driverStart`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lazy-loads heavy browser/driver assets and key definitions at runtime with a cache to reduce startup cost and optionally install on demand.
  * Added graceful fail-soft behavior when key definitions can’t be loaded.

* **Bug Fixes**
  * Fixes around install/release/runtime behavior, publish manifest ordering, and dry-run app detection.
  * Updates Node engine requirement for compatibility.

* **Chores**
  * Release/version update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->