### PR TITLE
feat(install): pre-install runtime and browsers at postinstall by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# [4.6.0-postinstall-runtime-default.1](https://github.com/doc-detective/doc-detective/compare/v4.5.0...v4.6.0-postinstall-runtime-default.1) (2026-06-04)
+
+
+### Bug Fixes
+
+* **core:** lazy-load webdriverio Key in typeKeys so lean installs run ([#314](https://github.com/doc-detective/doc-detective/issues/314)) ([65b65fc](https://github.com/doc-detective/doc-detective/commit/65b65fc7bce576639ecf1a63ca363fb27211dbab)), closes [#312](https://github.com/doc-detective/doc-detective/issues/312)
+* declare node >=22.12.0 engine requirement ([999378e](https://github.com/doc-detective/doc-detective/commit/999378e6d3af1ffe9105e6be259ffb9b6884debe))
+* **install:** buffer npm stream remainders before filtering noise ([2ac5e0a](https://github.com/doc-detective/doc-detective/commit/2ac5e0a2daa3f3e1c218750970ba29d241a0e6b3))
+* **install:** stop heavy deps installing (and warning) on npm i ([#308](https://github.com/doc-detective/doc-detective/issues/308)) ([17a8579](https://github.com/doc-detective/doc-detective/commit/17a85793981ecb8f3255d1db530670f7b98d1ee4))
+* **postinstall:** guard main() rejection and address review nits ([7a63379](https://github.com/doc-detective/doc-detective/commit/7a6337939591171c305eacadefbc55d1067fb71f))
+* re-cut next prerelease after npm publish token failure ([197232b](https://github.com/doc-detective/doc-detective/commit/197232b6feb5795e1b134f1b5fbdb39c940c3a43))
+* **release:** apply publish manifest transform before npm reads it ([#312](https://github.com/doc-detective/doc-detective/issues/312)) ([ef86d51](https://github.com/doc-detective/doc-detective/commit/ef86d510d5bea0e251eb68e7bb51c351c6febb90))
+* **runtime:** bump @puppeteer/browsers to v3 for node 24 support ([#309](https://github.com/doc-detective/doc-detective/issues/309)) ([21603dd](https://github.com/doc-detective/doc-detective/commit/21603dd653749c71855c004154984fab200ec74c))
+* **runtime:** skip app detection in dry-run runs ([#311](https://github.com/doc-detective/doc-detective/issues/311)) ([82aa6d5](https://github.com/doc-detective/doc-detective/commit/82aa6d58a2e2bd93ec3cf08aed7d1e81b55b42ac))
+
+
+### Features
+
+* **install:** filter npm deprecation/funding noise from all install output ([06619e1](https://github.com/doc-detective/doc-detective/commit/06619e1afdb7e972cf7d830199f7c952c62333e6))
+* **install:** lazy-install heavy deps and browsers via runtime cache ([#305](https://github.com/doc-detective/doc-detective/issues/305)) ([e7e1623](https://github.com/doc-detective/doc-detective/commit/e7e162364e3b1d6fbd637b5453ba1190f8772de2)), closes [#60](https://github.com/doc-detective/doc-detective/issues/60) [#60](https://github.com/doc-detective/doc-detective/issues/60)
+* **install:** pre-install runtime and browsers at postinstall by default ([b2363f4](https://github.com/doc-detective/doc-detective/commit/b2363f41a804f01fd6f43da97c4b3837974203a3))
+
 # [4.6.0-typekeys-lazy-webdriverio.2](https://github.com/doc-detective/doc-detective/compare/v4.6.0-typekeys-lazy-webdriverio.1...v4.6.0-typekeys-lazy-webdriverio.2) (2026-06-04)
 
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Doc Detective has multiple components to integrate with your workflows as you ne
 
 `npm i doc-detective` installs the CLI and then, at postinstall, pre-installs the heavy runtime assets — browsers (Chrome, Firefox), drivers (ChromeDriver, Geckodriver), ffmpeg, and the npm packages that drive them (webdriverio, appium, sharp, etc.) — into `<os.tmpdir()>/doc-detective/` (or `DOC_DETECTIVE_CACHE_DIR`). This keeps a fresh install — and any Docker image built `FROM` it — ready to run without a separate step. The pre-install runs in a child process whose output is captured, so npm's deprecation warnings from the heavy transitive trees never reach your terminal.
 
-**Opt out of the heavy pre-install** by setting `DOC_DETECTIVE_INSTALL_RUNTIME=0` (also accepts `false`/`no`/`off`). The CLI install then stays small — no browser download, no heavy npm packages — and the heavy assets install lazily the first time a test needs them instead, or up front via `doc-detective install all`.
+**Opt out of the heavy pre-install** by setting `DOC_DETECTIVE_AUTOINSTALL=0` (also accepts `false`/`no`/`off`). The CLI install then stays small — no browser download, no heavy npm packages — and the heavy assets install lazily the first time a test needs them instead, or up front via `doc-detective install all`.
 
 Either way, the heavy packages are never declared in `dependencies` or `optionalDependencies`, so npm itself never fetches them as part of the dependency tree. Their version constraints live in a custom `ddRuntimeDependencies` field that the resolver reads when it installs each dep into the cache — whether at postinstall or on first use.
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ Doc Detective has multiple components to integrate with your workflows as you ne
 
 ### Lazy-installed runtime
 
-`npm i doc-detective` installs only the CLI and a small set of light dependencies — no browser download, no heavy npm packages, no deprecation warnings from their transitive trees. Heavy runtime assets — browsers (Chrome, Firefox), drivers (ChromeDriver, Geckodriver), ffmpeg, and the npm packages that drive them (webdriverio, appium, sharp, etc.) — install lazily into `<os.tmpdir()>/doc-detective/` the first time a test needs them, or up front via `doc-detective install all`.
+`npm i doc-detective` installs the CLI and then, at postinstall, pre-installs the heavy runtime assets — browsers (Chrome, Firefox), drivers (ChromeDriver, Geckodriver), ffmpeg, and the npm packages that drive them (webdriverio, appium, sharp, etc.) — into `<os.tmpdir()>/doc-detective/` (or `DOC_DETECTIVE_CACHE_DIR`). This keeps a fresh install — and any Docker image built `FROM` it — ready to run without a separate step. The pre-install runs in a child process whose output is captured, so npm's deprecation warnings from the heavy transitive trees never reach your terminal.
 
-The published package does not declare the heavy packages in `dependencies` or `optionalDependencies`, so npm never fetches them at install time. Their version constraints live in a custom `ddRuntimeDependencies` field that the lazy resolver reads when it installs each dep into the cache on first use.
+**Opt out of the heavy pre-install** by setting `DOC_DETECTIVE_INSTALL_RUNTIME=0` (also accepts `false`/`no`/`off`). The CLI install then stays small — no browser download, no heavy npm packages — and the heavy assets install lazily the first time a test needs them instead, or up front via `doc-detective install all`.
+
+Either way, the heavy packages are never declared in `dependencies` or `optionalDependencies`, so npm itself never fetches them as part of the dependency tree. Their version constraints live in a custom `ddRuntimeDependencies` field that the resolver reads when it installs each dep into the cache — whether at postinstall or on first use.
 
 - **Pre-install everything up front:**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective",
-  "version": "4.6.0-typekeys-lazy-webdriverio.2",
+  "version": "4.6.0-postinstall-runtime-default.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective",
-      "version": "4.6.0-typekeys-lazy-webdriverio.2",
+      "version": "4.6.0-postinstall-runtime-default.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [
@@ -26118,7 +26118,7 @@
     },
     "src/common": {
       "name": "doc-detective-common",
-      "version": "4.6.0-typekeys-lazy-webdriverio.2",
+      "version": "4.6.0-postinstall-runtime-default.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective",
-  "version": "4.6.0-typekeys-lazy-webdriverio.2",
+  "version": "4.6.0-postinstall-runtime-default.1",
   "description": "Treat doc content as testable assertions to validate doc accuracy and product UX.",
   "workspaces": [
     "src/common"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -57,17 +57,20 @@ export function isProgressLine(line) {
 
 /**
  * Pure npm noise (deprecation/funding/notice). Dropped from the captured
- * buffer when surfacing a failure tail so the dump stays readable. Exported
- * for tests.
+ * buffer when surfacing a failure tail so the dump stays readable — genuine
+ * warnings/errors (e.g. EBADENGINE) are kept. Exported for tests.
+ *
+ * Kept in sync with src/runtime/installOutput.ts#isNpmNoiseLine (this is a
+ * plain Node script that can't import the compiled TS module reliably).
  */
 export function isNpmNoiseLine(line) {
   const l = line.trim();
   if (!l) return true;
   return (
     /^npm warn deprecated/i.test(l) ||
-    /^npm warn /i.test(l) ||
     /^npm notice/i.test(l) ||
-    /^npm fund/i.test(l)
+    /^npm fund/i.test(l) ||
+    /packages are looking for funding/i.test(l)
   );
 }
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,21 +1,150 @@
+import fs from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Browsers, ffmpeg, geckodriver, and the heavy npm packages are no longer
-// downloaded at `npm install` time. The shim now lazy-installs them on
-// first use into <cacheDir>/ (default <os.tmpdir()>/doc-detective/), or
-// up-front via `doc-detective install all`. This postinstall script
-// keeps only the optional agent-tools install prompt — it's lightweight
-// (TTY-gated, time-bounded, skipped in CI) and unrelated to the runtime.
-
+// Two steps run at `npm install` time:
+//   1. maybeInstallRuntime(): eagerly install the heavy runtime assets
+//      (webdriverio/appium/sharp + browsers) via `doc-detective install all`,
+//      so a fresh install — and any Docker image built `FROM` it — is ready to
+//      run without a separate install step. On by default; opt out with
+//      DOC_DETECTIVE_INSTALL_RUNTIME=0.
+//   2. maybePromptInstallAgents(): the optional agent-tools install prompt —
+//      lightweight (TTY-gated, time-bounded, skipped in CI).
 async function main() {
+  await maybeInstallRuntime();
   await maybePromptInstallAgents();
 }
 
-main();
+// Only run the install steps when executed as the npm lifecycle script, not
+// when a test imports this module for the exported pure helpers below.
+function isInvokedDirectly() {
+  try {
+    if (!process.argv[1]) return false;
+    return (
+      fs.realpathSync(process.argv[1]) ===
+      fs.realpathSync(fileURLToPath(import.meta.url))
+    );
+  } catch {
+    return false;
+  }
+}
+if (isInvokedDirectly()) main();
+
+// --- Runtime + browsers auto-install ----------------------------------------
+
+/**
+ * True when the user has opted out of the postinstall heavy install via
+ * DOC_DETECTIVE_INSTALL_RUNTIME (0/false/no/off, case-insensitive). Default
+ * (unset or any other value) installs. Exported for tests.
+ */
+export function isRuntimeInstallOptedOut(env = process.env) {
+  const v = String(env.DOC_DETECTIVE_INSTALL_RUNTIME ?? "").trim().toLowerCase();
+  return v === "0" || v === "false" || v === "no" || v === "off";
+}
+
+/**
+ * A line we surface to the user: the installer's own clean progress output
+ * (`Installing runtime…`, `  [npm] webdriverio — installed`, …). Everything
+ * else from the child — npm deprecation/funding noise, blank lines — is
+ * suppressed on the success path. Exported for tests.
+ */
+export function isProgressLine(line) {
+  return /^\s*Installing\b/.test(line) || /^\s*\[(npm|browser)\]/.test(line);
+}
+
+/**
+ * Pure npm noise (deprecation/funding/notice). Dropped from the captured
+ * buffer when surfacing a failure tail so the dump stays readable. Exported
+ * for tests.
+ */
+export function isNpmNoiseLine(line) {
+  const l = line.trim();
+  if (!l) return true;
+  return (
+    /^npm warn deprecated/i.test(l) ||
+    /^npm warn /i.test(l) ||
+    /^npm notice/i.test(l) ||
+    /^npm fund/i.test(l)
+  );
+}
+
+// Install the heavy runtime assets in a CHILD PROCESS whose stdout/stderr we
+// capture (pipe) rather than inherit, so npm's deprecated-transitive-dependency
+// warnings (glob, whatwg-encoding, …) never reach the user's terminal. We
+// forward only the installer's own progress lines; on failure we surface a
+// curated tail. This never fails the npm install — the assets also lazy-install
+// on first use, so a failure here just forfeits the pre-warm.
+async function maybeInstallRuntime() {
+  if (isRuntimeInstallOptedOut()) return;
+
+  const cliPath = path.join(__dirname, "..", "bin", "doc-detective.js");
+  const distDir = path.join(__dirname, "..", "dist");
+  // Dev checkout / partial install without a build: the CLI can't run yet.
+  // Skip silently — postinstall must never fail.
+  if (!fs.existsSync(cliPath) || !fs.existsSync(distDir)) return;
+
+  console.log(
+    "doc-detective: installing runtime + browsers " +
+      "(set DOC_DETECTIVE_INSTALL_RUNTIME=0 to skip)…"
+  );
+
+  const captured = [];
+  const handleLine = (raw, forward) => {
+    if (raw === "") return;
+    captured.push(raw);
+    if (forward && isProgressLine(raw)) console.log("  " + raw.trim());
+  };
+  // Buffer per stream so a line split across data chunks is reassembled before
+  // the allow-list filter sees it. Returns the new buffer remainder.
+  const consume = (buf, chunk, forward) => {
+    const parts = (buf + chunk.toString()).split(/\r?\n/);
+    const remainder = parts.pop(); // trailing partial line (no newline yet)
+    for (const line of parts) handleLine(line, forward);
+    return remainder;
+  };
+
+  const { code, signal, errored } = await new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(
+        process.execPath,
+        [cliPath, "install", "all", "--yes"],
+        { stdio: ["ignore", "pipe", "pipe"], env: process.env }
+      );
+    } catch {
+      resolve({ code: 1, signal: null, errored: true });
+      return;
+    }
+    let outBuf = "";
+    let errBuf = "";
+    child.stdout?.on("data", (c) => (outBuf = consume(outBuf, c, true)));
+    // stderr is captured for a possible failure dump but never forwarded live.
+    child.stderr?.on("data", (c) => (errBuf = consume(errBuf, c, false)));
+    child.on("close", (c, s) => {
+      // Flush any trailing partial lines left without a final newline.
+      handleLine(outBuf, true);
+      handleLine(errBuf, false);
+      resolve({ code: c, signal: s, errored: false });
+    });
+    child.on("error", () => resolve({ code: 1, signal: null, errored: true }));
+  });
+
+  if (!errored && !signal && code === 0) {
+    console.log("doc-detective: runtime + browsers ready.");
+    return;
+  }
+
+  const tail = captured.filter((l) => !isNpmNoiseLine(l)).slice(-20);
+  console.error(
+    "doc-detective: runtime install did not complete " +
+      (signal ? `(signal ${signal})` : `(exit ${code})`) +
+      ". Assets will install on first use, or run `doc-detective install all`."
+  );
+  if (tail.length) console.error(tail.map((l) => "  " + l).join("\n"));
+}
 
 async function maybePromptInstallAgents() {
   // Don't prompt in non-interactive contexts. npm sets many of these during

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -130,11 +130,11 @@ async function maybeInstallRuntime() {
     child.stdout?.on("data", (chunk) => (outBuf = consume(outBuf, chunk, true)));
     // stderr is captured for a possible failure dump but never forwarded live.
     child.stderr?.on("data", (chunk) => (errBuf = consume(errBuf, chunk, false)));
-    child.on("close", (code, signal) => {
+    child.on("close", (exitCode, exitSignal) => {
       // Flush any trailing partial lines left without a final newline.
       handleLine(outBuf, true);
       handleLine(errBuf, false);
-      resolve({ code, signal, errored: false });
+      resolve({ code: exitCode, signal: exitSignal, errored: false });
     });
     child.on("error", () => resolve({ code: 1, signal: null, errored: true }));
   });

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -13,7 +13,7 @@ const CLI_PATH = path.join(__dirname, "..", "bin", "doc-detective.js");
 //      (webdriverio/appium/sharp + browsers) via `doc-detective install all`,
 //      so a fresh install — and any Docker image built `FROM` it — is ready to
 //      run without a separate install step. On by default; opt out with
-//      DOC_DETECTIVE_INSTALL_RUNTIME=0.
+//      DOC_DETECTIVE_AUTOINSTALL=0.
 //   2. maybePromptInstallAgents(): the optional agent-tools install prompt —
 //      lightweight (TTY-gated, time-bounded, skipped in CI).
 async function main() {
@@ -42,11 +42,11 @@ if (isInvokedDirectly()) main().catch(() => {});
 
 /**
  * True when the user has opted out of the postinstall heavy install via
- * DOC_DETECTIVE_INSTALL_RUNTIME (0/false/no/off, case-insensitive). Default
+ * DOC_DETECTIVE_AUTOINSTALL (0/false/no/off, case-insensitive). Default
  * (unset or any other value) installs. Exported for tests.
  */
 export function isRuntimeInstallOptedOut(env = process.env) {
-  const v = String(env.DOC_DETECTIVE_INSTALL_RUNTIME ?? "").trim().toLowerCase();
+  const v = String(env.DOC_DETECTIVE_AUTOINSTALL ?? "").trim().toLowerCase();
   return v === "0" || v === "false" || v === "no" || v === "off";
 }
 
@@ -95,7 +95,7 @@ async function maybeInstallRuntime() {
 
   console.log(
     "doc-detective: installing runtime + browsers " +
-      "(set DOC_DETECTIVE_INSTALL_RUNTIME=0 to skip)…"
+      "(set DOC_DETECTIVE_AUTOINSTALL=0 to skip)…"
   );
 
   const captured = [];

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -5,6 +5,9 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Resolved path to the compiled CLI, shared by both install steps below.
+const CLI_PATH = path.join(__dirname, "..", "bin", "doc-detective.js");
+
 // Two steps run at `npm install` time:
 //   1. maybeInstallRuntime(): eagerly install the heavy runtime assets
 //      (webdriverio/appium/sharp + browsers) via `doc-detective install all`,
@@ -31,7 +34,9 @@ function isInvokedDirectly() {
     return false;
   }
 }
-if (isInvokedDirectly()) main();
+// Swallow any unexpected rejection: a postinstall script must always exit 0,
+// otherwise it fails the user's `npm install`.
+if (isInvokedDirectly()) main().catch(() => {});
 
 // --- Runtime + browsers auto-install ----------------------------------------
 
@@ -83,11 +88,10 @@ export function isNpmNoiseLine(line) {
 async function maybeInstallRuntime() {
   if (isRuntimeInstallOptedOut()) return;
 
-  const cliPath = path.join(__dirname, "..", "bin", "doc-detective.js");
   const distDir = path.join(__dirname, "..", "dist");
   // Dev checkout / partial install without a build: the CLI can't run yet.
   // Skip silently — postinstall must never fail.
-  if (!fs.existsSync(cliPath) || !fs.existsSync(distDir)) return;
+  if (!fs.existsSync(CLI_PATH) || !fs.existsSync(distDir)) return;
 
   console.log(
     "doc-detective: installing runtime + browsers " +
@@ -96,7 +100,7 @@ async function maybeInstallRuntime() {
 
   const captured = [];
   const handleLine = (raw, forward) => {
-    if (raw === "") return;
+    if (!raw.trim()) return;
     captured.push(raw);
     if (forward && isProgressLine(raw)) console.log("  " + raw.trim());
   };
@@ -114,7 +118,7 @@ async function maybeInstallRuntime() {
     try {
       child = spawn(
         process.execPath,
-        [cliPath, "install", "all", "--yes"],
+        [CLI_PATH, "install", "all", "--yes"],
         { stdio: ["ignore", "pipe", "pipe"], env: process.env }
       );
     } catch {
@@ -123,14 +127,14 @@ async function maybeInstallRuntime() {
     }
     let outBuf = "";
     let errBuf = "";
-    child.stdout?.on("data", (c) => (outBuf = consume(outBuf, c, true)));
+    child.stdout?.on("data", (chunk) => (outBuf = consume(outBuf, chunk, true)));
     // stderr is captured for a possible failure dump but never forwarded live.
-    child.stderr?.on("data", (c) => (errBuf = consume(errBuf, c, false)));
-    child.on("close", (c, s) => {
+    child.stderr?.on("data", (chunk) => (errBuf = consume(errBuf, chunk, false)));
+    child.on("close", (code, signal) => {
       // Flush any trailing partial lines left without a final newline.
       handleLine(outBuf, true);
       handleLine(errBuf, false);
-      resolve({ code: c, signal: s, errored: false });
+      resolve({ code, signal, errored: false });
     });
     child.on("error", () => resolve({ code: 1, signal: null, errored: true }));
   });
@@ -319,7 +323,6 @@ async function maybePromptInstallAgents() {
 
   // Pre-fill --agent so the CLI doesn't re-prompt for the picker. Scope stays
   // interactive on purpose — project vs global is a per-user decision.
-  const cliPath = path.join(__dirname, "..", "bin", "doc-detective.js");
   const cliArgs = ["install-agents"];
   for (const a of adaptersNeedingInstall) {
     cliArgs.push("--agent", a.id);
@@ -329,7 +332,7 @@ async function maybePromptInstallAgents() {
   // `node_modules/.bin` during the install step either.
   const childEnv = { ...process.env, [pathKey]: sanitizedPath };
   const { code, signal } = await new Promise((resolve) => {
-    const child = spawn(process.execPath, [cliPath, ...cliArgs], {
+    const child = spawn(process.execPath, [CLI_PATH, ...cliArgs], {
       stdio: "inherit",
       cwd: targetCwd,
       env: childEnv,

--- a/src/common/package-lock.json
+++ b/src/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "4.6.0-typekeys-lazy-webdriverio.2",
+  "version": "4.6.0-postinstall-runtime-default.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "4.6.0-typekeys-lazy-webdriverio.2",
+      "version": "4.6.0-postinstall-runtime-default.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/src/common/package.json
+++ b/src/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "4.6.0-typekeys-lazy-webdriverio.2",
+  "version": "4.6.0-postinstall-runtime-default.1",
   "description": "Shared components for Doc Detective projects.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/container/linux.Dockerfile
+++ b/src/container/linux.Dockerfile
@@ -38,10 +38,12 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Doc Detective from NPM. The shim lazy-installs heavy deps
-# (browsers, ffmpeg, webdriverio, appium, sharp) on first use, so the
-# initial install is small. The follow-up `doc-detective install all`
-# pre-warms the cache so the image is ready to run tests offline.
+# Install Doc Detective from NPM. By default its postinstall pre-installs the
+# heavy deps (browsers, ffmpeg, webdriverio, appium, sharp) into
+# DOC_DETECTIVE_CACHE_DIR (set above), so this `npm install -g` already warms
+# the cache. The follow-up `doc-detective install all` is then an idempotent
+# safety net — and the cache pre-warm path for older versions whose postinstall
+# predates the auto-install.
 #
 # Detect whether the installed CLI has the new `install <subcommand>`
 # surface by grepping for it in the root `--help` output. yargs always

--- a/src/runtime/installOutput.ts
+++ b/src/runtime/installOutput.ts
@@ -1,0 +1,23 @@
+// Shared classifier for npm's noisy, non-actionable output. Deprecation,
+// funding, and notice lines (e.g. `npm warn deprecated glob@10.5.0: …`,
+// `npm warn deprecated whatwg-encoding@3.1.1: …`) are about transitive
+// dependencies the user can't change, and they alarm users out of context.
+// We drop them from all user-facing install output — `install all`,
+// lazy-install on first use, and the postinstall pre-warm — so a noisy
+// transitive tree never produces scary terminal output.
+//
+// NOTE: scripts/postinstall.js keeps a parallel copy of this predicate because
+// it is a plain Node script that runs before/without the compiled `dist/`. Keep
+// the two in sync.
+
+/** True for npm deprecation / funding / notice noise (and blank lines). */
+export function isNpmNoiseLine(line: string): boolean {
+  const l = line.trim();
+  if (!l) return true;
+  return (
+    /^npm warn deprecated/i.test(l) ||
+    /^npm notice/i.test(l) ||
+    /^npm fund/i.test(l) ||
+    /packages are looking for funding/i.test(l)
+  );
+}

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -4,6 +4,7 @@ import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from "node:c
 import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
 import { getDeclaredVersion, satisfiesRange, withPeerCompanions } from "./heavyDeps.js";
+import { isNpmNoiseLine } from "./installOutput.js";
 import {
   assertSafeRuntimePath,
   getRuntimeDir,
@@ -273,7 +274,12 @@ export async function ensureRuntimeInstalled(
     const onLine = (stream: "stdout" | "stderr", chunk: Buffer | string) => {
       const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
       for (const line of text.split(/\r?\n/)) {
-        if (line.length > 0) logger(`npm[${stream}]: ${line}`, "debug");
+        if (line.length === 0) continue;
+        // Drop npm's deprecation/funding/notice noise (about transitive deps
+        // the user can't fix) so even `--verbose` install output stays calm.
+        // DOC_DETECTIVE_RUNTIME_DEBUG=1 shows everything raw for diagnostics.
+        if (!RUNTIME_DEBUG && isNpmNoiseLine(line)) continue;
+        logger(`npm[${stream}]: ${line}`, "debug");
       }
     };
     if (child.stdout) child.stdout.on("data", (c) => onLine("stdout", c));

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -271,19 +271,32 @@ export async function ensureRuntimeInstalled(
       shell: process.platform === "win32",
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const onLine = (stream: "stdout" | "stderr", chunk: Buffer | string) => {
-      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
-      for (const line of text.split(/\r?\n/)) {
-        if (line.length === 0) continue;
-        // Drop npm's deprecation/funding/notice noise (about transitive deps
-        // the user can't fix) so even `--verbose` install output stays calm.
-        // DOC_DETECTIVE_RUNTIME_DEBUG=1 shows everything raw for diagnostics.
-        if (!RUNTIME_DEBUG && isNpmNoiseLine(line)) continue;
-        logger(`npm[${stream}]: ${line}`, "debug");
-      }
+    const emitLine = (stream: "stdout" | "stderr", line: string) => {
+      if (line.length === 0) return;
+      // Drop npm's deprecation/funding/notice noise (about transitive deps
+      // the user can't fix) so even `--verbose` install output stays calm.
+      // DOC_DETECTIVE_RUNTIME_DEBUG=1 shows everything raw for diagnostics.
+      if (!RUNTIME_DEBUG && isNpmNoiseLine(line)) return;
+      logger(`npm[${stream}]: ${line}`, "debug");
     };
-    if (child.stdout) child.stdout.on("data", (c) => onLine("stdout", c));
-    if (child.stderr) child.stderr.on("data", (c) => onLine("stderr", c));
+    // Buffer each stream so a line split across `data` chunks is reassembled
+    // before isNpmNoiseLine classifies it — otherwise a fragmented
+    // `npm warn deprecated …` line could slip past the filter.
+    const buffers: Record<"stdout" | "stderr", string> = { stdout: "", stderr: "" };
+    const onChunk = (stream: "stdout" | "stderr", chunk: Buffer | string) => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      const parts = (buffers[stream] + text).split(/\r?\n/);
+      buffers[stream] = parts.pop() ?? ""; // trailing partial line
+      for (const line of parts) emitLine(stream, line);
+    };
+    const flushBuffers = () => {
+      emitLine("stdout", buffers.stdout);
+      emitLine("stderr", buffers.stderr);
+      buffers.stdout = "";
+      buffers.stderr = "";
+    };
+    if (child.stdout) child.stdout.on("data", (c) => onChunk("stdout", c));
+    if (child.stderr) child.stderr.on("data", (c) => onChunk("stderr", c));
     // Wall-clock cap so a stalled npm never freezes the first run. 0 opts
     // out (callers that explicitly want to wait forever, or unit tests
     // with a synchronously-resolving fake spawner).
@@ -313,6 +326,7 @@ export async function ensureRuntimeInstalled(
     });
     child.on("close", (code: number | null) => {
       clearTimer();
+      flushBuffers();
       if (code === 0) resolve();
       else reject(new Error(`npm install exited with code ${code ?? "null"}`));
     });

--- a/test/postinstall-runtime.test.js
+++ b/test/postinstall-runtime.test.js
@@ -18,7 +18,7 @@ describe("scripts/postinstall runtime auto-install helpers", function () {
     it("opts out on 0/false/no/off (case-insensitive)", function () {
       for (const v of ["0", "false", "FALSE", "No", "off", " off "]) {
         expect(
-          isRuntimeInstallOptedOut({ DOC_DETECTIVE_INSTALL_RUNTIME: v }),
+          isRuntimeInstallOptedOut({ DOC_DETECTIVE_AUTOINSTALL: v }),
           v
         ).to.equal(true);
       }
@@ -27,7 +27,7 @@ describe("scripts/postinstall runtime auto-install helpers", function () {
     it("installs for any other value", function () {
       for (const v of ["1", "true", "yes", "", "anything"]) {
         expect(
-          isRuntimeInstallOptedOut({ DOC_DETECTIVE_INSTALL_RUNTIME: v }),
+          isRuntimeInstallOptedOut({ DOC_DETECTIVE_AUTOINSTALL: v }),
           v
         ).to.equal(false);
       }

--- a/test/postinstall-runtime.test.js
+++ b/test/postinstall-runtime.test.js
@@ -1,0 +1,66 @@
+import {
+  isRuntimeInstallOptedOut,
+  isProgressLine,
+  isNpmNoiseLine,
+} from "../scripts/postinstall.js";
+
+before(async function () {
+  const { expect } = await import("chai");
+  global.expect = expect;
+});
+
+describe("scripts/postinstall runtime auto-install helpers", function () {
+  describe("isRuntimeInstallOptedOut", function () {
+    it("installs by default (env unset)", function () {
+      expect(isRuntimeInstallOptedOut({})).to.equal(false);
+    });
+
+    it("opts out on 0/false/no/off (case-insensitive)", function () {
+      for (const v of ["0", "false", "FALSE", "No", "off", " off "]) {
+        expect(
+          isRuntimeInstallOptedOut({ DOC_DETECTIVE_INSTALL_RUNTIME: v }),
+          v
+        ).to.equal(true);
+      }
+    });
+
+    it("installs for any other value", function () {
+      for (const v of ["1", "true", "yes", "", "anything"]) {
+        expect(
+          isRuntimeInstallOptedOut({ DOC_DETECTIVE_INSTALL_RUNTIME: v }),
+          v
+        ).to.equal(false);
+      }
+    });
+  });
+
+  describe("isProgressLine", function () {
+    it("surfaces the installer's own progress lines", function () {
+      expect(isProgressLine("Installing runtime…")).to.equal(true);
+      expect(isProgressLine("Installing browsers…")).to.equal(true);
+      expect(isProgressLine("  [npm] webdriverio — installed @ 9.27.0")).to.equal(true);
+      expect(isProgressLine("  [browser] chrome — installed")).to.equal(true);
+    });
+
+    it("does not surface npm noise", function () {
+      expect(isProgressLine("npm warn deprecated glob@10.5.0: …")).to.equal(false);
+      expect(isProgressLine("npm notice")).to.equal(false);
+      expect(isProgressLine("added 93 packages in 4s")).to.equal(false);
+    });
+  });
+
+  describe("isNpmNoiseLine", function () {
+    it("flags npm deprecation/funding/notice lines and blanks", function () {
+      expect(isNpmNoiseLine("npm warn deprecated glob@10.5.0: …")).to.equal(true);
+      expect(isNpmNoiseLine("npm warn deprecated whatwg-encoding@3.1.1: …")).to.equal(true);
+      expect(isNpmNoiseLine("npm notice New version available")).to.equal(true);
+      expect(isNpmNoiseLine("npm fund packages are looking for funding")).to.equal(true);
+      expect(isNpmNoiseLine("   ")).to.equal(true);
+    });
+
+    it("keeps the installer's own output and real errors", function () {
+      expect(isNpmNoiseLine("  [npm] webdriverio — installed")).to.equal(false);
+      expect(isNpmNoiseLine("Error: ENOSPC: no space left on device")).to.equal(false);
+    });
+  });
+});

--- a/test/runtime-loader.test.js
+++ b/test/runtime-loader.test.js
@@ -143,6 +143,37 @@ describe("runtime/loader", function () {
       expect(record.npmPackages.pngjs.installedVersion).to.equal("7.0.0");
     });
 
+    it("drops npm deprecation/funding noise from install output but keeps real lines", async function () {
+      // Even a verbose-style logger (records every level) must not see the
+      // scary deprecation/funding noise — only the loader's filtered output.
+      const logged = [];
+      const spawner = makeFakeSpawner({
+        stdout: "added 1 package in 2s\nnpm fund packages are looking for funding\n",
+        stderr:
+          "npm warn deprecated glob@10.5.0: old versions are not supported\n" +
+          "npm warn deprecated whatwg-encoding@3.1.1: use @exodus/bytes instead\n",
+        onSpawn: ({ args }) => {
+          const prefix = args[args.indexOf("--prefix") + 1];
+          const target = path.join(prefix, "node_modules", "pngjs");
+          fs.mkdirSync(target, { recursive: true });
+          fs.writeFileSync(
+            path.join(target, "package.json"),
+            JSON.stringify({ name: "pngjs", version: "7.0.0" })
+          );
+        },
+      });
+
+      await ensureRuntimeInstalled(["pngjs"], {
+        deps: { spawn: spawner, logger: (msg) => logged.push(msg) },
+        force: true,
+      });
+
+      const out = logged.join("\n");
+      expect(out, "deprecation noise must be dropped").to.not.match(/deprecated/i);
+      expect(out, "funding noise must be dropped").to.not.match(/looking for funding/i);
+      expect(out, "real npm output must be kept").to.match(/added 1 package/);
+    });
+
     it("rejects when npm exits non-zero", async function () {
       // pngjs resolves from the shim's node_modules (in a source checkout it's
       // declared in optionalDependencies, installed by default), so the

--- a/test/runtime-loader.test.js
+++ b/test/runtime-loader.test.js
@@ -10,7 +10,14 @@ before(async function () {
   global.expect = expect;
 });
 
-function makeFakeSpawner({ exitCode = 0, stdout = "", stderr = "", onSpawn } = {}) {
+function makeFakeSpawner({
+  exitCode = 0,
+  stdout = "",
+  stderr = "",
+  stdoutChunks,
+  stderrChunks,
+  onSpawn,
+} = {}) {
   const calls = [];
   const spawner = (cmd, args, opts) => {
     calls.push({ cmd, args, opts });
@@ -20,7 +27,11 @@ function makeFakeSpawner({ exitCode = 0, stdout = "", stderr = "", onSpawn } = {
     child.stderr = new EventEmitter();
     setImmediate(() => {
       if (stdout) child.stdout.emit("data", stdout);
+      // Emit each chunk as a separate `data` event to simulate a line split
+      // across chunk boundaries.
+      for (const c of stdoutChunks || []) child.stdout.emit("data", c);
       if (stderr) child.stderr.emit("data", stderr);
+      for (const c of stderrChunks || []) child.stderr.emit("data", c);
       child.emit("close", exitCode);
     });
     return child;
@@ -172,6 +183,35 @@ describe("runtime/loader", function () {
       expect(out, "deprecation noise must be dropped").to.not.match(/deprecated/i);
       expect(out, "funding noise must be dropped").to.not.match(/looking for funding/i);
       expect(out, "real npm output must be kept").to.match(/added 1 package/);
+    });
+
+    it("reassembles lines split across data chunks before filtering", async function () {
+      // A deprecation line and a real line each arrive in two fragments with no
+      // newline until the second — the per-stream buffer must reassemble them
+      // before isNpmNoiseLine classifies, or fragmented noise would leak.
+      const logged = [];
+      const spawner = makeFakeSpawner({
+        stderrChunks: ["npm warn deprecated gl", "ob@10.5.0: old versions\n"],
+        stdoutChunks: ["added 1 packa", "ge in 2s\n"],
+        onSpawn: ({ args }) => {
+          const prefix = args[args.indexOf("--prefix") + 1];
+          const target = path.join(prefix, "node_modules", "pngjs");
+          fs.mkdirSync(target, { recursive: true });
+          fs.writeFileSync(
+            path.join(target, "package.json"),
+            JSON.stringify({ name: "pngjs", version: "7.0.0" })
+          );
+        },
+      });
+
+      await ensureRuntimeInstalled(["pngjs"], {
+        deps: { spawn: spawner, logger: (msg) => logged.push(msg) },
+        force: true,
+      });
+
+      const out = logged.join("\n");
+      expect(out, "fragmented deprecation noise must still be dropped").to.not.match(/deprecated/i);
+      expect(out, "fragmented real line must be reassembled and kept").to.match(/added 1 package in 2s/);
     });
 
     it("rejects when npm exits non-zero", async function () {


### PR DESCRIPTION
## What

`npm i doc-detective` now eagerly installs the heavy runtime assets (webdriverio/appium/sharp + browsers, drivers, ffmpeg) at **postinstall by default**, so a fresh install — and any Docker image built `FROM` it — is ready to run without a separate `doc-detective install all`.

- **Opt out** with `DOC_DETECTIVE_INSTALL_RUNTIME=0` (also accepts `false`/`no`/`off`). The CLI install then stays small and the heavy assets lazy-install on first use, exactly as before.
- Scope: full `install all` — runtime npm packages **and** browser binaries.

## Clean output (no resurrected warnings)

The pre-install runs in a **child process whose stdout/stderr are captured, not inherited**. Only the installer's own progress lines (`Installing runtime…`, `  [npm] webdriverio — installed`, `  [browser] chrome — installed`) are forwarded; everything else is suppressed. So npm's deprecated-transitive-dependency warnings (`glob@10.5.0`, `whatwg-encoding`) — the ones we just eliminated from the lean install — **never reach the user's terminal**, even though the heavy tree is being installed.

The step **never fails the npm install**: on error it prints a curated, noise-filtered tail and the assets fall back to lazy-install on first use.

## Why this is safe for the lean-install work

The heavy packages are still **not** declared in `dependencies`/`optionalDependencies` (they live in `ddRuntimeDependencies`), so npm itself never pulls them into the dependency tree. Opting out (`=0`) yields the exact lean install we shipped in #312/#314. This change only adds an opt-out-able postinstall pre-warm on top.

## Changes

- `scripts/postinstall.js`: `maybeInstallRuntime()` + pure exported helpers (`isRuntimeInstallOptedOut` / `isProgressLine` / `isNpmNoiseLine`); the top-level `main()` is now guarded by an `isInvokedDirectly()` check so the module is import-safe for tests.
- `test/postinstall-runtime.test.js`: unit tests for the helpers (7 cases).
- `README.md`: documents the new default + opt-out env var.
- `src/container/linux.Dockerfile`: refreshes the now-stale comment — `ENV DOC_DETECTIVE_CACHE_DIR` is set before `npm install -g`, so postinstall warms the right cache and the explicit `install all` becomes an idempotent safety net (also the pre-warm path for older versions).

## Verification

- `node --check` + opt-out path (`DOC_DETECTIVE_INSTALL_RUNTIME=0`) skips cleanly.
- Helpers unit-tested (7/7).
- Filter validated against **real** installer output (`install all --dry-run`): all 17 progress lines forwarded, 0 noise lines leaked.
- Module import does not trigger `main()` (guard verified).

> Note: this changes the default install footprint (browsers download on `npm i`). That's intentional per the feature request; users keep the lean path via `DOC_DETECTIVE_INSTALL_RUNTIME=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime assets (browsers, drivers) now auto-install to cache during `npm install`; disable via `DOC_DETECTIVE_INSTALL_RUNTIME=0`.

* **Documentation**
  * Updated README describing lazy-installed runtime behavior, cache directory usage, and opt-out mechanism.

* **Bug Fixes**
  * Suppressed npm deprecation warnings and funding notices from appearing during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->