### PR TITLE
fix(core): handle contexts with no resolvable browser

### DIFF
--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -66,6 +66,10 @@ const driverActions = [
   "type",
 ];
 
+// Browser names getDriverCapabilities knows how to build caps for. `safari` is
+// rewritten to `webkit` during context resolution, so both appear here.
+const KNOWN_BROWSERS = ["firefox", "chrome", "safari", "webkit"];
+
 // Get Appium driver capabilities and apply options.
 function getDriverCapabilities({ runnerDetails, name, options }: { runnerDetails: any; name: any; options: any }): any {
   let capabilities: any = {};
@@ -75,11 +79,10 @@ function getDriverCapabilities({ runnerDetails, name, options }: { runnerDetails
   // returning empty capabilities. Empty caps used to surface downstream as the
   // cryptic "Failed to start context 'undefined'" driver error, hiding the real
   // problem (no browser was ever resolved for the context).
-  const knownBrowsers = ["firefox", "chrome", "safari", "webkit"];
-  if (!name || !knownBrowsers.includes(name)) {
+  if (!name || !KNOWN_BROWSERS.includes(name)) {
     throw new Error(
       `Cannot build driver capabilities: unknown or missing browser name '${name}'. ` +
-        `Expected one of: ${knownBrowsers.join(", ")}.`
+        `Expected one of: ${KNOWN_BROWSERS.join(", ")}.`
     );
   }
 
@@ -212,7 +215,10 @@ function isSupportedContext({ context, apps, platform }: { context: any; apps: a
   } else if (Array.isArray(context?.steps) && isDriverRequired({ test: context })) {
     // A context that needs a browser driver but has no resolvable browser name
     // can't run. Treat it as unsupported so it's cleanly skipped rather than
-    // failing later with "Failed to start context 'undefined'".
+    // failing later with "Failed to start context 'undefined'". The
+    // Array.isArray(steps) guard keeps isDriverRequired (which iterates steps)
+    // from throwing on a steps-less context; such a context does no driver work
+    // anyway, so leaving it supported here is harmless.
     isSupportedApp = false;
   }
   // Return boolean
@@ -628,9 +634,9 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
           const errorMessage = `Skipping context on '${context.platform}': no supported browser is available in the current environment.`;
           log(config, "warning", errorMessage);
           contextReport = {
+            ...contextReport,
             result: "SKIPPED",
             resultDescription: errorMessage,
-            ...contextReport,
           };
           report.summary.contexts.skipped++;
           testReport.contexts.push(contextReport);

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -211,7 +211,13 @@ function isSupportedContext({ context, apps, platform }: { context: any; apps: a
   // Check platform
   const isSupportedPlatform = context.platform === platform;
   if (context?.browser?.name) {
-    isSupportedApp = apps.find((app: any) => app.name === context.browser.name);
+    // `safari` is normalized to `webkit` during context resolution, but
+    // getAvailableApps reports Safari as `safari`. Map it back so a Safari
+    // context isn't wrongly treated as unsupported (which would skip it before
+    // getDriverCapabilities could apply the same alias).
+    const appName =
+      context.browser.name === "webkit" ? "safari" : context.browser.name;
+    isSupportedApp = apps.find((app: any) => app.name === appName);
   } else if (Array.isArray(context?.steps) && isDriverRequired({ test: context })) {
     // A context that needs a browser driver but has no resolvable browser name
     // can't run. Treat it as unsupported so it's cleanly skipped rather than

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -39,7 +39,15 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export { runSpecs, runViaApi, getRunner, ensureChromeAvailable };
+export {
+  runSpecs,
+  runViaApi,
+  getRunner,
+  ensureChromeAvailable,
+  getDriverCapabilities,
+  getDefaultBrowser,
+  isSupportedContext,
+};
 // exports.appiumStart = appiumStart;
 // exports.appiumIsReady = appiumIsReady;
 // exports.driverStart = driverStart;
@@ -62,6 +70,18 @@ const driverActions = [
 function getDriverCapabilities({ runnerDetails, name, options }: { runnerDetails: any; name: any; options: any }): any {
   let capabilities: any = {};
   let args: string[] = [];
+
+  // Fail loudly on an unknown or missing browser name instead of silently
+  // returning empty capabilities. Empty caps used to surface downstream as the
+  // cryptic "Failed to start context 'undefined'" driver error, hiding the real
+  // problem (no browser was ever resolved for the context).
+  const knownBrowsers = ["firefox", "chrome", "safari", "webkit"];
+  if (!name || !knownBrowsers.includes(name)) {
+    throw new Error(
+      `Cannot build driver capabilities: unknown or missing browser name '${name}'. ` +
+        `Expected one of: ${knownBrowsers.join(", ")}.`
+    );
+  }
 
   // Set Firefox capabilities
   switch (name) {
@@ -95,6 +115,9 @@ function getDriverCapabilities({ runnerDetails, name, options }: { runnerDetails
       break;
     }
     case "safari":
+    // `safari` is rewritten to `webkit` during context resolution, so the
+    // runtime browser name is usually `webkit`. Both map to Safari.
+    case "webkit":
       // Set Safari capabilities
       if (runnerDetails.availableApps.find((app: any) => app.name === "safari")) {
         let safari = runnerDetails.availableApps.find(
@@ -184,14 +207,16 @@ function isSupportedContext({ context, apps, platform }: { context: any; apps: a
   let isSupportedApp: any = true;
   // Check platform
   const isSupportedPlatform = context.platform === platform;
-  if (context?.browser?.name)
+  if (context?.browser?.name) {
     isSupportedApp = apps.find((app: any) => app.name === context.browser.name);
-  // Return boolean
-  if (isSupportedApp && isSupportedPlatform) {
-    return true;
-  } else {
-    return false;
+  } else if (Array.isArray(context?.steps) && isDriverRequired({ test: context })) {
+    // A context that needs a browser driver but has no resolvable browser name
+    // can't run. Treat it as unsupported so it's cleanly skipped rather than
+    // failing later with "Failed to start context 'undefined'".
+    isSupportedApp = false;
   }
+  // Return boolean
+  return Boolean(isSupportedApp && isSupportedPlatform);
 }
 
 function getDefaultBrowser({ runnerDetails }: { runnerDetails: any }) {
@@ -594,6 +619,23 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
         metaValues.specs[spec.specId].tests[test.testId].contexts[
           context.contextId
         ] = { steps: {} };
+
+        // If a driver is required but no browser could be resolved (e.g.
+        // getDefaultBrowser found nothing installed, or the context supplied a
+        // browser object with no name), skip with an explicit reason instead of
+        // letting it fail later as "Failed to start context 'undefined'".
+        if (isDriverRequired({ test: context }) && !context.browser?.name) {
+          const errorMessage = `Skipping context on '${context.platform}': no supported browser is available in the current environment.`;
+          log(config, "warning", errorMessage);
+          contextReport = {
+            result: "SKIPPED",
+            resultDescription: errorMessage,
+            ...contextReport,
+          };
+          report.summary.contexts.skipped++;
+          testReport.contexts.push(contextReport);
+          continue;
+        }
 
         // Check if current environment supports given contexts
         const supportedContext = isSupportedContext({

--- a/test/context-resolution.test.js
+++ b/test/context-resolution.test.js
@@ -84,7 +84,9 @@ describe("getDefaultBrowser", function () {
     const runnerDetails = {
       availableApps: [{ name: "chrome" }, { name: "firefox" }],
     };
-    // firefox is preferred over chrome in the lookup order.
+    // getDefaultBrowser walks its browserNames preference list
+    // (["firefox", "chrome", "safari"] in src/core/tests.ts) and returns the
+    // first available, so firefox wins over chrome here.
     assert.deepEqual(getDefaultBrowser({ runnerDetails }), {
       name: "firefox",
     });

--- a/test/context-resolution.test.js
+++ b/test/context-resolution.test.js
@@ -52,6 +52,22 @@ describe("isSupportedContext", function () {
     );
   });
 
+  it("supports a webkit context when Safari is available", function () {
+    // resolveContexts normalizes safari -> webkit, but getAvailableApps reports
+    // Safari as `safari`. A webkit context must still be supported on macOS so
+    // it isn't skipped before getDriverCapabilities applies the same alias.
+    const macApps = [{ name: "safari" }];
+    const context = {
+      platform: "mac",
+      browser: { name: "webkit" },
+      steps: [driverStep],
+    };
+    assert.equal(
+      isSupportedContext({ context, apps: macApps, platform: "mac" }),
+      true
+    );
+  });
+
   it("rejects a driver-required context with no resolvable browser name", function () {
     // This is the case that produced "Failed to start context 'undefined'":
     // a driver is required but the browser object carries no name.

--- a/test/context-resolution.test.js
+++ b/test/context-resolution.test.js
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import {
+  isSupportedContext,
+  getDefaultBrowser,
+  getDriverCapabilities,
+} from "../dist/core/tests.js";
+
+// A step that requires a browser driver, and one that doesn't.
+const driverStep = { goTo: "https://example.com" };
+const nonDriverStep = { runShell: "echo hi" };
+
+describe("isSupportedContext", function () {
+  const apps = [{ name: "chrome" }, { name: "firefox" }];
+
+  it("supports a non-driver context on the current platform", function () {
+    const context = { platform: "linux", steps: [nonDriverStep] };
+    assert.equal(
+      isSupportedContext({ context, apps, platform: "linux" }),
+      true
+    );
+  });
+
+  it("rejects a context on a different platform", function () {
+    const context = { platform: "windows", steps: [nonDriverStep] };
+    assert.equal(
+      isSupportedContext({ context, apps, platform: "linux" }),
+      false
+    );
+  });
+
+  it("supports a driver context whose browser is available", function () {
+    const context = {
+      platform: "linux",
+      browser: { name: "chrome" },
+      steps: [driverStep],
+    };
+    assert.equal(
+      isSupportedContext({ context, apps, platform: "linux" }),
+      true
+    );
+  });
+
+  it("rejects a driver context whose named browser is not available", function () {
+    const context = {
+      platform: "linux",
+      browser: { name: "safari" },
+      steps: [driverStep],
+    };
+    assert.equal(
+      isSupportedContext({ context, apps, platform: "linux" }),
+      false
+    );
+  });
+
+  it("rejects a driver-required context with no resolvable browser name", function () {
+    // This is the case that produced "Failed to start context 'undefined'":
+    // a driver is required but the browser object carries no name.
+    const context = {
+      platform: "windows",
+      browser: { headless: true },
+      steps: [driverStep],
+    };
+    assert.equal(
+      isSupportedContext({ context, apps, platform: "windows" }),
+      false
+    );
+  });
+
+  it("rejects a driver-required context with an empty browser object", function () {
+    const context = {
+      platform: "linux",
+      browser: {},
+      steps: [driverStep],
+    };
+    assert.equal(
+      isSupportedContext({ context, apps, platform: "linux" }),
+      false
+    );
+  });
+});
+
+describe("getDefaultBrowser", function () {
+  it("returns the first available browser by preference order", function () {
+    const runnerDetails = {
+      availableApps: [{ name: "chrome" }, { name: "firefox" }],
+    };
+    // firefox is preferred over chrome in the lookup order.
+    assert.deepEqual(getDefaultBrowser({ runnerDetails }), {
+      name: "firefox",
+    });
+  });
+
+  it("returns an empty object when no supported browser is available", function () {
+    const runnerDetails = { availableApps: [{ name: "node" }] };
+    assert.deepEqual(getDefaultBrowser({ runnerDetails }), {});
+  });
+});
+
+describe("getDriverCapabilities", function () {
+  const baseRunner = {
+    environment: { platform: "linux" },
+    availableApps: [
+      { name: "chrome", path: "/usr/bin/chrome", driver: "/usr/bin/chromedriver" },
+      { name: "safari", path: "" },
+    ],
+  };
+  const options = { width: 1200, height: 800, headless: true };
+
+  it("throws a clear error for a missing browser name", function () {
+    assert.throws(
+      () =>
+        getDriverCapabilities({
+          runnerDetails: baseRunner,
+          name: undefined,
+          options,
+        }),
+      /unknown or missing browser name/i
+    );
+  });
+
+  it("throws a clear error for an unknown browser name", function () {
+    assert.throws(
+      () =>
+        getDriverCapabilities({
+          runnerDetails: baseRunner,
+          name: "edge",
+          options,
+        }),
+      /unknown or missing browser name/i
+    );
+  });
+
+  it("builds chrome capabilities", function () {
+    const caps = getDriverCapabilities({
+      runnerDetails: baseRunner,
+      name: "chrome",
+      options,
+    });
+    assert.equal(caps.browserName, "chrome");
+  });
+
+  it("builds safari capabilities for the webkit alias", function () {
+    // resolveContexts rewrites `safari` -> `webkit`, so the runtime name is
+    // `webkit`. It must still map to Safari capabilities.
+    const caps = getDriverCapabilities({
+      runnerDetails: baseRunner,
+      name: "webkit",
+      options,
+    });
+    assert.equal(caps.browserName, "Safari");
+  });
+});


### PR DESCRIPTION
## Background

A test result was reported with the odd error:

```
"Failed to start context 'undefined' on 'windows'."
```

The context was `SKIPPED` with `browser: { headless: true }` — note the **missing `name`**.

## Root cause

A driver-requiring context can end up with a browser that has no resolvable `name`:

- **No browser installed** — when a driver-required context has no explicit browser, `getDefaultBrowser()` returns `{}` if none of firefox/chrome/safari are detected.
- **Partial browser object** — `runOn` entries like `browsers: { headless: true }` carry no `name`.

That nameless browser then:

1. Slipped past `isSupportedContext`, which only validated `browser.name` *when present* — so `isSupportedApp` defaulted to `true`.
2. Reached `getDriverCapabilities`, whose `switch` had no matching case and returned **empty capabilities `{}`**.
3. Failed to start the driver, and the retry-as-headless path mutated `browser` to `{ headless: true }` before failing again — emitting the cryptic `Failed to start context 'undefined'` message.

A **sibling bug**: `resolveContexts` rewrites `safari` → `webkit`, but `getDriverCapabilities` only handled `safari`/`firefox`/`chrome`. A `webkit` name also fell through to empty caps (with a `'webkit'` message instead of `'undefined'`).

## Changes

1. **`isSupportedContext`** — a driver-required context with no resolvable browser name is now treated as **unsupported** (cleanly skipped) rather than failing later.
2. **`runSpecs`** — when no browser can be resolved, the context is skipped with an explicit `"no supported browser is available in the current environment"` reason instead of the `'undefined'` driver error.
3. **`getDriverCapabilities`** — throws a clear error on an unknown/missing browser name instead of silently returning `{}`, and maps the `webkit` alias to Safari capabilities.

## Tests

New `test/context-resolution.test.js` covers all three helpers (12 cases), including the exact "nameless browser" scenario from the report. Existing `dryRun` / `resolvedTests` suites still pass.

> Note: targets `next` as the base branch per request.

https://claude.ai/code/session_01P8a7bLhN6uRfyHJdRffd4o

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8a7bLhN6uRfyHJdRffd4o)_