### PR TITLE
fix(runtime): map webkit alias to safari in inferRuntimeNeeds

### DIFF
--- a/src/runtime/inferRuntimeNeeds.ts
+++ b/src/runtime/inferRuntimeNeeds.ts
@@ -112,7 +112,12 @@ function addBrowserName(set: Set<BrowserName>, name: string): void {
   if (normalized === "chrome" || normalized === "chromium")
     set.add("chrome");
   else if (normalized === "firefox") set.add("firefox");
-  else if (normalized === "safari") set.add("safari");
+  // `webkit` is the resolved alias for `safari` (resolveContexts rewrites
+  // safari -> webkit), so both map to the safari bucket. Without this, a
+  // Safari-only spec looks browser-less and falls through to the chrome
+  // default — provisioning Chrome for a run that only wanted Safari.
+  else if (normalized === "safari" || normalized === "webkit")
+    set.add("safari");
   // edge / others — ignored; runner already restricts to chrome/firefox/safari.
 }
 

--- a/test/runtime-infer-needs.test.js
+++ b/test/runtime-infer-needs.test.js
@@ -46,8 +46,7 @@ describe("runtime/inferRuntimeNeeds", function () {
     expect(needs.npmPackages.has("@ffmpeg-installer/ffmpeg")).to.equal(false);
   });
 
-  it("respects an explicit runOn browser at the spec level", function () {
-    const needs = inferRuntimeNeeds([
+  it("respects an explicit runOn browser at the spec level", function () {    const needs = inferRuntimeNeeds([
       makeSpec([{ goTo: { url: "https://x.test" } }], {
         runOn: [{ browsers: [{ name: "firefox" }] }],
       }),
@@ -75,6 +74,43 @@ describe("runtime/inferRuntimeNeeds", function () {
     expect(needs.npmPackages.has("appium-safari-driver")).to.equal(true);
     expect(needs.npmPackages.has("appium-chromium-driver")).to.equal(true);
     expect(needs.npmPackages.has("appium-geckodriver")).to.equal(true);
+  });
+
+  it("maps a resolved `webkit` context browser to the safari bucket (not chrome)", function () {
+    // resolveContexts rewrites `safari` -> `webkit`, so a resolved Safari
+    // context carries browser.name === "webkit". inferRuntimeNeeds must treat
+    // that as safari, not let it fall through to the chrome default.
+    const needs = inferRuntimeNeeds([
+      {
+        specId: "s1",
+        tests: [
+          {
+            testId: "t1",
+            contexts: [
+              {
+                contextId: "c1",
+                browser: { name: "webkit" },
+                steps: [{ goTo: { url: "https://x.test" } }],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    expect([...needs.browsers]).to.deep.equal(["safari"]);
+    expect(needs.npmPackages.has("appium-safari-driver")).to.equal(true);
+    expect(needs.npmPackages.has("appium-chromium-driver")).to.equal(false);
+  });
+
+  it("maps a `webkit` runOn browser to the safari bucket", function () {
+    const needs = inferRuntimeNeeds([
+      makeSpec([{ goTo: { url: "https://x.test" } }], {
+        runOn: [{ browsers: [{ name: "webkit" }] }],
+      }),
+    ]);
+    expect([...needs.browsers]).to.deep.equal(["safari"]);
+    expect(needs.npmPackages.has("appium-safari-driver")).to.equal(true);
+    expect(needs.npmPackages.has("appium-chromium-driver")).to.equal(false);
   });
 
   it("a screenshot step adds sharp / pngjs / pixelmatch", function () {

--- a/test/runtime-infer-needs.test.js
+++ b/test/runtime-infer-needs.test.js
@@ -46,7 +46,8 @@ describe("runtime/inferRuntimeNeeds", function () {
     expect(needs.npmPackages.has("@ffmpeg-installer/ffmpeg")).to.equal(false);
   });
 
-  it("respects an explicit runOn browser at the spec level", function () {    const needs = inferRuntimeNeeds([
+  it("respects an explicit runOn browser at the spec level", function () {
+    const needs = inferRuntimeNeeds([
       makeSpec([{ goTo: { url: "https://x.test" } }], {
         runOn: [{ browsers: [{ name: "firefox" }] }],
       }),


### PR DESCRIPTION
## What

Fixes #322 — the just-in-time browser pre-flight mis-infers the browser for Safari/WebKit specs.

`resolveContexts` rewrites `safari` → `webkit` during resolution, but `inferRuntimeNeeds` (which runs on the *resolved* specs) only recognized `chrome`/`firefox`/`safari`. Its `addBrowserName` had no `webkit` branch, so:

1. A resolved Safari context's `browser.name === "webkit"` was silently ignored.
2. With no other browser declared, `browsers.size === 0`.
3. The "default to chrome" fallback kicked in → the pre-flight provisioned **Chrome** for a run that only wanted Safari.

On macOS this was masked (Safari is detected and runs regardless), but it caused spurious Chrome downloads and an inaccurate runtime-needs view for any WebKit context.

## Change

- `addBrowserName` now maps `webkit` → the `safari` bucket, matching how `getDriverCapabilities` treats the alias. `BrowserName` stays `chrome | firefox | safari` — `webkit` is just an input alias. Safari has no installable binary, so this triggers no download; it just stops the spurious Chrome default.

## Tests

Added two regression cases to `test/runtime-infer-needs.test.js` (context-level and `runOn`-level `webkit`), each asserting `needs.browsers` is `["safari"]` and **not** `chrome`. Verified red → green; full file (12 cases) passes.

## Context

Follow-up to #320, which fixed the `isSupportedContext` side of the same `safari`/`webkit` naming split. This is the inference-side counterpart.

https://claude.ai/code/session_01P8a7bLhN6uRfyHJdRffd4o

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8a7bLhN6uRfyHJdRffd4o)_