### PR TITLE
ci(vale): scope lint to changed files instead of whole repo

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -43,6 +43,10 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
           files: ${{ steps.changed-files.outputs.all_changed_files }}
+          # changed-files emits a space-separated list. Without a matching
+          # separator, vale-action treats the whole string as one path, fails
+          # to resolve it, and silently falls back to linting the entire repo.
+          separator: " "
           version: 3.13.0
           vale_flags: "--config=docs/.vale.ini"
           reporter: github-pr-review


### PR DESCRIPTION
## Problem

The Vale style check was failing on PRs that only touched a doc file or two (e.g. [#324](https://github.com/doc-detective/doc-detective/pull/324)).

Root cause is in the workflow, not the docs. `tj-actions/changed-files` emits `all_changed_files` as a **space-separated** string, but the `errata-ai/vale-action` `files` input was passed that string with no matching `separator`. The action's input parser:

1. checks `files == 'all'` → no,
2. checks `fs.existsSync(<the joined string>)` → no (it's not a real path),
3. checks for a `separator` → none set,
4. tries `JSON.parse(files)` → throws,
5. warns `User-specified path (...) is invalid; falling back to 'all'` and **lints the entire repository**.

That fallback surfaced **164 pre-existing ERROR-level findings** in unrelated files (`CONTRIBUTING.md`, `AGENTS.md`, `CONTRIBUTIONS.md`, `.claude/skills/**`, etc.) and failed the check, even though the actually-changed docs had **zero** ERROR-level issues.

## Fix

Set `separator: " "` on the `vale-action` step so it splits the space-separated list back into individual file arguments — restoring the intended "lint only changed docs" scope. Single-file PRs already worked (they hit the `fs.existsSync` branch); this only affects the multi-file case that was broken.

## Verification

- Confirmed against the [#324 Vale run](https://github.com/doc-detective/doc-detective/actions/runs/27315824247/job/80696038034): the log contains the `falling back to 'all'` warning, and all 164 ERROR findings are in files outside the PR's changed set.
- The two changed docs in that PR (`heretto.mdx`, `input-formats/dita.mdx`) produced only WARNING-level findings, which don't fail the check at `level: error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Vale linting workflow to correctly process changed file lists, preventing unintended full repository linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->