### PR TITLE
ci(docker): repair sharp/libvips version mismatch in linux image

### DIFF
--- a/src/container/linux.Dockerfile
+++ b/src/container/linux.Dockerfile
@@ -59,6 +59,25 @@ RUN npm install -g doc-detective@$PACKAGE_VERSION \
          echo "[postinstall] doc-detective install all unavailable in $(doc-detective --version 2>/dev/null || echo 'unknown'); skipping cache pre-warm."; \
        fi
 
+# Repair a sharp/libvips version mismatch in the installed tree. Some published
+# versions pin `@img/sharp-libvips-linux-*` at a newer release than `sharp`'s
+# own platform package needs; npm hoists the newer libvips to the top level,
+# the prebuilt `sharp-linux-*.node` RPATH resolves to it, and the load fails
+# with "libvips-cpp.so.<ver>: cannot open shared object file" — crashing any run
+# that touches an image step. Detect the broken load and pin the top-level
+# libvips back to the version `@img/sharp-linux-<arch>` declares, then re-verify.
+# Guarded on a present-but-unloadable sharp, so it is a no-op both when sharp is
+# healthy and when it is deferred to the lazy runtime cache (not installed here).
+RUN DD=/usr/local/lib/node_modules/doc-detective; \
+    if [ -d "$DD/node_modules/sharp" ] && ! ( cd "$DD" && node -e "require('sharp')" ) >/dev/null 2>&1; then \
+      case "$(uname -m)" in x86_64) CPU=x64 ;; aarch64) CPU=arm64 ;; *) CPU="" ;; esac; \
+      LV="@img/sharp-libvips-linux-$CPU"; \
+      REQ="$(node -p "require('$DD/node_modules/@img/sharp-linux-$CPU/package.json').optionalDependencies['$LV']")"; \
+      echo "[sharp] libvips mismatch detected; pinning $LV@$REQ for linux/$CPU"; \
+      npm install --prefix "$DD" --no-save --include=optional --os=linux --cpu="$CPU" --libc=glibc "$LV@$REQ"; \
+      ( cd "$DD" && node -e "const s=require('sharp'); console.log('[sharp] verified OK, libvips', s.versions.vips)" ); \
+    fi
+
 # Install DITA-OT
 ARG DITA_OT_VERSION=4.3.4
 RUN curl -fSL https://github.com/dita-ot/dita-ot/releases/download/${DITA_OT_VERSION}/dita-ot-${DITA_OT_VERSION}.zip -o /tmp/dita-ot.zip \


### PR DESCRIPTION
## Problem

The `build-linux` container smoke test (`npm run container:test`) crashes:

```
Error: Could not load the "sharp" module using the linux-x64 runtime
ERR_DLOPEN_FAILED: libvips-cpp.so.8.17.3: cannot open shared object file
```

## Root cause

The published `doc-detective@latest` (currently 4.5.0 — the version the PR Docker
job installs) has a conflicting dependency tree: it pins
`@img/sharp-libvips-linux-x64@1.3.0` (libvips **8.18.3**) directly, while
`sharp@0.34.5` requires `1.2.4` (libvips **8.17.3**). npm hoists the newer libvips
to the top level; the prebuilt `sharp-linux-x64.node` RPATH resolves to it and the
load fails, killing any run that touches an image step.

## Fix

A Dockerfile step that — **only when sharp is present but fails to load** — pins the
top-level `@img/sharp-libvips-linux-<arch>` back to the version
`@img/sharp-linux-<arch>` declares, then re-verifies `require("sharp")`. It is a
no-op when sharp loads fine or is deferred to the lazy runtime cache (so it stays
inert once 4.6.0 becomes `latest`).

## Validation

Reproduced and fixed locally in `node:22-slim`, then built the **real image**
(`PACKAGE_VERSION=4.5.0`):

- build succeeds; logs `[sharp] verified OK, libvips 8.17.3`
- final image: `require("sharp")` loads, `libvips 8.17.3`

CI `build-linux` (amd64 + arm64) will confirm against the full container test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
