### PR TITLE
fix(core): detect appium drivers from combined stdout+stderr

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -677,7 +677,10 @@ async function getAvailableApps({ config }: any) {
       const child = spawnChild(
         process.execPath,
         [appiumEntry, "driver", "list"],
-        { env: process.env }
+        // 30s ceiling so a hung/misconfigured appium can't block environment
+        // detection indefinitely; a timeout kills the child and the close/error
+        // handlers below degrade to "no drivers detected".
+        { env: process.env, timeout: 30_000 }
       );
       let stdout = "";
       let stderr = "";
@@ -710,6 +713,12 @@ async function getAvailableApps({ config }: any) {
     // Note: Edge/Microsoft Edge detection is intentionally excluded
     // Only Chrome, Firefox, and Safari are supported browsers
 
+    // `appium driver list` writes its formatted table to stdout on some
+    // versions and stderr on others. Match against both so driver presence
+    // detection doesn't silently fail depending on which stream is used.
+    const appiumDriverList =
+      installedAppiumDrivers.stdout + "\n" + installedAppiumDrivers.stderr;
+
     // Detect Chrome
     const chrome = installedBrowsers.find(
       (browser: any) => browser.browser === "chrome"
@@ -718,7 +727,7 @@ async function getAvailableApps({ config }: any) {
     const chromedriver = installedBrowsers.find(
       (browser: any) => browser.browser === "chromedriver"
     );
-    const appiumChromium = installedAppiumDrivers.stderr.match(
+    const appiumChromium = appiumDriverList.match(
       /\n.*chromium.*installed \(npm\).*\n/
     );
 
@@ -735,7 +744,7 @@ async function getAvailableApps({ config }: any) {
     const firefox = installedBrowsers.find(
       (browser: any) => browser.browser === "firefox"
     );
-    const appiumFirefox = installedAppiumDrivers.stderr.match(
+    const appiumFirefox = appiumDriverList.match(
       /\n.*gecko.*installed \(npm\).*\n/
     );
 
@@ -752,7 +761,7 @@ async function getAvailableApps({ config }: any) {
       const safariVersion = await spawnCommand(
         "defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString"
       );
-      const appiumSafari = installedAppiumDrivers.stderr.match(
+      const appiumSafari = appiumDriverList.match(
         /\n.*safari.*installed \(npm\).*\n/
       );
 

--- a/test/dryRun.test.js
+++ b/test/dryRun.test.js
@@ -82,12 +82,19 @@ describe("--dry-run short-circuits before execution", function () {
   });
 
   it("without dryRun, runTests returns an executed-results shape", async function () {
-    // Sanity control: the same spec, run normally, returns an object with
-    // `summary` and `specs[].tests[].contexts[].steps[]` carrying step
-    // results (a `result` field). This proves the dry-run case above is
-    // returning a *different* shape, not just an empty execution.
+    // Sanity control: run normally and confirm an executed-results shape
+    // (has `summary`, no `resolvedTestsId`). Uses a browser-free `wait` step
+    // so the assertion holds deterministically regardless of which browsers
+    // the environment detects — it must not depend on app detection returning
+    // nothing (which is what the prior `goTo` spec accidentally relied on).
+    const waitSpecPath = path.join(tmpDir, "wait.spec.json");
+    fs.writeFileSync(
+      waitSpecPath,
+      JSON.stringify({ tests: [{ steps: [{ wait: 10 }] }] }, null, 2)
+    );
+
     const result = await runTests({
-      input: [specPath],
+      input: [waitSpecPath],
       output: tmpDir,
       logLevel: "silent",
       telemetry: { send: false },


### PR DESCRIPTION
## Problem

`getAvailableApps()` in `src/core/config.ts` detects Appium-backed browsers by matching
`appium driver list` output against `installedAppiumDrivers.stderr`. But appium writes its
formatted driver table to **stdout** on some versions (confirmed locally), so on those setups
the three regexes always return `null` and the browser is never added to
`config.environment.apps` — silently disabling Appium-backed Chrome/Firefox/Safari detection.

Pre-existing on `main` (4.5.0 has the same `.stderr` checks); flagged across several review rounds.

## Fix

- Match the **combined** `stdout + "\n" + stderr` so detection works regardless of stream
  (safe superset where appium uses stderr; load-bearing where it uses stdout).
- Cap the `appium driver list` spawn at **30s** so a hung appium can't block environment
  detection (`spawnChild` is `node:child_process.spawn`, which honors `timeout`).
- Make the `dryRun.test.js` control test use a browser-free `wait` step so it asserts the
  executed-results shape deterministically rather than relying on detection returning no apps.

## Validation

- Locally: appium writes `driver list` to **stdout** here, so the combined match is load-bearing;
  unit suites green (`dryRun`, `context-resolution`, `core-getrunner-provision` — 21 passing, no hang).
- **CI is the real check for the execution path** (this PR changes what `runTests` executes once
  detection succeeds): the full test matrix runs with browsers installed.

## Why a separate PR (not folded into #326)

The fix changes execution behavior (detection now succeeds → `runTests` launches the detected
browser). It was kept out of the 4.6.0 promotion ([#326](https://github.com/doc-detective/doc-detective/pull/326)) to validate that path in isolation before it rides the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
