### PR TITLE
fix(install): bound the postinstall runtime pre-warm with a timeout

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -113,7 +113,13 @@ async function maybeInstallRuntime() {
     return remainder;
   };
 
-  const { code, signal, errored } = await new Promise((resolve) => {
+  // Wall-clock ceiling so a hung npm/network can't make the parent
+  // `npm install` hang forever. Heavy deps + browser downloads are large, so
+  // this is generous; on expiry we kill the child and let the assets install
+  // lazily on first use instead.
+  const RUNTIME_INSTALL_TIMEOUT_MS = 10 * 60 * 1000;
+
+  const { code, signal, errored, timedOut } = await new Promise((resolve) => {
     let child;
     try {
       child = spawn(
@@ -122,9 +128,26 @@ async function maybeInstallRuntime() {
         { stdio: ["ignore", "pipe", "pipe"], env: process.env }
       );
     } catch {
-      resolve({ code: 1, signal: null, errored: true });
+      resolve({ code: 1, signal: null, errored: true, timedOut: false });
       return;
     }
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    // unref() so the timer itself never holds the event loop open.
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* already gone */
+      }
+      finish({ code: null, signal: null, errored: false, timedOut: true });
+    }, RUNTIME_INSTALL_TIMEOUT_MS);
+    timer.unref?.();
     let outBuf = "";
     let errBuf = "";
     child.stdout?.on("data", (chunk) => (outBuf = consume(outBuf, chunk, true)));
@@ -134,10 +157,24 @@ async function maybeInstallRuntime() {
       // Flush any trailing partial lines left without a final newline.
       handleLine(outBuf, true);
       handleLine(errBuf, false);
-      resolve({ code: exitCode, signal: exitSignal, errored: false });
+      finish({ code: exitCode, signal: exitSignal, errored: false, timedOut: false });
     });
-    child.on("error", () => resolve({ code: 1, signal: null, errored: true }));
+    child.on("error", () =>
+      finish({ code: 1, signal: null, errored: true, timedOut: false })
+    );
   });
+
+  if (timedOut) {
+    console.error(
+      `doc-detective: runtime pre-warm timed out after ${Math.round(
+        RUNTIME_INSTALL_TIMEOUT_MS / 1000
+      )}s; heavy deps will install on first use, or run \`doc-detective install all\`.`
+    );
+    // A killed `install all` can leave orphaned npm grandchildren that keep the
+    // event loop alive and freeze the parent `npm install` (the same hazard the
+    // agent-detection phase guards against). Exit 0 so the install completes.
+    process.exit(0);
+  }
 
   if (!errored && !signal && code === 0) {
     console.log("doc-detective: runtime + browsers ready.");


### PR DESCRIPTION
## Problem

`maybeInstallRuntime()` in `scripts/postinstall.js` spawns `doc-detective install all --yes` during the npm `postinstall` lifecycle (the lazy-install pre-warm from #316) with **no timeout/kill path**. If npm or the network hangs, the parent `npm install doc-detective` can hang **indefinitely** — and the script swallows top-level rejections, so the user gets no actionable signal. (Flagged by Copilot on #326.)

## Fix

- Add a **10-minute wall-clock ceiling** to the spawn, mirroring the existing timeout pattern in the agent-detection phase of the same file.
- On expiry: kill the child (`SIGTERM`), warn clearly (`runtime pre-warm timed out after Ns; heavy deps will install on first use…`), and **exit 0** so the install completes and orphaned npm grandchildren cannot keep the event loop alive (the same hazard the agent phase guards against).
- Non-fatal: a timed-out pre-warm degrades to lazy install on first use, never breaks `npm install`.

## Validation

- `node --check` clean; existing `postinstall-runtime.test.js` helper suite passes (7/7).
- Standalone test of the exact race logic against a hanging child: timer fires, child is killed, promise resolves in ~418ms with `timedOut=true`.
- Full install-flow behavior is exercised by CI (the postinstall/Docker paths) — this is why it was kept out of the #326 promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
