### PR TITLE
fix(core): keep browser detection read-only (no auto-install)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -635,27 +635,45 @@ async function getAvailableApps({ config }: any) {
   const cwd = process.cwd();
   process.chdir(path.join(__dirname, "../.."));
   const apps: any[] = [];
+  // Set only on an *unexpected* browser-detection failure (the dep is present
+  // but fails to load/scan). Used to skip caching so a transient failure can't
+  // poison the per-dir cache and suppress later successful detection. A simply
+  // absent dep (lean install) is the normal "no browsers" case and stays
+  // cacheable.
+  let browserDetectionFailed = false;
 
   try {
-    // Detect installed browsers read-only: pass autoInstall=false so config
+    // Detect installed browsers read-only: autoInstall=false so config
     // resolution never triggers a heavy @puppeteer/browsers install (which
     // would defeat DOC_DETECTIVE_AUTOINSTALL=0 and the lazy-install contract).
     // Provisioning is the JIT pre-flight's job (core/index.ts) when a run
-    // actually needs a browser. Thread the configured cache dir through so this
-    // lookup matches the pre-flight's resolution. On a lean install the dep
-    // isn't present and loadHeavyDep throws — degrade to "no browsers detected"
-    // rather than installing or crashing config resolution.
+    // actually needs a browser. Gate the load on a non-installing presence
+    // check so a missing dep (lean install) is a normal empty result rather
+    // than a thrown error; only a present-but-broken dep counts as a failure.
     let installedBrowsers: any[] = [];
-    try {
-      const browsers = await loadHeavyDep<any>("@puppeteer/browsers", {
-        ctx: { cacheDir: config?.cacheDir },
-        autoInstall: false,
-      });
-      installedBrowsers = await browsers.getInstalledBrowsers({
-        cacheDir: browsersDir,
-      });
-    } catch {
-      installedBrowsers = [];
+    const browsersInstalled = resolveHeavyDepPath("@puppeteer/browsers", {
+      cacheDir: config?.cacheDir,
+    });
+    if (browsersInstalled) {
+      try {
+        const browsers = await loadHeavyDep<any>("@puppeteer/browsers", {
+          ctx: { cacheDir: config?.cacheDir },
+          autoInstall: false,
+        });
+        installedBrowsers = await browsers.getInstalledBrowsers({
+          cacheDir: browsersDir,
+        });
+      } catch (err: any) {
+        // Present but failed to load/scan (corrupt cache, API change, etc.):
+        // non-fatal for detection, but surface the reason and don't cache it.
+        browserDetectionFailed = true;
+        log(
+          config,
+          "warning",
+          `Browser detection failed; continuing without detected browsers: ${err?.message ?? err}`
+        );
+        installedBrowsers = [];
+      }
     }
     // Resolve `appium` from <cacheDir>/runtime via `npm exec --prefix`
     // so a `--omit=optional` install (where appium only lives in the
@@ -783,6 +801,8 @@ async function getAvailableApps({ config }: any) {
   // Detect Android Studio
   // Detect iOS Simulator
 
-  cachedAppsByDir.set(key, apps);
+  // Don't cache a result built on a failed browser detection — a transient
+  // failure must not suppress later successful detection in this process.
+  if (!browserDetectionFailed) cachedAppsByDir.set(key, apps);
   return apps;
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -637,17 +637,26 @@ async function getAvailableApps({ config }: any) {
   const apps: any[] = [];
 
   try {
-    // Lazy-load @puppeteer/browsers; it's a heavy runtime dep that should
-    // only materialize when a runner that actually drives browsers boots up.
-    // Thread the configured cache dir through so a non-default cacheDir is
-    // honored by the resolver (otherwise this lookup could diverge from the
-    // pre-flight install that already used config.cacheDir).
-    const browsers = await loadHeavyDep<any>("@puppeteer/browsers", {
-      ctx: { cacheDir: config?.cacheDir },
-    });
-    const installedBrowsers = await browsers.getInstalledBrowsers({
-      cacheDir: browsersDir,
-    });
+    // Detect installed browsers read-only: pass autoInstall=false so config
+    // resolution never triggers a heavy @puppeteer/browsers install (which
+    // would defeat DOC_DETECTIVE_AUTOINSTALL=0 and the lazy-install contract).
+    // Provisioning is the JIT pre-flight's job (core/index.ts) when a run
+    // actually needs a browser. Thread the configured cache dir through so this
+    // lookup matches the pre-flight's resolution. On a lean install the dep
+    // isn't present and loadHeavyDep throws — degrade to "no browsers detected"
+    // rather than installing or crashing config resolution.
+    let installedBrowsers: any[] = [];
+    try {
+      const browsers = await loadHeavyDep<any>("@puppeteer/browsers", {
+        ctx: { cacheDir: config?.cacheDir },
+        autoInstall: false,
+      });
+      installedBrowsers = await browsers.getInstalledBrowsers({
+        cacheDir: browsersDir,
+      });
+    } catch {
+      installedBrowsers = [];
+    }
     // Resolve `appium` from <cacheDir>/runtime via `npm exec --prefix`
     // so a `--omit=optional` install (where appium only lives in the
     // cache) still finds the CLI. Bare `npx appium` would fail in that


### PR DESCRIPTION
## Problem

`getAvailableApps()` in `src/core/config.ts` loaded `@puppeteer/browsers` via `loadHeavyDep` with the default `autoInstall=true`. Since `getAvailableApps` runs during config resolution on **every non-dry-run invocation**, this could trigger a heavy `@puppeteer/browsers` install — even with `DOC_DETECTIVE_AUTOINSTALL=0` set to keep installs lean. Detection should be read-only; the JIT pre-flight in `core/index.ts` already provisions browsers when a run actually needs them. (Flagged by Copilot on #326; pre-existing — not a 4.6.0 regression.)

## Fix

- Pass `autoInstall: false` to the detection `loadHeavyDep` call.
- Wrap the load + `getInstalledBrowsers` in a `try/catch` that degrades to an empty browser list. The enclosing block had only `try/finally` (no `catch`), so on a lean install `loadHeavyDep` would otherwise **throw and crash config resolution**. Now detection simply reports no browsers and the pre-flight handles provisioning.
- `resolveHeavyDepPath` (the appium path in the same function) is already non-installing — confirmed, no change needed.

## Validation

- Compile clean; `context-resolution` + `core-getrunner-provision` (17 passing); `dryRun.test.js` exit 0 (detection found the cached browser, no install triggered).
- Posture (a) browsers present: detection still lists them. Posture (b) lean/no browsers: degrades to empty list without installing or crashing — exercised by the full CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of browser detection during app initialization: failures no longer trigger installation attempts and are handled gracefully with warnings.
  * Prevented transient detection failures from being cached, avoiding stale/poisoned app lists after a detection error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->