### PR TITLE
feat(debug): add diagnostic dump via debug subcommand and DOC_DETECTIVE_DEBUG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ src/container/test/artifacts/*.png
 # Common subpackage build artifacts
 src/common/dist/
 src/common/node_modules/
+
+# Diagnostic dump output (`doc-detective debug`)
+.doc-detective/

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,11 +13,7 @@ import {
 import { installAgentsCommand } from "./agents/command.js";
 import { maybeShowHint } from "./hints/index.js";
 import { installCommand } from "./runtime/installCommand.js";
-import {
-  printDebug,
-  defaultDebugOutFile,
-  defaultDebugJsonFile,
-} from "./debug/index.js";
+import { printDebug, defaultDebugDir } from "./debug/index.js";
 import { debugCommand } from "./debug/command.js";
 import { argv as processArgv } from "node:process";
 import path from "node:path";
@@ -112,8 +108,7 @@ async function runTestsHandler(args: any) {
         config: stubConfig,
         configPath: configPath,
         configError: err instanceof Error ? err : new Error(String(err)),
-        outFile: defaultDebugOutFile(),
-        jsonOutFile: defaultDebugJsonFile(),
+        outDir: defaultDebugDir(),
       });
       // The env-var dump replaced a real test run; a broken config must
       // still fail the process so CI doesn't go green on an unran suite.
@@ -134,8 +129,7 @@ async function runTestsHandler(args: any) {
       config,
       configPath,
       configError: null,
-      outFile: defaultDebugOutFile(),
-      jsonOutFile: defaultDebugJsonFile(),
+      outDir: defaultDebugDir(),
     });
     return;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,7 +78,7 @@ async function runTestsHandler(args: any) {
   const hasExplicitConfig =
     typeof args.config === "string" && args.config.trim().length > 0;
   const configPath = hasExplicitConfig
-    ? path.resolve(args.config)
+    ? path.resolve(args.config.trim())
     : fs.existsSync(configPathJSON)
     ? configPathJSON
     : fs.existsSync(configPathYAML)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,10 +8,13 @@ import {
   log,
   getResolvedTestsFromEnv,
   reportResults,
+  isDebugRequested,
 } from "./utils.js";
 import { installAgentsCommand } from "./agents/command.js";
 import { maybeShowHint } from "./hints/index.js";
 import { installCommand } from "./runtime/installCommand.js";
+import { printDebug } from "./debug/index.js";
+import { debugCommand } from "./debug/command.js";
 import { argv as processArgv } from "node:process";
 import path from "node:path";
 import fs from "node:fs";
@@ -47,6 +50,7 @@ async function main(argv: string[]) {
     // to the same implementation as `doc-detective install agents`.
     .command({ ...installAgentsCommand, describe: false } as any)
     .command(installCommand as any)
+    .command(debugCommand)
     .strict()
     .demandCommand(0)
     // Suppress yargs' default help-dump on failure; surface the concrete error
@@ -78,8 +82,48 @@ async function runTestsHandler(args: any) {
     ? configPathYML
     : null;
 
+  // Detect env-var debug intent before setConfig so we can still emit
+  // the diagnostic dump when validation fails. `isDebugRequested`
+  // reads `process.env.DOC_DETECTIVE_DEBUG`. Users who want diagnostic
+  // output on the CLI should prefer the dedicated `doc-detective
+  // debug` subcommand (which also supports `--include-env`); this
+  // env-var path stays as the CI-friendly trigger.
+  const debugRequested = isDebugRequested(args);
+
   // Set config
-  const config: any = await setConfig({ configPath: configPath, args: args });
+  let config: any;
+  try {
+    config = await setConfig({ configPath: configPath, args: args });
+  } catch (err: any) {
+    if (debugRequested) {
+      // Build a minimal stub config so the dump can still render.
+      // `printDebug` tolerates undefined fields; the configError banner
+      // surfaces the underlying validation message.
+      const stubConfig: any = {
+        logLevel: typeof args.logLevel === "string" ? args.logLevel : "info",
+        input: typeof args.input === "string" ? args.input : ".",
+      };
+      await printDebug({
+        config: stubConfig,
+        configPath: configPath,
+        configError: err instanceof Error ? err : new Error(String(err)),
+      });
+      return;
+    }
+    throw err;
+  }
+
+  // Diagnostic dump — fires when DOC_DETECTIVE_DEBUG is truthy. The
+  // env-var path intentionally does NOT enable --include-env; users
+  // who want the full process.env must run `doc-detective debug
+  // --include-env` explicitly. (There is no config-file equivalent —
+  // the `debug` field was removed because making test runs silently
+  // skip themselves via a saved config setting was more footgun than
+  // feature.)
+  if (debugRequested) {
+    await printDebug({ config, configPath, configError: null });
+    return;
+  }
 
   log(
     `CLI:VERSION INFO:\n${JSON.stringify(getVersionData(), null, 2)}`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,12 +72,13 @@ async function runTestsHandler(args: any) {
   const configPathJSON = path.resolve(process.cwd(), ".doc-detective.json");
   const configPathYAML = path.resolve(process.cwd(), ".doc-detective.yaml");
   const configPathYML = path.resolve(process.cwd(), ".doc-detective.yml");
-  // Guard `args.config` so the handler falls back to the defaults cleanly
-  // when --config is omitted (args.config is undefined in that case).
+  // Treat any non-empty `--config` as authoritative (resolved to an
+  // absolute path). A mistyped path then fails deterministically via
+  // setConfig rather than silently falling back to auto-discovery.
   const hasExplicitConfig =
-    typeof args.config === "string" && args.config.length > 0 && fs.existsSync(args.config);
+    typeof args.config === "string" && args.config.trim().length > 0;
   const configPath = hasExplicitConfig
-    ? args.config
+    ? path.resolve(args.config)
     : fs.existsSync(configPathJSON)
     ? configPathJSON
     : fs.existsSync(configPathYAML)
@@ -114,6 +115,9 @@ async function runTestsHandler(args: any) {
         outFile: defaultDebugOutFile(),
         jsonOutFile: defaultDebugJsonFile(),
       });
+      // The env-var dump replaced a real test run; a broken config must
+      // still fail the process so CI doesn't go green on an unran suite.
+      process.exitCode = 1;
       return;
     }
     throw err;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import {
 import { installAgentsCommand } from "./agents/command.js";
 import { maybeShowHint } from "./hints/index.js";
 import { installCommand } from "./runtime/installCommand.js";
-import { printDebug } from "./debug/index.js";
+import { printDebug, defaultDebugOutFile } from "./debug/index.js";
 import { debugCommand } from "./debug/command.js";
 import { argv as processArgv } from "node:process";
 import path from "node:path";
@@ -107,6 +107,7 @@ async function runTestsHandler(args: any) {
         config: stubConfig,
         configPath: configPath,
         configError: err instanceof Error ? err : new Error(String(err)),
+        outFile: defaultDebugOutFile(),
       });
       return;
     }
@@ -117,11 +118,10 @@ async function runTestsHandler(args: any) {
   // env-var path intentionally does NOT enable --include-env; users
   // who want the full process.env must run `doc-detective debug
   // --include-env` explicitly. (There is no config-file equivalent —
-  // the `debug` field was removed because making test runs silently
-  // skip themselves via a saved config setting was more footgun than
-  // feature.)
+  // the `debug` config field is deprecated and ignored; diagnostics live
+  // behind this env var and the `debug` subcommand.)
   if (debugRequested) {
-    await printDebug({ config, configPath, configError: null });
+    await printDebug({ config, configPath, configError: null, outFile: defaultDebugOutFile() });
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,7 +93,7 @@ async function runTestsHandler(args: any) {
   // output on the CLI should prefer the dedicated `doc-detective
   // debug` subcommand (which also supports `--include-env`); this
   // env-var path stays as the CI-friendly trigger.
-  const debugRequested = isDebugRequested(args);
+  const debugRequested = isDebugRequested();
 
   // Set config
   let config: any;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,11 @@ import {
 import { installAgentsCommand } from "./agents/command.js";
 import { maybeShowHint } from "./hints/index.js";
 import { installCommand } from "./runtime/installCommand.js";
-import { printDebug, defaultDebugOutFile } from "./debug/index.js";
+import {
+  printDebug,
+  defaultDebugOutFile,
+  defaultDebugJsonFile,
+} from "./debug/index.js";
 import { debugCommand } from "./debug/command.js";
 import { argv as processArgv } from "node:process";
 import path from "node:path";
@@ -108,6 +112,7 @@ async function runTestsHandler(args: any) {
         configPath: configPath,
         configError: err instanceof Error ? err : new Error(String(err)),
         outFile: defaultDebugOutFile(),
+        jsonOutFile: defaultDebugJsonFile(),
       });
       return;
     }
@@ -121,7 +126,13 @@ async function runTestsHandler(args: any) {
   // the `debug` config field is deprecated and ignored; diagnostics live
   // behind this env var and the `debug` subcommand.)
   if (debugRequested) {
-    await printDebug({ config, configPath, configError: null, outFile: defaultDebugOutFile() });
+    await printDebug({
+      config,
+      configPath,
+      configError: null,
+      outFile: defaultDebugOutFile(),
+      jsonOutFile: defaultDebugJsonFile(),
+    });
     return;
   }
 

--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -9425,7 +9425,8 @@
       "title": "Environment details"
     },
     "debug": {
-      "description": "Enable debugging mode. `true` allows pausing on breakpoints, waiting for user input before continuing. `stepThrough` pauses at every step, waiting for user input before continuing. `false` disables all debugging.",
+      "description": "Deprecated and ignored. Previously reserved for an interactive step-through debugger that was never implemented. Retained so existing configs continue to validate. For diagnostics, run `doc-detective debug` or set the `DOC_DETECTIVE_DEBUG` environment variable.",
+      "deprecated": true,
       "anyOf": [
         {
           "type": "boolean"
@@ -9436,8 +9437,7 @@
             "stepThrough"
           ]
         }
-      ],
-      "default": false
+      ]
     },
     "dryRun": {
       "description": "If `true`, fully resolve tests (file/env config merge, schema validation, file detection, inline-test extraction) and emit the resolved test plan as JSON, but do not execute any steps. Equivalent to `--dry-run` on the CLI.",
@@ -17746,12 +17746,6 @@
     },
     {
       "debug": false
-    },
-    {
-      "debug": true
-    },
-    {
-      "debug": "stepThrough"
     },
     {
       "integrations": {

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -9438,7 +9438,8 @@
           "title": "Environment details"
         },
         "debug": {
-          "description": "Enable debugging mode. `true` allows pausing on breakpoints, waiting for user input before continuing. `stepThrough` pauses at every step, waiting for user input before continuing. `false` disables all debugging.",
+          "description": "Deprecated and ignored. Previously reserved for an interactive step-through debugger that was never implemented. Retained so existing configs continue to validate. For diagnostics, run `doc-detective debug` or set the `DOC_DETECTIVE_DEBUG` environment variable.",
+          "deprecated": true,
           "anyOf": [
             {
               "type": "boolean"
@@ -9449,8 +9450,7 @@
                 "stepThrough"
               ]
             }
-          ],
-          "default": false
+          ]
         },
         "dryRun": {
           "description": "If `true`, fully resolve tests (file/env config merge, schema validation, file detection, inline-test extraction) and emit the resolved test plan as JSON, but do not execute any steps. Equivalent to `--dry-run` on the CLI.",
@@ -17759,12 +17759,6 @@
         },
         {
           "debug": false
-        },
-        {
-          "debug": true
-        },
-        {
-          "debug": "stepThrough"
         },
         {
           "integrations": {

--- a/src/common/src/schemas/src_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/config_v3.schema.json
@@ -402,7 +402,8 @@
       "$ref": "#/components/schemas/environment"
     },
     "debug": {
-      "description": "Enable debugging mode. `true` allows pausing on breakpoints, waiting for user input before continuing. `stepThrough` pauses at every step, waiting for user input before continuing. `false` disables all debugging.",
+      "description": "Deprecated and ignored. Previously reserved for an interactive step-through debugger that was never implemented. Retained so existing configs continue to validate. For diagnostics, run `doc-detective debug` or set the `DOC_DETECTIVE_DEBUG` environment variable.",
+      "deprecated": true,
       "anyOf": [
         {
           "type": "boolean"
@@ -411,8 +412,7 @@
           "type": "string",
           "enum": ["stepThrough"]
         }
-      ],
-      "default": false
+      ]
     },
     "dryRun": {
       "description": "If `true`, fully resolve tests (file/env config merge, schema validation, file detection, inline-test extraction) and emit the resolved test plan as JSON, but do not execute any steps. Equivalent to `--dry-run` on the CLI.",
@@ -672,12 +672,6 @@
     },
     {
       "debug": false
-    },
-    {
-      "debug": true
-    },
-    {
-      "debug": "stepThrough"
     },
     {
       "integrations": {

--- a/src/common/src/types/generated/config_v3.ts
+++ b/src/common/src/types/generated/config_v3.ts
@@ -138,7 +138,8 @@ export interface Config {
   concurrentRunners?: number | boolean;
   environment?: EnvironmentDetails;
   /**
-   * Enable debugging mode. `true` allows pausing on breakpoints, waiting for user input before continuing. `stepThrough` pauses at every step, waiting for user input before continuing. `false` disables all debugging.
+   * @deprecated
+   * Deprecated and ignored. Previously reserved for an interactive step-through debugger that was never implemented. Retained so existing configs continue to validate. For diagnostics, run `doc-detective debug` or set the `DOC_DETECTIVE_DEBUG` environment variable.
    */
   debug?: boolean | "stepThrough";
   /**

--- a/src/common/src/types/generated/resolvedTests_v3.ts
+++ b/src/common/src/types/generated/resolvedTests_v3.ts
@@ -175,7 +175,8 @@ export interface Config {
   concurrentRunners?: number | boolean;
   environment?: EnvironmentDetails;
   /**
-   * Enable debugging mode. `true` allows pausing on breakpoints, waiting for user input before continuing. `stepThrough` pauses at every step, waiting for user input before continuing. `false` disables all debugging.
+   * @deprecated
+   * Deprecated and ignored. Previously reserved for an interactive step-through debugger that was never implemented. Retained so existing configs continue to validate. For diagnostics, run `doc-detective debug` or set the `DOC_DETECTIVE_DEBUG` environment variable.
    */
   debug?: boolean | "stepThrough";
   /**

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -141,6 +141,19 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.include("dryRun");
       });
 
+      it("should accept a config_v3 object with the deprecated `debug` field (ignored; kept so existing configs still validate)", function () {
+        // `debug` is deprecated and ignored — diagnostics moved to the
+        // DOC_DETECTIVE_DEBUG env var / `doc-detective debug` subcommand —
+        // but old configs that still carry it must keep validating.
+        for (const value of [false, true, "stepThrough"]) {
+          const result = validate({
+            schemaKey: "config_v3",
+            object: { debug: value },
+          });
+          expect(result.valid, `debug: ${JSON.stringify(value)}`).to.be.true;
+        }
+      });
+
       it("should validate a config_v3 object with hints set", function () {
         const result = validate({
           schemaKey: "config_v3",

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -154,6 +154,20 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         }
       });
 
+      it("should reject a config_v3 object whose deprecated `debug` value is malformed", function () {
+        // The accepted envelope is boolean | "stepThrough". Use values that
+        // are neither (and not AJV-coercible to boolean, so not "true"/"false"
+        // or 0/1) so the deprecated field's contract can't silently widen.
+        for (const value of ["yes", "stepthrough", "enabled", "on"]) {
+          const result = validate({
+            schemaKey: "config_v3",
+            object: { debug: value },
+          });
+          expect(result.valid, `debug: ${JSON.stringify(value)}`).to.be.false;
+          expect(result.errors).to.be.a("string");
+        }
+      });
+
       it("should validate a config_v3 object with hints set", function () {
         const result = validate({
           schemaKey: "config_v3",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import fs from "node:fs";
 import { validate } from "../common/src/validate.js";
 import { log, spawnCommand, loadEnvs, replaceEnvs } from "./utils.js";
 import path from "node:path";
@@ -11,7 +12,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export { setConfig, getAvailableApps, getEnvironment, resolveConcurrentRunners, clearAppCache };
+export { setConfig, getAvailableApps, getBrowserDiagnostics, getEnvironment, resolveConcurrentRunners, clearAppCache };
 
 /**
  * Deep merge two objects, with override properties taking precedence
@@ -618,30 +619,30 @@ function clearAppCache(config?: any) {
 }
 
 // Detect available apps.
-async function getAvailableApps({ config }: any) {
-  // Resolve the browsers cache dir *before* chdir-ing. `getBrowsersDir`'s
-  // legacy-snapshot fallback probes `path.resolve('browser-snapshots')`
-  // relative to the current CWD, so it has to run against the user's
-  // original CWD to honor a project-local `./browser-snapshots/` directory.
-  // Reusing the same resolved absolute path for both the cache key and the
-  // `getInstalledBrowsers` call below keeps `cachedAppsByDir` consistent
-  // with the directory actually scanned.
-  const browsersDir = getBrowsersDir({ cacheDir: config?.cacheDir });
-  const key = browsersDir;
-  const hit = cachedAppsByDir.get(key);
-  if (hit) return hit;
-
+// Shared browser/driver probing used by both `getAvailableApps` (which
+// filters to fully-usable browsers) and `getBrowserDiagnostics` (which
+// reports per-component status). Keeping a single probe here means the
+// diagnostic dump can never disagree with what a real run detects.
+//
+// Returns the raw `@puppeteer/browsers` install list and the combined
+// `appium driver list` output, plus a `browserDetectionFailed` flag set
+// only on an *unexpected* failure (the dep is present but fails to
+// load/scan) so callers can skip caching. A simply-absent dep (lean
+// install) is the normal "nothing installed" case, not a failure.
+async function probeBrowserEnvironment({
+  config,
+  browsersDir,
+}: any): Promise<{
+  installedBrowsers: any[];
+  appiumDriverOutput: string;
+  browserDetectionFailed: boolean;
+}> {
   setAppiumHome({ cacheDir: config?.cacheDir });
   const cwd = process.cwd();
   process.chdir(path.join(__dirname, "../.."));
-  const apps: any[] = [];
-  // Set only on an *unexpected* browser-detection failure (the dep is present
-  // but fails to load/scan). Used to skip caching so a transient failure can't
-  // poison the per-dir cache and suppress later successful detection. A simply
-  // absent dep (lean install) is the normal "no browsers" case and stays
-  // cacheable.
+  let installedBrowsers: any[] = [];
   let browserDetectionFailed = false;
-
+  let appiumDriverOutput = "";
   try {
     // Detect installed browsers read-only: autoInstall=false so config
     // resolution never triggers a heavy @puppeteer/browsers install (which
@@ -650,7 +651,6 @@ async function getAvailableApps({ config }: any) {
     // actually needs a browser. Gate the load on a non-installing presence
     // check so a missing dep (lean install) is a normal empty result rather
     // than a thrown error; only a present-but-broken dep counts as a failure.
-    let installedBrowsers: any[] = [];
     const browsersInstalled = resolveHeavyDepPath("@puppeteer/browsers", {
       cacheDir: config?.cacheDir,
     });
@@ -675,12 +675,6 @@ async function getAvailableApps({ config }: any) {
         installedBrowsers = [];
       }
     }
-    // Resolve `appium` from <cacheDir>/runtime via `npm exec --prefix`
-    // so a `--omit=optional` install (where appium only lives in the
-    // cache) still finds the CLI. Bare `npx appium` would fail in that
-    // posture even with APPIUM_HOME set, because APPIUM_HOME only
-    // governs driver lookup, not binary resolution.
-    //
     // Resolve appium's JS entry directly (shim first, then cache)
     // and spawn `node <entry> driver list`. Bypasses `.cmd` shims,
     // `npm exec`, and shell:true — the same pattern as the Appium
@@ -734,67 +728,87 @@ async function getAvailableApps({ config }: any) {
       });
     });
 
-    // Note: Edge/Microsoft Edge detection is intentionally excluded
-    // Only Chrome, Firefox, and Safari are supported browsers
-
     // `appium driver list` writes its formatted table to stdout; combine both
     // streams so detection works regardless of which version uses which stream.
-    const appiumDriverOutput =
+    appiumDriverOutput =
       installedAppiumDrivers.stdout + "\n" + installedAppiumDrivers.stderr;
-
-    // Detect Chrome
-    const chrome = installedBrowsers.find(
-      (browser: any) => browser.browser === "chrome"
-    );
-    const chromeVersion = chrome?.buildId;
-    const chromedriver = installedBrowsers.find(
-      (browser: any) => browser.browser === "chromedriver"
-    );
-    const appiumChromium = appiumDriverOutput.match(
-      /\n.*chromium.*installed \(npm\).*\n/
-    );
-
-    if (chrome && chromedriver && appiumChromium) {
-      apps.push({
-        name: "chrome",
-        version: chromeVersion,
-        path: chrome.executablePath,
-        driver: chromedriver.executablePath,
-      });
-    }
-
-    // Detect Firefox
-    const firefox = installedBrowsers.find(
-      (browser: any) => browser.browser === "firefox"
-    );
-    const appiumFirefox = appiumDriverOutput.match(
-      /\n.*gecko.*installed \(npm\).*\n/
-    );
-
-    if (firefox && appiumFirefox) {
-      apps.push({
-        name: "firefox",
-        version: firefox.buildId,
-        path: firefox.executablePath,
-      });
-    }
-
-    // Detect Safari
-    if (config.environment.platform === "mac") {
-      const safariVersion = await spawnCommand(
-        "defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString"
-      );
-      const appiumSafari = appiumDriverOutput.match(
-        /\n.*safari.*installed \(npm\).*\n/
-      );
-
-      if (safariVersion.exitCode === 0 && appiumSafari) {
-        apps.push({ name: "safari", version: safariVersion.stdout.trim(), path: "" });
-      }
-    }
   } finally {
     // Always restore the original working directory
     process.chdir(cwd);
+  }
+
+  return { installedBrowsers, appiumDriverOutput, browserDetectionFailed };
+}
+
+async function getAvailableApps({ config }: any) {
+  // Resolve the browsers cache dir *before* chdir-ing. `getBrowsersDir`'s
+  // legacy-snapshot fallback probes `path.resolve('browser-snapshots')`
+  // relative to the current CWD, so it has to run against the user's
+  // original CWD to honor a project-local `./browser-snapshots/` directory.
+  // Reusing the same resolved absolute path for both the cache key and the
+  // `getInstalledBrowsers` call below keeps `cachedAppsByDir` consistent
+  // with the directory actually scanned.
+  const browsersDir = getBrowsersDir({ cacheDir: config?.cacheDir });
+  const key = browsersDir;
+  const hit = cachedAppsByDir.get(key);
+  if (hit) return hit;
+
+  const { installedBrowsers, appiumDriverOutput, browserDetectionFailed } =
+    await probeBrowserEnvironment({ config, browsersDir });
+
+  // Note: Edge/Microsoft Edge detection is intentionally excluded
+  // Only Chrome, Firefox, and Safari are supported browsers
+  const apps: any[] = [];
+
+  // Detect Chrome
+  const chrome = installedBrowsers.find(
+    (browser: any) => browser.browser === "chrome"
+  );
+  const chromeVersion = chrome?.buildId;
+  const chromedriver = installedBrowsers.find(
+    (browser: any) => browser.browser === "chromedriver"
+  );
+  const appiumChromium = appiumDriverOutput.match(
+    /\n.*chromium.*installed \(npm\).*\n/
+  );
+
+  if (chrome && chromedriver && appiumChromium) {
+    apps.push({
+      name: "chrome",
+      version: chromeVersion,
+      path: chrome.executablePath,
+      driver: chromedriver.executablePath,
+    });
+  }
+
+  // Detect Firefox
+  const firefox = installedBrowsers.find(
+    (browser: any) => browser.browser === "firefox"
+  );
+  const appiumFirefox = appiumDriverOutput.match(
+    /\n.*gecko.*installed \(npm\).*\n/
+  );
+
+  if (firefox && appiumFirefox) {
+    apps.push({
+      name: "firefox",
+      version: firefox.buildId,
+      path: firefox.executablePath,
+    });
+  }
+
+  // Detect Safari
+  if (config.environment.platform === "mac") {
+    const safariVersion = await spawnCommand(
+      "defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString"
+    );
+    const appiumSafari = appiumDriverOutput.match(
+      /\n.*safari.*installed \(npm\).*\n/
+    );
+
+    if (safariVersion.exitCode === 0 && appiumSafari) {
+      apps.push({ name: "safari", version: safariVersion.stdout.trim(), path: "" });
+    }
   }
 
   // TODO
@@ -805,4 +819,137 @@ async function getAvailableApps({ config }: any) {
   // failure must not suppress later successful detection in this process.
   if (!browserDetectionFailed) cachedAppsByDir.set(key, apps);
   return apps;
+}
+
+interface BrowserComponent {
+  // What this component is, e.g. "chrome browser", "chromedriver",
+  // "appium-chromium-driver".
+  label: string;
+  installed: boolean;
+  // Version and/or path when known.
+  detail?: string;
+}
+
+interface BrowserDiagnostic {
+  name: "chrome" | "firefox" | "safari";
+  // false when the browser can't run on this platform at all (Safari off macOS).
+  supported: boolean;
+  // true when every component Doc Detective gates on for a real run is present
+  // (mirrors `getAvailableApps`).
+  available: boolean;
+  components: BrowserComponent[];
+  note?: string;
+}
+
+// Per-browser, per-component status for the diagnostic dump. Always reports
+// all supported browsers (Chrome, Firefox, Safari) whether or not they're
+// usable, so a user can see exactly which piece is missing. `available`
+// matches the gate in `getAvailableApps`; `geckodriver` / `safaridriver` are
+// reported as informational components (Doc Detective auto-installs
+// geckodriver and safaridriver ships with macOS) even though the gate keys on
+// the browser binary plus the Appium driver.
+async function getBrowserDiagnostics({ config }: any): Promise<{
+  browsers: BrowserDiagnostic[];
+  detectionFailed: boolean;
+}> {
+  const browsersDir = getBrowsersDir({ cacheDir: config?.cacheDir });
+  const { installedBrowsers, appiumDriverOutput, browserDetectionFailed } =
+    await probeBrowserEnvironment({ config, browsersDir });
+
+  const find = (b: string) =>
+    installedBrowsers.find((x: any) => x.browser === b);
+  const platform = config?.environment?.platform;
+  const browsers: BrowserDiagnostic[] = [];
+
+  // Chrome
+  const chrome = find("chrome");
+  const chromedriver = find("chromedriver");
+  const appiumChromium = /\n.*chromium.*installed \(npm\).*\n/.test(
+    appiumDriverOutput
+  );
+  browsers.push({
+    name: "chrome",
+    supported: true,
+    available: Boolean(chrome && chromedriver && appiumChromium),
+    components: [
+      {
+        label: "chrome browser",
+        installed: Boolean(chrome),
+        detail: chrome ? `${chrome.buildId} (${chrome.executablePath})` : undefined,
+      },
+      {
+        label: "chromedriver",
+        installed: Boolean(chromedriver),
+        detail: chromedriver?.executablePath,
+      },
+      { label: "appium-chromium-driver", installed: appiumChromium },
+    ],
+  });
+
+  // Firefox
+  const firefox = find("firefox");
+  const geckodriver = find("geckodriver");
+  const appiumGecko = /\n.*gecko.*installed \(npm\).*\n/.test(appiumDriverOutput);
+  browsers.push({
+    name: "firefox",
+    supported: true,
+    available: Boolean(firefox && appiumGecko),
+    components: [
+      {
+        label: "firefox browser",
+        installed: Boolean(firefox),
+        detail: firefox
+          ? `${firefox.buildId} (${firefox.executablePath})`
+          : undefined,
+      },
+      {
+        label: "geckodriver",
+        installed: Boolean(geckodriver),
+        detail: geckodriver?.executablePath,
+      },
+      { label: "appium-geckodriver", installed: appiumGecko },
+    ],
+    note:
+      firefox && appiumGecko && !geckodriver
+        ? "geckodriver is auto-installed at run time when missing"
+        : undefined,
+  });
+
+  // Safari (macOS only)
+  const isMac = platform === "mac";
+  const appiumSafari = /\n.*safari.*installed \(npm\).*\n/.test(appiumDriverOutput);
+  let safariApp = false;
+  let safariVersion: string | undefined;
+  let safaridriver = false;
+  if (isMac) {
+    const result = await spawnCommand(
+      "defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString"
+    );
+    safariApp = result.exitCode === 0;
+    safariVersion = safariApp ? result.stdout.trim() : undefined;
+    try {
+      // safaridriver ships with macOS; it still needs `safaridriver --enable`
+      // and "Allow Remote Automation" before a run can use it.
+      safaridriver = fs.existsSync("/usr/bin/safaridriver");
+    } catch {
+      // Stat failures are non-fatal for diagnostics.
+    }
+  }
+  browsers.push({
+    name: "safari",
+    supported: isMac,
+    available: Boolean(isMac && safariApp && appiumSafari),
+    components: [
+      { label: "Safari app", installed: safariApp, detail: safariVersion },
+      {
+        label: "safaridriver",
+        installed: safaridriver,
+        detail: safaridriver ? "/usr/bin/safaridriver" : undefined,
+      },
+      { label: "appium-safari-driver", installed: appiumSafari },
+    ],
+    note: isMac ? undefined : "Safari is only available on macOS",
+  });
+
+  return { browsers, detectionFailed: browserDetectionFailed };
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -5,7 +5,7 @@ import { log, spawnCommand, loadEnvs, replaceEnvs } from "./utils.js";
 import path from "node:path";
 import { spawn as spawnChild } from "node:child_process";
 import { loadHeavyDep, resolveHeavyDepPath } from "../runtime/loader.js";
-import { getBrowsersDir } from "../runtime/cacheDir.js";
+import { getBrowsersDir, readInstalledRecord } from "../runtime/cacheDir.js";
 import { setAppiumHome } from "./appium.js";
 import { loadDescription } from "./openapi.js";
 import { fileURLToPath } from "node:url";
@@ -618,17 +618,18 @@ function clearAppCache(config?: any) {
   cachedAppsByDir.delete(cacheKeyFor(config));
 }
 
-// Detect available apps.
-// Shared browser/driver probing used by both `getAvailableApps` (which
-// filters to fully-usable browsers) and `getBrowserDiagnostics` (which
-// reports per-component status). Keeping a single probe here means the
-// diagnostic dump can never disagree with what a real run detects.
+// Live browser/driver probing for `getAvailableApps` — the runtime gate
+// that decides whether a real run can launch a browser right now.
 //
 // Returns the raw `@puppeteer/browsers` install list and the combined
 // `appium driver list` output, plus a `browserDetectionFailed` flag set
 // only on an *unexpected* failure (the dep is present but fails to
 // load/scan) so callers can skip caching. A simply-absent dep (lean
 // install) is the normal "nothing installed" case, not a failure.
+//
+// Note: the diagnostic dump uses `getBrowserDiagnostics` instead, which
+// reads doc-detective's `installed.json` record so it reports the same
+// values as `doc-detective install` / `install status`.
 async function probeBrowserEnvironment({
   config,
   browsersDir,
@@ -843,81 +844,70 @@ interface BrowserDiagnostic {
 
 // Per-browser, per-component status for the diagnostic dump. Always reports
 // all supported browsers (Chrome, Firefox, Safari) whether or not they're
-// usable, so a user can see exactly which piece is missing. `available`
-// matches the gate in `getAvailableApps`; `geckodriver` / `safaridriver` are
-// reported as informational components (Doc Detective auto-installs
-// geckodriver and safaridriver ships with macOS) even though the gate keys on
-// the browser binary plus the Appium driver.
+// usable, so a user can see exactly which piece is missing.
+//
+// Reads from the same `<cacheDir>/installed.json` record that
+// `doc-detective install` / `install status` use (`readInstalledRecord`),
+// NOT live `@puppeteer/browsers` / `appium driver list` probing — so the
+// dump reports the SAME values as the installer (e.g. the appium-*-driver
+// npm packages and the geckodriver binary that live probing misses). A
+// browser is `available` when its browser binary, its webdriver, and its
+// Appium driver are all recorded as installed.
 async function getBrowserDiagnostics({ config }: any): Promise<{
   browsers: BrowserDiagnostic[];
   detectionFailed: boolean;
 }> {
-  const browsersDir = getBrowsersDir({ cacheDir: config?.cacheDir });
-  const { installedBrowsers, appiumDriverOutput, browserDetectionFailed } =
-    await probeBrowserEnvironment({ config, browsersDir });
-
-  const find = (b: string) =>
-    installedBrowsers.find((x: any) => x.browser === b);
+  const record = readInstalledRecord({ cacheDir: config?.cacheDir });
+  const browsersRec = record.browsers || {};
   const platform = config?.environment?.platform;
+
+  // Browser binaries are tracked in installed.json (matches the `@version`
+  // shown by `install`/`install status`).
+  const brow = (name: string) => browsersRec[name];
+  // Heavy npm packages (the appium-*-driver wrappers) count as installed
+  // when resolvable from the shim's node_modules OR the runtime cache —
+  // the same presence check `ensureRuntimeInstalled` uses to decide
+  // "already-up-to-date". The cache record alone would miss packages that
+  // resolve from node_modules (e.g. a dev checkout or pre-installed deps).
+  const npmInstalled = (name: string) =>
+    Boolean(resolveHeavyDepPath(name, { cacheDir: config?.cacheDir }));
   const browsers: BrowserDiagnostic[] = [];
 
-  // Chrome
-  const chrome = find("chrome");
-  const chromedriver = find("chromedriver");
-  const appiumChromium = /\n.*chromium.*installed \(npm\).*\n/.test(
-    appiumDriverOutput
-  );
+  // Chrome: browser binary + chromedriver + appium-chromium-driver.
+  const chrome = brow("chrome");
+  const chromedriver = brow("chromedriver");
+  const appiumChromium = npmInstalled("appium-chromium-driver");
   browsers.push({
     name: "chrome",
     supported: true,
     available: Boolean(chrome && chromedriver && appiumChromium),
     components: [
-      {
-        label: "chrome browser",
-        installed: Boolean(chrome),
-        detail: chrome ? `${chrome.buildId} (${chrome.executablePath})` : undefined,
-      },
-      {
-        label: "chromedriver",
-        installed: Boolean(chromedriver),
-        detail: chromedriver?.executablePath,
-      },
+      { label: "chrome browser", installed: Boolean(chrome), detail: chrome?.installedVersion },
+      { label: "chromedriver", installed: Boolean(chromedriver), detail: chromedriver?.installedVersion },
       { label: "appium-chromium-driver", installed: appiumChromium },
     ],
   });
 
-  // Firefox
-  const firefox = find("firefox");
-  const geckodriver = find("geckodriver");
-  const appiumGecko = /\n.*gecko.*installed \(npm\).*\n/.test(appiumDriverOutput);
+  // Firefox: browser binary + geckodriver + appium-geckodriver.
+  const firefox = brow("firefox");
+  const geckodriver = brow("geckodriver");
+  const appiumGecko = npmInstalled("appium-geckodriver");
   browsers.push({
     name: "firefox",
     supported: true,
-    available: Boolean(firefox && appiumGecko),
+    available: Boolean(firefox && geckodriver && appiumGecko),
     components: [
-      {
-        label: "firefox browser",
-        installed: Boolean(firefox),
-        detail: firefox
-          ? `${firefox.buildId} (${firefox.executablePath})`
-          : undefined,
-      },
-      {
-        label: "geckodriver",
-        installed: Boolean(geckodriver),
-        detail: geckodriver?.executablePath,
-      },
+      { label: "firefox browser", installed: Boolean(firefox), detail: firefox?.installedVersion },
+      { label: "geckodriver", installed: Boolean(geckodriver), detail: geckodriver?.installedVersion },
       { label: "appium-geckodriver", installed: appiumGecko },
     ],
-    note:
-      firefox && appiumGecko && !geckodriver
-        ? "geckodriver is auto-installed at run time when missing"
-        : undefined,
   });
 
-  // Safari (macOS only)
+  // Safari (macOS only): the OS-provided app + safaridriver, plus the
+  // appium-safari-driver npm package. The app/driver are OS-provided (not
+  // tracked in installed.json), so they're probed directly.
   const isMac = platform === "mac";
-  const appiumSafari = /\n.*safari.*installed \(npm\).*\n/.test(appiumDriverOutput);
+  const appiumSafari = npmInstalled("appium-safari-driver");
   let safariApp = false;
   let safariVersion: string | undefined;
   let safaridriver = false;
@@ -938,7 +928,7 @@ async function getBrowserDiagnostics({ config }: any): Promise<{
   browsers.push({
     name: "safari",
     supported: isMac,
-    available: Boolean(isMac && safariApp && appiumSafari),
+    available: Boolean(isMac && safariApp && safaridriver && appiumSafari),
     components: [
       { label: "Safari app", installed: safariApp, detail: safariVersion },
       {
@@ -951,5 +941,5 @@ async function getBrowserDiagnostics({ config }: any): Promise<{
     note: isMac ? undefined : "Safari is only available on macOS",
   });
 
-  return { browsers, detectionFailed: browserDetectionFailed };
+  return { browsers, detectionFailed: false };
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -842,6 +842,53 @@ interface BrowserDiagnostic {
   note?: string;
 }
 
+// Bounded, killable Safari version probe for diagnostics. `spawnCommand`
+// has no timeout and the debug-side `Promise.race` doesn't cancel the
+// child, so a hung `defaults` could keep the process alive past the cap.
+// Spawn it directly (no shell) with a hard kill-on-timeout. Returns the
+// version string, or null if Safari is absent / the probe times out / errors.
+function probeSafariVersion(timeoutMs: number): Promise<string | null> {
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawnChild>;
+    try {
+      child = spawnChild(
+        "defaults",
+        [
+          "read",
+          "/Applications/Safari.app/Contents/Info.plist",
+          "CFBundleShortVersionString",
+        ],
+        { stdio: ["ignore", "pipe", "ignore"] }
+      );
+    } catch {
+      resolve(null);
+      return;
+    }
+    let stdout = "";
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        // Best-effort.
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    timer.unref?.();
+    child.stdout?.on("data", (c: Buffer | string) => {
+      stdout += typeof c === "string" ? c : c.toString("utf8");
+    });
+    child.on("error", () => finish(null));
+    child.on("close", (code: number | null) =>
+      finish(code === 0 ? stdout.trim() : null)
+    );
+  });
+}
+
 // Per-browser, per-component status for the diagnostic dump. Always reports
 // all supported browsers (Chrome, Firefox, Safari) whether or not they're
 // usable, so a user can see exactly which piece is missing.
@@ -924,11 +971,9 @@ async function getBrowserDiagnostics({ config }: any): Promise<{
   let safaridriver = false;
   if (isMac) {
     try {
-      const result = await spawnCommand(
-        "defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString"
-      );
-      safariApp = result.exitCode === 0;
-      safariVersion = safariApp ? result.stdout.trim() : undefined;
+      const version = await probeSafariVersion(4000);
+      safariApp = version !== null;
+      safariVersion = version ?? undefined;
       // safaridriver ships with macOS; it still needs `safaridriver --enable`
       // and "Allow Remote Automation" before a run can use it.
       safaridriver = fs.existsSync("/usr/bin/safaridriver");

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -857,7 +857,18 @@ async function getBrowserDiagnostics({ config }: any): Promise<{
   browsers: BrowserDiagnostic[];
   detectionFailed: boolean;
 }> {
-  const record = readInstalledRecord({ cacheDir: config?.cacheDir });
+  // Track unexpected failures so the caller can warn that component status
+  // may be incomplete. Reading the record is normally defensive (returns an
+  // empty record on a bad/missing file), but guard it anyway, and flag a
+  // throwing Safari probe below.
+  let detectionFailed = false;
+  let record: ReturnType<typeof readInstalledRecord>;
+  try {
+    record = readInstalledRecord({ cacheDir: config?.cacheDir });
+  } catch {
+    detectionFailed = true;
+    record = { npmPackages: {}, browsers: {} };
+  }
   const browsersRec = record.browsers || {};
   const platform = config?.environment?.platform;
 
@@ -912,17 +923,19 @@ async function getBrowserDiagnostics({ config }: any): Promise<{
   let safariVersion: string | undefined;
   let safaridriver = false;
   if (isMac) {
-    const result = await spawnCommand(
-      "defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString"
-    );
-    safariApp = result.exitCode === 0;
-    safariVersion = safariApp ? result.stdout.trim() : undefined;
     try {
+      const result = await spawnCommand(
+        "defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString"
+      );
+      safariApp = result.exitCode === 0;
+      safariVersion = safariApp ? result.stdout.trim() : undefined;
       // safaridriver ships with macOS; it still needs `safaridriver --enable`
       // and "Allow Remote Automation" before a run can use it.
       safaridriver = fs.existsSync("/usr/bin/safaridriver");
     } catch {
-      // Stat failures are non-fatal for diagnostics.
+      // An unexpected probe failure (not just "Safari absent") — flag it so
+      // the caller can note the component status may be incomplete.
+      detectionFailed = true;
     }
   }
   browsers.push({
@@ -941,5 +954,5 @@ async function getBrowserDiagnostics({ config }: any): Promise<{
     note: isMac ? undefined : "Safari is only available on macOS",
   });
 
-  return { browsers, detectionFailed: false };
+  return { browsers, detectionFailed };
 }

--- a/src/debug/command.ts
+++ b/src/debug/command.ts
@@ -30,10 +30,8 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
   handler: async (args) => {
     // Lazy-load so the default `runTests` path doesn't pay the import cost.
     const { setConfig } = await import("../utils.js");
-    const { printDebug, defaultDebugOutFile, defaultDebugJsonFile } =
-      await import("./index.js");
-    const outFile = defaultDebugOutFile();
-    const jsonOutFile = defaultDebugJsonFile();
+    const { printDebug, defaultDebugDir } = await import("./index.js");
+    const outDir = defaultDebugDir();
 
     const configPathJSON = path.resolve(process.cwd(), ".doc-detective.json");
     const configPathYAML = path.resolve(process.cwd(), ".doc-detective.yaml");
@@ -71,8 +69,7 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
         configPath,
         configError: err instanceof Error ? err : new Error(String(err)),
         includeEnv,
-        outFile,
-        jsonOutFile,
+        outDir,
       });
       // Config is broken — exit non-zero so scripts/CI that gate on the
       // exit code don't treat a CONFIG INVALID dump as success. Mirrors
@@ -85,8 +82,7 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
       configPath,
       configError: null,
       includeEnv,
-      outFile,
-      jsonOutFile,
+      outDir,
     });
   },
 };

--- a/src/debug/command.ts
+++ b/src/debug/command.ts
@@ -30,7 +30,8 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
   handler: async (args) => {
     // Lazy-load so the default `runTests` path doesn't pay the import cost.
     const { setConfig } = await import("../utils.js");
-    const { printDebug } = await import("./index.js");
+    const { printDebug, defaultDebugOutFile } = await import("./index.js");
+    const outFile = defaultDebugOutFile();
 
     const configPathJSON = path.resolve(process.cwd(), ".doc-detective.json");
     const configPathYAML = path.resolve(process.cwd(), ".doc-detective.yaml");
@@ -67,9 +68,10 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
         configPath,
         configError: err instanceof Error ? err : new Error(String(err)),
         includeEnv,
+        outFile,
       });
       return;
     }
-    await printDebug({ config, configPath, configError: null, includeEnv });
+    await printDebug({ config, configPath, configError: null, includeEnv, outFile });
   },
 };

--- a/src/debug/command.ts
+++ b/src/debug/command.ts
@@ -74,6 +74,10 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
         outFile,
         jsonOutFile,
       });
+      // Config is broken — exit non-zero so scripts/CI that gate on the
+      // exit code don't treat a CONFIG INVALID dump as success. Mirrors
+      // the DOC_DETECTIVE_DEBUG env-var path in cli.ts.
+      process.exitCode = 1;
       return;
     }
     await printDebug({

--- a/src/debug/command.ts
+++ b/src/debug/command.ts
@@ -30,8 +30,10 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
   handler: async (args) => {
     // Lazy-load so the default `runTests` path doesn't pay the import cost.
     const { setConfig } = await import("../utils.js");
-    const { printDebug, defaultDebugOutFile } = await import("./index.js");
+    const { printDebug, defaultDebugOutFile, defaultDebugJsonFile } =
+      await import("./index.js");
     const outFile = defaultDebugOutFile();
+    const jsonOutFile = defaultDebugJsonFile();
 
     const configPathJSON = path.resolve(process.cwd(), ".doc-detective.json");
     const configPathYAML = path.resolve(process.cwd(), ".doc-detective.yaml");
@@ -69,9 +71,17 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
         configError: err instanceof Error ? err : new Error(String(err)),
         includeEnv,
         outFile,
+        jsonOutFile,
       });
       return;
     }
-    await printDebug({ config, configPath, configError: null, includeEnv, outFile });
+    await printDebug({
+      config,
+      configPath,
+      configError: null,
+      includeEnv,
+      outFile,
+      jsonOutFile,
+    });
   },
 };

--- a/src/debug/command.ts
+++ b/src/debug/command.ts
@@ -44,7 +44,7 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
     const hasExplicitConfig =
       typeof args.config === "string" && args.config.trim().length > 0;
     const configPath = hasExplicitConfig
-      ? path.resolve(args.config as string)
+      ? path.resolve((args.config as string).trim())
       : fs.existsSync(configPathJSON)
       ? configPathJSON
       : fs.existsSync(configPathYAML)

--- a/src/debug/command.ts
+++ b/src/debug/command.ts
@@ -1,0 +1,75 @@
+import type { CommandModule } from "yargs";
+import path from "node:path";
+import fs from "node:fs";
+
+export interface DebugArgv {
+  config?: string;
+  input?: string;
+  logLevel?: string;
+  "include-env": boolean;
+  includeEnv?: boolean;
+}
+
+// `doc-detective debug` — print a paste-friendly diagnostic dump and
+// exit without running tests. See `src/debug/index.ts` for the renderer.
+//
+// `--include-env` opts into the full `process.env` dump (still redacted
+// by name AND by value shape). Without it, the dump only lists env
+// vars referenced via `$VAR` in config or input files.
+export const debugCommand: CommandModule<{}, DebugArgv> = {
+  command: "debug",
+  describe:
+    "Print diagnostic information about the runtime environment (OS, Doc Detective version, tool versions, browsers, referenced env vars) and exit without running tests.",
+  builder: (yargs) =>
+    yargs.option("include-env", {
+      type: "boolean",
+      default: false,
+      describe:
+        "Also dump the full process.env (redacted by name and value shape). Off by default to avoid leaking PaaS-injected credentials (DATABASE_URL, Sentry DSN, webhooks).",
+    }) as unknown as import("yargs").Argv<DebugArgv>,
+  handler: async (args) => {
+    // Lazy-load so the default `runTests` path doesn't pay the import cost.
+    const { setConfig } = await import("../utils.js");
+    const { printDebug } = await import("./index.js");
+
+    const configPathJSON = path.resolve(process.cwd(), ".doc-detective.json");
+    const configPathYAML = path.resolve(process.cwd(), ".doc-detective.yaml");
+    const configPathYML = path.resolve(process.cwd(), ".doc-detective.yml");
+    const hasExplicitConfig =
+      typeof args.config === "string" &&
+      args.config.length > 0 &&
+      fs.existsSync(args.config);
+    const configPath = hasExplicitConfig
+      ? (args.config as string)
+      : fs.existsSync(configPathJSON)
+      ? configPathJSON
+      : fs.existsSync(configPathYAML)
+      ? configPathYAML
+      : fs.existsSync(configPathYML)
+      ? configPathYML
+      : null;
+
+    // `--include-env` lands on argv as both kebab and camel; tolerate either.
+    const includeEnv = Boolean(args["include-env"] ?? args.includeEnv);
+
+    let config: any;
+    try {
+      config = await setConfig({ configPath, args });
+    } catch (err: any) {
+      // Bad config is exactly the case the user is debugging — emit the
+      // dump under a CONFIG INVALID banner instead of bailing.
+      await printDebug({
+        config: {
+          logLevel:
+            typeof args.logLevel === "string" ? args.logLevel : "info",
+          input: typeof args.input === "string" ? args.input : ".",
+        },
+        configPath,
+        configError: err instanceof Error ? err : new Error(String(err)),
+        includeEnv,
+      });
+      return;
+    }
+    await printDebug({ config, configPath, configError: null, includeEnv });
+  },
+};

--- a/src/debug/command.ts
+++ b/src/debug/command.ts
@@ -38,12 +38,13 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
     const configPathJSON = path.resolve(process.cwd(), ".doc-detective.json");
     const configPathYAML = path.resolve(process.cwd(), ".doc-detective.yaml");
     const configPathYML = path.resolve(process.cwd(), ".doc-detective.yml");
+    // Treat any non-empty `--config` as authoritative (resolved to an
+    // absolute path) — a mistyped path must surface as a CONFIG INVALID
+    // dump for that path, not silently fall back to auto-discovery.
     const hasExplicitConfig =
-      typeof args.config === "string" &&
-      args.config.length > 0 &&
-      fs.existsSync(args.config);
+      typeof args.config === "string" && args.config.trim().length > 0;
     const configPath = hasExplicitConfig
-      ? (args.config as string)
+      ? path.resolve(args.config as string)
       : fs.existsSync(configPathJSON)
       ? configPathJSON
       : fs.existsSync(configPathYAML)

--- a/src/debug/envvars.ts
+++ b/src/debug/envvars.ts
@@ -146,6 +146,13 @@ export function resolveDocExtensions(fileTypes: unknown): Set<string> {
   return exts;
 }
 
+// Hard cap on how many filesystem entries the walk will examine, separate
+// from the matched-file `cap`. Without it, an input pointed at `/` or a
+// huge repo with no doc-extension matches would traverse the whole tree
+// (the matched-file cap never trips), making `doc-detective debug` look
+// hung. 50k entries is plenty for any real docs tree.
+const MAX_ENTRIES_EXAMINED = 50_000;
+
 // Walk a list of input paths (files or directories) and return a list of
 // readable file paths up to `cap` entries. Bounded so the debug dump can
 // never hang on a giant tree. Skips node_modules and .git.
@@ -176,13 +183,15 @@ export function enumerateInputFiles(
   // keep the stack non-empty forever — a real hang risk, especially when
   // the extension filter means no files ever pass to bound the walk.
   const visitedDirs = new Set<string>();
+  let examined = 0;
   for (const i of inputs) {
     if (typeof i === "string" && i.length > 0) {
       stack.push(i);
       explicit.add(i);
     }
   }
-  while (stack.length > 0 && out.length < cap) {
+  while (stack.length > 0 && out.length < cap && examined < MAX_ENTRIES_EXAMINED) {
+    examined++;
     const p = stack.shift() as string;
     let stat;
     try {

--- a/src/debug/envvars.ts
+++ b/src/debug/envvars.ts
@@ -192,7 +192,9 @@ export function enumerateInputFiles(
   }
   while (stack.length > 0 && out.length < cap && examined < MAX_ENTRIES_EXAMINED) {
     examined++;
-    const p = stack.shift() as string;
+    // pop() (LIFO) keeps the walk O(n); shift() reindexes the array on every
+    // iteration, degrading a large tree to O(n²). Order doesn't matter here.
+    const p = stack.pop() as string;
     let stat;
     try {
       stat = fs.statSync(p);

--- a/src/debug/envvars.ts
+++ b/src/debug/envvars.ts
@@ -18,7 +18,7 @@ import path from "node:path";
 // Env-var references, scoped to POSIX-valid variable names: a leading
 // letter or underscore followed by letters / digits / underscores.
 //
-// `replaceEnvs` (src/core/utils.ts:454) uses the looser `\$[a-zA-Z0-9_]+`
+// `replaceEnvs` (in src/core/utils.ts) uses the looser `\$[a-zA-Z0-9_]+`
 // shape, but that's harmless there — it only ever resolves names that
 // actually exist in `process.env`, and env var names can't start with a
 // digit. The debug dump GREPS raw source, so the loose shape matched
@@ -123,7 +123,10 @@ export function resolveDocExtensions(fileTypes: unknown): Set<string> {
         for (const e of DOC_EXTENSIONS_BY_TYPE[ft] || []) add(e);
       } else if (ft && typeof ft === "object") {
         const obj = ft as Record<string, unknown>;
-        if (Array.isArray(obj.extensions)) {
+        // The schema allows `extensions` as a string OR an array.
+        if (typeof obj.extensions === "string") {
+          add(obj.extensions);
+        } else if (Array.isArray(obj.extensions)) {
           for (const e of obj.extensions) add(e);
         }
         for (const key of ["name", "extends"]) {
@@ -168,6 +171,11 @@ export function enumerateInputFiles(
   const out: string[] = [];
   const stack: string[] = [];
   const explicit = new Set<string>();
+  // Canonical paths of directories already walked. Guards against cyclic
+  // symlinked directory graphs (e.g. `a/link -> ..`) that would otherwise
+  // keep the stack non-empty forever — a real hang risk, especially when
+  // the extension filter means no files ever pass to bound the walk.
+  const visitedDirs = new Set<string>();
   for (const i of inputs) {
     if (typeof i === "string" && i.length > 0) {
       stack.push(i);
@@ -189,6 +197,14 @@ export function enumerateInputFiles(
       continue;
     }
     if (stat.isDirectory()) {
+      let realDir: string;
+      try {
+        realDir = fs.realpathSync(p);
+      } catch {
+        realDir = p;
+      }
+      if (visitedDirs.has(realDir)) continue;
+      visitedDirs.add(realDir);
       let entries: string[];
       try {
         entries = fs.readdirSync(p);

--- a/src/debug/envvars.ts
+++ b/src/debug/envvars.ts
@@ -1,0 +1,205 @@
+// Env-var enumeration for the debug dump.
+//
+// Two collection paths:
+//   1. `findReferencedEnvVars` walks raw text (config file source,
+//      DOC_DETECTIVE_CONFIG env value, input file contents) for
+//      `$VAR` style references — the same shape `replaceEnvs` in
+//      `src/core/utils.ts` substitutes at runtime.
+//   2. `detectContainer` returns a small struct describing whether
+//      Doc Detective is running inside a container (IN_CONTAINER
+//      canary, /.dockerenv probe, or /proc/1/cgroup substring).
+//
+// Both helpers are pure / cheap and safe to call in any order. File
+// I/O lives in the orchestrator, not here.
+
+import fs from "node:fs";
+import path from "node:path";
+
+// Env-var references, scoped to POSIX-valid variable names: a leading
+// letter or underscore followed by letters / digits / underscores.
+//
+// `replaceEnvs` (src/core/utils.ts:454) uses the looser `\$[a-zA-Z0-9_]+`
+// shape, but that's harmless there — it only ever resolves names that
+// actually exist in `process.env`, and env var names can't start with a
+// digit. The debug dump GREPS raw source, so the loose shape matched
+// shell positionals (`$0`, `$1`), regex backreferences (`$2`), and
+// numeric tokens (`$86`) that can never be env vars — pure noise in a
+// pasted report. Anchoring on a non-digit first char drops all of it
+// without hiding anything `replaceEnvs` would ever substitute.
+const ENV_REF_REGEX = /\$[a-zA-Z_][a-zA-Z0-9_]*/g;
+
+export function findReferencedEnvVars(value: unknown): Set<string> {
+  const found = new Set<string>();
+  collect(value, found, new WeakSet());
+  return found;
+}
+
+function collect(value: unknown, out: Set<string>, seen: WeakSet<object>): void {
+  if (value == null) return;
+  if (typeof value === "string") {
+    const matches = value.match(ENV_REF_REGEX);
+    if (matches) {
+      for (const m of matches) out.add(m.slice(1));
+    }
+    return;
+  }
+  if (typeof value !== "object") return;
+  if (seen.has(value as object)) return;
+  seen.add(value as object);
+  if (Array.isArray(value)) {
+    for (const item of value) collect(item, out, seen);
+    return;
+  }
+  for (const k of Object.keys(value as Record<string, unknown>)) {
+    if (k === "__proto__" || k === "constructor" || k === "prototype") continue;
+    collect((value as Record<string, unknown>)[k], out, seen);
+  }
+}
+
+export interface ContainerInfo {
+  inContainer: boolean;
+  signals: string[];
+}
+
+export function detectContainer(): ContainerInfo {
+  const signals: string[] = [];
+
+  if (process.env.IN_CONTAINER === "true") {
+    signals.push("IN_CONTAINER=true");
+  }
+
+  // /.dockerenv exists in Docker containers on Linux. Safe to stat on
+  // Windows too — it just returns false.
+  try {
+    if (fs.existsSync("/.dockerenv")) signals.push("/.dockerenv exists");
+  } catch {
+    // Stat errors are non-fatal — diagnostics should never crash.
+  }
+
+  // /proc/1/cgroup substring check (Linux only). Skip on win32 / darwin
+  // where /proc doesn't exist.
+  if (process.platform === "linux") {
+    try {
+      const cgroup = fs.readFileSync("/proc/1/cgroup", "utf8");
+      if (/docker|containerd|kubepods/.test(cgroup)) {
+        signals.push("/proc/1/cgroup matches container runtime");
+      }
+    } catch {
+      // Non-fatal — /proc/1/cgroup may not be readable.
+    }
+  }
+
+  return { inContainer: signals.length > 0, signals };
+}
+
+// Default file-type → extension map, mirroring core's `defaultFileTypes`
+// (src/core/config.ts). Used to scope the referenced-env-var scan to the
+// files doc-detective actually parses, instead of every file in the tree
+// (where the `$VAR` grep matched shell/code/CI syntax — see the dump's
+// noise before this was added).
+const DOC_EXTENSIONS_BY_TYPE: Record<string, string[]> = {
+  markdown: ["md", "markdown", "mdx"],
+  asciidoc: ["adoc", "asciidoc", "asc"],
+  html: ["html", "htm"],
+  dita: ["dita", "ditamap", "xml"],
+};
+
+// Resolve `config.fileTypes` into the set of lowercase extensions (no
+// leading dot) that doc-detective would treat as input. Handles both the
+// post-setConfig string-name form (`["markdown", "dita"]`) and richer
+// object entries that carry their own `extensions` / `name` / `extends`.
+// Falls back to the union of all known doc extensions when fileTypes is
+// absent or yields nothing, so the scan still targets something sensible.
+export function resolveDocExtensions(fileTypes: unknown): Set<string> {
+  const exts = new Set<string>();
+  const add = (e: unknown) => {
+    if (typeof e === "string" && e.length > 0) {
+      exts.add(e.replace(/^\./, "").toLowerCase());
+    }
+  };
+  if (Array.isArray(fileTypes)) {
+    for (const ft of fileTypes) {
+      if (typeof ft === "string") {
+        for (const e of DOC_EXTENSIONS_BY_TYPE[ft] || []) add(e);
+      } else if (ft && typeof ft === "object") {
+        const obj = ft as Record<string, unknown>;
+        if (Array.isArray(obj.extensions)) {
+          for (const e of obj.extensions) add(e);
+        }
+        for (const key of ["name", "extends"]) {
+          const named = obj[key];
+          if (typeof named === "string") {
+            for (const e of DOC_EXTENSIONS_BY_TYPE[named] || []) add(e);
+          }
+        }
+      }
+    }
+  }
+  if (exts.size === 0) {
+    for (const list of Object.values(DOC_EXTENSIONS_BY_TYPE)) {
+      for (const e of list) add(e);
+    }
+  }
+  return exts;
+}
+
+// Walk a list of input paths (files or directories) and return a list of
+// readable file paths up to `cap` entries. Bounded so the debug dump can
+// never hang on a giant tree. Skips node_modules and .git.
+//
+// When `allowedExtensions` is provided and non-empty, only files whose
+// extension is in the set are returned — directories are always traversed.
+// An explicitly-passed input file is returned regardless of extension
+// (the user pointed at it directly); the filter only prunes files
+// discovered by walking a directory.
+export function enumerateInputFiles(
+  inputs: string[],
+  cap: number = 200,
+  allowedExtensions?: Set<string>
+): string[] {
+  const filter =
+    allowedExtensions && allowedExtensions.size > 0 ? allowedExtensions : null;
+  const matches = (p: string): boolean => {
+    if (!filter) return true;
+    const ext = path.extname(p).replace(/^\./, "").toLowerCase();
+    return filter.has(ext);
+  };
+
+  const out: string[] = [];
+  const stack: string[] = [];
+  const explicit = new Set<string>();
+  for (const i of inputs) {
+    if (typeof i === "string" && i.length > 0) {
+      stack.push(i);
+      explicit.add(i);
+    }
+  }
+  while (stack.length > 0 && out.length < cap) {
+    const p = stack.shift() as string;
+    let stat;
+    try {
+      stat = fs.statSync(p);
+    } catch {
+      continue;
+    }
+    if (stat.isFile()) {
+      // Honor an explicitly-passed file path even if its extension isn't
+      // a recognized doc type; only filter files found by walking dirs.
+      if (explicit.has(p) || matches(p)) out.push(p);
+      continue;
+    }
+    if (stat.isDirectory()) {
+      let entries: string[];
+      try {
+        entries = fs.readdirSync(p);
+      } catch {
+        continue;
+      }
+      for (const e of entries) {
+        if (e === "node_modules" || e === ".git") continue;
+        stack.push(path.join(p, e));
+      }
+    }
+  }
+  return out;
+}

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -52,27 +52,27 @@ export interface PrintDebugOptions {
    */
   includeEnv?: boolean;
   /**
-   * When set, the rendered plaintext dump is also written here (parent
-   * directories are created). Production callers pass
-   * `defaultDebugOutFile()`; unit tests omit it so calling `printDebug`
-   * never writes a file as a side effect.
+   * When set, the dump is written into this directory as two timestamped
+   * files — `debug-<timestamp>.txt` and `debug-<timestamp>.json` — using
+   * the same timestamp printed at the top of the dump. Parent directories
+   * are created. Production callers pass `defaultDebugDir()`; unit tests
+   * omit it so calling `printDebug` never writes a file as a side effect.
    */
-  outFile?: string;
-  /**
-   * When set, the structured dump is written here as JSON. Production
-   * callers pass `defaultDebugJsonFile()`; unit tests omit it.
-   */
-  jsonOutFile?: string;
+  outDir?: string;
   print?: (line: string) => void;
 }
 
-// Where the dump is saved by default, under `<cwd>/.doc-detective/`.
-// Functions (not constants) because they read the live cwd at call time.
-export function defaultDebugOutFile(): string {
-  return path.join(process.cwd(), ".doc-detective", "debug.txt");
+// Where the dump is saved by default: `<cwd>/.doc-detective/`. A function
+// (not a constant) because it reads the live cwd at call time.
+export function defaultDebugDir(): string {
+  return path.join(process.cwd(), ".doc-detective");
 }
-export function defaultDebugJsonFile(): string {
-  return path.join(process.cwd(), ".doc-detective", "debug.json");
+
+// Turn the dump's ISO timestamp into a filesystem-safe token (the `:` and
+// `.` in an ISO string are illegal/awkward in filenames, notably on
+// Windows). Same instant, just `-`-separated: 2026-06-13T13-40-11-123Z.
+function timestampForFilename(iso: string): string {
+  return iso.replace(/[:.]/g, "-");
 }
 
 // ---------------------------------------------------------------------------
@@ -355,12 +355,18 @@ export async function printDebug(opts: PrintDebugOptions): Promise<void> {
   const document = renderText(data, opts);
   print(document);
 
-  // Persist copies for easy attachment to bug reports. Best-effort: a
-  // write failure (read-only fs, permissions) must never crash the dump.
-  if (opts.outFile) {
-    writeFileSafe(opts.outFile, document + "\n", print, "Diagnostic dump saved to");
-  }
-  if (opts.jsonOutFile) {
+  // Persist copies for easy attachment to bug reports, named with the same
+  // timestamp printed at the top of the dump so each run is distinct and
+  // the file matches its contents. Best-effort: a write failure (read-only
+  // fs, permissions) must never crash the dump.
+  if (opts.outDir) {
+    const stamp = timestampForFilename(data.generatedAt);
+    writeFileSafe(
+      path.join(opts.outDir, `debug-${stamp}.txt`),
+      document + "\n",
+      print,
+      "Diagnostic dump saved to"
+    );
     let json: string;
     try {
       json = JSON.stringify(data, null, 2);
@@ -369,7 +375,12 @@ export async function printDebug(opts: PrintDebugOptions): Promise<void> {
         error: `failed to serialize debug data: ${err?.message || err}`,
       });
     }
-    writeFileSafe(opts.jsonOutFile, json + "\n", print, "Diagnostic JSON saved to");
+    writeFileSafe(
+      path.join(opts.outDir, `debug-${stamp}.json`),
+      json + "\n",
+      print,
+      "Diagnostic JSON saved to"
+    );
   }
 }
 
@@ -402,7 +413,7 @@ function renderText(data: DebugData, opts: PrintDebugOptions): string {
     renderEnvSection(data.environment),
     renderConfigSection(data.config, opts.configError ?? null),
   ];
-  return renderDocument(sections);
+  return renderDocument(sections, data.generatedAt);
 }
 
 function renderSystemSection(info: SystemInfo): Section {

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -243,12 +243,19 @@ async function collectBrowsers(config: any): Promise<BrowsersData> {
         : { ...(config || {}), environment: { platform: detectPlatform() } };
 
     const timeoutSentinel: unique symbol = Symbol("browser-timeout") as any;
+    // `.unref()` so the pending timer never keeps the process alive after
+    // the real probe resolves (otherwise `doc-detective debug` would idle
+    // until the timer fires), and clear it once the race settles.
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const result = await Promise.race<any>([
       getBrowserDiagnostics({ config: safeConfig }),
-      new Promise((resolve) =>
-        setTimeout(() => resolve(timeoutSentinel), BROWSER_DETECTION_TIMEOUT_MS)
-      ),
-    ]);
+      new Promise((resolve) => {
+        timer = setTimeout(() => resolve(timeoutSentinel), BROWSER_DETECTION_TIMEOUT_MS);
+        timer.unref?.();
+      }),
+    ]).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
     if (result === timeoutSentinel) return { timedOut: true };
     return {
       detectionFailed: result.detectionFailed,

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -136,9 +136,9 @@ export interface DebugData {
   config: ConfigData;
 }
 
-// Hard cap on browser-detection latency. Detection shells out to
-// `appium driver list`, which can take ~74s on cold caches without local
-// Appium. Diagnostics must not block that long.
+// Hard cap on browser-detection latency. Detection reads doc-detective's
+// installed.json record (fast), but the macOS Safari probe shells out to
+// `defaults read`; this bounds that so diagnostics never block.
 const BROWSER_DETECTION_TIMEOUT_MS = 5000;
 
 async function collectDebugData(opts: PrintDebugOptions): Promise<DebugData> {
@@ -452,7 +452,7 @@ function renderToolsSection(results: ToolResult[]): Section {
 function renderBrowsersSection(data: BrowsersData): Section {
   if (data.timedOut) {
     return renderSection("Browsers", [
-      `  <browser detection timed out after ${BROWSER_DETECTION_TIMEOUT_MS}ms — most often means Appium isn't installed locally, since detection shells out to \`appium driver list\`>`,
+      `  <browser detection timed out after ${BROWSER_DETECTION_TIMEOUT_MS}ms>`,
     ]);
   }
   if (data.error) {

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -243,7 +243,7 @@ async function collectBrowsers(config: any): Promise<BrowsersData> {
         ? config
         : { ...(config || {}), environment: { platform: detectPlatform() } };
 
-    const timeoutSentinel: unique symbol = Symbol("browser-timeout") as any;
+    const timeoutSentinel = Symbol("browser-timeout");
     // `.unref()` so the pending timer never keeps the process alive after
     // the real probe resolves (otherwise `doc-detective debug` would idle
     // until the timer fires), and clear it once the race settles.

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -4,10 +4,11 @@
 // `printDebug` collects environment information into a single structured
 // object (`collectDebugData`), then renders it two ways from that one
 // source of truth: a paste-friendly plaintext document printed to stdout
-// (and optionally saved to `debug.txt`) and a machine-readable
-// `debug.json`. Rendering from shared data means the two outputs can
-// never disagree. Callers (currently src/cli.ts) handle `process.exit(0)`
-// separately so tests can assert on output without forking.
+// (and optionally saved to `<outDir>/debug-<timestamp>.txt`) and a
+// machine-readable `debug-<timestamp>.json`. Rendering from shared data
+// means the two outputs can never disagree. Callers (currently src/cli.ts)
+// handle `process.exit(0)` separately so tests can assert on output
+// without forking.
 //
 // The dump runs even when config validation failed — the caller passes
 // the original error as `configError`, and the renderer surfaces it under
@@ -391,8 +392,18 @@ function writeFileSafe(
   successPrefix: string
 ): void {
   try {
-    fs.mkdirSync(path.dirname(file), { recursive: true });
-    fs.writeFileSync(file, contents, "utf8");
+    // The dump can contain environment/config data, so keep it private to
+    // the user: owner-only dir (0700) and file (0600). chmod the dir too in
+    // case it already existed with looser perms. (No-ops on Windows, which
+    // doesn't use POSIX modes.)
+    const dir = path.dirname(file);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      fs.chmodSync(dir, 0o700);
+    } catch {
+      // Best-effort — not all platforms/filesystems honor chmod.
+    }
+    fs.writeFileSync(file, contents, { encoding: "utf8", mode: 0o600 });
     print(`\n${successPrefix} ${file}`);
   } catch (err: any) {
     print(`\n<failed to save ${file}: ${err?.message || err}>`);

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -137,9 +137,13 @@ export interface DebugData {
   config: ConfigData;
 }
 
-// Hard cap on browser-detection latency. Detection reads doc-detective's
-// installed.json record (fast), but the macOS Safari probe shells out to
-// `defaults read`; this bounds that so diagnostics never block.
+// Secondary cap on browser-detection latency. Detection reads
+// doc-detective's installed.json record (fast); the only subprocess is the
+// macOS Safari probe, which already bounds and kills itself
+// (`probeSafariVersion`). This race is belt-and-suspenders for any
+// unforeseen slow path — it returns `{ timedOut: true }` rather than
+// cancelling the work, so the self-bounding probe is what actually
+// guarantees the cap.
 const BROWSER_DETECTION_TIMEOUT_MS = 5000;
 
 async function collectDebugData(opts: PrintDebugOptions): Promise<DebugData> {
@@ -148,7 +152,7 @@ async function collectDebugData(opts: PrintDebugOptions): Promise<DebugData> {
     generatedAt: system.wallclockIso,
     system,
     docDetective: collectDocDetective(),
-    tools: await probeAllTools(),
+    tools: await probeAllTools(opts.config?.cacheDir),
     browsers: await collectBrowsers(opts.config),
     container: detectContainer(),
     environment: collectEnvVars(opts),

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,26 +1,31 @@
 // Public entry point for the `--debug` / `DOC_DETECTIVE_DEBUG` dump.
 //
-// `printDebug` collects environment information, formats it into
-// paste-friendly sections, prints to stdout, and returns. Callers
-// (currently src/cli.ts) handle the `process.exit(0)` separately so
-// that tests can assert on the rendered output without forking.
+// `printDebug` collects environment information into a single structured
+// object (`collectDebugData`), then renders it two ways from that one
+// source of truth: a paste-friendly plaintext document printed to stdout
+// (and optionally saved to `debug.txt`) and a machine-readable
+// `debug.json`. Rendering from shared data means the two outputs can
+// never disagree. Callers (currently src/cli.ts) handle `process.exit(0)`
+// separately so tests can assert on output without forking.
 //
 // The dump runs even when config validation failed — the caller passes
-// the original error as `configError`, and the renderer surfaces it
-// under a CONFIG INVALID banner. The point of the flag is debugging, so
-// "your config is broken" is the most useful thing we can show.
+// the original error as `configError`, and the renderer surfaces it under
+// a CONFIG INVALID banner. The point of the flag is debugging, so "your
+// config is broken" is the most useful thing we can show.
 
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { getVersionData } from "../utils.js";
 import { getBrowserDiagnostics } from "../core/config.js";
-import { collectSystemInfo } from "./system.js";
-import { probeAllTools } from "./tools.js";
+import { collectSystemInfo, type SystemInfo } from "./system.js";
+import { probeAllTools, type ToolResult } from "./tools.js";
 import {
   findReferencedEnvVars,
   detectContainer,
   enumerateInputFiles,
   resolveDocExtensions,
+  type ContainerInfo,
 } from "./envvars.js";
 import { redactValue, redactObject } from "./redact.js";
 import {
@@ -46,57 +51,349 @@ export interface PrintDebugOptions {
    */
   includeEnv?: boolean;
   /**
-   * When set, the rendered dump is also written to this path (parent
+   * When set, the rendered plaintext dump is also written here (parent
    * directories are created). Production callers pass
    * `defaultDebugOutFile()`; unit tests omit it so calling `printDebug`
    * never writes a file as a side effect.
    */
   outFile?: string;
+  /**
+   * When set, the structured dump is written here as JSON. Production
+   * callers pass `defaultDebugJsonFile()`; unit tests omit it.
+   */
+  jsonOutFile?: string;
   print?: (line: string) => void;
 }
 
-// Where the dump is saved by default: `<cwd>/.doc-detective/debug.txt`.
-// A function (not a constant) because it reads the live cwd at call time.
+// Where the dump is saved by default, under `<cwd>/.doc-detective/`.
+// Functions (not constants) because they read the live cwd at call time.
 export function defaultDebugOutFile(): string {
   return path.join(process.cwd(), ".doc-detective", "debug.txt");
+}
+export function defaultDebugJsonFile(): string {
+  return path.join(process.cwd(), ".doc-detective", "debug.json");
+}
+
+// ---------------------------------------------------------------------------
+// Structured data — the single source both renderers read from.
+// ---------------------------------------------------------------------------
+
+interface BrowserComponent {
+  label: string;
+  installed: boolean;
+  detail?: string;
+}
+interface BrowserDiagnostic {
+  name: string;
+  supported: boolean;
+  available: boolean;
+  components: BrowserComponent[];
+  note?: string;
+}
+interface BrowsersData {
+  timedOut?: boolean;
+  error?: string;
+  detectionFailed?: boolean;
+  browsers?: BrowserDiagnostic[];
+}
+
+interface DocDetectiveData {
+  version: string;
+  executionMethod?: string;
+  // Directory the running doc-detective package resolves from — answers
+  // "which install is npm/npx actually executing?".
+  loadedFrom: string;
+  // The script node was invoked with (the bin entry / npx cache path).
+  entryPoint: string;
+  nodeVersion?: string;
+  platform?: string;
+  timestamp?: string;
+  dependencies: Record<string, string>;
+  lockstepWarning?: string;
+  error?: string;
+}
+
+interface EnvData {
+  mode: "referenced" | "full";
+  scannedFileCount?: number;
+  variables: Array<{ name: string; value: string }>;
+}
+
+interface ConfigData {
+  configPath: string | null;
+  configError?: string;
+  redacted: unknown;
+}
+
+export interface DebugData {
+  generatedAt: string;
+  system: SystemInfo;
+  docDetective: DocDetectiveData;
+  tools: ToolResult[];
+  browsers: BrowsersData;
+  container: ContainerInfo;
+  environment: EnvData;
+  config: ConfigData;
+}
+
+// Hard cap on browser-detection latency. Detection shells out to
+// `appium driver list`, which can take ~74s on cold caches without local
+// Appium. Diagnostics must not block that long.
+const BROWSER_DETECTION_TIMEOUT_MS = 5000;
+
+async function collectDebugData(opts: PrintDebugOptions): Promise<DebugData> {
+  const system = collectSystemInfo();
+  return {
+    generatedAt: system.wallclockIso,
+    system,
+    docDetective: collectDocDetective(),
+    tools: await probeAllTools(),
+    browsers: await collectBrowsers(opts.config),
+    container: detectContainer(),
+    environment: collectEnvVars(opts),
+    config: {
+      configPath: opts.configPath ?? null,
+      configError: opts.configError?.message,
+      redacted: safeRedactConfig(opts.config),
+    },
+  };
+}
+
+function collectDocDetective(): DocDetectiveData {
+  const { loadedFrom, entryPoint } = resolveLoadedFrom();
+  let versionData: any;
+  try {
+    versionData = getVersionData();
+  } catch (err: any) {
+    return {
+      version: "<unknown>",
+      loadedFrom,
+      entryPoint,
+      dependencies: {},
+      error: `failed to collect version data: ${err?.message || err}`,
+    };
+  }
+  const main = versionData?.main || {};
+  const ddVersion = main["doc-detective"]?.version || "<unknown>";
+  const ctx = versionData?.context || {};
+  const deps = versionData?.dependencies || {};
+
+  const dependencies: Record<string, string> = {};
+  let lockstepWarning: string | undefined;
+  for (const depName of Object.keys(deps)) {
+    const dep = deps[depName];
+    const version = dep?.version || dep || "<unknown>";
+    dependencies[depName] = String(version);
+    if (
+      depName === "doc-detective-common" &&
+      typeof dep?.version === "string" &&
+      typeof ddVersion === "string" &&
+      ddVersion !== "<unknown>" &&
+      dep.version !== ddVersion
+    ) {
+      lockstepWarning = `doc-detective (${ddVersion}) and doc-detective-common (${dep.version}) versions differ — they ship in lockstep, mismatch usually means a stale install.`;
+    }
+  }
+
+  return {
+    version: ddVersion,
+    executionMethod: ctx.executionMethod,
+    loadedFrom,
+    entryPoint,
+    nodeVersion: ctx.nodeVersion,
+    platform: ctx.platform,
+    timestamp: ctx.timestamp,
+    dependencies,
+    lockstepWarning,
+  };
+}
+
+// Resolve where the running doc-detective is loaded from. `loadedFrom` is
+// the package root (the first ancestor of this module with a package.json),
+// which differs between a project-local `node_modules` install, a global
+// install, and an `npx` cache dir. `entryPoint` is the script node ran.
+function resolveLoadedFrom(): { loadedFrom: string; entryPoint: string } {
+  const entryPoint = process.argv[1] || "<unknown>";
+  let loadedFrom = "<unknown>";
+  try {
+    let dir = path.dirname(fileURLToPath(import.meta.url));
+    for (let i = 0; i < 8; i++) {
+      if (fs.existsSync(path.join(dir, "package.json"))) {
+        loadedFrom = dir;
+        break;
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Best-effort — diagnostics must never crash.
+  }
+  return { loadedFrom, entryPoint };
+}
+
+async function collectBrowsers(config: any): Promise<BrowsersData> {
+  try {
+    // getBrowserDiagnostics mutates cwd and reads process.env for
+    // APPIUM_HOME; it expects a config with an `environment.platform`
+    // field. Synthesize a minimal one if validation never completed.
+    const safeConfig =
+      config && config.environment
+        ? config
+        : { ...(config || {}), environment: { platform: detectPlatform() } };
+
+    const timeoutSentinel: unique symbol = Symbol("browser-timeout") as any;
+    const result = await Promise.race<any>([
+      getBrowserDiagnostics({ config: safeConfig }),
+      new Promise((resolve) =>
+        setTimeout(() => resolve(timeoutSentinel), BROWSER_DETECTION_TIMEOUT_MS)
+      ),
+    ]);
+    if (result === timeoutSentinel) return { timedOut: true };
+    return {
+      detectionFailed: result.detectionFailed,
+      browsers: result.browsers,
+    };
+  } catch (err: any) {
+    return { error: err?.message || String(err) };
+  }
+}
+
+function collectEnvVars(opts: PrintDebugOptions): EnvData {
+  // Full env dump is OPT-IN via `--include-env`. Earlier revisions
+  // auto-dumped when running in a container, but that meant common
+  // PaaS-injected secrets (DATABASE_URL with embedded password, Sentry
+  // DSN, webhook URLs) ended up in pasted bug reports unless every user
+  // knew about the redaction regex. Now the user must explicitly ask for
+  // the bulk dump; the default is the referenced-only listing.
+  if (opts.includeEnv) {
+    const names = Object.keys(process.env).sort();
+    return {
+      mode: "full",
+      variables: names.map((name) => ({
+        name,
+        value: redactValue(name, process.env[name]),
+      })),
+    };
+  }
+
+  const referenced = new Set<string>();
+
+  // 1. DOC_DETECTIVE_CONFIG raw string.
+  const rawEnvConfig = process.env.DOC_DETECTIVE_CONFIG;
+  if (typeof rawEnvConfig === "string") {
+    for (const n of findReferencedEnvVars(rawEnvConfig)) referenced.add(n);
+  }
+
+  // 2. Config file raw source (before substitution).
+  if (opts.configPath && typeof opts.configPath === "string") {
+    try {
+      const raw = fs.readFileSync(opts.configPath, "utf8");
+      for (const n of findReferencedEnvVars(raw)) referenced.add(n);
+    } catch {
+      // Best-effort — if the config file is unreadable, just skip.
+    }
+  }
+
+  // 3. Input files raw text. Walk config.input (already a string|array of
+  //    absolute paths after setConfig). Cap the walk to 200 files so a
+  //    misconfigured input pointed at "/" can't hang the dump. Scope to
+  //    the extensions doc-detective actually parses (per config.fileTypes)
+  //    — otherwise the `$VAR` grep matches shell/code/CI syntax in
+  //    unrelated source files and floods the section with junk like `$0`.
+  const inputs = normalizeInputs(opts.config?.input);
+  const allowedExtensions = resolveDocExtensions(opts.config?.fileTypes);
+  const files = enumerateInputFiles(inputs, 200, allowedExtensions);
+  for (const file of files) {
+    try {
+      const raw = fs.readFileSync(file, "utf8");
+      for (const n of findReferencedEnvVars(raw)) referenced.add(n);
+    } catch {
+      // Skip unreadable / binary files.
+    }
+  }
+
+  const sorted = Array.from(referenced).sort();
+  return {
+    mode: "referenced",
+    scannedFileCount: files.length,
+    variables: sorted.map((name) => ({
+      name,
+      value: redactValue(name, process.env[name]),
+    })),
+  };
+}
+
+function safeRedactConfig(config: unknown): unknown {
+  try {
+    // Redact secret-looking key values and credential-shaped strings.
+    // Without this the config bypasses the env-var redaction layer —
+    // integrations.heretto[].apiToken, docDetectiveApi.apiKey, inline
+    // webhook URLs, and anything from DOC_DETECTIVE_CONFIG would leak.
+    return redactObject(config ?? {});
+  } catch (err: any) {
+    return `<could not process config: ${err?.message || err}>`;
+  }
 }
 
 export async function printDebug(opts: PrintDebugOptions): Promise<void> {
   const print = opts.print ?? ((line: string) => console.log(line));
-  const sections: Section[] = [];
+  const data = await collectDebugData(opts);
 
-  sections.push(renderSystemSection());
-  sections.push(renderDocDetectiveSection());
-  sections.push(await renderToolsSection());
-  sections.push(await renderBrowsersSection(opts.config));
-
-  const containerInfo = detectContainer();
-  sections.push(renderContainerSection(containerInfo));
-
-  sections.push(renderReferencedEnvVarsSection(opts));
-
-  sections.push(renderConfigSection(opts));
-
-  const document = renderDocument(sections);
+  const document = renderText(data, opts);
   print(document);
 
-  // Persist a copy for easy attachment to bug reports. Best-effort: a
+  // Persist copies for easy attachment to bug reports. Best-effort: a
   // write failure (read-only fs, permissions) must never crash the dump.
   if (opts.outFile) {
+    writeFileSafe(opts.outFile, document + "\n", print, "Diagnostic dump saved to");
+  }
+  if (opts.jsonOutFile) {
+    let json: string;
     try {
-      fs.mkdirSync(path.dirname(opts.outFile), { recursive: true });
-      fs.writeFileSync(opts.outFile, document + "\n", "utf8");
-      print(`\nDiagnostic dump saved to ${opts.outFile}`);
+      json = JSON.stringify(data, null, 2);
     } catch (err: any) {
-      print(
-        `\n<failed to save diagnostic dump to ${opts.outFile}: ${err?.message || err}>`
-      );
+      json = JSON.stringify({
+        error: `failed to serialize debug data: ${err?.message || err}`,
+      });
     }
+    writeFileSafe(opts.jsonOutFile, json + "\n", print, "Diagnostic JSON saved to");
   }
 }
 
-function renderSystemSection(): Section {
-  const info = collectSystemInfo();
+function writeFileSafe(
+  file: string,
+  contents: string,
+  print: (line: string) => void,
+  successPrefix: string
+): void {
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, contents, "utf8");
+    print(`\n${successPrefix} ${file}`);
+  } catch (err: any) {
+    print(`\n<failed to save ${file}: ${err?.message || err}>`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plaintext rendering — consumes the structured data above.
+// ---------------------------------------------------------------------------
+
+function renderText(data: DebugData, opts: PrintDebugOptions): string {
+  const sections: Section[] = [
+    renderSystemSection(data.system),
+    renderDocDetectiveSection(data.docDetective),
+    renderToolsSection(data.tools),
+    renderBrowsersSection(data.browsers),
+    renderContainerSection(data.container),
+    renderEnvSection(data.environment),
+    renderConfigSection(data.config, opts.configError ?? null),
+  ];
+  return renderDocument(sections);
+}
+
+function renderSystemSection(info: SystemInfo): Section {
   return renderSection(
     "System",
     renderKeyValues([
@@ -119,56 +416,31 @@ function renderSystemSection(): Section {
   );
 }
 
-function renderDocDetectiveSection(): Section {
-  let versionData: any;
-  try {
-    versionData = getVersionData();
-  } catch (err: any) {
-    return renderSection("Doc Detective", [
-      `  <failed to collect version data: ${err?.message || err}>`,
-    ]);
+function renderDocDetectiveSection(dd: DocDetectiveData): Section {
+  if (dd.error) {
+    return renderSection("Doc Detective", [`  <${dd.error}>`]);
   }
-  const main = versionData?.main || {};
-  const ddVersion = main["doc-detective"]?.version || "<unknown>";
-  const ctx = versionData?.context || {};
-  const deps = versionData?.dependencies || {};
-
   const rows: Array<[string, unknown]> = [
-    ["doc-detective", ddVersion],
-    ["executionMethod", ctx.executionMethod],
-    ["nodeVersion", ctx.nodeVersion],
-    ["platform", ctx.platform],
-    ["timestamp", ctx.timestamp],
+    ["doc-detective", dd.version],
+    ["executionMethod", dd.executionMethod],
+    ["loadedFrom", dd.loadedFrom],
+    ["entryPoint", dd.entryPoint],
+    ["nodeVersion", dd.nodeVersion],
+    ["platform", dd.platform],
+    ["timestamp", dd.timestamp],
   ];
-
-  // Surface every detected doc-detective-* package and warn on version drift.
-  const lockstepWarnings: string[] = [];
-  for (const depName of Object.keys(deps)) {
-    const dep = deps[depName];
-    rows.push([depName, dep?.version || dep || "<unknown>"]);
-    if (
-      depName === "doc-detective-common" &&
-      typeof dep?.version === "string" &&
-      typeof ddVersion === "string" &&
-      ddVersion !== "<unknown>" &&
-      dep.version !== ddVersion
-    ) {
-      lockstepWarnings.push(
-        `  ! WARNING: doc-detective (${ddVersion}) and doc-detective-common (${dep.version}) versions differ — they ship in lockstep, mismatch usually means a stale install.`
-      );
-    }
+  for (const [depName, version] of Object.entries(dd.dependencies)) {
+    rows.push([depName, version]);
   }
-
   const lines = renderKeyValues(rows);
-  if (lockstepWarnings.length > 0) {
+  if (dd.lockstepWarning) {
     lines.push("");
-    lines.push(...lockstepWarnings);
+    lines.push(`  ! WARNING: ${dd.lockstepWarning}`);
   }
   return renderSection("Doc Detective", lines);
 }
 
-async function renderToolsSection(): Promise<Section> {
-  const results = await probeAllTools();
+function renderToolsSection(results: ToolResult[]): Section {
   const rows: Array<[string, unknown]> = results.map((r) => {
     const value = r.notes ? `${r.version}  (${r.notes})` : r.version;
     return [r.name, value];
@@ -177,65 +449,43 @@ async function renderToolsSection(): Promise<Section> {
   return renderSection("Tools", renderKeyValues(rows));
 }
 
-// Hard cap on browser-detection latency. Detection shells out to
-// `appium driver list`, which can take ~74s on cold caches without local
-// Appium. Diagnostics must not block that long.
-const BROWSER_DETECTION_TIMEOUT_MS = 5000;
-
-async function renderBrowsersSection(config: any): Promise<Section> {
-  try {
-    // getBrowserDiagnostics mutates cwd and reads process.env for
-    // APPIUM_HOME; it expects a config with an `environment.platform`
-    // field. Synthesize a minimal one if validation never completed.
-    const safeConfig = config && config.environment
-      ? config
-      : { ...(config || {}), environment: { platform: detectPlatform() } };
-
-    const timeoutSentinel: unique symbol = Symbol("browser-timeout") as any;
-    const result = await Promise.race<any>([
-      getBrowserDiagnostics({ config: safeConfig }),
-      new Promise((resolve) =>
-        setTimeout(() => resolve(timeoutSentinel), BROWSER_DETECTION_TIMEOUT_MS)
-      ),
-    ]);
-
-    if (result === timeoutSentinel) {
-      return renderSection("Browsers", [
-        `  <browser detection timed out after ${BROWSER_DETECTION_TIMEOUT_MS}ms — most often means Appium isn't installed locally, since detection shells out to \`appium driver list\`>`,
-      ]);
-    }
-
-    const lines: string[] = [];
-    if (result.detectionFailed) {
-      lines.push(
-        "  ! browser detection hit an error; component status may be incomplete."
-      );
-      lines.push("");
-    }
-    // Always enumerate every supported browser with a clear AVAILABLE /
-    // NOT AVAILABLE / NOT SUPPORTED status, then break down each
-    // component (browser binary, webdriver, Appium driver) so the user
-    // can see exactly which piece is missing.
-    for (const browser of result.browsers) {
-      const status = !browser.supported
-        ? "NOT SUPPORTED"
-        : browser.available
-        ? "AVAILABLE"
-        : "NOT AVAILABLE";
-      const note = browser.note ? `  (${browser.note})` : "";
-      lines.push(`  ${browser.name.padEnd(8)} ${status}${note}`);
-      for (const c of browser.components) {
-        const mark = c.installed ? "installed" : "not installed";
-        const detail = c.detail ? `  ${c.detail}` : "";
-        lines.push(`    ${`${c.label}:`.padEnd(25)} ${mark}${detail}`);
-      }
-    }
-    return renderSection("Browsers", lines);
-  } catch (err: any) {
+function renderBrowsersSection(data: BrowsersData): Section {
+  if (data.timedOut) {
     return renderSection("Browsers", [
-      `  <browser detection failed: ${err?.message || err}>`,
+      `  <browser detection timed out after ${BROWSER_DETECTION_TIMEOUT_MS}ms — most often means Appium isn't installed locally, since detection shells out to \`appium driver list\`>`,
     ]);
   }
+  if (data.error) {
+    return renderSection("Browsers", [
+      `  <browser detection failed: ${data.error}>`,
+    ]);
+  }
+  const lines: string[] = [];
+  if (data.detectionFailed) {
+    lines.push(
+      "  ! browser detection hit an error; component status may be incomplete."
+    );
+    lines.push("");
+  }
+  // Always enumerate every supported browser with a clear AVAILABLE /
+  // NOT AVAILABLE / NOT SUPPORTED status, then break down each component
+  // (browser binary, webdriver, Appium driver) so the user can see
+  // exactly which piece is missing.
+  for (const browser of data.browsers || []) {
+    const status = !browser.supported
+      ? "NOT SUPPORTED"
+      : browser.available
+      ? "AVAILABLE"
+      : "NOT AVAILABLE";
+    const note = browser.note ? `  (${browser.note})` : "";
+    lines.push(`  ${browser.name.padEnd(8)} ${status}${note}`);
+    for (const c of browser.components) {
+      const mark = c.installed ? "installed" : "not installed";
+      const detail = c.detail ? `  ${c.detail}` : "";
+      lines.push(`    ${`${c.label}:`.padEnd(25)} ${mark}${detail}`);
+    }
+  }
+  return renderSection("Browsers", lines);
 }
 
 function detectPlatform(): "linux" | "mac" | "windows" {
@@ -249,7 +499,7 @@ function detectPlatform(): "linux" | "mac" | "windows" {
   }
 }
 
-function renderContainerSection(info: ReturnType<typeof detectContainer>): Section {
+function renderContainerSection(info: ContainerInfo): Section {
   const lines: string[] = [];
   lines.push(...renderKeyValues([["container", info.inContainer]]));
   if (info.signals.length > 0) {
@@ -259,79 +509,32 @@ function renderContainerSection(info: ReturnType<typeof detectContainer>): Secti
   return renderSection("Container state", lines);
 }
 
-function renderReferencedEnvVarsSection(opts: PrintDebugOptions): Section {
-  // Full env dump is OPT-IN via `--include-env`. Earlier revisions
-  // auto-dumped when running in a container, but that meant common
-  // PaaS-injected secrets (DATABASE_URL with embedded password, Sentry
-  // DSN, webhook URLs) ended up in pasted bug reports unless every
-  // user knew about the redaction regex. Now the user must explicitly
-  // ask for the bulk dump; the default is the referenced-only listing
-  // regardless of container state.
-  if (opts.includeEnv) {
-    const names = Object.keys(process.env).sort();
+function renderEnvSection(env: EnvData): Section {
+  if (env.mode === "full") {
     const lines: string[] = [];
     lines.push(
-      `  --include-env was set — listing all ${names.length} env vars (redacted by name and by value shape).`
+      `  --include-env was set — listing all ${env.variables.length} env vars (redacted by name and by value shape).`
     );
     lines.push(
       `  REVIEW BEFORE PASTING. Redaction catches common patterns but is best-effort; values with novel names or shapes may slip through.`
     );
     lines.push("");
-    for (const name of names) {
-      lines.push(`  ${name} = ${redactValue(name, process.env[name])}`);
+    for (const { name, value } of env.variables) {
+      lines.push(`  ${name} = ${value}`);
     }
     return renderSection("Environment variables (full)", lines);
   }
 
-  // Default path: collect names referenced by config + inputs only.
-  const referenced = new Set<string>();
-
-  // 1. DOC_DETECTIVE_CONFIG raw string.
-  const rawEnvConfig = process.env.DOC_DETECTIVE_CONFIG;
-  if (typeof rawEnvConfig === "string") {
-    for (const n of findReferencedEnvVars(rawEnvConfig)) referenced.add(n);
-  }
-
-  // 2. Config file raw source (before substitution).
-  if (opts.configPath && typeof opts.configPath === "string") {
-    try {
-      const raw = fs.readFileSync(opts.configPath, "utf8");
-      for (const n of findReferencedEnvVars(raw)) referenced.add(n);
-    } catch {
-      // Best-effort — if the config file is unreadable, just skip.
-    }
-  }
-
-  // 3. Input files raw text. Walk config.input (already a string|array
-  //    of absolute paths after setConfig). Cap the walk to 200 files so
-  //    a misconfigured input pointed at "/" can't hang the dump.
-  //    Scope to the extensions doc-detective actually parses (per
-  //    config.fileTypes) — otherwise the `$VAR` grep matches shell/code/
-  //    CI syntax in unrelated source files and floods the section with
-  //    junk like `$0`, `$1`, and stray single letters.
-  const inputs = normalizeInputs(opts.config?.input);
-  const allowedExtensions = resolveDocExtensions(opts.config?.fileTypes);
-  const files = enumerateInputFiles(inputs, 200, allowedExtensions);
-  for (const file of files) {
-    try {
-      const raw = fs.readFileSync(file, "utf8");
-      for (const n of findReferencedEnvVars(raw)) referenced.add(n);
-    } catch {
-      // Skip unreadable / binary files.
-    }
-  }
-
-  const sorted = Array.from(referenced).sort();
   const lines: string[] = [];
   lines.push(
-    `  Scanned ${files.length} documentation file(s) plus config + DOC_DETECTIVE_CONFIG for $VAR references.`
+    `  Scanned ${env.scannedFileCount ?? 0} documentation file(s) plus config + DOC_DETECTIVE_CONFIG for $VAR references.`
   );
   lines.push("");
-  if (sorted.length === 0) {
+  if (env.variables.length === 0) {
     lines.push("  <no $VAR references found>");
   } else {
-    for (const name of sorted) {
-      lines.push(`  ${name} = ${redactValue(name, process.env[name])}`);
+    for (const { name, value } of env.variables) {
+      lines.push(`  ${name} = ${value}`);
     }
   }
   return renderSection("Referenced environment variables", lines);
@@ -345,29 +548,21 @@ function normalizeInputs(input: unknown): string[] {
   return [];
 }
 
-function renderConfigSection(opts: PrintDebugOptions): Section {
+function renderConfigSection(cfg: ConfigData, configError: Error | null): Section {
   const lines: string[] = [];
-  if (opts.configError) {
+  if (configError) {
     lines.push("  === CONFIG INVALID ===");
-    lines.push(`  ${opts.configError.message}`);
+    lines.push(`  ${configError.message}`);
     lines.push("");
     lines.push("  Best-effort raw config (validation failed):");
   } else {
-    lines.push(`  configPath: ${opts.configPath || "<none>"}`);
+    lines.push(`  configPath: ${cfg.configPath || "<none>"}`);
     lines.push("");
     lines.push("  Effective config (post-validation):");
   }
   let json: string;
   try {
-    // Walk the config object and redact secret-looking key values and
-    // credential-shaped strings BEFORE stringifying. Without this, the
-    // Config section bypasses the env-var redaction layer — values
-    // like `integrations.heretto[].apiToken`,
-    // `integrations.docDetectiveApi.apiKey`, inline webhook URLs, and
-    // anything supplied via DOC_DETECTIVE_CONFIG would land in the
-    // pasted bug report verbatim.
-    const safeConfig = redactObject(opts.config ?? {});
-    json = JSON.stringify(safeConfig, null, 2);
+    json = JSON.stringify(cfg.redacted, null, 2);
   } catch (err: any) {
     json = `<could not stringify config: ${err?.message || err}>`;
   }

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -11,10 +11,11 @@
 // "your config is broken" is the most useful thing we can show.
 
 import fs from "node:fs";
+import path from "node:path";
 import { getVersionData } from "../utils.js";
-import { getAvailableApps } from "../core/config.js";
+import { getBrowserDiagnostics } from "../core/config.js";
 import { collectSystemInfo } from "./system.js";
-import { probeAllTools, probeAppiumDrivers } from "./tools.js";
+import { probeAllTools } from "./tools.js";
 import {
   findReferencedEnvVars,
   detectContainer,
@@ -44,7 +45,20 @@ export interface PrintDebugOptions {
    * implicit full env dump unless they explicitly ask for it.
    */
   includeEnv?: boolean;
+  /**
+   * When set, the rendered dump is also written to this path (parent
+   * directories are created). Production callers pass
+   * `defaultDebugOutFile()`; unit tests omit it so calling `printDebug`
+   * never writes a file as a side effect.
+   */
+  outFile?: string;
   print?: (line: string) => void;
+}
+
+// Where the dump is saved by default: `<cwd>/.doc-detective/debug.txt`.
+// A function (not a constant) because it reads the live cwd at call time.
+export function defaultDebugOutFile(): string {
+  return path.join(process.cwd(), ".doc-detective", "debug.txt");
 }
 
 export async function printDebug(opts: PrintDebugOptions): Promise<void> {
@@ -63,7 +77,22 @@ export async function printDebug(opts: PrintDebugOptions): Promise<void> {
 
   sections.push(renderConfigSection(opts));
 
-  print(renderDocument(sections));
+  const document = renderDocument(sections);
+  print(document);
+
+  // Persist a copy for easy attachment to bug reports. Best-effort: a
+  // write failure (read-only fs, permissions) must never crash the dump.
+  if (opts.outFile) {
+    try {
+      fs.mkdirSync(path.dirname(opts.outFile), { recursive: true });
+      fs.writeFileSync(opts.outFile, document + "\n", "utf8");
+      print(`\nDiagnostic dump saved to ${opts.outFile}`);
+    } catch (err: any) {
+      print(
+        `\n<failed to save diagnostic dump to ${opts.outFile}: ${err?.message || err}>`
+      );
+    }
+  }
 }
 
 function renderSystemSection(): Section {
@@ -144,61 +173,62 @@ async function renderToolsSection(): Promise<Section> {
     const value = r.notes ? `${r.version}  (${r.notes})` : r.version;
     return [r.name, value];
   });
-  const lines = renderKeyValues(rows);
-
-  // Appium drivers — separate block since the output is multi-line.
-  let driversText = "<not probed>";
-  try {
-    driversText = await probeAppiumDrivers();
-  } catch (err: any) {
-    driversText = `<probe error: ${err?.message || err}>`;
-  }
-  lines.push("");
-  lines.push("  appium drivers:");
-  for (const dl of driversText.split("\n")) {
-    lines.push(`    ${dl}`);
-  }
-  return renderSection("Tools", lines);
+  // Browser/Appium drivers are reported per-browser in the Browsers section.
+  return renderSection("Tools", renderKeyValues(rows));
 }
 
-// Hard cap on browser-detection latency. `getAvailableApps` internally
-// runs `npx appium driver list` with no timeout (~74s observed on cold
-// caches without local Appium). Diagnostics must not block that long.
+// Hard cap on browser-detection latency. Detection shells out to
+// `appium driver list`, which can take ~74s on cold caches without local
+// Appium. Diagnostics must not block that long.
 const BROWSER_DETECTION_TIMEOUT_MS = 5000;
 
 async function renderBrowsersSection(config: any): Promise<Section> {
   try {
-    // getAvailableApps mutates cwd and reads process.env for APPIUM_HOME;
-    // it expects a config with an `environment.platform` field. Synthesize
-    // a minimal one if validation never completed.
+    // getBrowserDiagnostics mutates cwd and reads process.env for
+    // APPIUM_HOME; it expects a config with an `environment.platform`
+    // field. Synthesize a minimal one if validation never completed.
     const safeConfig = config && config.environment
       ? config
       : { ...(config || {}), environment: { platform: detectPlatform() } };
 
     const timeoutSentinel: unique symbol = Symbol("browser-timeout") as any;
-    const apps = await Promise.race<any>([
-      getAvailableApps({ config: safeConfig }),
+    const result = await Promise.race<any>([
+      getBrowserDiagnostics({ config: safeConfig }),
       new Promise((resolve) =>
         setTimeout(() => resolve(timeoutSentinel), BROWSER_DETECTION_TIMEOUT_MS)
       ),
     ]);
 
-    if (apps === timeoutSentinel) {
+    if (result === timeoutSentinel) {
       return renderSection("Browsers", [
-        `  <browser detection timed out after ${BROWSER_DETECTION_TIMEOUT_MS}ms — most often means Appium isn't installed locally, since detection shells out to \`npx appium driver list\`>`,
+        `  <browser detection timed out after ${BROWSER_DETECTION_TIMEOUT_MS}ms — most often means Appium isn't installed locally, since detection shells out to \`appium driver list\`>`,
       ]);
     }
 
-    if (!Array.isArray(apps) || apps.length === 0) {
-      return renderSection("Browsers", [
-        "  <no supported browsers detected — Chrome, Firefox, or Safari with a matching Appium driver is required>",
-      ]);
-    }
     const lines: string[] = [];
-    for (const app of apps) {
-      lines.push(`  ${app.name} ${app.version || ""}`.trimEnd());
-      if (app.path) lines.push(`    path:    ${app.path}`);
-      if (app.driver) lines.push(`    driver:  ${app.driver}`);
+    if (result.detectionFailed) {
+      lines.push(
+        "  ! browser detection hit an error; component status may be incomplete."
+      );
+      lines.push("");
+    }
+    // Always enumerate every supported browser with a clear AVAILABLE /
+    // NOT AVAILABLE / NOT SUPPORTED status, then break down each
+    // component (browser binary, webdriver, Appium driver) so the user
+    // can see exactly which piece is missing.
+    for (const browser of result.browsers) {
+      const status = !browser.supported
+        ? "NOT SUPPORTED"
+        : browser.available
+        ? "AVAILABLE"
+        : "NOT AVAILABLE";
+      const note = browser.note ? `  (${browser.note})` : "";
+      lines.push(`  ${browser.name.padEnd(8)} ${status}${note}`);
+      for (const c of browser.components) {
+        const mark = c.installed ? "installed" : "not installed";
+        const detail = c.detail ? `  ${c.detail}` : "";
+        lines.push(`    ${`${c.label}:`.padEnd(25)} ${mark}${detail}`);
+      }
     }
     return renderSection("Browsers", lines);
   } catch (err: any) {

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,4 +1,5 @@
-// Public entry point for the `--debug` / `DOC_DETECTIVE_DEBUG` dump.
+// Public entry point for the diagnostic dump, reachable via the
+// `doc-detective debug` subcommand or `DOC_DETECTIVE_DEBUG=true`.
 //
 // `printDebug` collects environment information into a single structured
 // object (`collectDebugData`), then renders it two ways from that one

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,0 +1,346 @@
+// Public entry point for the `--debug` / `DOC_DETECTIVE_DEBUG` dump.
+//
+// `printDebug` collects environment information, formats it into
+// paste-friendly sections, prints to stdout, and returns. Callers
+// (currently src/cli.ts) handle the `process.exit(0)` separately so
+// that tests can assert on the rendered output without forking.
+//
+// The dump runs even when config validation failed — the caller passes
+// the original error as `configError`, and the renderer surfaces it
+// under a CONFIG INVALID banner. The point of the flag is debugging, so
+// "your config is broken" is the most useful thing we can show.
+
+import fs from "node:fs";
+import { getVersionData } from "../utils.js";
+import { getAvailableApps } from "../core/config.js";
+import { collectSystemInfo } from "./system.js";
+import { probeAllTools, probeAppiumDrivers } from "./tools.js";
+import {
+  findReferencedEnvVars,
+  detectContainer,
+  enumerateInputFiles,
+  resolveDocExtensions,
+} from "./envvars.js";
+import { redactValue, redactObject } from "./redact.js";
+import {
+  renderSection,
+  renderKeyValues,
+  renderDocument,
+  type Section,
+} from "./render.js";
+
+export interface PrintDebugOptions {
+  config: any;
+  configPath?: string | null;
+  configError?: Error | null;
+  /**
+   * When `true`, dump every `process.env` entry (redacted by name and
+   * by value-shape). When falsy (the default), only env vars actually
+   * referenced via `$VAR` in config / input files are listed.
+   *
+   * Wired from the `--include-env` flag on the `debug` subcommand.
+   * Intentionally separate from container detection so users in
+   * containers (the common case for env-leak risk) do NOT get an
+   * implicit full env dump unless they explicitly ask for it.
+   */
+  includeEnv?: boolean;
+  print?: (line: string) => void;
+}
+
+export async function printDebug(opts: PrintDebugOptions): Promise<void> {
+  const print = opts.print ?? ((line: string) => console.log(line));
+  const sections: Section[] = [];
+
+  sections.push(renderSystemSection());
+  sections.push(renderDocDetectiveSection());
+  sections.push(await renderToolsSection());
+  sections.push(await renderBrowsersSection(opts.config));
+
+  const containerInfo = detectContainer();
+  sections.push(renderContainerSection(containerInfo));
+
+  sections.push(renderReferencedEnvVarsSection(opts));
+
+  sections.push(renderConfigSection(opts));
+
+  print(renderDocument(sections));
+}
+
+function renderSystemSection(): Section {
+  const info = collectSystemInfo();
+  return renderSection(
+    "System",
+    renderKeyValues([
+      ["platform", `${info.platform} (${info.arch})`],
+      ["release", info.release],
+      ["os version", info.osVersion],
+      ["cpus", `${info.cpuCount} × ${info.cpuModel} @ ${info.cpuSpeedMhz}MHz`],
+      ["memory", `${info.freeMemoryMb}MB free / ${info.totalMemoryMb}MB total`],
+      ["uptime", `${info.uptimeSeconds}s`],
+      ["hostname", info.hostname],
+      ["wallclock", `${info.wallclockIso} (${info.timezone})`],
+      ["pid", info.pid],
+      ["ppid", info.ppid],
+      ["cwd", info.cwd],
+      ["argv", info.argv],
+      ["execPath", info.execPath],
+      ["isTTY", info.isTTY],
+      ["CI", info.ci],
+    ])
+  );
+}
+
+function renderDocDetectiveSection(): Section {
+  let versionData: any;
+  try {
+    versionData = getVersionData();
+  } catch (err: any) {
+    return renderSection("Doc Detective", [
+      `  <failed to collect version data: ${err?.message || err}>`,
+    ]);
+  }
+  const main = versionData?.main || {};
+  const ddVersion = main["doc-detective"]?.version || "<unknown>";
+  const ctx = versionData?.context || {};
+  const deps = versionData?.dependencies || {};
+
+  const rows: Array<[string, unknown]> = [
+    ["doc-detective", ddVersion],
+    ["executionMethod", ctx.executionMethod],
+    ["nodeVersion", ctx.nodeVersion],
+    ["platform", ctx.platform],
+    ["timestamp", ctx.timestamp],
+  ];
+
+  // Surface every detected doc-detective-* package and warn on version drift.
+  const lockstepWarnings: string[] = [];
+  for (const depName of Object.keys(deps)) {
+    const dep = deps[depName];
+    rows.push([depName, dep?.version || dep || "<unknown>"]);
+    if (
+      depName === "doc-detective-common" &&
+      typeof dep?.version === "string" &&
+      typeof ddVersion === "string" &&
+      ddVersion !== "<unknown>" &&
+      dep.version !== ddVersion
+    ) {
+      lockstepWarnings.push(
+        `  ! WARNING: doc-detective (${ddVersion}) and doc-detective-common (${dep.version}) versions differ — they ship in lockstep, mismatch usually means a stale install.`
+      );
+    }
+  }
+
+  const lines = renderKeyValues(rows);
+  if (lockstepWarnings.length > 0) {
+    lines.push("");
+    lines.push(...lockstepWarnings);
+  }
+  return renderSection("Doc Detective", lines);
+}
+
+async function renderToolsSection(): Promise<Section> {
+  const results = await probeAllTools();
+  const rows: Array<[string, unknown]> = results.map((r) => {
+    const value = r.notes ? `${r.version}  (${r.notes})` : r.version;
+    return [r.name, value];
+  });
+  const lines = renderKeyValues(rows);
+
+  // Appium drivers — separate block since the output is multi-line.
+  let driversText = "<not probed>";
+  try {
+    driversText = await probeAppiumDrivers();
+  } catch (err: any) {
+    driversText = `<probe error: ${err?.message || err}>`;
+  }
+  lines.push("");
+  lines.push("  appium drivers:");
+  for (const dl of driversText.split("\n")) {
+    lines.push(`    ${dl}`);
+  }
+  return renderSection("Tools", lines);
+}
+
+// Hard cap on browser-detection latency. `getAvailableApps` internally
+// runs `npx appium driver list` with no timeout (~74s observed on cold
+// caches without local Appium). Diagnostics must not block that long.
+const BROWSER_DETECTION_TIMEOUT_MS = 5000;
+
+async function renderBrowsersSection(config: any): Promise<Section> {
+  try {
+    // getAvailableApps mutates cwd and reads process.env for APPIUM_HOME;
+    // it expects a config with an `environment.platform` field. Synthesize
+    // a minimal one if validation never completed.
+    const safeConfig = config && config.environment
+      ? config
+      : { ...(config || {}), environment: { platform: detectPlatform() } };
+
+    const timeoutSentinel: unique symbol = Symbol("browser-timeout") as any;
+    const apps = await Promise.race<any>([
+      getAvailableApps({ config: safeConfig }),
+      new Promise((resolve) =>
+        setTimeout(() => resolve(timeoutSentinel), BROWSER_DETECTION_TIMEOUT_MS)
+      ),
+    ]);
+
+    if (apps === timeoutSentinel) {
+      return renderSection("Browsers", [
+        `  <browser detection timed out after ${BROWSER_DETECTION_TIMEOUT_MS}ms — most often means Appium isn't installed locally, since detection shells out to \`npx appium driver list\`>`,
+      ]);
+    }
+
+    if (!Array.isArray(apps) || apps.length === 0) {
+      return renderSection("Browsers", [
+        "  <no supported browsers detected — Chrome, Firefox, or Safari with a matching Appium driver is required>",
+      ]);
+    }
+    const lines: string[] = [];
+    for (const app of apps) {
+      lines.push(`  ${app.name} ${app.version || ""}`.trimEnd());
+      if (app.path) lines.push(`    path:    ${app.path}`);
+      if (app.driver) lines.push(`    driver:  ${app.driver}`);
+    }
+    return renderSection("Browsers", lines);
+  } catch (err: any) {
+    return renderSection("Browsers", [
+      `  <browser detection failed: ${err?.message || err}>`,
+    ]);
+  }
+}
+
+function detectPlatform(): "linux" | "mac" | "windows" {
+  switch (process.platform) {
+    case "win32":
+      return "windows";
+    case "darwin":
+      return "mac";
+    default:
+      return "linux";
+  }
+}
+
+function renderContainerSection(info: ReturnType<typeof detectContainer>): Section {
+  const lines: string[] = [];
+  lines.push(...renderKeyValues([["container", info.inContainer]]));
+  if (info.signals.length > 0) {
+    lines.push("  signals:");
+    for (const s of info.signals) lines.push(`    - ${s}`);
+  }
+  return renderSection("Container state", lines);
+}
+
+function renderReferencedEnvVarsSection(opts: PrintDebugOptions): Section {
+  // Full env dump is OPT-IN via `--include-env`. Earlier revisions
+  // auto-dumped when running in a container, but that meant common
+  // PaaS-injected secrets (DATABASE_URL with embedded password, Sentry
+  // DSN, webhook URLs) ended up in pasted bug reports unless every
+  // user knew about the redaction regex. Now the user must explicitly
+  // ask for the bulk dump; the default is the referenced-only listing
+  // regardless of container state.
+  if (opts.includeEnv) {
+    const names = Object.keys(process.env).sort();
+    const lines: string[] = [];
+    lines.push(
+      `  --include-env was set — listing all ${names.length} env vars (redacted by name and by value shape).`
+    );
+    lines.push(
+      `  REVIEW BEFORE PASTING. Redaction catches common patterns but is best-effort; values with novel names or shapes may slip through.`
+    );
+    lines.push("");
+    for (const name of names) {
+      lines.push(`  ${name} = ${redactValue(name, process.env[name])}`);
+    }
+    return renderSection("Environment variables (full)", lines);
+  }
+
+  // Default path: collect names referenced by config + inputs only.
+  const referenced = new Set<string>();
+
+  // 1. DOC_DETECTIVE_CONFIG raw string.
+  const rawEnvConfig = process.env.DOC_DETECTIVE_CONFIG;
+  if (typeof rawEnvConfig === "string") {
+    for (const n of findReferencedEnvVars(rawEnvConfig)) referenced.add(n);
+  }
+
+  // 2. Config file raw source (before substitution).
+  if (opts.configPath && typeof opts.configPath === "string") {
+    try {
+      const raw = fs.readFileSync(opts.configPath, "utf8");
+      for (const n of findReferencedEnvVars(raw)) referenced.add(n);
+    } catch {
+      // Best-effort — if the config file is unreadable, just skip.
+    }
+  }
+
+  // 3. Input files raw text. Walk config.input (already a string|array
+  //    of absolute paths after setConfig). Cap the walk to 200 files so
+  //    a misconfigured input pointed at "/" can't hang the dump.
+  //    Scope to the extensions doc-detective actually parses (per
+  //    config.fileTypes) — otherwise the `$VAR` grep matches shell/code/
+  //    CI syntax in unrelated source files and floods the section with
+  //    junk like `$0`, `$1`, and stray single letters.
+  const inputs = normalizeInputs(opts.config?.input);
+  const allowedExtensions = resolveDocExtensions(opts.config?.fileTypes);
+  const files = enumerateInputFiles(inputs, 200, allowedExtensions);
+  for (const file of files) {
+    try {
+      const raw = fs.readFileSync(file, "utf8");
+      for (const n of findReferencedEnvVars(raw)) referenced.add(n);
+    } catch {
+      // Skip unreadable / binary files.
+    }
+  }
+
+  const sorted = Array.from(referenced).sort();
+  const lines: string[] = [];
+  lines.push(
+    `  Scanned ${files.length} documentation file(s) plus config + DOC_DETECTIVE_CONFIG for $VAR references.`
+  );
+  lines.push("");
+  if (sorted.length === 0) {
+    lines.push("  <no $VAR references found>");
+  } else {
+    for (const name of sorted) {
+      lines.push(`  ${name} = ${redactValue(name, process.env[name])}`);
+    }
+  }
+  return renderSection("Referenced environment variables", lines);
+}
+
+function normalizeInputs(input: unknown): string[] {
+  if (typeof input === "string") return [input];
+  if (Array.isArray(input)) {
+    return input.filter((v): v is string => typeof v === "string" && v.length > 0);
+  }
+  return [];
+}
+
+function renderConfigSection(opts: PrintDebugOptions): Section {
+  const lines: string[] = [];
+  if (opts.configError) {
+    lines.push("  === CONFIG INVALID ===");
+    lines.push(`  ${opts.configError.message}`);
+    lines.push("");
+    lines.push("  Best-effort raw config (validation failed):");
+  } else {
+    lines.push(`  configPath: ${opts.configPath || "<none>"}`);
+    lines.push("");
+    lines.push("  Effective config (post-validation):");
+  }
+  let json: string;
+  try {
+    // Walk the config object and redact secret-looking key values and
+    // credential-shaped strings BEFORE stringifying. Without this, the
+    // Config section bypasses the env-var redaction layer — values
+    // like `integrations.heretto[].apiToken`,
+    // `integrations.docDetectiveApi.apiKey`, inline webhook URLs, and
+    // anything supplied via DOC_DETECTIVE_CONFIG would land in the
+    // pasted bug report verbatim.
+    const safeConfig = redactObject(opts.config ?? {});
+    json = JSON.stringify(safeConfig, null, 2);
+  } catch (err: any) {
+    json = `<could not stringify config: ${err?.message || err}>`;
+  }
+  for (const l of json.split("\n")) lines.push(`  ${l}`);
+  return renderSection("Config", lines);
+}

--- a/src/debug/redact.ts
+++ b/src/debug/redact.ts
@@ -77,6 +77,34 @@ export function redactValue(name: string, value: string | undefined): string {
   return value;
 }
 
+// Redact a single `process.argv` entry so the dump stays safe to paste.
+// CLI args can carry credentials that bypass the env/config redaction:
+//   - `--token=ghp_…` / `--api-key=…`  → value redacted when the flag name
+//     looks secret;
+//   - an embedded credential anywhere (`https://user:pass@host`, a JWT, a
+//     GitHub/AWS token) → redacted by value shape.
+// Node + entry-point paths and ordinary flags pass through unchanged.
+export function redactArg(arg: string): string {
+  if (typeof arg !== "string" || arg.length === 0) return arg;
+  const eq = arg.indexOf("=");
+  if (eq > 0) {
+    const flag = arg.slice(0, eq);
+    const value = arg.slice(eq + 1);
+    const name = flag.replace(/^-+/, "");
+    if (isSecretName(name)) {
+      return `${flag}=***redacted (${value.length} chars)***`;
+    }
+    if (isSecretValue(value)) {
+      return `${flag}=***redacted (${value.length} chars, value shape)***`;
+    }
+    return arg;
+  }
+  if (isSecretValue(arg)) {
+    return `***redacted (${arg.length} chars, value shape)***`;
+  }
+  return arg;
+}
+
 // Recursively walk an arbitrary value (object / array / primitive) and
 // return a deep-cloned copy with sensitive strings replaced. Used by
 // the Config section of the debug dump so secrets in config files

--- a/src/debug/redact.ts
+++ b/src/debug/redact.ts
@@ -27,7 +27,12 @@
 // over-redaction while catching every common credential carrier
 // surveyed in the security review.
 const SECRET_NAME_PATTERNS: RegExp[] = [
-  /token|secret|key|password|auth|credential|bearer/i,
+  /token|secret|password|auth|credential|bearer/i,
+  // `key` only as a tokenized word (KEY / API_KEY / api-key / bare `key`)
+  // or a CamelCase suffix (apiKey, accessKey) — NOT the raw substring,
+  // which over-redacts innocuous names like MONKEY / hockeyStats.
+  /(^|[_-])key([_-]|$)/i,
+  /[a-z]Key([^a-z]|$)/,
   /(_URL|_URI|_DSN|_PASS|_PASSWD|_PWD)$/i,
   /WEBHOOK/i,
   /^(JWT|PAT)$/i,

--- a/src/debug/redact.ts
+++ b/src/debug/redact.ts
@@ -105,6 +105,34 @@ export function redactArg(arg: string): string {
   return arg;
 }
 
+// Redact a full argv array with flag/value context. Beyond what redactArg
+// catches per-token, this handles the SPLIT form where a secret-named flag
+// and its value are separate args (`--password hunter2`) — `hunter2` alone
+// matches no value-shape, so it would otherwise leak. When a bare
+// secret-named flag is seen, the next non-flag token is redacted.
+export function redactArgv(args: string[]): string[] {
+  const out: string[] = [];
+  let expectSecretValue = false;
+  for (const arg of args) {
+    if (expectSecretValue && !arg.startsWith("-")) {
+      out.push(`***redacted (${arg.length} chars)***`);
+      expectSecretValue = false;
+      continue;
+    }
+    expectSecretValue = false;
+    // Bare secret-named flag (`--password`, `-p`) with no `=value` — its
+    // value is the following token.
+    const bareFlag = arg.match(/^--?([^=]+)$/);
+    if (bareFlag && isSecretName(bareFlag[1])) {
+      out.push(arg);
+      expectSecretValue = true;
+      continue;
+    }
+    out.push(redactArg(arg));
+  }
+  return out;
+}
+
 // Recursively walk an arbitrary value (object / array / primitive) and
 // return a deep-cloned copy with sensitive strings replaced. Used by
 // the Config section of the debug dump so secrets in config files

--- a/src/debug/redact.ts
+++ b/src/debug/redact.ts
@@ -54,6 +54,8 @@ const SECRET_VALUE_PATTERNS: RegExp[] = [
   /:\/\/[^/\s:@]*:[^@\s]+@/,
   /\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b/,
   /\bgh[pousr]_[A-Za-z0-9]{36,255}\b/,
+  // GitHub fine-grained PAT: `github_pat_` + base62/underscore body.
+  /\bgithub_pat_[A-Za-z0-9_]{20,255}\b/,
   /\b(AKIA|ASIA)[0-9A-Z]{16}\b/,
 ];
 

--- a/src/debug/redact.ts
+++ b/src/debug/redact.ts
@@ -120,8 +120,11 @@ export function redactArgv(args: string[]): string[] {
       continue;
     }
     expectSecretValue = false;
-    // Bare secret-named flag (`--password`, `-p`) with no `=value` — its
-    // value is the following token.
+    // Bare secret-named flag (e.g. `--password`) with no `=value` — its
+    // value is the following token. Matched by flag NAME, so single-letter
+    // aliases (`-p`) are intentionally NOT treated as secret: none of Doc
+    // Detective's flags carry a credential via a short alias, and blanket-
+    // redacting any `-x value` would clobber legitimate flags (`-i`, `-o`).
     const bareFlag = arg.match(/^--?([^=]+)$/);
     if (bareFlag && isSecretName(bareFlag[1])) {
       out.push(arg);

--- a/src/debug/redact.ts
+++ b/src/debug/redact.ts
@@ -1,0 +1,129 @@
+// Redaction helpers for the debug-dump env-var listings.
+//
+// Doc Detective's `debug` subcommand and `DOC_DETECTIVE_DEBUG=true` env
+// var dump enumerate env vars referenced by config / input files and,
+// when `--include-env` is passed, dump the full `process.env`. Both
+// flows route values through `redactValue` so credentials don't end up
+// in pasted bug reports.
+//
+// We never redact the NAME — knowing which variable was referenced is
+// often more useful than the value, and it lets users grep their config
+// for the offender.
+//
+// Two layers of detection:
+//   1. Name-based: catches conventional secret naming (TOKEN, SECRET,
+//      KEY, PASSWORD, AUTH, CREDENTIAL, BEARER) PLUS connection-string-
+//      shaped suffixes (_URL, _URI, _DSN, _PASS, _PASSWD, _PWD), the
+//      WEBHOOK substring, and the bare names JWT / PAT.
+//   2. Value-based: catches credentials embedded in values regardless
+//      of name — URL userinfo (`://user:pass@`), JWTs, GitHub tokens,
+//      and AWS access key IDs. This is what keeps a sloppy
+//      `MY_THING = postgres://app:hunter2@host/db` from leaking.
+
+// Name patterns. Both must miss for a value to be considered name-safe.
+//
+// `_PASS$` covers SMTP_PASS / DB_PASS but NOT PASSAGE / PASSPORT. The
+// other suffix anchors are similarly chosen to minimize collateral
+// over-redaction while catching every common credential carrier
+// surveyed in the security review.
+const SECRET_NAME_PATTERNS: RegExp[] = [
+  /token|secret|key|password|auth|credential|bearer/i,
+  /(_URL|_URI|_DSN|_PASS|_PASSWD|_PWD)$/i,
+  /WEBHOOK/i,
+  /^(JWT|PAT)$/i,
+];
+
+// Value patterns. Even when the NAME looks innocuous, a value matching
+// any of these is almost certainly a credential and gets redacted.
+//
+// Userinfo regex matches `scheme://user:pass@host/...` — the colon-
+// separated credentials embedded in connection strings. Anchored on
+// `://` to avoid matching arbitrary "x:y@z" substrings.
+//
+// JWT shape is the canonical three-segment base64url. Anchored on the
+// `eyJ` header prefix that all JWTs begin with.
+//
+// GitHub token patterns from
+// https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
+//
+// AWS access key ID pattern from AWS docs (20 chars, AKIA/ASIA prefix).
+const SECRET_VALUE_PATTERNS: RegExp[] = [
+  // URL userinfo: `scheme://[user]:password@host`. The user portion is
+  // optional so we also catch `redis://:password@host` (a common Redis
+  // password-only form).
+  /:\/\/[^/\s:@]*:[^@\s]+@/,
+  /\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b/,
+  /\bgh[pousr]_[A-Za-z0-9]{36,255}\b/,
+  /\b(AKIA|ASIA)[0-9A-Z]{16}\b/,
+];
+
+export function isSecretName(name: string): boolean {
+  return SECRET_NAME_PATTERNS.some((p) => p.test(name));
+}
+
+export function isSecretValue(value: string): boolean {
+  return SECRET_VALUE_PATTERNS.some((p) => p.test(value));
+}
+
+export function redactValue(name: string, value: string | undefined): string {
+  if (value === undefined) return "<unset>";
+  if (value === "") return "<empty>";
+  if (isSecretName(name)) {
+    return `***redacted (${value.length} chars)***`;
+  }
+  if (isSecretValue(value)) {
+    return `***redacted (${value.length} chars, value shape)***`;
+  }
+  return value;
+}
+
+// Recursively walk an arbitrary value (object / array / primitive) and
+// return a deep-cloned copy with sensitive strings replaced. Used by
+// the Config section of the debug dump so secrets in config files
+// (integrations.heretto[].apiToken, integrations.docDetectiveApi.apiKey,
+// inline webhook URLs, anything in DOC_DETECTIVE_CONFIG, etc.) don't
+// land in pasted bug reports.
+//
+// Redaction rules, applied per leaf string:
+//   1. If the string's parent key matches a secret-name pattern → redact.
+//   2. Else if the string's contents match a secret-value pattern → redact.
+//   3. Otherwise → return as-is.
+//
+// Non-string leaves (numbers / booleans / null) are returned as-is even
+// under a secret-named key: in practice these don't carry credentials,
+// and preserving them keeps the dump useful for debugging non-secret
+// numeric / boolean state.
+export function redactObject(value: unknown): unknown {
+  return redactWalk(value, null, new WeakSet());
+}
+
+function redactWalk(
+  value: unknown,
+  parentKey: string | null,
+  seen: WeakSet<object>
+): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") {
+    if (parentKey !== null && isSecretName(parentKey)) {
+      return `***redacted (${value.length} chars)***`;
+    }
+    if (isSecretValue(value)) {
+      return `***redacted (${value.length} chars, value shape)***`;
+    }
+    return value;
+  }
+  if (typeof value !== "object") return value;
+  if (seen.has(value as object)) return "<circular>";
+  seen.add(value as object);
+  if (Array.isArray(value)) {
+    // Array elements inherit the parent key (e.g. `tokens: ["a","b"]`
+    // → each element evaluated against `tokens` for name-based check).
+    return value.map((v) => redactWalk(v, parentKey, seen));
+  }
+  const out: Record<string, unknown> = {};
+  for (const k of Object.keys(value as Record<string, unknown>)) {
+    if (k === "__proto__" || k === "constructor" || k === "prototype") continue;
+    out[k] = redactWalk((value as Record<string, unknown>)[k], k, seen);
+  }
+  return out;
+}

--- a/src/debug/render.ts
+++ b/src/debug/render.ts
@@ -27,10 +27,11 @@ function formatValue(value: unknown): string {
   return String(value);
 }
 
-export function renderDocument(sections: Section[]): string {
+export function renderDocument(sections: Section[], generatedAt?: string): string {
   const out: string[] = [];
   out.push("=".repeat(72));
   out.push("Doc Detective diagnostic dump");
+  if (generatedAt) out.push(`Generated: ${generatedAt}`);
   out.push("=".repeat(72));
   for (const s of sections) {
     out.push("");

--- a/src/debug/render.ts
+++ b/src/debug/render.ts
@@ -1,0 +1,43 @@
+// Plaintext sectioned renderer for the debug dump.
+//
+// No ANSI colors — output is meant to be pasted into a GitHub issue, so
+// we keep it grep-friendly and copyable. Each section is a header line
+// followed by `key: value` lines or a free-form text block.
+
+export interface Section {
+  title: string;
+  body: string;
+}
+
+export function renderSection(title: string, lines: string[]): Section {
+  return { title, body: lines.join("\n") };
+}
+
+export function renderKeyValues(rows: Array<[string, unknown]>): string[] {
+  const maxKey = rows.reduce((m, [k]) => Math.max(m, k.length), 0);
+  return rows.map(([k, v]) => `  ${k.padEnd(maxKey, " ")}  ${formatValue(v)}`);
+}
+
+function formatValue(value: unknown): string {
+  if (value === undefined) return "<unset>";
+  if (value === null) return "<null>";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return JSON.stringify(value);
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+export function renderDocument(sections: Section[]): string {
+  const out: string[] = [];
+  out.push("=".repeat(72));
+  out.push("Doc Detective diagnostic dump");
+  out.push("=".repeat(72));
+  for (const s of sections) {
+    out.push("");
+    out.push(`-- ${s.title} `.padEnd(72, "-"));
+    out.push(s.body);
+  }
+  out.push("");
+  out.push("=".repeat(72));
+  return out.join("\n");
+}

--- a/src/debug/system.ts
+++ b/src/debug/system.ts
@@ -4,7 +4,7 @@
 // Output is consumed by `render.ts` and `index.ts` only.
 
 import os from "node:os";
-import { redactArg } from "./redact.js";
+import { redactArgv } from "./redact.js";
 
 export interface SystemInfo {
   platform: string;
@@ -64,9 +64,10 @@ export function collectSystemInfo(): SystemInfo {
     pid: process.pid,
     ppid: process.ppid,
     cwd: safe(() => process.cwd(), "<unknown>"),
-    // Redact credentials that may ride in CLI args (e.g. `--token=…`, an
-    // embedded URL with userinfo) so the dump stays safe to paste.
-    argv: process.argv.map(redactArg),
+    // Redact credentials that may ride in CLI args — `--token=…`, the split
+    // `--password hunter2` form, or an embedded URL with userinfo — so the
+    // dump stays safe to paste.
+    argv: redactArgv(process.argv),
     execPath: process.execPath,
     isTTY: Boolean(process.stdout.isTTY),
     ci: process.env.CI,

--- a/src/debug/system.ts
+++ b/src/debug/system.ts
@@ -1,0 +1,79 @@
+// System-information collectors for the debug dump.
+//
+// Pure synchronous reads of `os` and `process`. No I/O, no spawns.
+// Output is consumed by `render.ts` and `index.ts` only.
+
+import os from "node:os";
+
+export interface SystemInfo {
+  platform: string;
+  arch: string;
+  release: string;
+  osVersion: string;
+  cpuCount: number;
+  cpuModel: string;
+  cpuSpeedMhz: number;
+  totalMemoryMb: number;
+  freeMemoryMb: number;
+  uptimeSeconds: number;
+  hostname: string;
+  wallclockIso: string;
+  timezone: string;
+  pid: number;
+  ppid: number;
+  cwd: string;
+  argv: string[];
+  execPath: string;
+  isTTY: boolean;
+  ci: string | undefined;
+}
+
+export function collectSystemInfo(): SystemInfo {
+  const cpus = (() => {
+    try {
+      return os.cpus() || [];
+    } catch {
+      return [];
+    }
+  })();
+  const first = cpus[0];
+
+  const timezone = (() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || "<unknown>";
+    } catch {
+      return "<unknown>";
+    }
+  })();
+
+  return {
+    platform: os.platform(),
+    arch: os.arch(),
+    release: os.release(),
+    osVersion: safe(() => os.version(), "<unknown>"),
+    cpuCount: cpus.length,
+    cpuModel: first?.model || "<unknown>",
+    cpuSpeedMhz: first?.speed || 0,
+    totalMemoryMb: Math.round(os.totalmem() / (1024 * 1024)),
+    freeMemoryMb: Math.round(os.freemem() / (1024 * 1024)),
+    uptimeSeconds: Math.round(os.uptime()),
+    hostname: safe(() => os.hostname(), "<unknown>"),
+    wallclockIso: new Date().toISOString(),
+    timezone,
+    pid: process.pid,
+    ppid: process.ppid,
+    cwd: safe(() => process.cwd(), "<unknown>"),
+    argv: process.argv.slice(),
+    execPath: process.execPath,
+    isTTY: Boolean(process.stdout.isTTY),
+    ci: process.env.CI,
+  };
+}
+
+function safe<T>(fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}

--- a/src/debug/system.ts
+++ b/src/debug/system.ts
@@ -4,6 +4,7 @@
 // Output is consumed by `render.ts` and `index.ts` only.
 
 import os from "node:os";
+import { redactArg } from "./redact.js";
 
 export interface SystemInfo {
   platform: string;
@@ -63,7 +64,9 @@ export function collectSystemInfo(): SystemInfo {
     pid: process.pid,
     ppid: process.ppid,
     cwd: safe(() => process.cwd(), "<unknown>"),
-    argv: process.argv.slice(),
+    // Redact credentials that may ride in CLI args (e.g. `--token=…`, an
+    // embedded URL with userinfo) so the dump stays safe to paste.
+    argv: process.argv.map(redactArg),
     execPath: process.execPath,
     isTTY: Boolean(process.stdout.isTTY),
     ci: process.env.CI,

--- a/src/debug/tools.ts
+++ b/src/debug/tools.ts
@@ -20,6 +20,7 @@
 
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
+import path from "node:path";
 
 const require = createRequire(import.meta.url);
 
@@ -61,7 +62,9 @@ export async function probeTool(
       };
     }
     // Some tools (java, appium with stderr noise) print version on stderr.
-    const text = (stdout + (stdout ? "" : stderr) || "").trim();
+    // Fall back to stderr when stdout is empty OR whitespace-only — a bare
+    // "\n" on stdout is truthy but carries no version.
+    const text = (stdout.trim() ? stdout : stderr || "").trim();
     const firstLine = text.split("\n")[0] || "<unknown>";
     return { name, version: firstLine };
   } catch (err: any) {
@@ -159,33 +162,19 @@ function probeFromPackageJson(
 }
 
 function probeFfmpeg(): ToolResult {
-  // Doc Detective bundles ffmpeg via @ffmpeg-installer/ffmpeg. We
-  // report the installer's package version plus the resolved bundled
-  // binary path WITHOUT invoking the binary — earlier revisions ran
-  // `<bundledPath> -version`, which means `doc-detective debug` would
-  // execute whatever lives at that path. A compromised installer dep
-  // would therefore execute on every diagnostic run; reading the
-  // package.json + path avoids that while still surfacing the
-  // information a user needs ("is ffmpeg bundled? at what version?
-  // from where?").
+  // Doc Detective bundles ffmpeg via @ffmpeg-installer/ffmpeg. Report the
+  // installer's package version and location using metadata only —
+  // `require.resolve` + reading the package.json (JSON, no code). We
+  // deliberately do NOT `require("@ffmpeg-installer/ffmpeg")` (its index.js
+  // runs platform-branching code) nor invoke the binary, so a compromised
+  // installer dep can never execute during `doc-detective debug`.
   try {
     const pkgPath = require.resolve("@ffmpeg-installer/ffmpeg/package.json");
     const pkg = require(pkgPath);
-    let binPath = "<unknown>";
-    try {
-      // The installer's main export carries the binary path. Loading
-      // it can run a small index.js that branches by platform — no
-      // subprocess.
-      const installer = require("@ffmpeg-installer/ffmpeg");
-      binPath = installer?.path || "<unknown>";
-    } catch {
-      // Platform-specific binary package not installed for this
-      // platform — fall through with binPath unset.
-    }
     return {
       name: "ffmpeg",
       version: `@ffmpeg-installer/ffmpeg ${pkg.version}`,
-      notes: `bundled binary: ${binPath}`,
+      notes: `installer package: ${path.dirname(pkgPath)}`,
     };
   } catch {
     return { name: "ffmpeg", version: "<bundled installer not found>" };

--- a/src/debug/tools.ts
+++ b/src/debug/tools.ts
@@ -44,8 +44,21 @@ export async function probeTool(
     );
     if (timedOut) return { name, version: `<timed out after ${timeoutMs}ms>` };
     if (exitCode !== 0) {
-      const tail = (stderr || stdout || "").split("\n")[0] || "";
-      return { name, version: `<not found>`, notes: tail };
+      const firstLine = (stderr || stdout || "").split("\n")[0]?.trim() || "";
+      // "command not found" shell errors (e.g. Windows' "'java' is not
+      // recognized as an internal or external command,") are just noise —
+      // the `<not found>` marker already says the tool is absent, and the
+      // raw message is a truncated, comma-dangling fragment. Suppress those;
+      // keep genuinely-informative errors as a note.
+      const notFoundNoise =
+        /not recognized|not found|no such file|cannot find|command not found/i.test(
+          firstLine
+        );
+      return {
+        name,
+        version: "<not found>",
+        notes: notFoundNoise ? undefined : firstLine || undefined,
+      };
     }
     // Some tools (java, appium with stderr noise) print version on stderr.
     const text = (stdout + (stdout ? "" : stderr) || "").trim();

--- a/src/debug/tools.ts
+++ b/src/debug/tools.ts
@@ -21,6 +21,10 @@
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 import path from "node:path";
+import {
+  resolveHeavyDepPath,
+  resolveHeavyDepVersion,
+} from "../runtime/loader.js";
 
 const require = createRequire(import.meta.url);
 
@@ -109,8 +113,9 @@ function runWithTimeout(
   });
 }
 
-// The probe set the debug dump runs. Order is the print order.
-export async function probeAllTools(): Promise<ToolResult[]> {
+// The probe set the debug dump runs. Order is the print order. `cacheDir`
+// (from config) lets the appium probe see cache-installed runtime deps.
+export async function probeAllTools(cacheDir?: string): Promise<ToolResult[]> {
   const probes: Array<ToolResult | Promise<ToolResult>> = [
     { name: "node", version: process.version },
     probeTool("npm", "npm --version"),
@@ -118,7 +123,7 @@ export async function probeAllTools(): Promise<ToolResult[]> {
     probePython(),
     probeTool("java", "java -version"),
     probeFfmpeg(),
-    probeAppium(),
+    probeAppium(cacheDir),
     probeTool("git", "git --version"),
     probeTool("docker", "docker --version"),
   ];
@@ -132,33 +137,6 @@ async function probePython(): Promise<ToolResult> {
   }
   const py = await probeTool("python", "python --version");
   return { name: "python", version: py.version, notes: py.notes };
-}
-
-// Read `{ name, version }` from a package's package.json without
-// executing any of its binaries. Used for tools shipped via npm
-// dependencies so a compromised `node_modules/.bin/<tool>` doesn't get
-// invoked just to report a version.
-function probeFromPackageJson(
-  displayName: string,
-  packageName: string,
-  notesPrefix?: string
-): ToolResult {
-  try {
-    const pkgPath = require.resolve(`${packageName}/package.json`);
-    const pkg = require(pkgPath);
-    const version = typeof pkg?.version === "string" ? pkg.version : "<unknown>";
-    return {
-      name: displayName,
-      version,
-      notes: notesPrefix ? `${notesPrefix}: ${pkgPath}` : pkgPath,
-    };
-  } catch (err: any) {
-    return {
-      name: displayName,
-      version: "<not installed>",
-      notes: err?.code === "MODULE_NOT_FOUND" ? undefined : err?.message,
-    };
-  }
 }
 
 function probeFfmpeg(): ToolResult {
@@ -181,6 +159,20 @@ function probeFfmpeg(): ToolResult {
   }
 }
 
-function probeAppium(): ToolResult {
-  return probeFromPackageJson("appium", "appium", "from");
+// Resolve appium the same way the runtime does — shim node_modules OR
+// `<cacheDir>/runtime` — so a cached install (`doc-detective install`) is
+// reported as present here too, instead of `<not installed>` while the
+// Browsers section shows it available. Reads version metadata only; never
+// executes an appium binary.
+function probeAppium(cacheDir?: string): ToolResult {
+  const resolved = resolveHeavyDepPath("appium", { cacheDir });
+  if (!resolved) {
+    return { name: "appium", version: "<not installed>" };
+  }
+  const version = resolveHeavyDepVersion("appium", { cacheDir });
+  return {
+    name: "appium",
+    version: version ?? "<unknown>",
+    notes: `from: ${resolved}`,
+  };
 }

--- a/src/debug/tools.ts
+++ b/src/debug/tools.ts
@@ -1,0 +1,209 @@
+// Tool-version probes for the debug dump.
+//
+// Two flavors of probe:
+//   1. Spawn-based (`probeTool`) — runs `<binary> --version` with a
+//      hard timeout (default 3000 ms). Used ONLY for system binaries
+//      whose path comes from PATH (node, npm, npx, git, docker, java,
+//      python). PATH is system-level and trusted.
+//   2. Package-read (`probeFromPackageJson`) — reads `version` from a
+//      named package's `package.json` via `require.resolve`. Used for
+//      anything that would otherwise route through a project-local
+//      `node_modules/.bin` binary (appium, appium drivers, ffmpeg
+//      bundled by @ffmpeg-installer). Avoids executing project-local
+//      binaries just to collect diagnostics — a compromised
+//      `node_modules/.bin/appium` would otherwise run on
+//      `doc-detective debug`.
+//
+// All spawn-based probes use `shell: true` for PATH lookup consistency
+// across Windows (where binaries can be `.cmd`). Package-read probes
+// do no I/O beyond a `require` call.
+
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+export interface ToolResult {
+  name: string;
+  version: string;
+  notes?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 3000;
+
+export async function probeTool(
+  name: string,
+  command: string,
+  options: { timeoutMs?: number } = {}
+): Promise<ToolResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  try {
+    const { stdout, stderr, exitCode, timedOut } = await runWithTimeout(
+      command,
+      timeoutMs
+    );
+    if (timedOut) return { name, version: `<timed out after ${timeoutMs}ms>` };
+    if (exitCode !== 0) {
+      const tail = (stderr || stdout || "").split("\n")[0] || "";
+      return { name, version: `<not found>`, notes: tail };
+    }
+    // Some tools (java, appium with stderr noise) print version on stderr.
+    const text = (stdout + (stdout ? "" : stderr) || "").trim();
+    const firstLine = text.split("\n")[0] || "<unknown>";
+    return { name, version: firstLine };
+  } catch (err: any) {
+    return { name, version: "<probe failed>", notes: err?.message };
+  }
+}
+
+function runWithTimeout(
+  command: string,
+  timeoutMs: number
+): Promise<{ stdout: string; stderr: string; exitCode: number; timedOut: boolean }> {
+  return new Promise((resolve) => {
+    const child = spawn(command, { shell: true });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const settle = (result: { stdout: string; stderr: string; exitCode: number; timedOut: boolean }) => {
+      if (settled) return;
+      settled = true;
+      try {
+        child.kill();
+      } catch {
+        // Best-effort kill.
+      }
+      resolve(result);
+    };
+    const t = setTimeout(() => settle({ stdout, stderr, exitCode: -1, timedOut: true }), timeoutMs);
+    child.stdout?.on("data", (c) => {
+      stdout += c.toString();
+    });
+    child.stderr?.on("data", (c) => {
+      stderr += c.toString();
+    });
+    child.on("error", (err) => {
+      clearTimeout(t);
+      settle({ stdout, stderr: stderr + (err.message || ""), exitCode: -1, timedOut: false });
+    });
+    child.on("close", (code) => {
+      clearTimeout(t);
+      settle({ stdout, stderr, exitCode: code ?? -1, timedOut: false });
+    });
+  });
+}
+
+// The probe set the debug dump runs. Order is the print order.
+export async function probeAllTools(): Promise<ToolResult[]> {
+  const probes: Array<ToolResult | Promise<ToolResult>> = [
+    { name: "node", version: process.version },
+    probeTool("npm", "npm --version"),
+    probeTool("npx", "npx --version"),
+    probePython(),
+    probeTool("java", "java -version"),
+    probeFfmpeg(),
+    probeAppium(),
+    probeTool("git", "git --version"),
+    probeTool("docker", "docker --version"),
+  ];
+  return Promise.all(probes);
+}
+
+async function probePython(): Promise<ToolResult> {
+  const py3 = await probeTool("python3", "python3 --version");
+  if (py3.version !== "<not found>" && !py3.version.startsWith("<timed out")) {
+    return { name: "python", version: py3.version };
+  }
+  const py = await probeTool("python", "python --version");
+  return { name: "python", version: py.version, notes: py.notes };
+}
+
+// Read `{ name, version }` from a package's package.json without
+// executing any of its binaries. Used for tools shipped via npm
+// dependencies so a compromised `node_modules/.bin/<tool>` doesn't get
+// invoked just to report a version.
+function probeFromPackageJson(
+  displayName: string,
+  packageName: string,
+  notesPrefix?: string
+): ToolResult {
+  try {
+    const pkgPath = require.resolve(`${packageName}/package.json`);
+    const pkg = require(pkgPath);
+    const version = typeof pkg?.version === "string" ? pkg.version : "<unknown>";
+    return {
+      name: displayName,
+      version,
+      notes: notesPrefix ? `${notesPrefix}: ${pkgPath}` : pkgPath,
+    };
+  } catch (err: any) {
+    return {
+      name: displayName,
+      version: "<not installed>",
+      notes: err?.code === "MODULE_NOT_FOUND" ? undefined : err?.message,
+    };
+  }
+}
+
+function probeFfmpeg(): ToolResult {
+  // Doc Detective bundles ffmpeg via @ffmpeg-installer/ffmpeg. We
+  // report the installer's package version plus the resolved bundled
+  // binary path WITHOUT invoking the binary — earlier revisions ran
+  // `<bundledPath> -version`, which means `doc-detective debug` would
+  // execute whatever lives at that path. A compromised installer dep
+  // would therefore execute on every diagnostic run; reading the
+  // package.json + path avoids that while still surfacing the
+  // information a user needs ("is ffmpeg bundled? at what version?
+  // from where?").
+  try {
+    const pkgPath = require.resolve("@ffmpeg-installer/ffmpeg/package.json");
+    const pkg = require(pkgPath);
+    let binPath = "<unknown>";
+    try {
+      // The installer's main export carries the binary path. Loading
+      // it can run a small index.js that branches by platform — no
+      // subprocess.
+      const installer = require("@ffmpeg-installer/ffmpeg");
+      binPath = installer?.path || "<unknown>";
+    } catch {
+      // Platform-specific binary package not installed for this
+      // platform — fall through with binPath unset.
+    }
+    return {
+      name: "ffmpeg",
+      version: `@ffmpeg-installer/ffmpeg ${pkg.version}`,
+      notes: `bundled binary: ${binPath}`,
+    };
+  } catch {
+    return { name: "ffmpeg", version: "<bundled installer not found>" };
+  }
+}
+
+function probeAppium(): ToolResult {
+  return probeFromPackageJson("appium", "appium", "from");
+}
+
+// Returns the list of known Appium driver packages with their
+// installed versions, read straight from each package's package.json.
+// Replaces an earlier `npx --no-install appium driver list` spawn that
+// could have executed a project-local `node_modules/.bin/appium`.
+//
+// The candidate list mirrors the drivers Doc Detective itself depends
+// on (`appium-chromium-driver`, `appium-geckodriver`,
+// `appium-safari-driver`). Drivers installed via Appium's own
+// extension manager into `~/.appium/node_modules` are NOT enumerated
+// here — they'd require parsing `~/.appium/extensions.yaml`, which
+// is a follow-up if it turns out to be useful.
+export async function probeAppiumDrivers(): Promise<string> {
+  const candidates = [
+    "appium-chromium-driver",
+    "appium-geckodriver",
+    "appium-safari-driver",
+  ];
+  const lines: string[] = [];
+  for (const name of candidates) {
+    const result = probeFromPackageJson(name, name);
+    lines.push(`${result.name} ${result.version}`);
+  }
+  return lines.join("\n");
+}

--- a/src/debug/tools.ts
+++ b/src/debug/tools.ts
@@ -182,28 +182,3 @@ function probeFfmpeg(): ToolResult {
 function probeAppium(): ToolResult {
   return probeFromPackageJson("appium", "appium", "from");
 }
-
-// Returns the list of known Appium driver packages with their
-// installed versions, read straight from each package's package.json.
-// Replaces an earlier `npx --no-install appium driver list` spawn that
-// could have executed a project-local `node_modules/.bin/appium`.
-//
-// The candidate list mirrors the drivers Doc Detective itself depends
-// on (`appium-chromium-driver`, `appium-geckodriver`,
-// `appium-safari-driver`). Drivers installed via Appium's own
-// extension manager into `~/.appium/node_modules` are NOT enumerated
-// here — they'd require parsing `~/.appium/extensions.yaml`, which
-// is a follow-up if it turns out to be useful.
-export async function probeAppiumDrivers(): Promise<string> {
-  const candidates = [
-    "appium-chromium-driver",
-    "appium-geckodriver",
-    "appium-safari-driver",
-  ];
-  const lines: string[] = [];
-  for (const name of candidates) {
-    const result = probeFromPackageJson(name, name);
-    lines.push(`${result.name} ${result.version}`);
-  }
-  return lines.join("\n");
-}

--- a/src/debug/tools.ts
+++ b/src/debug/tools.ts
@@ -2,16 +2,16 @@
 //
 // Two flavors of probe:
 //   1. Spawn-based (`probeTool`) — runs `<binary> --version` with a
-//      hard timeout (default 3000 ms). Used ONLY for system binaries
-//      whose path comes from PATH (node, npm, npx, git, docker, java,
-//      python). PATH is system-level and trusted.
-//   2. Package-read (`probeFromPackageJson`) — reads `version` from a
-//      named package's `package.json` via `require.resolve`. Used for
-//      anything that would otherwise route through a project-local
-//      `node_modules/.bin` binary (appium, appium drivers, ffmpeg
-//      bundled by @ffmpeg-installer). Avoids executing project-local
-//      binaries just to collect diagnostics — a compromised
-//      `node_modules/.bin/appium` would otherwise run on
+//      hard timeout (default 3000 ms). Used for system binaries (node,
+//      npm, npx, git, docker, java, python). To keep with the
+//      "don't execute project-local binaries" model, the spawn runs with
+//      a PATH that has any `node_modules/.bin` segments stripped, so a
+//      repo-local shim (common when launched from an npm/yarn/pnpm
+//      script, which prepends `node_modules/.bin`) can't shadow a system
+//      tool during diagnostics.
+//   2. Metadata-read (`resolveHeavyDep*`) — reads `version` from a named
+//      package's `package.json` without executing it. Used for appium and
+//      ffmpeg so a compromised `node_modules/.bin/<tool>` doesn't run on
 //      `doc-detective debug`.
 //
 // All spawn-based probes use `shell: true` for PATH lookup consistency
@@ -27,6 +27,21 @@ import {
 } from "../runtime/loader.js";
 
 const require = createRequire(import.meta.url);
+
+// Return a copy of `process.env` whose PATH has any `node_modules/.bin`
+// segments removed, so a repo-local shim can't shadow a system tool the
+// probes invoke by bare name. Exported for testing.
+export function envWithoutNodeModulesBin(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  const pathKey = Object.keys(env).find((k) => k.toLowerCase() === "path");
+  if (pathKey && typeof env[pathKey] === "string") {
+    env[pathKey] = (env[pathKey] as string)
+      .split(path.delimiter)
+      .filter((seg) => !/[\\/]node_modules[\\/]\.bin([\\/]|$)/i.test(seg))
+      .join(path.delimiter);
+  }
+  return env;
+}
 
 export interface ToolResult {
   name: string;
@@ -81,7 +96,10 @@ function runWithTimeout(
   timeoutMs: number
 ): Promise<{ stdout: string; stderr: string; exitCode: number; timedOut: boolean }> {
   return new Promise((resolve) => {
-    const child = spawn(command, { shell: true });
+    const child = spawn(command, {
+      shell: true,
+      env: envWithoutNodeModulesBin(),
+    });
     let stdout = "";
     let stderr = "";
     let settled = false;

--- a/src/hints/hints.ts
+++ b/src/hints/hints.ts
@@ -348,6 +348,24 @@ export const HINTS: Hint[] = [
   },
 
   // ------------------------------------------------------------------
+  // useDebugFlag (current-run problem)
+  // ------------------------------------------------------------------
+  {
+    id: "useDebugFlag",
+    priority: 20,
+    markdown: [
+      "Stuck on a setup problem? `doc-detective debug` captures your OS, Doc Detective version, browsers, tool versions, and any env vars referenced by your config:",
+      "",
+      "```bash",
+      "doc-detective debug",
+      "```",
+      "",
+      "Review the output before pasting into a bug report — secrets are best-effort-redacted by name and value shape, but values with novel names or shapes (custom URL-style connection strings, in-house token formats) may slip through. `--include-env` opts into a full `process.env` dump if you need it.",
+    ].join("\n"),
+    when: (ctx) => ctx.failedCount > 0,
+  },
+
+  // ------------------------------------------------------------------
   // useDryRunToDebugNoTests (current-run problem)
   // ------------------------------------------------------------------
   {

--- a/src/runtime/installer.ts
+++ b/src/runtime/installer.ts
@@ -10,6 +10,8 @@ import {
 } from "./cacheDir.js";
 import {
   ensureRuntimeInstalled,
+  resolveHeavyDepSource,
+  resolveHeavyDepVersion,
   type Logger,
   type SpawnFn,
 } from "./loader.js";
@@ -232,20 +234,47 @@ export function status(ctx: CacheDirContext = {}): StatusRow[] {
         return undefined;
       }
     })();
+    // A package counts as installed when it's recorded in the cache OR
+    // resolvable from the shim's node_modules / runtime cache — the same
+    // presence check `ensureRuntimeInstalled` uses to report
+    // "already-up-to-date". Without the resolvable fallback, `status`
+    // showed `installed=—` for pre-installed optionalDependencies (and dev
+    // checkouts) that `install all` reports as present — an inconsistency.
+    //
+    // The package.json range is a constraint (e.g. ^7.0.0), not a target —
+    // string equality would flag `7.1.2` against `^7.0.0` as outdated even
+    // though npm legitimately resolved it; use a semver-range check, and
+    // only where the installer would actually act on it:
+    //   - cache record / cache resolution → freshness-checked (the
+    //     installer reinstalls a stale cache);
+    //   - shim resolution → never flagged outdated (the installer never
+    //     overrides a shim-pinned version), matching `install all`.
+    let installed = Boolean(entry);
+    let installedVersion: string | undefined = entry?.installedVersion;
+    let outdated = Boolean(
+      entry && expected && !satisfiesRange(entry.installedVersion, expected)
+    );
+    if (!installed) {
+      const source = resolveHeavyDepSource(name, ctx);
+      if (source) {
+        installed = true;
+        installedVersion = resolveHeavyDepVersion(name, ctx) ?? undefined;
+        outdated =
+          source === "cache" &&
+          Boolean(
+            installedVersion &&
+              expected &&
+              !satisfiesRange(installedVersion, expected)
+          );
+      }
+    }
     rows.push({
       assetId: name,
       kind: "npm",
-      installed: Boolean(entry),
-      installedVersion: entry?.installedVersion,
+      installed,
+      installedVersion,
       expectedVersion: expected,
-      // The package.json range is a constraint (e.g. ^7.0.0), not a
-      // target — string equality would flag `7.1.2` against `^7.0.0` as
-      // outdated even though npm legitimately resolved it. Use a small
-      // semver-range check instead; missing data degrades to "not
-      // outdated" so we don't surface false positives.
-      outdated: Boolean(
-        entry && expected && !satisfiesRange(entry.installedVersion, expected)
-      ),
+      outdated,
     });
   }
   for (const name of Object.keys(BROWSER_CHANNELS) as BrowserAssetName[]) {

--- a/src/runtime/installer.ts
+++ b/src/runtime/installer.ts
@@ -249,24 +249,30 @@ export function status(ctx: CacheDirContext = {}): StatusRow[] {
     //     installer reinstalls a stale cache);
     //   - shim resolution → never flagged outdated (the installer never
     //     overrides a shim-pinned version), matching `install all`.
-    let installed = Boolean(entry);
-    let installedVersion: string | undefined = entry?.installedVersion;
-    let outdated = Boolean(
-      entry && expected && !satisfiesRange(entry.installedVersion, expected)
-    );
-    if (!installed) {
-      const source = resolveHeavyDepSource(name, ctx);
-      if (source) {
-        installed = true;
-        installedVersion = resolveHeavyDepVersion(name, ctx) ?? undefined;
-        outdated =
-          source === "cache" &&
-          Boolean(
-            installedVersion &&
-              expected &&
-              !satisfiesRange(installedVersion, expected)
-          );
-      }
+    // Mirror the runtime resolution order: the shim's node_modules wins
+    // over the cache. A shim-resolved package is never "outdated" because
+    // ensureRuntimeInstalled never overrides a shim-pinned version — so a
+    // stale cache record must NOT flag a shim-resolved dep as outdated.
+    // Only genuine cache installs are freshness-checked against the range.
+    const source = resolveHeavyDepSource(name, ctx);
+    let installed = false;
+    let installedVersion: string | undefined;
+    let outdated = false;
+    if (source === "shim") {
+      installed = true;
+      installedVersion = resolveHeavyDepVersion(name, ctx) ?? undefined;
+    } else if (entry) {
+      installed = true;
+      installedVersion = entry.installedVersion;
+      outdated = Boolean(expected && !satisfiesRange(entry.installedVersion, expected));
+    } else if (source === "cache") {
+      // Resolvable in the cache but no record entry (edge case) — still a
+      // cache install, so apply the same freshness check.
+      installed = true;
+      installedVersion = resolveHeavyDepVersion(name, ctx) ?? undefined;
+      outdated = Boolean(
+        installedVersion && expected && !satisfiesRange(installedVersion, expected)
+      );
     }
     rows.push({
       assetId: name,

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -90,6 +90,59 @@ export function resolveHeavyDepPath(
 }
 
 /**
+ * Where a heavy dep resolves from, or `null` if it doesn't resolve.
+ * "shim" = the doc-detective package's own node_modules (a pre-installed
+ * optionalDependency or dev checkout); "cache" = <cacheDir>/runtime. The
+ * distinction matters for freshness: `ensureRuntimeInstalled` never
+ * overrides a shim-resolved version but DOES reinstall a stale cache, so
+ * callers reporting "outdated" must only apply the declared-range check to
+ * cache resolutions.
+ */
+export function resolveHeavyDepSource(
+  name: string,
+  ctx: CacheDirContext = {}
+): "shim" | "cache" | null {
+  if (tryResolveFromShim(name)) return "shim";
+  if (tryResolveFromCache(name, ctx)) return "cache";
+  return null;
+}
+
+/**
+ * Read the installed version of a heavy dep that's resolvable (shim
+ * node_modules OR runtime cache) but may not be recorded in
+ * <cacheDir>/installed.json — e.g. a pre-installed optionalDependency or a
+ * dev checkout. Walks up from the resolved entry to the package's own
+ * package.json (the first one whose `name` matches, so a nested
+ * `dist/package.json` with only `{"type":"module"}` is skipped). Returns
+ * `null` when the dep isn't resolvable or the version can't be read.
+ */
+export function resolveHeavyDepVersion(
+  name: string,
+  ctx: CacheDirContext = {}
+): string | null {
+  const entry = resolveHeavyDepPath(name, ctx);
+  if (!entry) return null;
+  let dir = path.dirname(entry);
+  for (let i = 0; i < 12; i++) {
+    const pkgJsonPath = path.join(dir, "package.json");
+    try {
+      if (fs.existsSync(pkgJsonPath)) {
+        const parsed = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+        if (parsed?.name === name && typeof parsed.version === "string") {
+          return parsed.version;
+        }
+      }
+    } catch {
+      // Unreadable / malformed package.json — keep walking.
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
  * Resolve and import a heavy dep, lazy-installing into <cacheDir>/runtime
  * if neither the shim's node_modules nor the cache currently has it. The
  * shim's own node_modules wins so a user who kept the optionalDependency

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,22 @@ export {
   reportResults,
   reporters,
   registerReporter,
+  isDebugRequested,
 };
+
+// True when `DOC_DETECTIVE_DEBUG` env var is set to a truthy value.
+// Used by `runTestsHandler` in cli.ts to decide whether to catch
+// setConfig failures and still emit a diagnostic dump.
+//
+// The `--debug` CLI flag was retired in favor of the dedicated
+// `doc-detective debug` subcommand; the subcommand handler does its
+// own setConfig-error handling, so this helper is now env-var-only.
+//
+// `args` is accepted for signature stability but no longer consulted.
+function isDebugRequested(_args: any = {}): boolean {
+  const envVal = process.env.DOC_DETECTIVE_DEBUG;
+  return typeof envVal === "string" && /^(1|true|yes)$/i.test(envVal);
+}
 
 // Log function that respects logLevel
 function log(message: any, level: string = "info", config: any = {}) {
@@ -220,19 +235,19 @@ async function getConfigFromEnv() {
     });
 
     if (!envValidation.valid) {
-      console.error(
-        "Invalid config from DOC_DETECTIVE_CONFIG environment variable.",
-        envValidation.errors
+      throw new Error(
+        `Invalid config from DOC_DETECTIVE_CONFIG environment variable. ${envValidation.errors}`
       );
-      process.exit(1);
     }
 
     log(`CLI:ENV_CONFIG:\n${JSON.stringify(envConfig, null, 2)}`, "debug", envConfig);
   } catch (error: any) {
-    console.error(
-      `Error parsing DOC_DETECTIVE_CONFIG environment variable: ${error.message}`
-    );
-    process.exit(1);
+    if (error instanceof SyntaxError) {
+      throw new Error(
+        `Error parsing DOC_DETECTIVE_CONFIG environment variable: ${error.message}`
+      );
+    }
+    throw error;
   }
   return envConfig;
 }
@@ -267,9 +282,7 @@ async function setConfig({ configPath, args }: { configPath?: any; args: any }) 
     object: config,
   });
   if (!validation.valid) {
-    // Output validation errors
-    console.error("Invalid config.", validation.errors);
-    process.exit(1);
+    throw new Error(`Invalid config. ${validation.errors}`);
   }
 
   // Accept coerced and defaulted values

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -228,6 +228,15 @@ async function getConfigFromEnv() {
     // Parse the environment variable as JSON
     envConfig = JSON.parse(process.env.DOC_DETECTIVE_CONFIG);
 
+    // JSON.parse legally yields non-objects (null, arrays, primitives).
+    // validate() would then throw a generic "Object is required." that
+    // doesn't point at the env var — give a targeted message instead.
+    if (envConfig === null || typeof envConfig !== "object" || Array.isArray(envConfig)) {
+      throw new Error(
+        "DOC_DETECTIVE_CONFIG environment variable must be a JSON object."
+      );
+    }
+
     // Validate the environment variable config
     const envValidation = validate({
       schemaKey: "config_v3",
@@ -258,14 +267,27 @@ async function setConfig({ configPath, args }: { configPath?: any; args: any }) 
     configPath = args.config;
   }
 
-  // If config file exists, read it
+  // If a config path is given, read it. `readFile` returns null on a read
+  // failure (missing/unreadable file) and may throw on bad input; in both
+  // cases throw a clear error rather than letting a null config fall
+  // through to a generic "Object is required." validation message. Throwing
+  // (rather than returning null) means an unreadable / mistyped config path
+  // follows the same error path as a validation failure: the normal run
+  // exits non-zero via the top-level catch, and the debug flows render it
+  // under the CONFIG INVALID banner.
   let config: any = {};
   if (configPath) {
     try {
       config = await readFile({ fileURLOrPath: configPath });
-    } catch (error) {
-      console.error(`Error reading config file at ${configPath}: ${error}`);
-      return null;
+    } catch (error: any) {
+      throw new Error(
+        `Error reading config file at ${configPath}: ${error?.message || error}`
+      );
+    }
+    if (config === null || config === undefined) {
+      throw new Error(
+        `Could not read config file at ${configPath}. Check that the path exists and is readable.`
+      );
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,9 +34,7 @@ export {
 // The `--debug` CLI flag was retired in favor of the dedicated
 // `doc-detective debug` subcommand; the subcommand handler does its
 // own setConfig-error handling, so this helper is now env-var-only.
-//
-// `args` is accepted for signature stability but no longer consulted.
-function isDebugRequested(_args: any = {}): boolean {
+function isDebugRequested(): boolean {
   const envVal = process.env.DOC_DETECTIVE_DEBUG;
   return typeof envVal === "string" && /^(1|true|yes)$/i.test(envVal);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,9 @@ export {
 // own setConfig-error handling, so this helper is now env-var-only.
 function isDebugRequested(): boolean {
   const envVal = process.env.DOC_DETECTIVE_DEBUG;
-  return typeof envVal === "string" && /^(1|true|yes)$/i.test(envVal);
+  // Trim so a templated/copy-pasted value with stray whitespace (e.g.
+  // `"true "`) still activates debug mode.
+  return typeof envVal === "string" && /^(1|true|yes)$/i.test(envVal.trim());
 }
 
 // Log function that respects logLevel

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -110,6 +110,18 @@ describe("debug/redact", function () {
     // Anchored suffixes don't false-positive on similar prefixes
     expect(isSecretName("PASSAGE")).to.equal(false);
     expect(isSecretName("PASSPORT")).to.equal(false);
+    // `key` matches tokenized/CamelCase forms, not the raw substring.
+    expect(isSecretName("MONKEY")).to.equal(false);
+    expect(isSecretName("hockeyStats")).to.equal(false);
+    expect(isSecretName("keyboard")).to.equal(false);
+  });
+
+  it("flags tokenized and CamelCase `key` names", function () {
+    expect(isSecretName("API_KEY")).to.equal(true);
+    expect(isSecretName("api-key")).to.equal(true);
+    expect(isSecretName("key")).to.equal(true);
+    expect(isSecretName("apiKey")).to.equal(true);
+    expect(isSecretName("accessKey")).to.equal(true);
   });
 
   it("redacts values containing URL userinfo regardless of name", function () {

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -457,6 +457,49 @@ describe("debug/printDebug end-to-end", function () {
     // System info markers
     expect(text).to.match(/platform\s+\w+/);
     expect(text).to.match(/nodeVersion\s+v\d+\./);
+
+    // Browsers section always enumerates all three supported browsers with
+    // an explicit availability status and per-component breakdown.
+    expect(text).to.match(/\n\s+chrome\s+(AVAILABLE|NOT AVAILABLE)/);
+    expect(text).to.match(/\n\s+firefox\s+(AVAILABLE|NOT AVAILABLE)/);
+    // platform: linux -> Safari is unsupported.
+    expect(text).to.match(/\n\s+safari\s+NOT SUPPORTED/);
+    expect(text).to.include("appium-chromium-driver:");
+    expect(text).to.include("geckodriver:");
+    expect(text).to.include("safaridriver:");
+  });
+
+  it("writes the dump to outFile when provided (and not when omitted)", async function () {
+    this.timeout(60000);
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-outfile-"));
+    try {
+      const outFile = path.join(tmp, ".doc-detective", "debug.txt");
+      const out = [];
+      await printDebug({
+        config: { input: ".", environment: { platform: "linux" } },
+        configPath: null,
+        outFile,
+        print: (line) => out.push(line),
+      });
+      // File written, parent dir created, content matches the dump.
+      expect(fs.existsSync(outFile)).to.equal(true);
+      const fileContent = fs.readFileSync(outFile, "utf8");
+      expect(fileContent).to.include("Doc Detective diagnostic dump");
+      expect(fileContent).to.include("-- Browsers ");
+      // stdout gets a save-confirmation line pointing at the file.
+      expect(out.join("\n")).to.include(`Diagnostic dump saved to ${outFile}`);
+
+      // Omitting outFile must not write anything (no side effects in tests).
+      const before = fs.readdirSync(tmp);
+      await printDebug({
+        config: { input: ".", environment: { platform: "linux" } },
+        configPath: null,
+        print: () => {},
+      });
+      expect(fs.readdirSync(tmp)).to.deep.equal(before);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it("surfaces the CONFIG INVALID banner when configError is set", async function () {
@@ -594,6 +637,15 @@ describe("debug CLI smoke test", function () {
       expect(result.stdout).to.include(
         "-- Referenced environment variables "
       );
+      // The dump is also saved to <cwd>/.doc-detective/debug.txt.
+      const savedPath = path.join(tmp, ".doc-detective", "debug.txt");
+      expect(fs.existsSync(savedPath), "debug.txt should be saved in cwd").to.equal(
+        true
+      );
+      expect(fs.readFileSync(savedPath, "utf8")).to.include(
+        "Doc Detective diagnostic dump"
+      );
+      expect(result.stdout).to.include("Diagnostic dump saved to");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -409,6 +409,21 @@ describe("debug/tools", function () {
     expect(result.version).to.match(/<not found>|<probe failed>|<timed out/);
   });
 
+  it("suppresses the noisy 'command not found' note for a missing binary", async function () {
+    this.timeout(5000);
+    // The OS "not recognized"/"command not found" message is a truncated,
+    // comma-dangling fragment — `<not found>` already conveys absence, so
+    // no note should be attached (regression: java showed a half-sentence).
+    const result = await probeTool(
+      "definitely-not-a-real-binary",
+      "definitely-not-a-real-binary --version",
+      { timeoutMs: 2000 }
+    );
+    if (result.version === "<not found>") {
+      expect(result.notes).to.equal(undefined);
+    }
+  });
+
   it("returns process.version-style output for a real binary (node)", async function () {
     this.timeout(5000);
     const result = await probeTool("node", "node --version", { timeoutMs: 3000 });
@@ -457,6 +472,9 @@ describe("debug/printDebug end-to-end", function () {
     // System info markers
     expect(text).to.match(/platform\s+\w+/);
     expect(text).to.match(/nodeVersion\s+v\d+\./);
+    // Doc Detective section surfaces where the running package loaded from.
+    expect(text).to.match(/loadedFrom\s+\S/);
+    expect(text).to.match(/entryPoint\s+\S/);
 
     // Browsers section always enumerates all three supported browsers with
     // an explicit availability status and per-component breakdown.
@@ -498,6 +516,63 @@ describe("debug/printDebug end-to-end", function () {
       });
       expect(fs.readdirSync(tmp)).to.deep.equal(before);
     } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("writes structured, redacted JSON to jsonOutFile", async function () {
+    this.timeout(60000);
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-json-"));
+    const prev = process.env.DD_TEST_JSON_CONN;
+    process.env.DD_TEST_JSON_CONN = "postgres://app:hunter2@db.example.com/prod";
+    try {
+      const jsonOutFile = path.join(tmp, ".doc-detective", "debug.json");
+      const out = [];
+      await printDebug({
+        config: {
+          input: ".",
+          environment: { platform: "linux" },
+          integrations: { docDetectiveApi: { apiKey: "supersecret-key" } },
+        },
+        configPath: null,
+        includeEnv: true,
+        jsonOutFile,
+        print: (line) => out.push(line),
+      });
+      expect(fs.existsSync(jsonOutFile)).to.equal(true);
+      const data = JSON.parse(fs.readFileSync(jsonOutFile, "utf8"));
+
+      // Structured top-level shape.
+      expect(data).to.include.keys(
+        "system",
+        "docDetective",
+        "tools",
+        "browsers",
+        "container",
+        "environment",
+        "config"
+      );
+      // Where doc-detective loaded from is captured.
+      expect(data.docDetective.loadedFrom).to.be.a("string");
+      expect(data.docDetective.entryPoint).to.be.a("string");
+      // Browsers enumerated structurally with availability flags.
+      expect(data.browsers.browsers.map((b) => b.name)).to.deep.equal([
+        "chrome",
+        "firefox",
+        "safari",
+      ]);
+      // Redaction carries into JSON: no secrets in the serialized form.
+      const serialized = JSON.stringify(data);
+      expect(serialized).to.not.include("hunter2");
+      expect(serialized).to.not.include("supersecret-key");
+      expect(data.config.redacted.integrations.docDetectiveApi.apiKey).to.match(
+        /redacted/
+      );
+      // stdout reports the JSON save path.
+      expect(out.join("\n")).to.include(`Diagnostic JSON saved to ${jsonOutFile}`);
+    } finally {
+      if (prev === undefined) delete process.env.DD_TEST_JSON_CONN;
+      else process.env.DD_TEST_JSON_CONN = prev;
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
@@ -637,7 +712,7 @@ describe("debug CLI smoke test", function () {
       expect(result.stdout).to.include(
         "-- Referenced environment variables "
       );
-      // The dump is also saved to <cwd>/.doc-detective/debug.txt.
+      // The dump is also saved to <cwd>/.doc-detective/ as text + JSON.
       const savedPath = path.join(tmp, ".doc-detective", "debug.txt");
       expect(fs.existsSync(savedPath), "debug.txt should be saved in cwd").to.equal(
         true
@@ -646,6 +721,14 @@ describe("debug CLI smoke test", function () {
         "Doc Detective diagnostic dump"
       );
       expect(result.stdout).to.include("Diagnostic dump saved to");
+
+      const jsonPath = path.join(tmp, ".doc-detective", "debug.json");
+      expect(fs.existsSync(jsonPath), "debug.json should be saved in cwd").to.equal(
+        true
+      );
+      const parsed = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+      expect(parsed).to.include.keys("system", "docDetective", "browsers");
+      expect(result.stdout).to.include("Diagnostic JSON saved to");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -17,10 +17,34 @@ before(async function () {
 });
 
 describe("debug/redact", function () {
-  let redactValue, isSecretName, isSecretValue, redactObject;
+  let redactValue, isSecretName, isSecretValue, redactObject, redactArg;
   before(async function () {
-    ({ redactValue, isSecretName, isSecretValue, redactObject } =
+    ({ redactValue, isSecretName, isSecretValue, redactObject, redactArg } =
       await import("../dist/debug/redact.js"));
+  });
+
+  describe("redactArg", function () {
+    it("redacts secret-named --flag=value pairs but keeps the flag", function () {
+      expect(redactArg("--token=ghp_secretvalue")).to.match(
+        /^--token=\*{3}redacted/
+      );
+      expect(redactArg("--api-key=abc123")).to.match(/^--api-key=\*{3}redacted/);
+    });
+
+    it("redacts credential-shaped values regardless of flag name", function () {
+      expect(redactArg("--db=postgres://u:pw@host/db")).to.match(
+        /^--db=\*{3}redacted .*value shape/
+      );
+      const bareJwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.dummysig12345";
+      expect(redactArg(bareJwt)).to.match(/^\*{3}redacted .*value shape/);
+    });
+
+    it("passes through node/entry paths and ordinary flags/values", function () {
+      expect(redactArg("/usr/bin/node")).to.equal("/usr/bin/node");
+      expect(redactArg("debug")).to.equal("debug");
+      expect(redactArg("--include-env")).to.equal("--include-env");
+      expect(redactArg("--logLevel=info")).to.equal("--logLevel=info");
+    });
   });
 
   it("redacts classic secret-looking names case-insensitively", function () {

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -536,8 +536,9 @@ describe("debug/printDebug end-to-end", function () {
     });
     const text = out.join("\n");
 
-    // Header banner
+    // Header banner + generated-at timestamp at the top.
     expect(text).to.include("Doc Detective diagnostic dump");
+    expect(text).to.match(/Generated: \d{4}-\d{2}-\d{2}T[\d:.]+Z/);
     // Each section header
     expect(text).to.include("-- System ");
     expect(text).to.include("-- Doc Detective ");
@@ -564,46 +565,59 @@ describe("debug/printDebug end-to-end", function () {
     expect(text).to.include("safaridriver:");
   });
 
-  it("writes the dump to outFile when provided (and not when omitted)", async function () {
+  it("writes timestamped dump files to outDir, matching the header timestamp (and nothing when omitted)", async function () {
     this.timeout(60000);
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-outfile-"));
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-outdir-"));
     try {
-      const outFile = path.join(tmp, ".doc-detective", "debug.txt");
+      const outDir = path.join(tmp, ".doc-detective");
       const out = [];
       await printDebug({
         config: { input: ".", environment: { platform: "linux" } },
         configPath: null,
-        outFile,
+        outDir,
         print: (line) => out.push(line),
       });
-      // File written, parent dir created, content matches the dump.
-      expect(fs.existsSync(outFile)).to.equal(true);
-      const fileContent = fs.readFileSync(outFile, "utf8");
-      expect(fileContent).to.include("Doc Detective diagnostic dump");
-      expect(fileContent).to.include("-- Browsers ");
-      // stdout gets a save-confirmation line pointing at the file.
-      expect(out.join("\n")).to.include(`Diagnostic dump saved to ${outFile}`);
+      // Two timestamped files written, parent dir created.
+      const files = fs.readdirSync(outDir);
+      const txt = files.find((f) => /^debug-.+\.txt$/.test(f));
+      const json = files.find((f) => /^debug-.+\.json$/.test(f));
+      expect(txt, "timestamped .txt written").to.be.a("string");
+      expect(json, "timestamped .json written").to.be.a("string");
+      // Both files share the SAME timestamp token.
+      const stamp = txt.replace(/^debug-/, "").replace(/\.txt$/, "");
+      expect(json).to.equal(`debug-${stamp}.json`);
 
-      // Omitting outFile must not write anything (no side effects in tests).
-      const before = fs.readdirSync(tmp);
+      const content = fs.readFileSync(path.join(outDir, txt), "utf8");
+      expect(content).to.include("Doc Detective diagnostic dump");
+      expect(content).to.include("-- Browsers ");
+      // The "Generated:" header timestamp is the same instant as the
+      // filename timestamp (filename just swaps `:`/`.` for `-`).
+      const m = content.match(/Generated: (\S+)/);
+      expect(m, "Generated: header present").to.not.equal(null);
+      expect(m[1].replace(/[:.]/g, "-")).to.equal(stamp);
+      expect(out.join("\n")).to.include("Diagnostic dump saved to");
+      expect(out.join("\n")).to.include("Diagnostic JSON saved to");
+
+      // Omitting outDir must not write anything (no side effects in tests).
+      const before = fs.readdirSync(outDir);
       await printDebug({
         config: { input: ".", environment: { platform: "linux" } },
         configPath: null,
         print: () => {},
       });
-      expect(fs.readdirSync(tmp)).to.deep.equal(before);
+      expect(fs.readdirSync(outDir)).to.deep.equal(before);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
 
-  it("writes structured, redacted JSON to jsonOutFile", async function () {
+  it("writes structured, redacted JSON to the timestamped outDir file", async function () {
     this.timeout(60000);
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-json-"));
     const prev = process.env.DD_TEST_JSON_CONN;
     process.env.DD_TEST_JSON_CONN = "postgres://app:hunter2@db.example.com/prod";
     try {
-      const jsonOutFile = path.join(tmp, ".doc-detective", "debug.json");
+      const outDir = path.join(tmp, ".doc-detective");
       const out = [];
       await printDebug({
         config: {
@@ -613,11 +627,14 @@ describe("debug/printDebug end-to-end", function () {
         },
         configPath: null,
         includeEnv: true,
-        jsonOutFile,
+        outDir,
         print: (line) => out.push(line),
       });
-      expect(fs.existsSync(jsonOutFile)).to.equal(true);
-      const data = JSON.parse(fs.readFileSync(jsonOutFile, "utf8"));
+      const jsonName = fs
+        .readdirSync(outDir)
+        .find((f) => /^debug-.+\.json$/.test(f));
+      expect(jsonName, "timestamped .json written").to.be.a("string");
+      const data = JSON.parse(fs.readFileSync(path.join(outDir, jsonName), "utf8"));
 
       // Structured top-level shape.
       expect(data).to.include.keys(
@@ -646,7 +663,7 @@ describe("debug/printDebug end-to-end", function () {
         /redacted/
       );
       // stdout reports the JSON save path.
-      expect(out.join("\n")).to.include(`Diagnostic JSON saved to ${jsonOutFile}`);
+      expect(out.join("\n")).to.include("Diagnostic JSON saved to");
     } finally {
       if (prev === undefined) delete process.env.DD_TEST_JSON_CONN;
       else process.env.DD_TEST_JSON_CONN = prev;
@@ -828,22 +845,24 @@ describe("debug CLI smoke test", function () {
       expect(result.stdout).to.include(
         "-- Referenced environment variables "
       );
-      // The dump is also saved to <cwd>/.doc-detective/ as text + JSON.
-      const savedPath = path.join(tmp, ".doc-detective", "debug.txt");
-      expect(fs.existsSync(savedPath), "debug.txt should be saved in cwd").to.equal(
-        true
-      );
-      expect(fs.readFileSync(savedPath, "utf8")).to.include(
+      // A timestamp is printed at the top of the dump.
+      expect(result.stdout).to.match(/Generated: \S+/);
+      // The dump is also saved to <cwd>/.doc-detective/ as timestamped
+      // text + JSON files (debug-<timestamp>.txt / .json).
+      const savedDir = path.join(tmp, ".doc-detective");
+      const saved = fs.readdirSync(savedDir);
+      const txtName = saved.find((f) => /^debug-.+\.txt$/.test(f));
+      const jsonName = saved.find((f) => /^debug-.+\.json$/.test(f));
+      expect(txtName, "debug-<ts>.txt should be saved in cwd").to.be.a("string");
+      expect(jsonName, "debug-<ts>.json should be saved in cwd").to.be.a("string");
+      expect(fs.readFileSync(path.join(savedDir, txtName), "utf8")).to.include(
         "Doc Detective diagnostic dump"
       );
-      expect(result.stdout).to.include("Diagnostic dump saved to");
-
-      const jsonPath = path.join(tmp, ".doc-detective", "debug.json");
-      expect(fs.existsSync(jsonPath), "debug.json should be saved in cwd").to.equal(
-        true
+      const parsed = JSON.parse(
+        fs.readFileSync(path.join(savedDir, jsonName), "utf8")
       );
-      const parsed = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
       expect(parsed).to.include.keys("system", "docDetective", "browsers");
+      expect(result.stdout).to.include("Diagnostic dump saved to");
       expect(result.stdout).to.include("Diagnostic JSON saved to");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -577,6 +577,45 @@ describe("debug/printDebug end-to-end", function () {
     }
   });
 
+  it("browser binaries are read from the install record (matches `doc-detective install`)", async function () {
+    this.timeout(60000);
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-record-"));
+    try {
+      // Craft an installed.json the way the installer writes it, then point
+      // config.cacheDir at it. The browser section must reflect THIS record
+      // (the same source `doc-detective install` / `install status` read),
+      // not a live browser-cache scan.
+      fs.writeFileSync(
+        path.join(tmp, "installed.json"),
+        JSON.stringify({
+          npmPackages: {},
+          browsers: {
+            chrome: { installedVersion: "140.0.test", installedAt: "now" },
+            chromedriver: { installedVersion: "140.0.test", installedAt: "now" },
+          },
+        })
+      );
+      const out = [];
+      await printDebug({
+        config: {
+          input: ".",
+          environment: { platform: "linux" },
+          cacheDir: tmp,
+        },
+        configPath: null,
+        print: (line) => out.push(line),
+      });
+      const text = out.join("\n");
+      // chrome browser + chromedriver reflect the record's versions.
+      expect(text).to.match(/chrome browser:\s+installed\s+140\.0\.test/);
+      expect(text).to.match(/chromedriver:\s+installed\s+140\.0\.test/);
+      // firefox browser is absent from the record -> reported not installed.
+      expect(text).to.match(/firefox browser:\s+not installed/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("surfaces the CONFIG INVALID banner when configError is set", async function () {
     this.timeout(60000);
     const out = [];

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -383,6 +383,10 @@ describe("debug/envvars", function () {
       "txt",
     ]);
 
+    // The schema allows `extensions` as a string too (e.g. `"ipynb"`).
+    const fromStringExt = resolveDocExtensions([{ extensions: ".IPYNB" }]);
+    expect(fromStringExt.has("ipynb")).to.equal(true);
+
     // Absent / empty / unrecognized → union of all known doc extensions.
     const fallback = resolveDocExtensions(undefined);
     expect(fallback.has("md")).to.equal(true);
@@ -390,6 +394,28 @@ describe("debug/envvars", function () {
     expect(fallback.has("html")).to.equal(true);
     expect(fallback.has("dita")).to.equal(true);
     expect(resolveDocExtensions(["nonexistent-type"]).has("md")).to.equal(true);
+  });
+
+  it("enumerateInputFiles terminates on a symlinked directory cycle", function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-cycle-"));
+    try {
+      const sub = path.join(tmp, "sub");
+      fs.mkdirSync(sub);
+      fs.writeFileSync(path.join(sub, "a.txt"), "alpha");
+      // `sub/loop -> tmp` makes a cycle: tmp/sub/loop/sub/loop/... Skip the
+      // test where the OS won't let us create a directory symlink (Windows
+      // without Developer Mode / admin).
+      try {
+        fs.symlinkSync(tmp, path.join(sub, "loop"), "dir");
+      } catch {
+        this.skip();
+      }
+      // Must return (not hang) thanks to the visited-dir guard.
+      const files = enumerateInputFiles([tmp], 100);
+      expect(files.some((f) => f.endsWith("a.txt"))).to.equal(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -138,6 +138,16 @@ describe("debug/redact", function () {
     expect(isSecretValue("ghp_short")).to.equal(false);
   });
 
+  it("redacts GitHub fine-grained PAT-shaped values (github_pat_…)", function () {
+    const fakeFineGrained = "github_pat_" + "A".repeat(82);
+    expect(isSecretValue(fakeFineGrained)).to.equal(true);
+    // Even under an innocuous name, the value shape catches it.
+    expect(redactValue("GITHUB_PAT", fakeFineGrained)).to.match(
+      /^\*{3}redacted/
+    );
+    expect(isSecretValue("github_pat_short")).to.equal(false);
+  });
+
   it("redacts AWS access key ID-shaped values regardless of name", function () {
     expect(isSecretValue("AKIAIOSFODNN7EXAMPLE")).to.equal(true);
     expect(isSecretValue("ASIAIOSFODNN7EXAMPLE")).to.equal(true);

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -1,0 +1,651 @@
+// Unit + integration tests for the `--debug` / `DOC_DETECTIVE_DEBUG`
+// diagnostic dump.
+//
+// Covers the pure helpers (redactValue, findReferencedEnvVars,
+// detectContainer, enumerateInputFiles), an end-to-end printDebug call
+// against an in-memory print sink, and a smoke test that runs the CLI
+// in --debug mode and asserts on the rendered output + exit code.
+
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { spawnSync } from "node:child_process";
+
+before(async function () {
+  const { expect } = await import("chai");
+  global.expect = expect;
+});
+
+describe("debug/redact", function () {
+  let redactValue, isSecretName, isSecretValue, redactObject;
+  before(async function () {
+    ({ redactValue, isSecretName, isSecretValue, redactObject } =
+      await import("../dist/debug/redact.js"));
+  });
+
+  it("redacts classic secret-looking names case-insensitively", function () {
+    expect(isSecretName("MY_TOKEN")).to.equal(true);
+    expect(isSecretName("api_key")).to.equal(true);
+    expect(isSecretName("DB_PASSWORD")).to.equal(true);
+    expect(isSecretName("AUTH_HEADER")).to.equal(true);
+    expect(isSecretName("Bearer")).to.equal(true);
+    expect(isSecretName("MyCredential")).to.equal(true);
+  });
+
+  it("redacts connection-string-style suffix names", function () {
+    // _URL / _URI / _DSN: PaaS credential conventions
+    expect(isSecretName("DATABASE_URL")).to.equal(true);
+    expect(isSecretName("MONGODB_URI")).to.equal(true);
+    expect(isSecretName("REDIS_URL")).to.equal(true);
+    expect(isSecretName("POSTGRES_URL")).to.equal(true);
+    expect(isSecretName("SENTRY_DSN")).to.equal(true);
+    // _PASS / _PASSWD / _PWD
+    expect(isSecretName("SMTP_PASS")).to.equal(true);
+    expect(isSecretName("DB_PASSWD")).to.equal(true);
+    expect(isSecretName("MAIL_PWD")).to.equal(true);
+    // WEBHOOK substring
+    expect(isSecretName("SLACK_WEBHOOK_URL")).to.equal(true);
+    expect(isSecretName("DISCORD_WEBHOOK")).to.equal(true);
+    // Bare JWT / PAT
+    expect(isSecretName("JWT")).to.equal(true);
+    expect(isSecretName("PAT")).to.equal(true);
+    expect(isSecretName("jwt")).to.equal(true);
+  });
+
+  it("does not flag non-secret names", function () {
+    expect(isSecretName("LOG_LEVEL")).to.equal(false);
+    expect(isSecretName("HOME")).to.equal(false);
+    expect(isSecretName("PATH")).to.equal(false);
+    // Anchored suffixes don't false-positive on similar prefixes
+    expect(isSecretName("PASSAGE")).to.equal(false);
+    expect(isSecretName("PASSPORT")).to.equal(false);
+  });
+
+  it("redacts values containing URL userinfo regardless of name", function () {
+    expect(
+      isSecretValue("postgres://app:hunter2@db.example.com:5432/prod")
+    ).to.equal(true);
+    // Empty user, password-only (common Redis form).
+    expect(isSecretValue("redis://:pwd@127.0.0.1:6379/0")).to.equal(true);
+    expect(isSecretValue("https://user:pass@example.com/path")).to.equal(true);
+    // Plain URL — no userinfo.
+    expect(isSecretValue("https://example.com/path")).to.equal(false);
+    // Host:port is NOT userinfo (no @).
+    expect(isSecretValue("http://example.com:8080/path")).to.equal(false);
+  });
+
+  it("redacts JWT-shaped values regardless of name", function () {
+    const fakeJwt =
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.dummysignaturepart12345";
+    expect(isSecretValue(fakeJwt)).to.equal(true);
+    expect(isSecretValue("eyJfoo")).to.equal(false); // not full JWT shape
+  });
+
+  it("redacts GitHub token-shaped values regardless of name", function () {
+    const fakePat = "ghp_" + "A".repeat(36);
+    expect(isSecretValue(fakePat)).to.equal(true);
+    expect(isSecretValue("ghp_short")).to.equal(false);
+  });
+
+  it("redacts AWS access key ID-shaped values regardless of name", function () {
+    expect(isSecretValue("AKIAIOSFODNN7EXAMPLE")).to.equal(true);
+    expect(isSecretValue("ASIAIOSFODNN7EXAMPLE")).to.equal(true);
+    expect(isSecretValue("akiainvalidcasing7example")).to.equal(false);
+  });
+
+  it("redactValue: name-pattern hit shows generic redacted message", function () {
+    const out = redactValue("MY_TOKEN", "abc123");
+    expect(out).to.equal("***redacted (6 chars)***");
+  });
+
+  it("redactValue: value-shape hit shows value-shape redacted message", function () {
+    const url = "postgres://app:hunter2@db.example.com/prod";
+    const out = redactValue("INNOCENT_NAME", url);
+    expect(out).to.equal(`***redacted (${url.length} chars, value shape)***`);
+  });
+
+  it("redactValue: <unset> for undefined and <empty> for empty string", function () {
+    expect(redactValue("FOO", undefined)).to.equal("<unset>");
+    expect(redactValue("FOO", "")).to.equal("<empty>");
+  });
+
+  it("redactValue: returns non-secret values verbatim", function () {
+    expect(redactValue("LOG_LEVEL", "debug")).to.equal("debug");
+    expect(redactValue("MY_URL_TEMPLATE", "https://example.com/{id}")).to.equal(
+      "https://example.com/{id}"
+    );
+  });
+
+  describe("redactObject", function () {
+    it("redacts string values under secret-named keys", function () {
+      const out = redactObject({
+        integrations: {
+          heretto: [
+            {
+              name: "main",
+              apiToken: "abc123def",
+              username: "harold@example.com",
+            },
+          ],
+          docDetectiveApi: { apiKey: "xyz789" },
+        },
+        logLevel: "info",
+      });
+      expect(out.integrations.heretto[0].apiToken).to.equal(
+        "***redacted (9 chars)***"
+      );
+      expect(out.integrations.docDetectiveApi.apiKey).to.equal(
+        "***redacted (6 chars)***"
+      );
+      // Non-secret-named string preserved.
+      expect(out.integrations.heretto[0].name).to.equal("main");
+      expect(out.integrations.heretto[0].username).to.equal("harold@example.com");
+      expect(out.logLevel).to.equal("info");
+    });
+
+    it("redacts value-shape secrets even under innocent keys", function () {
+      const out = redactObject({
+        // Innocent key, credential-shaped value → redacted by value shape.
+        connectionInfo: "postgres://app:hunter2@db.example.com/prod",
+        // Innocent key, mixed values → only the one with userinfo is redacted.
+        links: ["https://example.com/clean", "https://user:pw@svc/hook"],
+      });
+      expect(out.connectionInfo).to.match(/^\*{3}redacted .*value shape/);
+      expect(out.links[0]).to.equal("https://example.com/clean");
+      expect(out.links[1]).to.match(/^\*{3}redacted .*value shape/);
+    });
+
+    it("name-based redaction propagates to array elements (e.g. webhookList)", function () {
+      const out = redactObject({
+        // Parent key contains WEBHOOK — every string element is redacted
+        // by name, not by individual inspection.
+        webhookList: [
+          "https://example.com/clean",
+          "https://user:pw@svc/hook",
+        ],
+      });
+      expect(out.webhookList[0]).to.match(/^\*{3}redacted/);
+      expect(out.webhookList[1]).to.match(/^\*{3}redacted/);
+    });
+
+    it("preserves primitives, null, and undefined", function () {
+      const out = redactObject({
+        count: 42,
+        enabled: true,
+        missing: null,
+        absent: undefined,
+        name: "plain",
+      });
+      expect(out.count).to.equal(42);
+      expect(out.enabled).to.equal(true);
+      expect(out.missing).to.equal(null);
+      expect(out.absent).to.equal(undefined);
+      expect(out.name).to.equal("plain");
+    });
+
+    it("does not mutate the input", function () {
+      const input = {
+        integrations: {
+          docDetectiveApi: { apiKey: "secret-key-12345" },
+        },
+      };
+      const out = redactObject(input);
+      expect(input.integrations.docDetectiveApi.apiKey).to.equal(
+        "secret-key-12345"
+      );
+      expect(out.integrations.docDetectiveApi.apiKey).to.equal(
+        "***redacted (16 chars)***"
+      );
+      // Top-level returned object is a fresh reference.
+      expect(out).to.not.equal(input);
+    });
+
+    it("ignores prototype keys defensively", function () {
+      const obj = { real: "$REAL", apiToken: "secret" };
+      // eslint-disable-next-line no-proto
+      Object.defineProperty(obj, "__proto__", {
+        value: { hidden: "secret-hidden" },
+        enumerable: true,
+      });
+      const out = redactObject(obj);
+      expect(out.real).to.equal("$REAL");
+      expect(out.apiToken).to.equal("***redacted (6 chars)***");
+      expect(out.hidden).to.equal(undefined);
+    });
+
+    it("handles circular references without crashing", function () {
+      const a = { name: "a" };
+      a.self = a;
+      const out = redactObject(a);
+      expect(out.name).to.equal("a");
+      expect(out.self).to.equal("<circular>");
+    });
+  });
+});
+
+describe("debug/envvars", function () {
+  let findReferencedEnvVars,
+    detectContainer,
+    enumerateInputFiles,
+    resolveDocExtensions;
+  before(async function () {
+    ({
+      findReferencedEnvVars,
+      detectContainer,
+      enumerateInputFiles,
+      resolveDocExtensions,
+    } = await import("../dist/debug/envvars.js"));
+  });
+
+  it("finds $VAR references in a string", function () {
+    const refs = findReferencedEnvVars("hello $FOO and $BAR_BAZ done");
+    expect(Array.from(refs).sort()).to.deep.equal(["BAR_BAZ", "FOO"]);
+  });
+
+  it("ignores numeric-leading tokens (shell positionals, backreferences)", function () {
+    // `$0`/`$1`/`$2` are shell positionals or regex backreferences, never
+    // env vars — they must not appear, but real `$VAR9` (digit not first)
+    // and `$_PRIVATE` (leading underscore) must still be caught.
+    const refs = findReferencedEnvVars(
+      'sh "$0 $1 $2" and $86 but keep $VAR9 and $_PRIVATE'
+    );
+    expect(Array.from(refs).sort()).to.deep.equal(["VAR9", "_PRIVATE"]);
+  });
+
+  it("walks nested objects and arrays", function () {
+    const obj = {
+      a: "$ALPHA",
+      b: [{ c: "prefix $BETA suffix" }, "$GAMMA"],
+      d: null,
+      e: 42,
+    };
+    const refs = findReferencedEnvVars(obj);
+    expect(Array.from(refs).sort()).to.deep.equal([
+      "ALPHA",
+      "BETA",
+      "GAMMA",
+    ]);
+  });
+
+  it("returns an empty set when no $ refs are present", function () {
+    const refs = findReferencedEnvVars({ a: "plain", b: ["string"] });
+    expect(refs.size).to.equal(0);
+  });
+
+  it("ignores prototype keys defensively", function () {
+    const obj = { real: "$REAL" };
+    // eslint-disable-next-line no-proto
+    Object.defineProperty(obj, "__proto__", {
+      value: { hidden: "$HIDDEN" },
+      enumerable: true,
+    });
+    const refs = findReferencedEnvVars(obj);
+    expect(refs.has("REAL")).to.equal(true);
+    expect(refs.has("HIDDEN")).to.equal(false);
+  });
+
+  it("detectContainer returns false when no signals present", function () {
+    const prev = process.env.IN_CONTAINER;
+    delete process.env.IN_CONTAINER;
+    try {
+      const info = detectContainer();
+      // On a developer machine: should be false (unless tests run inside Docker).
+      expect(info).to.have.property("inContainer");
+      expect(info).to.have.property("signals");
+      expect(info.signals).to.be.an("array");
+    } finally {
+      if (prev !== undefined) process.env.IN_CONTAINER = prev;
+    }
+  });
+
+  it("detectContainer flags IN_CONTAINER=true", function () {
+    const prev = process.env.IN_CONTAINER;
+    process.env.IN_CONTAINER = "true";
+    try {
+      const info = detectContainer();
+      expect(info.inContainer).to.equal(true);
+      expect(info.signals).to.include("IN_CONTAINER=true");
+    } finally {
+      if (prev === undefined) delete process.env.IN_CONTAINER;
+      else process.env.IN_CONTAINER = prev;
+    }
+  });
+
+  it("enumerateInputFiles handles files, directories, missing paths, and respects the cap", function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-enum-"));
+    try {
+      fs.writeFileSync(path.join(tmp, "a.txt"), "alpha");
+      fs.writeFileSync(path.join(tmp, "b.txt"), "beta");
+      fs.mkdirSync(path.join(tmp, "sub"));
+      fs.writeFileSync(path.join(tmp, "sub", "c.txt"), "gamma");
+      fs.mkdirSync(path.join(tmp, "node_modules"));
+      fs.writeFileSync(path.join(tmp, "node_modules", "skip.txt"), "skip");
+
+      const files = enumerateInputFiles(
+        [tmp, "/nonexistent/path/that/does/not/exist"],
+        100
+      );
+      // Three real files; node_modules is skipped.
+      expect(files.length).to.equal(3);
+      expect(files.every((f) => !f.includes("node_modules"))).to.equal(true);
+
+      // Cap is honored.
+      const capped = enumerateInputFiles([tmp], 1);
+      expect(capped.length).to.equal(1);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("enumerateInputFiles filters discovered files by allowed extensions but keeps explicit file paths", function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-ext-"));
+    try {
+      fs.writeFileSync(path.join(tmp, "doc.md"), "# doc");
+      fs.writeFileSync(path.join(tmp, "page.html"), "<p>x</p>");
+      fs.writeFileSync(path.join(tmp, "script.js"), "const $x = 1;");
+      fs.writeFileSync(path.join(tmp, "ci.yaml"), "run: echo $HOME");
+
+      // Directory walk: only md + html survive the doc-extension filter.
+      const allowed = new Set(["md", "markdown", "html", "htm"]);
+      const found = enumerateInputFiles([tmp], 100, allowed);
+      const names = found.map((f) => path.basename(f)).sort();
+      expect(names).to.deep.equal(["doc.md", "page.html"]);
+
+      // An explicitly-passed file is honored even if its extension is
+      // outside the allow-set (the user pointed at it directly).
+      const explicit = enumerateInputFiles(
+        [path.join(tmp, "script.js")],
+        100,
+        allowed
+      );
+      expect(explicit.map((f) => path.basename(f))).to.deep.equal(["script.js"]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("resolveDocExtensions maps fileType names, reads object extensions, and falls back to the full set", function () {
+    // String names → their default extensions.
+    expect(
+      Array.from(resolveDocExtensions(["markdown", "dita"])).sort()
+    ).to.deep.equal(["dita", "ditamap", "markdown", "md", "mdx", "xml"]);
+
+    // Object entries: explicit extensions + name lookup, dot-stripped and
+    // lowercased.
+    const fromObjects = resolveDocExtensions([
+      { extensions: [".MD", "txt"] },
+      { name: "html" },
+    ]);
+    expect(Array.from(fromObjects).sort()).to.deep.equal([
+      "htm",
+      "html",
+      "md",
+      "txt",
+    ]);
+
+    // Absent / empty / unrecognized → union of all known doc extensions.
+    const fallback = resolveDocExtensions(undefined);
+    expect(fallback.has("md")).to.equal(true);
+    expect(fallback.has("adoc")).to.equal(true);
+    expect(fallback.has("html")).to.equal(true);
+    expect(fallback.has("dita")).to.equal(true);
+    expect(resolveDocExtensions(["nonexistent-type"]).has("md")).to.equal(true);
+  });
+});
+
+describe("debug/tools", function () {
+  let probeTool;
+  before(async function () {
+    ({ probeTool } = await import("../dist/debug/tools.js"));
+  });
+
+  it("returns <not found> for a non-existent binary", async function () {
+    this.timeout(5000);
+    const result = await probeTool(
+      "definitely-not-a-real-binary",
+      "definitely-not-a-real-binary --version",
+      { timeoutMs: 2000 }
+    );
+    expect(result.version).to.match(/<not found>|<probe failed>|<timed out/);
+  });
+
+  it("returns process.version-style output for a real binary (node)", async function () {
+    this.timeout(5000);
+    const result = await probeTool("node", "node --version", { timeoutMs: 3000 });
+    expect(result.version).to.match(/^v\d+\./);
+  });
+
+  it("honors the timeout for a hanging command", async function () {
+    this.timeout(5000);
+    // `node -e "setInterval(...)"` would hang forever; the probe should
+    // settle with a `<timed out ...>` marker.
+    const result = await probeTool(
+      "hanger",
+      `node -e "setInterval(() => {}, 1000)"`,
+      { timeoutMs: 500 }
+    );
+    expect(result.version).to.match(/<timed out after \d+ms>/);
+  });
+});
+
+describe("debug/printDebug end-to-end", function () {
+  let printDebug;
+  before(async function () {
+    ({ printDebug } = await import("../dist/debug/index.js"));
+  });
+
+  it("renders all sections to the print sink", async function () {
+    this.timeout(60000);
+    const out = [];
+    await printDebug({
+      config: { input: ".", logLevel: "info", environment: { platform: "linux" } },
+      configPath: null,
+      print: (line) => out.push(line),
+    });
+    const text = out.join("\n");
+
+    // Header banner
+    expect(text).to.include("Doc Detective diagnostic dump");
+    // Each section header
+    expect(text).to.include("-- System ");
+    expect(text).to.include("-- Doc Detective ");
+    expect(text).to.include("-- Tools ");
+    expect(text).to.include("-- Browsers ");
+    expect(text).to.include("-- Container state ");
+    expect(text).to.include("-- Referenced environment variables ");
+    expect(text).to.include("-- Config ");
+    // System info markers
+    expect(text).to.match(/platform\s+\w+/);
+    expect(text).to.match(/nodeVersion\s+v\d+\./);
+  });
+
+  it("surfaces the CONFIG INVALID banner when configError is set", async function () {
+    this.timeout(60000);
+    const out = [];
+    await printDebug({
+      config: { input: ".", logLevel: "info", environment: { platform: "linux" } },
+      configPath: null,
+      configError: new Error("Invalid config. boom"),
+      print: (line) => out.push(line),
+    });
+    const text = out.join("\n");
+    expect(text).to.include("=== CONFIG INVALID ===");
+    expect(text).to.include("Invalid config. boom");
+  });
+
+  it("redacts secret-named env vars in the referenced-vars section", async function () {
+    this.timeout(60000);
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-redact-"));
+    try {
+      // Spec file with a secret-shaped env ref + a plain one.
+      const specPath = path.join(tmp, "spec.md");
+      fs.writeFileSync(specPath, "url: $MY_TOKEN and $LOG_LEVEL\n");
+      const prevToken = process.env.MY_TOKEN;
+      const prevLog = process.env.LOG_LEVEL;
+      process.env.MY_TOKEN = "supersecret";
+      process.env.LOG_LEVEL = "info";
+      try {
+        const out = [];
+        await printDebug({
+          config: { input: [tmp], environment: { platform: "linux" } },
+          configPath: null,
+          print: (line) => out.push(line),
+        });
+        const text = out.join("\n");
+        expect(text).to.include("MY_TOKEN");
+        expect(text).to.include("***redacted (11 chars)***");
+        expect(text).to.match(/LOG_LEVEL\s*=\s*info/);
+        expect(text).to.not.include("supersecret");
+      } finally {
+        if (prevToken === undefined) delete process.env.MY_TOKEN;
+        else process.env.MY_TOKEN = prevToken;
+        if (prevLog === undefined) delete process.env.LOG_LEVEL;
+        else process.env.LOG_LEVEL = prevLog;
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("redacts secrets in the Config section so heretto apiToken / docDetectiveApi apiKey don't leak", async function () {
+    this.timeout(60000);
+    const out = [];
+    await printDebug({
+      config: {
+        input: ".",
+        environment: { platform: "linux" },
+        integrations: {
+          heretto: [
+            {
+              name: "main",
+              organizationId: "acme",
+              username: "u",
+              apiToken: "supersecret-heretto-token",
+            },
+          ],
+          docDetectiveApi: { apiKey: "supersecret-api-key" },
+        },
+      },
+      configPath: null,
+      print: (line) => out.push(line),
+    });
+    const text = out.join("\n");
+    expect(text).to.not.include("supersecret-heretto-token");
+    expect(text).to.not.include("supersecret-api-key");
+    // Redaction markers present.
+    expect(text).to.match(/apiToken.*\*{3}redacted/);
+    expect(text).to.match(/apiKey.*\*{3}redacted/);
+    // Non-secret fields preserved.
+    expect(text).to.match(/"organizationId":\s*"acme"/);
+  });
+
+  it("includeEnv:true emits the full env dump with value-shape redaction", async function () {
+    this.timeout(60000);
+    const prevDb = process.env.DD_TEST_FAKE_CONN;
+    const prevSafe = process.env.DD_TEST_SAFE_NAME;
+    process.env.DD_TEST_FAKE_CONN =
+      "postgres://app:hunter2@db.example.com/prod";
+    process.env.DD_TEST_SAFE_NAME = "harmless-value";
+    try {
+      const out = [];
+      await printDebug({
+        config: { input: ".", environment: { platform: "linux" } },
+        configPath: null,
+        includeEnv: true,
+        print: (line) => out.push(line),
+      });
+      const text = out.join("\n");
+      expect(text).to.include("-- Environment variables (full) ");
+      // Innocent-named value containing URL userinfo IS redacted by value shape.
+      expect(text).to.match(
+        /DD_TEST_FAKE_CONN\s*=\s*\*{3}redacted .*value shape/
+      );
+      expect(text).to.not.include("hunter2");
+      // Safe value still shown plainly.
+      expect(text).to.match(/DD_TEST_SAFE_NAME\s*=\s*harmless-value/);
+      // Warning banner is present.
+      expect(text).to.include("REVIEW BEFORE PASTING");
+    } finally {
+      if (prevDb === undefined) delete process.env.DD_TEST_FAKE_CONN;
+      else process.env.DD_TEST_FAKE_CONN = prevDb;
+      if (prevSafe === undefined) delete process.env.DD_TEST_SAFE_NAME;
+      else process.env.DD_TEST_SAFE_NAME = prevSafe;
+    }
+  });
+});
+
+describe("debug CLI smoke test", function () {
+  it("runs `doc-detective debug` and prints the diagnostic dump with exit 0", function () {
+    this.timeout(120000);
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-cli-"));
+    try {
+      const bin = path.resolve(process.cwd(), "bin/doc-detective.js");
+      const result = spawnSync(process.execPath, [bin, "debug"], {
+        cwd: tmp,
+        encoding: "utf8",
+        env: { ...process.env, DOC_DETECTIVE_DEBUG: "" },
+      });
+      expect(result.status).to.equal(0);
+      expect(result.stdout).to.include("Doc Detective diagnostic dump");
+      expect(result.stdout).to.include("-- System ");
+      expect(result.stdout).to.include("-- Doc Detective ");
+      // Without --include-env, full env dump is NOT emitted.
+      expect(result.stdout).to.not.include("-- Environment variables (full) ");
+      expect(result.stdout).to.include(
+        "-- Referenced environment variables "
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("--include-env emits the full env dump section", function () {
+    this.timeout(120000);
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-includeenv-"));
+    try {
+      const bin = path.resolve(process.cwd(), "bin/doc-detective.js");
+      const result = spawnSync(
+        process.execPath,
+        [bin, "debug", "--include-env"],
+        {
+          cwd: tmp,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            DOC_DETECTIVE_DEBUG: "",
+            DD_TEST_FAKE_DB: "postgres://app:hunter2@db.example.com/prod",
+            DD_TEST_LOG: "info",
+          },
+        }
+      );
+      expect(result.status).to.equal(0);
+      expect(result.stdout).to.include("-- Environment variables (full) ");
+      expect(result.stdout).to.match(/DD_TEST_LOG\s*=\s*info/);
+      // Value-shape redaction catches the embedded credential even
+      // though the env var name doesn't match the secret-name regex.
+      expect(result.stdout).to.match(/DD_TEST_FAKE_DB\s*=\s*\*{3}redacted/);
+      expect(result.stdout).to.not.include("hunter2");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("DOC_DETECTIVE_DEBUG=true on the default command also dumps (without --include-env)", function () {
+    this.timeout(120000);
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-envvar-"));
+    try {
+      const bin = path.resolve(process.cwd(), "bin/doc-detective.js");
+      const result = spawnSync(process.execPath, [bin], {
+        cwd: tmp,
+        encoding: "utf8",
+        env: { ...process.env, DOC_DETECTIVE_DEBUG: "true" },
+      });
+      expect(result.status).to.equal(0);
+      expect(result.stdout).to.include("Doc Detective diagnostic dump");
+      // Env-var path never opts into full env dump.
+      expect(result.stdout).to.not.include("-- Environment variables (full) ");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -17,10 +17,37 @@ before(async function () {
 });
 
 describe("debug/redact", function () {
-  let redactValue, isSecretName, isSecretValue, redactObject, redactArg;
+  let redactValue, isSecretName, isSecretValue, redactObject, redactArg, redactArgv;
   before(async function () {
-    ({ redactValue, isSecretName, isSecretValue, redactObject, redactArg } =
+    ({ redactValue, isSecretName, isSecretValue, redactObject, redactArg, redactArgv } =
       await import("../dist/debug/redact.js"));
+  });
+
+  describe("redactArgv", function () {
+    it("redacts the value of a split secret flag (--password hunter2)", function () {
+      const out = redactArgv(["node", "x", "--password", "hunter2", "--input", "."]);
+      expect(out).to.deep.equal([
+        "node",
+        "x",
+        "--password",
+        "***redacted (7 chars)***",
+        "--input",
+        ".",
+      ]);
+    });
+
+    it("does not consume the next token when the secret flag has no value", function () {
+      // `--token` immediately followed by another flag: nothing to redact.
+      const out = redactArgv(["--token", "--include-env"]);
+      expect(out).to.deep.equal(["--token", "--include-env"]);
+    });
+
+    it("still handles --flag=value and value-shape via redactArg", function () {
+      const out = redactArgv(["--api-key=abc123", "https://u:pw@host/x", "plain"]);
+      expect(out[0]).to.match(/^--api-key=\*{3}redacted/);
+      expect(out[1]).to.match(/^\*{3}redacted .*value shape/);
+      expect(out[2]).to.equal("plain");
+    });
   });
 
   describe("redactArg", function () {

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -481,9 +481,36 @@ describe("debug/envvars", function () {
 });
 
 describe("debug/tools", function () {
-  let probeTool;
+  let probeTool, envWithoutNodeModulesBin;
   before(async function () {
-    ({ probeTool } = await import("../dist/debug/tools.js"));
+    ({ probeTool, envWithoutNodeModulesBin } = await import(
+      "../dist/debug/tools.js"
+    ));
+  });
+
+  it("envWithoutNodeModulesBin strips node_modules/.bin segments, keeps system dirs", function () {
+    const sep = path.delimiter;
+    const prev = process.env.PATH;
+    const sysA = process.platform === "win32" ? "C:\\Windows\\System32" : "/usr/bin";
+    const sysB = process.platform === "win32" ? "C:\\Windows" : "/bin";
+    const bin = process.platform === "win32"
+      ? "C:\\repo\\node_modules\\.bin"
+      : "/repo/node_modules/.bin";
+    const nested = process.platform === "win32"
+      ? "C:\\repo\\packages\\x\\node_modules\\.bin"
+      : "/repo/packages/x/node_modules/.bin";
+    try {
+      process.env.PATH = [sysA, bin, sysB, nested].join(sep);
+      const env = envWithoutNodeModulesBin();
+      const key = Object.keys(env).find((k) => k.toLowerCase() === "path");
+      const segs = env[key].split(sep);
+      expect(segs).to.include(sysA);
+      expect(segs).to.include(sysB);
+      expect(segs.some((s) => /node_modules[\\/]\.bin/i.test(s))).to.equal(false);
+    } finally {
+      if (prev === undefined) delete process.env.PATH;
+      else process.env.PATH = prev;
+    }
   });
 
   it("returns <not found> for a non-existent binary", async function () {
@@ -616,6 +643,28 @@ describe("debug/printDebug end-to-end", function () {
         print: () => {},
       });
       expect(fs.readdirSync(outDir)).to.deep.equal(before);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("saves dump files with owner-only permissions (POSIX)", async function () {
+    if (process.platform === "win32") this.skip();
+    this.timeout(60000);
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-perms-"));
+    try {
+      const outDir = path.join(tmp, ".doc-detective");
+      await printDebug({
+        config: { input: ".", environment: { platform: "linux" } },
+        configPath: null,
+        outDir,
+        print: () => {},
+      });
+      // Dir is 0700, files are 0600 — dumps can carry env/config data.
+      expect(fs.statSync(outDir).mode & 0o777).to.equal(0o700);
+      for (const f of fs.readdirSync(outDir)) {
+        expect(fs.statSync(path.join(outDir, f)).mode & 0o777, f).to.equal(0o600);
+      }
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/hints.test.js
+++ b/test/hints.test.js
@@ -1369,12 +1369,12 @@ describe("hints/index pickByPriority + priorityWeight", function () {
 
 describe("hints/hints (registry)", function () {
   it("every hint has stable id, body, predicate, and a numeric priority when set", function () {
-    // 25 active hints. `useFileTypesForRst` is commented out in the
+    // 26 active hints. `useFileTypesForRst` is commented out in the
     // registry but the `RST_EXTENSIONS` constant, the
     // `detectRstFiles` helper, and the `hasRstFiles` context field
     // are kept in place so the hint can be re-enabled without
     // re-plumbing.
-    expect(HINTS.length).to.equal(25);
+    expect(HINTS.length).to.equal(26);
     const ids = new Set();
     // Ids are camelCase, matching the convention used everywhere else
     // in the project (step names like `goTo`, config fields like
@@ -1503,6 +1503,12 @@ describe("hints/hints (registry)", function () {
     const h = findHint("enableDebugLog");
     expect(h.when(fakeCtx({ failedCount: 0 }))).to.equal(false);
     expect(h.when(fakeCtx({ failedCount: 3 }))).to.equal(true);
+  });
+
+  it("useDebugFlag: fires only when run failed", function () {
+    const h = findHint("useDebugFlag");
+    expect(h.when(fakeCtx({ failedCount: 2 }))).to.equal(true);
+    expect(h.when(fakeCtx({ failedCount: 0 }))).to.equal(false);
   });
 
   it("useRecordStepOnFailure: fires only on failure with a browser run and no recordings produced", function () {

--- a/test/runtime-installer.test.js
+++ b/test/runtime-installer.test.js
@@ -3,6 +3,7 @@ import {
   installBrowsers,
   status,
 } from "../dist/runtime/installer.js";
+import { resolveHeavyDepSource } from "../dist/runtime/loader.js";
 import { writeInstalledRecord } from "../dist/runtime/cacheDir.js";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
@@ -214,14 +215,37 @@ describe("runtime/installer", function () {
   });
 
   describe("status", function () {
-    it("reports all HEAVY_NPM_DEPS + all browser assets, marking installed: false for missing entries", function () {
+    it("reports all HEAVY_NPM_DEPS + all browser assets; browsers absent on an empty cache", function () {
       const rows = status({});
       const npmRows = rows.filter((r) => r.kind === "npm");
       const browserRows = rows.filter((r) => r.kind === "browser");
       expect(npmRows.length).to.be.greaterThan(0);
       expect(browserRows.length).to.equal(4);
-      // Empty cache → nothing installed.
-      for (const r of rows) expect(r.installed).to.equal(false);
+      // Browsers only come from the cache/record (never the shim's
+      // node_modules), so an empty cache means none are installed.
+      for (const r of browserRows) expect(r.installed).to.equal(false);
+      // npm packages count as installed when resolvable from the shim's
+      // node_modules OR the cache — matching `install all`'s presence check
+      // — even with an empty cache record. Assert status agrees with the
+      // resolver rather than hard-coding env-dependent install state.
+      for (const r of npmRows) {
+        expect(r.installed).to.equal(Boolean(resolveHeavyDepSource(r.assetId)));
+      }
+    });
+
+    it("counts a shim/node_modules-resolved package as installed without flagging it outdated", function () {
+      // pngjs is declared as a heavy dep and present in this source
+      // checkout's node_modules. With an empty cache record it must still
+      // report installed (from the shim) — and never `outdated`, since the
+      // installer never overrides a shim-pinned version (matches the
+      // "already-up-to-date" `install all` reports).
+      const source = resolveHeavyDepSource("pngjs");
+      if (source !== "shim") this.skip();
+      const rows = status({});
+      const pngjs = rows.find((r) => r.assetId === "pngjs");
+      expect(pngjs.installed).to.equal(true);
+      expect(pngjs.installedVersion).to.be.a("string");
+      expect(pngjs.outdated).to.equal(false);
     });
 
     it("marks rows as outdated when installed version drifts from expected", function () {

--- a/test/runtime-installer.test.js
+++ b/test/runtime-installer.test.js
@@ -233,41 +233,50 @@ describe("runtime/installer", function () {
       }
     });
 
-    it("counts a shim/node_modules-resolved package as installed without flagging it outdated", function () {
+    it("never flags a shim-resolved package as outdated, even with a stale cache record", function () {
       // pngjs is declared as a heavy dep and present in this source
-      // checkout's node_modules. With an empty cache record it must still
-      // report installed (from the shim) — and never `outdated`, since the
-      // installer never overrides a shim-pinned version (matches the
-      // "already-up-to-date" `install all` reports).
+      // checkout's node_modules, so it resolves from the shim. The shim
+      // wins over the cache at runtime and is never overridden, so a stale
+      // cache record must NOT flag it outdated (regression: status consulted
+      // the cache record before the shim).
       const source = resolveHeavyDepSource("pngjs");
       if (source !== "shim") this.skip();
+      writeInstalledRecord(
+        {
+          npmPackages: {
+            pngjs: { installedVersion: "1.0.0", installedAt: "2026-01-01T00:00:00Z" },
+          },
+          browsers: {},
+        },
+        {}
+      );
       const rows = status({});
       const pngjs = rows.find((r) => r.assetId === "pngjs");
       expect(pngjs.installed).to.equal(true);
+      // Reports the real shim version, not the stale "1.0.0" record, and
+      // is not flagged outdated.
       expect(pngjs.installedVersion).to.be.a("string");
+      expect(pngjs.installedVersion).to.not.equal("1.0.0");
       expect(pngjs.outdated).to.equal(false);
     });
 
-    it("marks rows as outdated when installed version drifts from expected", function () {
-      writeInstalledRecord({
-        npmPackages: {
-          pngjs: { installedVersion: "6.0.0", installedAt: "2026-01-01T00:00:00Z" },
-        },
-        browsers: {
-          chrome: {
-            installedVersion: "100.0.0",
-            installedAt: "2026-01-01T00:00:00Z",
-            latestKnownVersion: "121.0.0",
+    it("marks a browser row outdated when its installed buildId drifts from the channel", function () {
+      // Browsers are never shim-resolved, so the cache record's freshness
+      // check applies directly.
+      writeInstalledRecord(
+        {
+          npmPackages: {},
+          browsers: {
+            chrome: {
+              installedVersion: "100.0.0",
+              installedAt: "2026-01-01T00:00:00Z",
+              latestKnownVersion: "121.0.0",
+            },
           },
         },
-      }, {});
+        {}
+      );
       const rows = status({});
-      const pngjs = rows.find((r) => r.assetId === "pngjs");
-      expect(pngjs.installed).to.equal(true);
-      // pngjs is in package.json#dependencies (constraint string like "^7.1.0"),
-      // and our installed entry is "6.0.0" — a mismatch.
-      expect(pngjs.outdated).to.equal(true);
-
       const chrome = rows.find((r) => r.assetId === "chrome");
       expect(chrome.installed).to.equal(true);
       expect(chrome.outdated).to.equal(true);

--- a/test/runtime-loader.test.js
+++ b/test/runtime-loader.test.js
@@ -1,4 +1,10 @@
-import { loadHeavyDep, ensureRuntimeInstalled } from "../dist/runtime/loader.js";
+import {
+  loadHeavyDep,
+  ensureRuntimeInstalled,
+  resolveHeavyDepPath,
+  resolveHeavyDepSource,
+  resolveHeavyDepVersion,
+} from "../dist/runtime/loader.js";
 import { readInstalledRecord } from "../dist/runtime/cacheDir.js";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
@@ -52,6 +58,21 @@ describe("runtime/loader", function () {
     if (originalEnv === undefined) delete process.env.DOC_DETECTIVE_CACHE_DIR;
     else process.env.DOC_DETECTIVE_CACHE_DIR = originalEnv;
     fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  describe("resolveHeavyDepSource / resolveHeavyDepVersion", function () {
+    it("reports a shim-resolvable dep's source and version", function () {
+      // pngjs is a declared heavy dep present in this source checkout.
+      if (!resolveHeavyDepPath("pngjs")) this.skip();
+      expect(resolveHeavyDepSource("pngjs")).to.equal("shim");
+      expect(resolveHeavyDepVersion("pngjs")).to.match(/^\d+\.\d+\.\d+/);
+    });
+
+    it("returns null for a name that doesn't resolve anywhere", function () {
+      const bogus = "definitely-not-a-real-heavy-dep-xyz";
+      expect(resolveHeavyDepSource(bogus)).to.equal(null);
+      expect(resolveHeavyDepVersion(bogus)).to.equal(null);
+    });
   });
 
   describe("loadHeavyDep", function () {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -217,9 +217,9 @@ describe("Util tests", function () {
     const { isDebugRequested } = await import("../dist/utils.js");
     const prev = process.env.DOC_DETECTIVE_DEBUG;
     try {
-      for (const v of ["true", "TRUE", "1", "yes", "Yes"]) {
+      for (const v of ["true", "TRUE", "1", "yes", "Yes", "true ", "  1  ", "\tyes\n"]) {
         process.env.DOC_DETECTIVE_DEBUG = v;
-        expect(isDebugRequested()).to.equal(true);
+        expect(isDebugRequested(), `value: ${JSON.stringify(v)}`).to.equal(true);
       }
       for (const v of ["false", "0", "no", "", "off"]) {
         process.env.DOC_DETECTIVE_DEBUG = v;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -213,6 +213,46 @@ describe("Util tests", function () {
     expect(configAbsent.dryRun).to.equal(false);
   });
 
+  it("isDebugRequested: returns true only for truthy DOC_DETECTIVE_DEBUG values", async function () {
+    const { isDebugRequested } = await import("../dist/utils.js");
+    const prev = process.env.DOC_DETECTIVE_DEBUG;
+    try {
+      for (const v of ["true", "TRUE", "1", "yes", "Yes"]) {
+        process.env.DOC_DETECTIVE_DEBUG = v;
+        expect(isDebugRequested()).to.equal(true);
+      }
+      for (const v of ["false", "0", "no", "", "off"]) {
+        process.env.DOC_DETECTIVE_DEBUG = v;
+        expect(isDebugRequested()).to.equal(false);
+      }
+      delete process.env.DOC_DETECTIVE_DEBUG;
+      expect(isDebugRequested()).to.equal(false);
+    } finally {
+      if (prev === undefined) delete process.env.DOC_DETECTIVE_DEBUG;
+      else process.env.DOC_DETECTIVE_DEBUG = prev;
+    }
+  });
+
+  it("setConfig: accepts a config with the deprecated `debug` field (ignored, not rejected)", async function () {
+    this.timeout(5000);
+    const { setConfig } = await import("../dist/utils.js");
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const os = await import("node:os");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debug-deprecated-"));
+    try {
+      const configPath = path.join(tmp, ".doc-detective.json");
+      // Old configs that still carry `debug` must keep validating; the
+      // field is deprecated and has no runtime effect.
+      fs.writeFileSync(configPath, JSON.stringify({ debug: true, input: "." }));
+      const config = await setConfig({ configPath, args: {} });
+      expect(config).to.be.an("object");
+      expect(config.input).to.exist;
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("setConfig stores --hints / --no-hints on config.hints.enabled", async function () {
     this.timeout(5000);
     // --no-hints turns hints off

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -253,6 +253,48 @@ describe("Util tests", function () {
     }
   });
 
+  it("setConfig: throws (does not return null) when an explicit config path can't be read", async function () {
+    this.timeout(5000);
+    const { setConfig } = await import("../dist/utils.js");
+    const path = await import("node:path");
+    const os = await import("node:os");
+    const missing = path.join(os.tmpdir(), "dd-nonexistent-config-xyz.json");
+    let threw = null;
+    try {
+      await setConfig({ configPath: missing, args: {} });
+    } catch (err) {
+      threw = err;
+    }
+    expect(threw, "expected setConfig to throw on an unreadable config path").to.be.an(
+      "error"
+    );
+    expect(threw.message).to.match(/config file/i);
+  });
+
+  it("setConfig: throws a targeted error when DOC_DETECTIVE_CONFIG is valid JSON but not an object", async function () {
+    this.timeout(5000);
+    const { setConfig } = await import("../dist/utils.js");
+    const prev = process.env.DOC_DETECTIVE_CONFIG;
+    try {
+      for (const bad of ["null", "true", "42", "[1,2]", '"str"']) {
+        process.env.DOC_DETECTIVE_CONFIG = bad;
+        let threw = null;
+        try {
+          await setConfig({ configPath: null, args: {} });
+        } catch (err) {
+          threw = err;
+        }
+        expect(threw, `expected throw for DOC_DETECTIVE_CONFIG=${bad}`).to.be.an(
+          "error"
+        );
+        expect(threw.message).to.match(/DOC_DETECTIVE_CONFIG/);
+      }
+    } finally {
+      if (prev === undefined) delete process.env.DOC_DETECTIVE_CONFIG;
+      else process.env.DOC_DETECTIVE_CONFIG = prev;
+    }
+  });
+
   it("setConfig stores --hints / --no-hints on config.hints.enabled", async function () {
     this.timeout(5000);
     // --no-hints turns hints off

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -258,7 +258,10 @@ describe("Util tests", function () {
     const { setConfig } = await import("../dist/utils.js");
     const path = await import("node:path");
     const os = await import("node:os");
-    const missing = path.join(os.tmpdir(), "dd-nonexistent-config-xyz.json");
+    const missing = path.join(
+      os.tmpdir(),
+      `dd-nonexistent-config-${process.pid}-${Date.now()}.json`
+    );
     let threw = null;
     try {
       await setConfig({ configPath: missing, args: {} });


### PR DESCRIPTION
## What

Adds a paste-friendly **diagnostic dump** to help users (and maintainers) debug environment/setup problems without a back-and-forth.

Two entry points, same renderer:
- `doc-detective debug` — dedicated subcommand. Add `--include-env` for a full `process.env` dump.
- `DOC_DETECTIVE_DEBUG=true` — env-var trigger on the default run path (CI-friendly). Never opts into the full env dump.

The dump reports: system/OS info, Doc Detective + tool versions, detected browsers, container state, the environment variables referenced by your config and docs, and the effective (or, on failure, raw) config.

## Why it's safe to paste

Secrets are redacted **by name** (`TOKEN`, `SECRET`, `KEY`, `PASSWORD`, `*_URL`/`*_DSN`, `WEBHOOK`, …) **and by value shape** (URL userinfo, JWTs, GitHub tokens, AWS keys) — in both the env-var listings and the `Config` section (so `integrations.*.apiToken`, `docDetectiveApi.apiKey`, inline webhook URLs don't leak). Redaction is best-effort and the output says so.

Tool/browser probes deliberately avoid executing project-local binaries (versions are read from `package.json`; browser detection is bounded by a timeout) so running diagnostics can't trigger a compromised `node_modules/.bin/*`.

## Notable design points

- `setConfig` / `getConfigFromEnv` now **throw** instead of `process.exit`, so the dump can catch a validation failure and render it under a `CONFIG INVALID` banner. The cli.ts top-level catch preserves the non-zero exit behavior for every other caller.
- The **referenced-env-var scan is scoped** to documentation file types (per `config.fileTypes`) and to POSIX-valid `$VAR` names. Without this, the `$VAR` grep matched shell/code/CI syntax across unrelated source files and flooded the section with junk like `$0`, `$1`, and stray single letters.
- The unused config `debug` field is **deprecated but retained** (not removed), so existing configs keep validating. This keeps the change a **minor** release rather than a major. Diagnostics live behind the env var / subcommand instead.

## Tests

New `test/debug.test.js` (redaction, env-var enumeration + scoping, tool probes, end-to-end render, CLI smoke tests) plus `setConfig`/hint/schema coverage. Full suite passes locally except pre-existing browser/screenshot tests that require a local Appium driver (no browser installed in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone debug command that produces redacted diagnostic dumps (plain text + JSON), with optional full environment inclusion and safe persisted output under .doc-detective.

* **Behavior Changes**
  * DOC_DETECTIVE_DEBUG now accepts specific truthy values; debug short-circuits normal CLI flow and may emit dumps on config errors. Explicit --config strings are treated as authoritative and config loading now throws on failures.

* **Deprecations**
  * Top-level "debug" config is deprecated and ignored in favor of the debug command / DOC_DETECTIVE_DEBUG.

* **Hints**
  * New hint suggests rerunning with the debug flag when failures occur.

* **Tests**
  * Expanded coverage for debug dumps, redaction, env/file handling, probes, browser diagnostics, and CLI outcomes.

* **Chores**
  * .gitignore updated to exclude diagnostic dump output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->