### PR TITLE
feat(reporters): emit per-run HTML report in runFolder archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [4.9.0-per-run-html-report.1](https://github.com/doc-detective/doc-detective/compare/v4.8.0...v4.9.0-per-run-html-report.1) (2026-06-15)
+
+
+### Features
+
+* auto screenshots, per-run artifact folders, and stable IDs ([#334](https://github.com/doc-detective/doc-detective/issues/334)) ([0527292](https://github.com/doc-detective/doc-detective/commit/0527292bb5270224548e4e03b22772531c8b33a6))
+* **reporters:** emit per-run HTML report in runFolder archive ([f8ad42a](https://github.com/doc-detective/doc-detective/commit/f8ad42a69c32b918e3315addfe913a2815ec0943))
+
 # [4.8.0](https://github.com/doc-detective/doc-detective/compare/v4.7.0...v4.8.0) (2026-06-14)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.10.0-per-run-html-report.1](https://github.com/doc-detective/doc-detective/compare/v4.9.0...v4.10.0-per-run-html-report.1) (2026-06-15)
+
+
+### Features
+
+* **reporters:** emit per-run HTML report in runFolder archive ([f8ad42a](https://github.com/doc-detective/doc-detective/commit/f8ad42a69c32b918e3315addfe913a2815ec0943))
+
 # [4.9.0](https://github.com/doc-detective/doc-detective/compare/v4.8.0...v4.9.0) (2026-06-14)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective",
-  "version": "4.8.0",
+  "version": "4.9.0-per-run-html-report.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective",
-      "version": "4.8.0",
+      "version": "4.9.0-per-run-html-report.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [
@@ -26297,7 +26297,7 @@
     },
     "src/common": {
       "name": "doc-detective-common",
-      "version": "4.8.0",
+      "version": "4.9.0-per-run-html-report.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective",
-  "version": "4.9.0",
+  "version": "4.10.0-per-run-html-report.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective",
-      "version": "4.9.0",
+      "version": "4.10.0-per-run-html-report.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [
@@ -26297,7 +26297,7 @@
     },
     "src/common": {
       "name": "doc-detective-common",
-      "version": "4.9.0",
+      "version": "4.10.0-per-run-html-report.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective",
-  "version": "4.9.0",
+  "version": "4.10.0-per-run-html-report.1",
   "description": "Treat doc content as testable assertions to validate doc accuracy and product UX.",
   "workspaces": [
     "src/common"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective",
-  "version": "4.8.0",
+  "version": "4.9.0-per-run-html-report.1",
   "description": "Treat doc content as testable assertions to validate doc accuracy and product UX.",
   "workspaces": [
     "src/common"

--- a/src/common/package-lock.json
+++ b/src/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "4.9.0",
+  "version": "4.10.0-per-run-html-report.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "4.9.0",
+      "version": "4.10.0-per-run-html-report.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/src/common/package-lock.json
+++ b/src/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "4.8.0",
+  "version": "4.9.0-per-run-html-report.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "4.8.0",
+      "version": "4.9.0-per-run-html-report.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/src/common/package.json
+++ b/src/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "4.9.0",
+  "version": "4.10.0-per-run-html-report.1",
   "description": "Shared components for Doc Detective projects.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/common/package.json
+++ b/src/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "4.8.0",
+  "version": "4.9.0-per-run-html-report.1",
   "description": "Shared components for Doc Detective projects.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/reporters/htmlReporter.ts
+++ b/src/reporters/htmlReporter.ts
@@ -54,7 +54,7 @@ export async function htmlReporter(
   }
 }
 
-function buildHtml(results: any): string {
+export function buildHtml(results: any): string {
   const reportJson = JSON.stringify(results, null, 2)
     .replace(/</g, "\\u003c")
     .replace(/>/g, "\\u003e")

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -574,6 +574,24 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
       fs.mkdirSync(runDir, { recursive: true });
       fs.writeFileSync(outputFile, JSON.stringify(persistedResults, null, 2));
       console.log(`See per-run results at ${outputFile}\n`);
+
+      // Also archive a human-readable HTML report beside the JSON so the run
+      // folder is a complete, shareable artifact without enabling the standalone
+      // `html` reporter. Best-effort and isolated in its own try/catch: an HTML
+      // failure must not break the JSON archive (this reporter's primary
+      // contract). Dynamic import keeps the large inlined CSS/JS off the hot
+      // path for non-reporting CLI invocations, matching the htmlReporter.
+      try {
+        const { buildHtml } = await import("./reporters/htmlReporter.js");
+        const htmlFile = path.resolve(runDir, `${reportType}.html`);
+        fs.writeFileSync(htmlFile, buildHtml(persistedResults));
+        console.log(`See per-run HTML report at ${htmlFile}\n`);
+      } catch (htmlErr) {
+        console.error(
+          `Error writing per-run HTML report to ${runDir}. ${htmlErr}`
+        );
+      }
+
       return outputFile;
     } catch (err) {
       console.error(`Error writing results to ${outputFile}. ${err}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -586,8 +586,11 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
         fs.writeFileSync(htmlFile, buildHtml(persistedResults));
         console.log(`See per-run HTML report at ${htmlFile}\n`);
       } catch (htmlErr) {
+        // Pass the error as a separate arg so its stack survives (string
+        // interpolation would flatten it, e.g. to "[object Object]").
         console.error(
-          `Error writing per-run HTML report to ${htmlFile}. ${htmlErr}`
+          `Error writing per-run HTML report to ${htmlFile}.`,
+          htmlErr
         );
       }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -575,20 +575,19 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
       fs.writeFileSync(outputFile, JSON.stringify(persistedResults, null, 2));
       console.log(`See per-run results at ${outputFile}\n`);
 
-      // Also archive a human-readable HTML report beside the JSON so the run
-      // folder is a complete, shareable artifact without enabling the standalone
-      // `html` reporter. Best-effort and isolated in its own try/catch: an HTML
-      // failure must not break the JSON archive (this reporter's primary
-      // contract). Dynamic import keeps the large inlined CSS/JS off the hot
-      // path for non-reporting CLI invocations, matching the htmlReporter.
+      // Archive a human-readable HTML report beside the JSON, so the run folder
+      // is a complete shareable artifact without the standalone `html` reporter.
+      // Best-effort and isolated: an HTML failure must not break the JSON
+      // archive (this reporter's primary contract). Dynamic import keeps the
+      // large inlined CSS/JS off the hot path, matching htmlReporter.
+      const htmlFile = path.resolve(runDir, `${reportType}.html`);
       try {
         const { buildHtml } = await import("./reporters/htmlReporter.js");
-        const htmlFile = path.resolve(runDir, `${reportType}.html`);
         fs.writeFileSync(htmlFile, buildHtml(persistedResults));
         console.log(`See per-run HTML report at ${htmlFile}\n`);
       } catch (htmlErr) {
         console.error(
-          `Error writing per-run HTML report to ${runDir}. ${htmlErr}`
+          `Error writing per-run HTML report to ${htmlFile}. ${htmlErr}`
         );
       }
 

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -3,6 +3,7 @@ import { resolveTests, detectTests } from "../dist/core/index.js";
 import { generateSpecId } from "../dist/core/detectTests.js";
 import { resolveAutoScreenshot } from "../dist/core/tests.js";
 import { reporters } from "../dist/utils.js";
+import { buildHtml } from "../dist/reporters/htmlReporter.js";
 import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
@@ -161,6 +162,59 @@ describe("runFolder reporter", function () {
     expect(
       path.relative(path.resolve(tempBase, ".doc-detective"), written)
     ).to.match(/^run-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z[\\/]/);
+  });
+
+  it("also writes an HTML report beside the JSON in the run folder", async function () {
+    const runDir = path.join(tempBase, ".doc-detective", "run-20260612-140000");
+    fs.mkdirSync(runDir, { recursive: true });
+    const results = { runId: "20260612-140000", runDir, summary: {}, specs: [] };
+    const written = await reporters.runFolderReporter({}, tempBase, results, {
+      command: "runTests",
+    });
+    // Return value stays the JSON path; HTML is a side artifact.
+    expect(written).to.equal(path.resolve(runDir, "testResults.json"));
+    const htmlFile = path.resolve(runDir, "testResults.html");
+    expect(fs.existsSync(htmlFile)).to.equal(true);
+    const html = fs.readFileSync(htmlFile, "utf8");
+    expect(html).to.include("<!DOCTYPE html>");
+    expect(html).to.include("20260612-140000");
+  });
+
+  it("names the HTML file to match the command's JSON report type", async function () {
+    const runDir = path.join(tempBase, ".doc-detective", "run-20260612-150000");
+    fs.mkdirSync(runDir, { recursive: true });
+    const results = { runId: "20260612-150000", runDir, summary: {}, specs: [] };
+    await reporters.runFolderReporter({}, tempBase, results, {
+      command: "runCoverage",
+    });
+    expect(fs.existsSync(path.resolve(runDir, "coverageResults.json"))).to.equal(
+      true
+    );
+    expect(fs.existsSync(path.resolve(runDir, "coverageResults.html"))).to.equal(
+      true
+    );
+  });
+
+  it("writes the HTML beside the JSON when the stamped runDir is rejected", async function () {
+    // When the stamped runDir is outside the output tree, both artifacts must
+    // land together in the fresh in-tree run folder.
+    const evilDir = path.join(tempBase, "elsewhere", "run-x");
+    const written = await reporters.runFolderReporter(
+      {},
+      tempBase,
+      { runDir: evilDir, summary: {}, specs: [] },
+      { command: "runTests" }
+    );
+    const htmlFile = path.resolve(path.dirname(written), "testResults.html");
+    expect(fs.existsSync(htmlFile)).to.equal(true);
+    expect(fs.existsSync(evilDir)).to.equal(false);
+  });
+
+  it("exports buildHtml that embeds the report data", function () {
+    const html = buildHtml({ runId: "abc123", summary: {}, specs: [] });
+    expect(html).to.be.a("string");
+    expect(html).to.include("<!DOCTYPE html>");
+    expect(html).to.include("abc123");
   });
 });
 

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -212,6 +212,29 @@ describe("runFolder reporter", function () {
     expect(fs.existsSync(evilDir)).to.equal(false);
   });
 
+  it("keeps the JSON archive when the HTML write fails (best-effort)", async function () {
+    const runDir = path.join(tempBase, ".doc-detective", "run-20260612-160000");
+    fs.mkdirSync(runDir, { recursive: true });
+    // Force only the HTML write to fail without mocking internals: occupy the
+    // HTML path with a directory so fs.writeFileSync throws (EISDIR/EPERM),
+    // while the JSON write to a different filename still succeeds. Validates
+    // the inner try/catch — an HTML failure must not break the JSON archive.
+    fs.mkdirSync(path.join(runDir, "testResults.html"));
+    const results = { runId: "20260612-160000", runDir, summary: {}, specs: [] };
+    const written = await reporters.runFolderReporter({}, tempBase, results, {
+      command: "runTests",
+    });
+    // JSON still written and returned; the call did not throw.
+    expect(written).to.equal(path.resolve(runDir, "testResults.json"));
+    expect(JSON.parse(fs.readFileSync(written, "utf8")).runId).to.equal(
+      "20260612-160000"
+    );
+    // The HTML path remains the pre-existing directory (the write never ran).
+    expect(
+      fs.statSync(path.join(runDir, "testResults.html")).isDirectory()
+    ).to.equal(true);
+  });
+
   it("exports buildHtml that embeds the report data", function () {
     const html = buildHtml({ runId: "abc123", summary: {}, specs: [] });
     expect(html).to.be.a("string");

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -190,9 +190,11 @@ describe("runFolder reporter", function () {
     expect(fs.existsSync(path.resolve(runDir, "coverageResults.json"))).to.equal(
       true
     );
-    expect(fs.existsSync(path.resolve(runDir, "coverageResults.html"))).to.equal(
-      true
-    );
+    const htmlFile = path.resolve(runDir, "coverageResults.html");
+    expect(fs.existsSync(htmlFile)).to.equal(true);
+    const html = fs.readFileSync(htmlFile, "utf8");
+    expect(html).to.include("<!DOCTYPE html>");
+    expect(html).to.include("20260612-150000");
   });
 
   it("writes the HTML beside the JSON when the stamped runDir is rejected", async function () {


### PR DESCRIPTION
## What

The `runFolder` reporter now writes a **human-readable HTML report** alongside the existing JSON in each per-run artifact folder. A run folder (`<output>/.doc-detective/run-<runId>/`) now contains a matched pair:

- `testResults.json` + `testResults.html` (for `runTests`)
- `coverageResults.json` + `coverageResults.html` (for `runCoverage`)

The HTML filename always tracks the JSON `reportType`.

## Why

Previously the per-run archive was JSON-only. Producing the HTML by default makes each run folder a complete, self-contained, shareable artifact — you can hand someone a run folder (or diff two of them over time) without also having to enable the standalone `html` reporter.

## How

- Exported the existing `buildHtml()` generator from `src/reporters/htmlReporter.ts` (no behavior change) so the runFolder reporter can reuse it instead of duplicating templating.
- In `runFolderReporter` (`src/utils.ts`), after the JSON write, render the HTML from the **same `persistedResults`** object (so HTML and JSON describe the identical, possibly runDir-rewritten, report) and write `${reportType}.html` into the same run folder.
  - Wrapped in its **own try/catch** — an HTML failure can never break the JSON archive (the reporter's primary contract).
  - Uses a **dynamic `import()`** to keep the large inlined CSS/JS off the hot path for non-reporting CLI invocations, matching the existing `htmlReporter` lazy-load.
  - The reporter **still returns the JSON path**; the HTML is a side artifact.

## Notes for reviewers

- Built test-first (red → green). New tests in `test/run-artifacts.test.js` cover: HTML written beside JSON, filename tracks `reportType` (`runCoverage` → `coverageResults.html`), HTML lands in the fresh in-tree folder when a stamped `runDir` is rejected, and the new `buildHtml` export. The existing JSON-return assertion is retained as a regression guard.
- Full suite: **855 passing**. The remaining failures are pre-existing, environment-dependent browser/screenshot/runner tests (Puppeteer/Appium) that require a real browser — none touch the reporter path.
- The `tryHtmlReporter` hint is intentionally unchanged: it nudges users to add `html` to their top-level `reporters` list, which remains distinct from the per-run `.doc-detective/run-*/` archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated HTML artifact generation now runs alongside JSON report output, creating human-readable HTML files in the run directory.

* **Tests**
  * Added test coverage for HTML artifact generation to verify correct file creation, naming across report types, and best-effort behavior when HTML writing fails.

* **Documentation**
  * Updated the changelog and package version for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->