### PR TITLE
feat(record): ffmpeg engine for any-app recording + concurrency-safe Chrome

### DIFF
--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -7065,7 +7065,7 @@
                                               "record": {
                                                 "$schema": "http://json-schema.org/draft-07/schema#",
                                                 "title": "record",
-                                                "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                                                "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
                                                 "anyOf": [
                                                   {
                                                     "title": "Record (simple)",
@@ -7100,6 +7100,55 @@
                                                         "enum": [
                                                           "true",
                                                           "false"
+                                                        ]
+                                                      },
+                                                      "engine": {
+                                                        "title": "Recording engine",
+                                                        "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                        "anyOf": [
+                                                          {
+                                                            "title": "Recording engine (simple)",
+                                                            "type": "string",
+                                                            "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                            "enum": [
+                                                              "browser",
+                                                              "ffmpeg"
+                                                            ]
+                                                          },
+                                                          {
+                                                            "title": "Recording engine (detailed)",
+                                                            "type": "object",
+                                                            "additionalProperties": false,
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "properties": {
+                                                              "name": {
+                                                                "type": "string",
+                                                                "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                                "enum": [
+                                                                  "browser",
+                                                                  "ffmpeg"
+                                                                ]
+                                                              },
+                                                              "target": {
+                                                                "type": "string",
+                                                                "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                                "enum": [
+                                                                  "display",
+                                                                  "window",
+                                                                  "viewport"
+                                                                ],
+                                                                "default": "display"
+                                                              },
+                                                              "fps": {
+                                                                "type": "integer",
+                                                                "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                                "default": 30,
+                                                                "minimum": 1
+                                                              }
+                                                            }
+                                                          }
                                                         ]
                                                       }
                                                     },
@@ -7147,9 +7196,107 @@
                                                             "true",
                                                             "false"
                                                           ]
+                                                        },
+                                                        "engine": {
+                                                          "title": "Recording engine",
+                                                          "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                          "anyOf": [
+                                                            {
+                                                              "title": "Recording engine (simple)",
+                                                              "type": "string",
+                                                              "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                              "enum": [
+                                                                "browser",
+                                                                "ffmpeg"
+                                                              ]
+                                                            },
+                                                            {
+                                                              "title": "Recording engine (detailed)",
+                                                              "type": "object",
+                                                              "additionalProperties": false,
+                                                              "required": [
+                                                                "name"
+                                                              ],
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string",
+                                                                  "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                                  "enum": [
+                                                                    "browser",
+                                                                    "ffmpeg"
+                                                                  ]
+                                                                },
+                                                                "target": {
+                                                                  "type": "string",
+                                                                  "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                                  "enum": [
+                                                                    "display",
+                                                                    "window",
+                                                                    "viewport"
+                                                                  ],
+                                                                  "default": "display"
+                                                                },
+                                                                "fps": {
+                                                                  "type": "integer",
+                                                                  "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                                  "default": 30,
+                                                                  "minimum": 1
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
                                                         }
                                                       },
                                                       "title": "Record (detailed)"
+                                                    },
+                                                    "engine": {
+                                                      "title": "Recording engine",
+                                                      "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                      "anyOf": [
+                                                        {
+                                                          "title": "Recording engine (simple)",
+                                                          "type": "string",
+                                                          "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                          "enum": [
+                                                            "browser",
+                                                            "ffmpeg"
+                                                          ]
+                                                        },
+                                                        {
+                                                          "title": "Recording engine (detailed)",
+                                                          "type": "object",
+                                                          "additionalProperties": false,
+                                                          "required": [
+                                                            "name"
+                                                          ],
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string",
+                                                              "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                              "enum": [
+                                                                "browser",
+                                                                "ffmpeg"
+                                                              ]
+                                                            },
+                                                            "target": {
+                                                              "type": "string",
+                                                              "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                              "enum": [
+                                                                "display",
+                                                                "window",
+                                                                "viewport"
+                                                              ],
+                                                              "default": "display"
+                                                            },
+                                                            "fps": {
+                                                              "type": "integer",
+                                                              "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                              "default": 30,
+                                                              "minimum": 1
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
                                                     }
                                                   }
                                                 },
@@ -7160,6 +7307,18 @@
                                                     "path": "results.mp4",
                                                     "directory": "static/media",
                                                     "overwrite": "true"
+                                                  },
+                                                  {
+                                                    "path": "results.mp4",
+                                                    "engine": "ffmpeg"
+                                                  },
+                                                  {
+                                                    "path": "results.mp4",
+                                                    "engine": {
+                                                      "name": "ffmpeg",
+                                                      "target": "window",
+                                                      "fps": 60
+                                                    }
                                                   }
                                                 ]
                                               }
@@ -15946,7 +16105,7 @@
                                 "record": {
                                   "$schema": "http://json-schema.org/draft-07/schema#",
                                   "title": "record",
-                                  "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                                  "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
                                   "anyOf": [
                                     {
                                       "title": "Record (simple)",
@@ -15981,6 +16140,55 @@
                                           "enum": [
                                             "true",
                                             "false"
+                                          ]
+                                        },
+                                        "engine": {
+                                          "title": "Recording engine",
+                                          "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                          "anyOf": [
+                                            {
+                                              "title": "Recording engine (simple)",
+                                              "type": "string",
+                                              "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                              "enum": [
+                                                "browser",
+                                                "ffmpeg"
+                                              ]
+                                            },
+                                            {
+                                              "title": "Recording engine (detailed)",
+                                              "type": "object",
+                                              "additionalProperties": false,
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string",
+                                                  "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                  "enum": [
+                                                    "browser",
+                                                    "ffmpeg"
+                                                  ]
+                                                },
+                                                "target": {
+                                                  "type": "string",
+                                                  "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                  "enum": [
+                                                    "display",
+                                                    "window",
+                                                    "viewport"
+                                                  ],
+                                                  "default": "display"
+                                                },
+                                                "fps": {
+                                                  "type": "integer",
+                                                  "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                  "default": 30,
+                                                  "minimum": 1
+                                                }
+                                              }
+                                            }
                                           ]
                                         }
                                       },
@@ -16028,9 +16236,107 @@
                                               "true",
                                               "false"
                                             ]
+                                          },
+                                          "engine": {
+                                            "title": "Recording engine",
+                                            "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                            "anyOf": [
+                                              {
+                                                "title": "Recording engine (simple)",
+                                                "type": "string",
+                                                "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                "enum": [
+                                                  "browser",
+                                                  "ffmpeg"
+                                                ]
+                                              },
+                                              {
+                                                "title": "Recording engine (detailed)",
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string",
+                                                    "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                    "enum": [
+                                                      "browser",
+                                                      "ffmpeg"
+                                                    ]
+                                                  },
+                                                  "target": {
+                                                    "type": "string",
+                                                    "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                    "enum": [
+                                                      "display",
+                                                      "window",
+                                                      "viewport"
+                                                    ],
+                                                    "default": "display"
+                                                  },
+                                                  "fps": {
+                                                    "type": "integer",
+                                                    "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                    "default": 30,
+                                                    "minimum": 1
+                                                  }
+                                                }
+                                              }
+                                            ]
                                           }
                                         },
                                         "title": "Record (detailed)"
+                                      },
+                                      "engine": {
+                                        "title": "Recording engine",
+                                        "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                        "anyOf": [
+                                          {
+                                            "title": "Recording engine (simple)",
+                                            "type": "string",
+                                            "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                            "enum": [
+                                              "browser",
+                                              "ffmpeg"
+                                            ]
+                                          },
+                                          {
+                                            "title": "Recording engine (detailed)",
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "properties": {
+                                              "name": {
+                                                "type": "string",
+                                                "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                "enum": [
+                                                  "browser",
+                                                  "ffmpeg"
+                                                ]
+                                              },
+                                              "target": {
+                                                "type": "string",
+                                                "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                "enum": [
+                                                  "display",
+                                                  "window",
+                                                  "viewport"
+                                                ],
+                                                "default": "display"
+                                              },
+                                              "fps": {
+                                                "type": "integer",
+                                                "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                "default": 30,
+                                                "minimum": 1
+                                              }
+                                            }
+                                          }
+                                        ]
                                       }
                                     }
                                   },
@@ -16041,6 +16347,18 @@
                                       "path": "results.mp4",
                                       "directory": "static/media",
                                       "overwrite": "true"
+                                    },
+                                    {
+                                      "path": "results.mp4",
+                                      "engine": "ffmpeg"
+                                    },
+                                    {
+                                      "path": "results.mp4",
+                                      "engine": {
+                                        "name": "ffmpeg",
+                                        "target": "window",
+                                        "fps": 60
+                                      }
                                     }
                                   ]
                                 }

--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -7157,7 +7157,7 @@
                                                   {
                                                     "type": "boolean",
                                                     "title": "Record (boolean)",
-                                                    "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                                                    "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                                                   }
                                                 ],
                                                 "components": {
@@ -16197,7 +16197,7 @@
                                     {
                                       "type": "boolean",
                                       "title": "Record (boolean)",
-                                      "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                                      "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                                     }
                                   ],
                                   "components": {

--- a/src/common/src/schemas/output_schemas/record_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/record_v3.schema.json
@@ -93,7 +93,7 @@
     {
       "type": "boolean",
       "title": "Record (boolean)",
-      "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+      "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
     }
   ],
   "components": {

--- a/src/common/src/schemas/output_schemas/record_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/record_v3.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "record",
-  "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+  "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
   "anyOf": [
     {
       "title": "Record (simple)",
@@ -36,6 +36,55 @@
           "enum": [
             "true",
             "false"
+          ]
+        },
+        "engine": {
+          "title": "Recording engine",
+          "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+          "anyOf": [
+            {
+              "title": "Recording engine (simple)",
+              "type": "string",
+              "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+              "enum": [
+                "browser",
+                "ffmpeg"
+              ]
+            },
+            {
+              "title": "Recording engine (detailed)",
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                  "enum": [
+                    "browser",
+                    "ffmpeg"
+                  ]
+                },
+                "target": {
+                  "type": "string",
+                  "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                  "enum": [
+                    "display",
+                    "window",
+                    "viewport"
+                  ],
+                  "default": "display"
+                },
+                "fps": {
+                  "type": "integer",
+                  "description": "Capture frame rate for the `ffmpeg` engine.",
+                  "default": 30,
+                  "minimum": 1
+                }
+              }
+            }
           ]
         }
       },
@@ -83,9 +132,107 @@
               "true",
               "false"
             ]
+          },
+          "engine": {
+            "title": "Recording engine",
+            "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+            "anyOf": [
+              {
+                "title": "Recording engine (simple)",
+                "type": "string",
+                "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                "enum": [
+                  "browser",
+                  "ffmpeg"
+                ]
+              },
+              {
+                "title": "Recording engine (detailed)",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                    "enum": [
+                      "browser",
+                      "ffmpeg"
+                    ]
+                  },
+                  "target": {
+                    "type": "string",
+                    "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                    "enum": [
+                      "display",
+                      "window",
+                      "viewport"
+                    ],
+                    "default": "display"
+                  },
+                  "fps": {
+                    "type": "integer",
+                    "description": "Capture frame rate for the `ffmpeg` engine.",
+                    "default": 30,
+                    "minimum": 1
+                  }
+                }
+              }
+            ]
           }
         },
         "title": "Record (detailed)"
+      },
+      "engine": {
+        "title": "Recording engine",
+        "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+        "anyOf": [
+          {
+            "title": "Recording engine (simple)",
+            "type": "string",
+            "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+            "enum": [
+              "browser",
+              "ffmpeg"
+            ]
+          },
+          {
+            "title": "Recording engine (detailed)",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                "enum": [
+                  "browser",
+                  "ffmpeg"
+                ]
+              },
+              "target": {
+                "type": "string",
+                "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                "enum": [
+                  "display",
+                  "window",
+                  "viewport"
+                ],
+                "default": "display"
+              },
+              "fps": {
+                "type": "integer",
+                "description": "Capture frame rate for the `ffmpeg` engine.",
+                "default": 30,
+                "minimum": 1
+              }
+            }
+          }
+        ]
       }
     }
   },
@@ -96,6 +243,18 @@
       "path": "results.mp4",
       "directory": "static/media",
       "overwrite": "true"
+    },
+    {
+      "path": "results.mp4",
+      "engine": "ffmpeg"
+    },
+    {
+      "path": "results.mp4",
+      "engine": {
+        "name": "ffmpeg",
+        "target": "window",
+        "fps": 60
+      }
     }
   ]
 }

--- a/src/common/src/schemas/output_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/report_v3.schema.json
@@ -7569,7 +7569,7 @@
                                           {
                                             "type": "boolean",
                                             "title": "Record (boolean)",
-                                            "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                                            "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                                           }
                                         ],
                                         "components": {
@@ -16043,7 +16043,7 @@
                                                 {
                                                   "type": "boolean",
                                                   "title": "Record (boolean)",
-                                                  "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                                                  "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                                                 }
                                               ],
                                               "components": {

--- a/src/common/src/schemas/output_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/report_v3.schema.json
@@ -7477,7 +7477,7 @@
                                       "record": {
                                         "$schema": "http://json-schema.org/draft-07/schema#",
                                         "title": "record",
-                                        "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                                        "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
                                         "anyOf": [
                                           {
                                             "title": "Record (simple)",
@@ -7512,6 +7512,55 @@
                                                 "enum": [
                                                   "true",
                                                   "false"
+                                                ]
+                                              },
+                                              "engine": {
+                                                "title": "Recording engine",
+                                                "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                "anyOf": [
+                                                  {
+                                                    "title": "Recording engine (simple)",
+                                                    "type": "string",
+                                                    "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                    "enum": [
+                                                      "browser",
+                                                      "ffmpeg"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "title": "Recording engine (detailed)",
+                                                    "type": "object",
+                                                    "additionalProperties": false,
+                                                    "required": [
+                                                      "name"
+                                                    ],
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string",
+                                                        "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                        "enum": [
+                                                          "browser",
+                                                          "ffmpeg"
+                                                        ]
+                                                      },
+                                                      "target": {
+                                                        "type": "string",
+                                                        "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                        "enum": [
+                                                          "display",
+                                                          "window",
+                                                          "viewport"
+                                                        ],
+                                                        "default": "display"
+                                                      },
+                                                      "fps": {
+                                                        "type": "integer",
+                                                        "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                        "default": 30,
+                                                        "minimum": 1
+                                                      }
+                                                    }
+                                                  }
                                                 ]
                                               }
                                             },
@@ -7559,9 +7608,107 @@
                                                     "true",
                                                     "false"
                                                   ]
+                                                },
+                                                "engine": {
+                                                  "title": "Recording engine",
+                                                  "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                  "anyOf": [
+                                                    {
+                                                      "title": "Recording engine (simple)",
+                                                      "type": "string",
+                                                      "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                      "enum": [
+                                                        "browser",
+                                                        "ffmpeg"
+                                                      ]
+                                                    },
+                                                    {
+                                                      "title": "Recording engine (detailed)",
+                                                      "type": "object",
+                                                      "additionalProperties": false,
+                                                      "required": [
+                                                        "name"
+                                                      ],
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string",
+                                                          "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                          "enum": [
+                                                            "browser",
+                                                            "ffmpeg"
+                                                          ]
+                                                        },
+                                                        "target": {
+                                                          "type": "string",
+                                                          "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                          "enum": [
+                                                            "display",
+                                                            "window",
+                                                            "viewport"
+                                                          ],
+                                                          "default": "display"
+                                                        },
+                                                        "fps": {
+                                                          "type": "integer",
+                                                          "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                          "default": 30,
+                                                          "minimum": 1
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
                                                 }
                                               },
                                               "title": "Record (detailed)"
+                                            },
+                                            "engine": {
+                                              "title": "Recording engine",
+                                              "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                              "anyOf": [
+                                                {
+                                                  "title": "Recording engine (simple)",
+                                                  "type": "string",
+                                                  "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                  "enum": [
+                                                    "browser",
+                                                    "ffmpeg"
+                                                  ]
+                                                },
+                                                {
+                                                  "title": "Recording engine (detailed)",
+                                                  "type": "object",
+                                                  "additionalProperties": false,
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string",
+                                                      "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                      "enum": [
+                                                        "browser",
+                                                        "ffmpeg"
+                                                      ]
+                                                    },
+                                                    "target": {
+                                                      "type": "string",
+                                                      "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                      "enum": [
+                                                        "display",
+                                                        "window",
+                                                        "viewport"
+                                                      ],
+                                                      "default": "display"
+                                                    },
+                                                    "fps": {
+                                                      "type": "integer",
+                                                      "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                      "default": 30,
+                                                      "minimum": 1
+                                                    }
+                                                  }
+                                                }
+                                              ]
                                             }
                                           }
                                         },
@@ -7572,6 +7719,18 @@
                                             "path": "results.mp4",
                                             "directory": "static/media",
                                             "overwrite": "true"
+                                          },
+                                          {
+                                            "path": "results.mp4",
+                                            "engine": "ffmpeg"
+                                          },
+                                          {
+                                            "path": "results.mp4",
+                                            "engine": {
+                                              "name": "ffmpeg",
+                                              "target": "window",
+                                              "fps": 60
+                                            }
                                           }
                                         ]
                                       }
@@ -15792,7 +15951,7 @@
                                             "record": {
                                               "$schema": "http://json-schema.org/draft-07/schema#",
                                               "title": "record",
-                                              "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                                              "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
                                               "anyOf": [
                                                 {
                                                   "title": "Record (simple)",
@@ -15827,6 +15986,55 @@
                                                       "enum": [
                                                         "true",
                                                         "false"
+                                                      ]
+                                                    },
+                                                    "engine": {
+                                                      "title": "Recording engine",
+                                                      "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                      "anyOf": [
+                                                        {
+                                                          "title": "Recording engine (simple)",
+                                                          "type": "string",
+                                                          "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                          "enum": [
+                                                            "browser",
+                                                            "ffmpeg"
+                                                          ]
+                                                        },
+                                                        {
+                                                          "title": "Recording engine (detailed)",
+                                                          "type": "object",
+                                                          "additionalProperties": false,
+                                                          "required": [
+                                                            "name"
+                                                          ],
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string",
+                                                              "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                              "enum": [
+                                                                "browser",
+                                                                "ffmpeg"
+                                                              ]
+                                                            },
+                                                            "target": {
+                                                              "type": "string",
+                                                              "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                              "enum": [
+                                                                "display",
+                                                                "window",
+                                                                "viewport"
+                                                              ],
+                                                              "default": "display"
+                                                            },
+                                                            "fps": {
+                                                              "type": "integer",
+                                                              "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                              "default": 30,
+                                                              "minimum": 1
+                                                            }
+                                                          }
+                                                        }
                                                       ]
                                                     }
                                                   },
@@ -15874,9 +16082,107 @@
                                                           "true",
                                                           "false"
                                                         ]
+                                                      },
+                                                      "engine": {
+                                                        "title": "Recording engine",
+                                                        "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                        "anyOf": [
+                                                          {
+                                                            "title": "Recording engine (simple)",
+                                                            "type": "string",
+                                                            "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                            "enum": [
+                                                              "browser",
+                                                              "ffmpeg"
+                                                            ]
+                                                          },
+                                                          {
+                                                            "title": "Recording engine (detailed)",
+                                                            "type": "object",
+                                                            "additionalProperties": false,
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "properties": {
+                                                              "name": {
+                                                                "type": "string",
+                                                                "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                                "enum": [
+                                                                  "browser",
+                                                                  "ffmpeg"
+                                                                ]
+                                                              },
+                                                              "target": {
+                                                                "type": "string",
+                                                                "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                                "enum": [
+                                                                  "display",
+                                                                  "window",
+                                                                  "viewport"
+                                                                ],
+                                                                "default": "display"
+                                                              },
+                                                              "fps": {
+                                                                "type": "integer",
+                                                                "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                                "default": 30,
+                                                                "minimum": 1
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
                                                       }
                                                     },
                                                     "title": "Record (detailed)"
+                                                  },
+                                                  "engine": {
+                                                    "title": "Recording engine",
+                                                    "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                    "anyOf": [
+                                                      {
+                                                        "title": "Recording engine (simple)",
+                                                        "type": "string",
+                                                        "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                        "enum": [
+                                                          "browser",
+                                                          "ffmpeg"
+                                                        ]
+                                                      },
+                                                      {
+                                                        "title": "Recording engine (detailed)",
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "properties": {
+                                                          "name": {
+                                                            "type": "string",
+                                                            "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                            "enum": [
+                                                              "browser",
+                                                              "ffmpeg"
+                                                            ]
+                                                          },
+                                                          "target": {
+                                                            "type": "string",
+                                                            "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                            "enum": [
+                                                              "display",
+                                                              "window",
+                                                              "viewport"
+                                                            ],
+                                                            "default": "display"
+                                                          },
+                                                          "fps": {
+                                                            "type": "integer",
+                                                            "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                            "default": 30,
+                                                            "minimum": 1
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
                                                   }
                                                 }
                                               },
@@ -15887,6 +16193,18 @@
                                                   "path": "results.mp4",
                                                   "directory": "static/media",
                                                   "overwrite": "true"
+                                                },
+                                                {
+                                                  "path": "results.mp4",
+                                                  "engine": "ffmpeg"
+                                                },
+                                                {
+                                                  "path": "results.mp4",
+                                                  "engine": {
+                                                    "name": "ffmpeg",
+                                                    "target": "window",
+                                                    "fps": 60
+                                                  }
                                                 }
                                               ]
                                             }

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -7170,7 +7170,7 @@
                                                       {
                                                         "type": "boolean",
                                                         "title": "Record (boolean)",
-                                                        "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                                                        "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                                                       }
                                                     ],
                                                     "components": {
@@ -16210,7 +16210,7 @@
                                         {
                                           "type": "boolean",
                                           "title": "Record (boolean)",
-                                          "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                                          "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                                         }
                                       ],
                                       "components": {
@@ -25925,7 +25925,7 @@
                                           {
                                             "type": "boolean",
                                             "title": "Record (boolean)",
-                                            "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                                            "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                                           }
                                         ],
                                         "components": {
@@ -34399,7 +34399,7 @@
                                                 {
                                                   "type": "boolean",
                                                   "title": "Record (boolean)",
-                                                  "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                                                  "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                                                 }
                                               ],
                                               "components": {

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -7078,7 +7078,7 @@
                                                   "record": {
                                                     "$schema": "http://json-schema.org/draft-07/schema#",
                                                     "title": "record",
-                                                    "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                                                    "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
                                                     "anyOf": [
                                                       {
                                                         "title": "Record (simple)",
@@ -7113,6 +7113,55 @@
                                                             "enum": [
                                                               "true",
                                                               "false"
+                                                            ]
+                                                          },
+                                                          "engine": {
+                                                            "title": "Recording engine",
+                                                            "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                            "anyOf": [
+                                                              {
+                                                                "title": "Recording engine (simple)",
+                                                                "type": "string",
+                                                                "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                                "enum": [
+                                                                  "browser",
+                                                                  "ffmpeg"
+                                                                ]
+                                                              },
+                                                              {
+                                                                "title": "Recording engine (detailed)",
+                                                                "type": "object",
+                                                                "additionalProperties": false,
+                                                                "required": [
+                                                                  "name"
+                                                                ],
+                                                                "properties": {
+                                                                  "name": {
+                                                                    "type": "string",
+                                                                    "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                                    "enum": [
+                                                                      "browser",
+                                                                      "ffmpeg"
+                                                                    ]
+                                                                  },
+                                                                  "target": {
+                                                                    "type": "string",
+                                                                    "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                                    "enum": [
+                                                                      "display",
+                                                                      "window",
+                                                                      "viewport"
+                                                                    ],
+                                                                    "default": "display"
+                                                                  },
+                                                                  "fps": {
+                                                                    "type": "integer",
+                                                                    "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                                    "default": 30,
+                                                                    "minimum": 1
+                                                                  }
+                                                                }
+                                                              }
                                                             ]
                                                           }
                                                         },
@@ -7160,9 +7209,107 @@
                                                                 "true",
                                                                 "false"
                                                               ]
+                                                            },
+                                                            "engine": {
+                                                              "title": "Recording engine",
+                                                              "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                              "anyOf": [
+                                                                {
+                                                                  "title": "Recording engine (simple)",
+                                                                  "type": "string",
+                                                                  "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                                  "enum": [
+                                                                    "browser",
+                                                                    "ffmpeg"
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "title": "Recording engine (detailed)",
+                                                                  "type": "object",
+                                                                  "additionalProperties": false,
+                                                                  "required": [
+                                                                    "name"
+                                                                  ],
+                                                                  "properties": {
+                                                                    "name": {
+                                                                      "type": "string",
+                                                                      "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                                      "enum": [
+                                                                        "browser",
+                                                                        "ffmpeg"
+                                                                      ]
+                                                                    },
+                                                                    "target": {
+                                                                      "type": "string",
+                                                                      "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                                      "enum": [
+                                                                        "display",
+                                                                        "window",
+                                                                        "viewport"
+                                                                      ],
+                                                                      "default": "display"
+                                                                    },
+                                                                    "fps": {
+                                                                      "type": "integer",
+                                                                      "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                                      "default": 30,
+                                                                      "minimum": 1
+                                                                    }
+                                                                  }
+                                                                }
+                                                              ]
                                                             }
                                                           },
                                                           "title": "Record (detailed)"
+                                                        },
+                                                        "engine": {
+                                                          "title": "Recording engine",
+                                                          "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                          "anyOf": [
+                                                            {
+                                                              "title": "Recording engine (simple)",
+                                                              "type": "string",
+                                                              "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                              "enum": [
+                                                                "browser",
+                                                                "ffmpeg"
+                                                              ]
+                                                            },
+                                                            {
+                                                              "title": "Recording engine (detailed)",
+                                                              "type": "object",
+                                                              "additionalProperties": false,
+                                                              "required": [
+                                                                "name"
+                                                              ],
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string",
+                                                                  "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                                  "enum": [
+                                                                    "browser",
+                                                                    "ffmpeg"
+                                                                  ]
+                                                                },
+                                                                "target": {
+                                                                  "type": "string",
+                                                                  "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                                  "enum": [
+                                                                    "display",
+                                                                    "window",
+                                                                    "viewport"
+                                                                  ],
+                                                                  "default": "display"
+                                                                },
+                                                                "fps": {
+                                                                  "type": "integer",
+                                                                  "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                                  "default": 30,
+                                                                  "minimum": 1
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
                                                         }
                                                       }
                                                     },
@@ -7173,6 +7320,18 @@
                                                         "path": "results.mp4",
                                                         "directory": "static/media",
                                                         "overwrite": "true"
+                                                      },
+                                                      {
+                                                        "path": "results.mp4",
+                                                        "engine": "ffmpeg"
+                                                      },
+                                                      {
+                                                        "path": "results.mp4",
+                                                        "engine": {
+                                                          "name": "ffmpeg",
+                                                          "target": "window",
+                                                          "fps": 60
+                                                        }
                                                       }
                                                     ]
                                                   }
@@ -15959,7 +16118,7 @@
                                     "record": {
                                       "$schema": "http://json-schema.org/draft-07/schema#",
                                       "title": "record",
-                                      "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                                      "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
                                       "anyOf": [
                                         {
                                           "title": "Record (simple)",
@@ -15994,6 +16153,55 @@
                                               "enum": [
                                                 "true",
                                                 "false"
+                                              ]
+                                            },
+                                            "engine": {
+                                              "title": "Recording engine",
+                                              "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                              "anyOf": [
+                                                {
+                                                  "title": "Recording engine (simple)",
+                                                  "type": "string",
+                                                  "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                  "enum": [
+                                                    "browser",
+                                                    "ffmpeg"
+                                                  ]
+                                                },
+                                                {
+                                                  "title": "Recording engine (detailed)",
+                                                  "type": "object",
+                                                  "additionalProperties": false,
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string",
+                                                      "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                      "enum": [
+                                                        "browser",
+                                                        "ffmpeg"
+                                                      ]
+                                                    },
+                                                    "target": {
+                                                      "type": "string",
+                                                      "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                      "enum": [
+                                                        "display",
+                                                        "window",
+                                                        "viewport"
+                                                      ],
+                                                      "default": "display"
+                                                    },
+                                                    "fps": {
+                                                      "type": "integer",
+                                                      "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                      "default": 30,
+                                                      "minimum": 1
+                                                    }
+                                                  }
+                                                }
                                               ]
                                             }
                                           },
@@ -16041,9 +16249,107 @@
                                                   "true",
                                                   "false"
                                                 ]
+                                              },
+                                              "engine": {
+                                                "title": "Recording engine",
+                                                "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                "anyOf": [
+                                                  {
+                                                    "title": "Recording engine (simple)",
+                                                    "type": "string",
+                                                    "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                    "enum": [
+                                                      "browser",
+                                                      "ffmpeg"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "title": "Recording engine (detailed)",
+                                                    "type": "object",
+                                                    "additionalProperties": false,
+                                                    "required": [
+                                                      "name"
+                                                    ],
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string",
+                                                        "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                        "enum": [
+                                                          "browser",
+                                                          "ffmpeg"
+                                                        ]
+                                                      },
+                                                      "target": {
+                                                        "type": "string",
+                                                        "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                        "enum": [
+                                                          "display",
+                                                          "window",
+                                                          "viewport"
+                                                        ],
+                                                        "default": "display"
+                                                      },
+                                                      "fps": {
+                                                        "type": "integer",
+                                                        "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                        "default": 30,
+                                                        "minimum": 1
+                                                      }
+                                                    }
+                                                  }
+                                                ]
                                               }
                                             },
                                             "title": "Record (detailed)"
+                                          },
+                                          "engine": {
+                                            "title": "Recording engine",
+                                            "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                            "anyOf": [
+                                              {
+                                                "title": "Recording engine (simple)",
+                                                "type": "string",
+                                                "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                "enum": [
+                                                  "browser",
+                                                  "ffmpeg"
+                                                ]
+                                              },
+                                              {
+                                                "title": "Recording engine (detailed)",
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string",
+                                                    "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                    "enum": [
+                                                      "browser",
+                                                      "ffmpeg"
+                                                    ]
+                                                  },
+                                                  "target": {
+                                                    "type": "string",
+                                                    "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                    "enum": [
+                                                      "display",
+                                                      "window",
+                                                      "viewport"
+                                                    ],
+                                                    "default": "display"
+                                                  },
+                                                  "fps": {
+                                                    "type": "integer",
+                                                    "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                    "default": 30,
+                                                    "minimum": 1
+                                                  }
+                                                }
+                                              }
+                                            ]
                                           }
                                         }
                                       },
@@ -16054,6 +16360,18 @@
                                           "path": "results.mp4",
                                           "directory": "static/media",
                                           "overwrite": "true"
+                                        },
+                                        {
+                                          "path": "results.mp4",
+                                          "engine": "ffmpeg"
+                                        },
+                                        {
+                                          "path": "results.mp4",
+                                          "engine": {
+                                            "name": "ffmpeg",
+                                            "target": "window",
+                                            "fps": 60
+                                          }
                                         }
                                       ]
                                     }
@@ -25515,7 +25833,7 @@
                                       "record": {
                                         "$schema": "http://json-schema.org/draft-07/schema#",
                                         "title": "record",
-                                        "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                                        "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
                                         "anyOf": [
                                           {
                                             "title": "Record (simple)",
@@ -25550,6 +25868,55 @@
                                                 "enum": [
                                                   "true",
                                                   "false"
+                                                ]
+                                              },
+                                              "engine": {
+                                                "title": "Recording engine",
+                                                "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                "anyOf": [
+                                                  {
+                                                    "title": "Recording engine (simple)",
+                                                    "type": "string",
+                                                    "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                    "enum": [
+                                                      "browser",
+                                                      "ffmpeg"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "title": "Recording engine (detailed)",
+                                                    "type": "object",
+                                                    "additionalProperties": false,
+                                                    "required": [
+                                                      "name"
+                                                    ],
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string",
+                                                        "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                        "enum": [
+                                                          "browser",
+                                                          "ffmpeg"
+                                                        ]
+                                                      },
+                                                      "target": {
+                                                        "type": "string",
+                                                        "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                        "enum": [
+                                                          "display",
+                                                          "window",
+                                                          "viewport"
+                                                        ],
+                                                        "default": "display"
+                                                      },
+                                                      "fps": {
+                                                        "type": "integer",
+                                                        "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                        "default": 30,
+                                                        "minimum": 1
+                                                      }
+                                                    }
+                                                  }
                                                 ]
                                               }
                                             },
@@ -25597,9 +25964,107 @@
                                                     "true",
                                                     "false"
                                                   ]
+                                                },
+                                                "engine": {
+                                                  "title": "Recording engine",
+                                                  "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                  "anyOf": [
+                                                    {
+                                                      "title": "Recording engine (simple)",
+                                                      "type": "string",
+                                                      "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                      "enum": [
+                                                        "browser",
+                                                        "ffmpeg"
+                                                      ]
+                                                    },
+                                                    {
+                                                      "title": "Recording engine (detailed)",
+                                                      "type": "object",
+                                                      "additionalProperties": false,
+                                                      "required": [
+                                                        "name"
+                                                      ],
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string",
+                                                          "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                          "enum": [
+                                                            "browser",
+                                                            "ffmpeg"
+                                                          ]
+                                                        },
+                                                        "target": {
+                                                          "type": "string",
+                                                          "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                          "enum": [
+                                                            "display",
+                                                            "window",
+                                                            "viewport"
+                                                          ],
+                                                          "default": "display"
+                                                        },
+                                                        "fps": {
+                                                          "type": "integer",
+                                                          "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                          "default": 30,
+                                                          "minimum": 1
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
                                                 }
                                               },
                                               "title": "Record (detailed)"
+                                            },
+                                            "engine": {
+                                              "title": "Recording engine",
+                                              "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                              "anyOf": [
+                                                {
+                                                  "title": "Recording engine (simple)",
+                                                  "type": "string",
+                                                  "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                  "enum": [
+                                                    "browser",
+                                                    "ffmpeg"
+                                                  ]
+                                                },
+                                                {
+                                                  "title": "Recording engine (detailed)",
+                                                  "type": "object",
+                                                  "additionalProperties": false,
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string",
+                                                      "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                      "enum": [
+                                                        "browser",
+                                                        "ffmpeg"
+                                                      ]
+                                                    },
+                                                    "target": {
+                                                      "type": "string",
+                                                      "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                      "enum": [
+                                                        "display",
+                                                        "window",
+                                                        "viewport"
+                                                      ],
+                                                      "default": "display"
+                                                    },
+                                                    "fps": {
+                                                      "type": "integer",
+                                                      "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                      "default": 30,
+                                                      "minimum": 1
+                                                    }
+                                                  }
+                                                }
+                                              ]
                                             }
                                           }
                                         },
@@ -25610,6 +26075,18 @@
                                             "path": "results.mp4",
                                             "directory": "static/media",
                                             "overwrite": "true"
+                                          },
+                                          {
+                                            "path": "results.mp4",
+                                            "engine": "ffmpeg"
+                                          },
+                                          {
+                                            "path": "results.mp4",
+                                            "engine": {
+                                              "name": "ffmpeg",
+                                              "target": "window",
+                                              "fps": 60
+                                            }
                                           }
                                         ]
                                       }
@@ -33830,7 +34307,7 @@
                                             "record": {
                                               "$schema": "http://json-schema.org/draft-07/schema#",
                                               "title": "record",
-                                              "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                                              "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
                                               "anyOf": [
                                                 {
                                                   "title": "Record (simple)",
@@ -33865,6 +34342,55 @@
                                                       "enum": [
                                                         "true",
                                                         "false"
+                                                      ]
+                                                    },
+                                                    "engine": {
+                                                      "title": "Recording engine",
+                                                      "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                      "anyOf": [
+                                                        {
+                                                          "title": "Recording engine (simple)",
+                                                          "type": "string",
+                                                          "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                          "enum": [
+                                                            "browser",
+                                                            "ffmpeg"
+                                                          ]
+                                                        },
+                                                        {
+                                                          "title": "Recording engine (detailed)",
+                                                          "type": "object",
+                                                          "additionalProperties": false,
+                                                          "required": [
+                                                            "name"
+                                                          ],
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string",
+                                                              "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                              "enum": [
+                                                                "browser",
+                                                                "ffmpeg"
+                                                              ]
+                                                            },
+                                                            "target": {
+                                                              "type": "string",
+                                                              "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                              "enum": [
+                                                                "display",
+                                                                "window",
+                                                                "viewport"
+                                                              ],
+                                                              "default": "display"
+                                                            },
+                                                            "fps": {
+                                                              "type": "integer",
+                                                              "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                              "default": 30,
+                                                              "minimum": 1
+                                                            }
+                                                          }
+                                                        }
                                                       ]
                                                     }
                                                   },
@@ -33912,9 +34438,107 @@
                                                           "true",
                                                           "false"
                                                         ]
+                                                      },
+                                                      "engine": {
+                                                        "title": "Recording engine",
+                                                        "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                        "anyOf": [
+                                                          {
+                                                            "title": "Recording engine (simple)",
+                                                            "type": "string",
+                                                            "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                            "enum": [
+                                                              "browser",
+                                                              "ffmpeg"
+                                                            ]
+                                                          },
+                                                          {
+                                                            "title": "Recording engine (detailed)",
+                                                            "type": "object",
+                                                            "additionalProperties": false,
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "properties": {
+                                                              "name": {
+                                                                "type": "string",
+                                                                "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                                "enum": [
+                                                                  "browser",
+                                                                  "ffmpeg"
+                                                                ]
+                                                              },
+                                                              "target": {
+                                                                "type": "string",
+                                                                "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                                "enum": [
+                                                                  "display",
+                                                                  "window",
+                                                                  "viewport"
+                                                                ],
+                                                                "default": "display"
+                                                              },
+                                                              "fps": {
+                                                                "type": "integer",
+                                                                "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                                "default": 30,
+                                                                "minimum": 1
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
                                                       }
                                                     },
                                                     "title": "Record (detailed)"
+                                                  },
+                                                  "engine": {
+                                                    "title": "Recording engine",
+                                                    "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                                    "anyOf": [
+                                                      {
+                                                        "title": "Recording engine (simple)",
+                                                        "type": "string",
+                                                        "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                        "enum": [
+                                                          "browser",
+                                                          "ffmpeg"
+                                                        ]
+                                                      },
+                                                      {
+                                                        "title": "Recording engine (detailed)",
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "properties": {
+                                                          "name": {
+                                                            "type": "string",
+                                                            "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                            "enum": [
+                                                              "browser",
+                                                              "ffmpeg"
+                                                            ]
+                                                          },
+                                                          "target": {
+                                                            "type": "string",
+                                                            "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                            "enum": [
+                                                              "display",
+                                                              "window",
+                                                              "viewport"
+                                                            ],
+                                                            "default": "display"
+                                                          },
+                                                          "fps": {
+                                                            "type": "integer",
+                                                            "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                            "default": 30,
+                                                            "minimum": 1
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
                                                   }
                                                 }
                                               },
@@ -33925,6 +34549,18 @@
                                                   "path": "results.mp4",
                                                   "directory": "static/media",
                                                   "overwrite": "true"
+                                                },
+                                                {
+                                                  "path": "results.mp4",
+                                                  "engine": "ffmpeg"
+                                                },
+                                                {
+                                                  "path": "results.mp4",
+                                                  "engine": {
+                                                    "name": "ffmpeg",
+                                                    "target": "window",
+                                                    "fps": 60
+                                                  }
                                                 }
                                               ]
                                             }

--- a/src/common/src/schemas/output_schemas/spec_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/spec_v3.schema.json
@@ -7449,7 +7449,7 @@
                             "record": {
                               "$schema": "http://json-schema.org/draft-07/schema#",
                               "title": "record",
-                              "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                              "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
                               "anyOf": [
                                 {
                                   "title": "Record (simple)",
@@ -7484,6 +7484,55 @@
                                       "enum": [
                                         "true",
                                         "false"
+                                      ]
+                                    },
+                                    "engine": {
+                                      "title": "Recording engine",
+                                      "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                      "anyOf": [
+                                        {
+                                          "title": "Recording engine (simple)",
+                                          "type": "string",
+                                          "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                          "enum": [
+                                            "browser",
+                                            "ffmpeg"
+                                          ]
+                                        },
+                                        {
+                                          "title": "Recording engine (detailed)",
+                                          "type": "object",
+                                          "additionalProperties": false,
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": "string",
+                                              "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                              "enum": [
+                                                "browser",
+                                                "ffmpeg"
+                                              ]
+                                            },
+                                            "target": {
+                                              "type": "string",
+                                              "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                              "enum": [
+                                                "display",
+                                                "window",
+                                                "viewport"
+                                              ],
+                                              "default": "display"
+                                            },
+                                            "fps": {
+                                              "type": "integer",
+                                              "description": "Capture frame rate for the `ffmpeg` engine.",
+                                              "default": 30,
+                                              "minimum": 1
+                                            }
+                                          }
+                                        }
                                       ]
                                     }
                                   },
@@ -7531,9 +7580,107 @@
                                           "true",
                                           "false"
                                         ]
+                                      },
+                                      "engine": {
+                                        "title": "Recording engine",
+                                        "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                        "anyOf": [
+                                          {
+                                            "title": "Recording engine (simple)",
+                                            "type": "string",
+                                            "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                            "enum": [
+                                              "browser",
+                                              "ffmpeg"
+                                            ]
+                                          },
+                                          {
+                                            "title": "Recording engine (detailed)",
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "properties": {
+                                              "name": {
+                                                "type": "string",
+                                                "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                "enum": [
+                                                  "browser",
+                                                  "ffmpeg"
+                                                ]
+                                              },
+                                              "target": {
+                                                "type": "string",
+                                                "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                "enum": [
+                                                  "display",
+                                                  "window",
+                                                  "viewport"
+                                                ],
+                                                "default": "display"
+                                              },
+                                              "fps": {
+                                                "type": "integer",
+                                                "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                "default": 30,
+                                                "minimum": 1
+                                              }
+                                            }
+                                          }
+                                        ]
                                       }
                                     },
                                     "title": "Record (detailed)"
+                                  },
+                                  "engine": {
+                                    "title": "Recording engine",
+                                    "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                    "anyOf": [
+                                      {
+                                        "title": "Recording engine (simple)",
+                                        "type": "string",
+                                        "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                        "enum": [
+                                          "browser",
+                                          "ffmpeg"
+                                        ]
+                                      },
+                                      {
+                                        "title": "Recording engine (detailed)",
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "properties": {
+                                          "name": {
+                                            "type": "string",
+                                            "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                            "enum": [
+                                              "browser",
+                                              "ffmpeg"
+                                            ]
+                                          },
+                                          "target": {
+                                            "type": "string",
+                                            "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                            "enum": [
+                                              "display",
+                                              "window",
+                                              "viewport"
+                                            ],
+                                            "default": "display"
+                                          },
+                                          "fps": {
+                                            "type": "integer",
+                                            "description": "Capture frame rate for the `ffmpeg` engine.",
+                                            "default": 30,
+                                            "minimum": 1
+                                          }
+                                        }
+                                      }
+                                    ]
                                   }
                                 }
                               },
@@ -7544,6 +7691,18 @@
                                   "path": "results.mp4",
                                   "directory": "static/media",
                                   "overwrite": "true"
+                                },
+                                {
+                                  "path": "results.mp4",
+                                  "engine": "ffmpeg"
+                                },
+                                {
+                                  "path": "results.mp4",
+                                  "engine": {
+                                    "name": "ffmpeg",
+                                    "target": "window",
+                                    "fps": 60
+                                  }
                                 }
                               ]
                             }
@@ -15764,7 +15923,7 @@
                                   "record": {
                                     "$schema": "http://json-schema.org/draft-07/schema#",
                                     "title": "record",
-                                    "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                                    "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
                                     "anyOf": [
                                       {
                                         "title": "Record (simple)",
@@ -15799,6 +15958,55 @@
                                             "enum": [
                                               "true",
                                               "false"
+                                            ]
+                                          },
+                                          "engine": {
+                                            "title": "Recording engine",
+                                            "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                            "anyOf": [
+                                              {
+                                                "title": "Recording engine (simple)",
+                                                "type": "string",
+                                                "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                "enum": [
+                                                  "browser",
+                                                  "ffmpeg"
+                                                ]
+                                              },
+                                              {
+                                                "title": "Recording engine (detailed)",
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string",
+                                                    "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                    "enum": [
+                                                      "browser",
+                                                      "ffmpeg"
+                                                    ]
+                                                  },
+                                                  "target": {
+                                                    "type": "string",
+                                                    "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                    "enum": [
+                                                      "display",
+                                                      "window",
+                                                      "viewport"
+                                                    ],
+                                                    "default": "display"
+                                                  },
+                                                  "fps": {
+                                                    "type": "integer",
+                                                    "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                    "default": 30,
+                                                    "minimum": 1
+                                                  }
+                                                }
+                                              }
                                             ]
                                           }
                                         },
@@ -15846,9 +16054,107 @@
                                                 "true",
                                                 "false"
                                               ]
+                                            },
+                                            "engine": {
+                                              "title": "Recording engine",
+                                              "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                              "anyOf": [
+                                                {
+                                                  "title": "Recording engine (simple)",
+                                                  "type": "string",
+                                                  "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                  "enum": [
+                                                    "browser",
+                                                    "ffmpeg"
+                                                  ]
+                                                },
+                                                {
+                                                  "title": "Recording engine (detailed)",
+                                                  "type": "object",
+                                                  "additionalProperties": false,
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string",
+                                                      "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                      "enum": [
+                                                        "browser",
+                                                        "ffmpeg"
+                                                      ]
+                                                    },
+                                                    "target": {
+                                                      "type": "string",
+                                                      "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                      "enum": [
+                                                        "display",
+                                                        "window",
+                                                        "viewport"
+                                                      ],
+                                                      "default": "display"
+                                                    },
+                                                    "fps": {
+                                                      "type": "integer",
+                                                      "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                      "default": 30,
+                                                      "minimum": 1
+                                                    }
+                                                  }
+                                                }
+                                              ]
                                             }
                                           },
                                           "title": "Record (detailed)"
+                                        },
+                                        "engine": {
+                                          "title": "Recording engine",
+                                          "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                          "anyOf": [
+                                            {
+                                              "title": "Recording engine (simple)",
+                                              "type": "string",
+                                              "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                              "enum": [
+                                                "browser",
+                                                "ffmpeg"
+                                              ]
+                                            },
+                                            {
+                                              "title": "Recording engine (detailed)",
+                                              "type": "object",
+                                              "additionalProperties": false,
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string",
+                                                  "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                                  "enum": [
+                                                    "browser",
+                                                    "ffmpeg"
+                                                  ]
+                                                },
+                                                "target": {
+                                                  "type": "string",
+                                                  "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                                  "enum": [
+                                                    "display",
+                                                    "window",
+                                                    "viewport"
+                                                  ],
+                                                  "default": "display"
+                                                },
+                                                "fps": {
+                                                  "type": "integer",
+                                                  "description": "Capture frame rate for the `ffmpeg` engine.",
+                                                  "default": 30,
+                                                  "minimum": 1
+                                                }
+                                              }
+                                            }
+                                          ]
                                         }
                                       }
                                     },
@@ -15859,6 +16165,18 @@
                                         "path": "results.mp4",
                                         "directory": "static/media",
                                         "overwrite": "true"
+                                      },
+                                      {
+                                        "path": "results.mp4",
+                                        "engine": "ffmpeg"
+                                      },
+                                      {
+                                        "path": "results.mp4",
+                                        "engine": {
+                                          "name": "ffmpeg",
+                                          "target": "window",
+                                          "fps": 60
+                                        }
                                       }
                                     ]
                                   }

--- a/src/common/src/schemas/output_schemas/spec_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/spec_v3.schema.json
@@ -7541,7 +7541,7 @@
                                 {
                                   "type": "boolean",
                                   "title": "Record (boolean)",
-                                  "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                                  "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                                 }
                               ],
                               "components": {
@@ -16015,7 +16015,7 @@
                                       {
                                         "type": "boolean",
                                         "title": "Record (boolean)",
-                                        "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                                        "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                                       }
                                     ],
                                     "components": {

--- a/src/common/src/schemas/output_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/step_v3.schema.json
@@ -6241,7 +6241,7 @@
             "record": {
               "$schema": "http://json-schema.org/draft-07/schema#",
               "title": "record",
-              "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+              "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
               "anyOf": [
                 {
                   "title": "Record (simple)",
@@ -6276,6 +6276,55 @@
                       "enum": [
                         "true",
                         "false"
+                      ]
+                    },
+                    "engine": {
+                      "title": "Recording engine",
+                      "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                      "anyOf": [
+                        {
+                          "title": "Recording engine (simple)",
+                          "type": "string",
+                          "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                          "enum": [
+                            "browser",
+                            "ffmpeg"
+                          ]
+                        },
+                        {
+                          "title": "Recording engine (detailed)",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "required": [
+                            "name"
+                          ],
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                              "enum": [
+                                "browser",
+                                "ffmpeg"
+                              ]
+                            },
+                            "target": {
+                              "type": "string",
+                              "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                              "enum": [
+                                "display",
+                                "window",
+                                "viewport"
+                              ],
+                              "default": "display"
+                            },
+                            "fps": {
+                              "type": "integer",
+                              "description": "Capture frame rate for the `ffmpeg` engine.",
+                              "default": 30,
+                              "minimum": 1
+                            }
+                          }
+                        }
                       ]
                     }
                   },
@@ -6323,9 +6372,107 @@
                           "true",
                           "false"
                         ]
+                      },
+                      "engine": {
+                        "title": "Recording engine",
+                        "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                        "anyOf": [
+                          {
+                            "title": "Recording engine (simple)",
+                            "type": "string",
+                            "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                            "enum": [
+                              "browser",
+                              "ffmpeg"
+                            ]
+                          },
+                          {
+                            "title": "Recording engine (detailed)",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                "enum": [
+                                  "browser",
+                                  "ffmpeg"
+                                ]
+                              },
+                              "target": {
+                                "type": "string",
+                                "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                "enum": [
+                                  "display",
+                                  "window",
+                                  "viewport"
+                                ],
+                                "default": "display"
+                              },
+                              "fps": {
+                                "type": "integer",
+                                "description": "Capture frame rate for the `ffmpeg` engine.",
+                                "default": 30,
+                                "minimum": 1
+                              }
+                            }
+                          }
+                        ]
                       }
                     },
                     "title": "Record (detailed)"
+                  },
+                  "engine": {
+                    "title": "Recording engine",
+                    "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                    "anyOf": [
+                      {
+                        "title": "Recording engine (simple)",
+                        "type": "string",
+                        "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                        "enum": [
+                          "browser",
+                          "ffmpeg"
+                        ]
+                      },
+                      {
+                        "title": "Recording engine (detailed)",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                            "enum": [
+                              "browser",
+                              "ffmpeg"
+                            ]
+                          },
+                          "target": {
+                            "type": "string",
+                            "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                            "enum": [
+                              "display",
+                              "window",
+                              "viewport"
+                            ],
+                            "default": "display"
+                          },
+                          "fps": {
+                            "type": "integer",
+                            "description": "Capture frame rate for the `ffmpeg` engine.",
+                            "default": 30,
+                            "minimum": 1
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               },
@@ -6336,6 +6483,18 @@
                   "path": "results.mp4",
                   "directory": "static/media",
                   "overwrite": "true"
+                },
+                {
+                  "path": "results.mp4",
+                  "engine": "ffmpeg"
+                },
+                {
+                  "path": "results.mp4",
+                  "engine": {
+                    "name": "ffmpeg",
+                    "target": "window",
+                    "fps": 60
+                  }
                 }
               ]
             }

--- a/src/common/src/schemas/output_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/step_v3.schema.json
@@ -6333,7 +6333,7 @@
                 {
                   "type": "boolean",
                   "title": "Record (boolean)",
-                  "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                  "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                 }
               ],
               "components": {

--- a/src/common/src/schemas/output_schemas/test_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/test_v3.schema.json
@@ -6844,7 +6844,7 @@
                   "record": {
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "title": "record",
-                    "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                    "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
                     "anyOf": [
                       {
                         "title": "Record (simple)",
@@ -6879,6 +6879,55 @@
                             "enum": [
                               "true",
                               "false"
+                            ]
+                          },
+                          "engine": {
+                            "title": "Recording engine",
+                            "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                            "anyOf": [
+                              {
+                                "title": "Recording engine (simple)",
+                                "type": "string",
+                                "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                "enum": [
+                                  "browser",
+                                  "ffmpeg"
+                                ]
+                              },
+                              {
+                                "title": "Recording engine (detailed)",
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                    "enum": [
+                                      "browser",
+                                      "ffmpeg"
+                                    ]
+                                  },
+                                  "target": {
+                                    "type": "string",
+                                    "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                    "enum": [
+                                      "display",
+                                      "window",
+                                      "viewport"
+                                    ],
+                                    "default": "display"
+                                  },
+                                  "fps": {
+                                    "type": "integer",
+                                    "description": "Capture frame rate for the `ffmpeg` engine.",
+                                    "default": 30,
+                                    "minimum": 1
+                                  }
+                                }
+                              }
                             ]
                           }
                         },
@@ -6926,9 +6975,107 @@
                                 "true",
                                 "false"
                               ]
+                            },
+                            "engine": {
+                              "title": "Recording engine",
+                              "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                              "anyOf": [
+                                {
+                                  "title": "Recording engine (simple)",
+                                  "type": "string",
+                                  "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                  "enum": [
+                                    "browser",
+                                    "ffmpeg"
+                                  ]
+                                },
+                                {
+                                  "title": "Recording engine (detailed)",
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                      "enum": [
+                                        "browser",
+                                        "ffmpeg"
+                                      ]
+                                    },
+                                    "target": {
+                                      "type": "string",
+                                      "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                      "enum": [
+                                        "display",
+                                        "window",
+                                        "viewport"
+                                      ],
+                                      "default": "display"
+                                    },
+                                    "fps": {
+                                      "type": "integer",
+                                      "description": "Capture frame rate for the `ffmpeg` engine.",
+                                      "default": 30,
+                                      "minimum": 1
+                                    }
+                                  }
+                                }
+                              ]
                             }
                           },
                           "title": "Record (detailed)"
+                        },
+                        "engine": {
+                          "title": "Recording engine",
+                          "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                          "anyOf": [
+                            {
+                              "title": "Recording engine (simple)",
+                              "type": "string",
+                              "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                              "enum": [
+                                "browser",
+                                "ffmpeg"
+                              ]
+                            },
+                            {
+                              "title": "Recording engine (detailed)",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "required": [
+                                "name"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                  "enum": [
+                                    "browser",
+                                    "ffmpeg"
+                                  ]
+                                },
+                                "target": {
+                                  "type": "string",
+                                  "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                  "enum": [
+                                    "display",
+                                    "window",
+                                    "viewport"
+                                  ],
+                                  "default": "display"
+                                },
+                                "fps": {
+                                  "type": "integer",
+                                  "description": "Capture frame rate for the `ffmpeg` engine.",
+                                  "default": 30,
+                                  "minimum": 1
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -6939,6 +7086,18 @@
                         "path": "results.mp4",
                         "directory": "static/media",
                         "overwrite": "true"
+                      },
+                      {
+                        "path": "results.mp4",
+                        "engine": "ffmpeg"
+                      },
+                      {
+                        "path": "results.mp4",
+                        "engine": {
+                          "name": "ffmpeg",
+                          "target": "window",
+                          "fps": 60
+                        }
                       }
                     ]
                   }
@@ -15159,7 +15318,7 @@
                         "record": {
                           "$schema": "http://json-schema.org/draft-07/schema#",
                           "title": "record",
-                          "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                          "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
                           "anyOf": [
                             {
                               "title": "Record (simple)",
@@ -15194,6 +15353,55 @@
                                   "enum": [
                                     "true",
                                     "false"
+                                  ]
+                                },
+                                "engine": {
+                                  "title": "Recording engine",
+                                  "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                  "anyOf": [
+                                    {
+                                      "title": "Recording engine (simple)",
+                                      "type": "string",
+                                      "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                      "enum": [
+                                        "browser",
+                                        "ffmpeg"
+                                      ]
+                                    },
+                                    {
+                                      "title": "Recording engine (detailed)",
+                                      "type": "object",
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                          "enum": [
+                                            "browser",
+                                            "ffmpeg"
+                                          ]
+                                        },
+                                        "target": {
+                                          "type": "string",
+                                          "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                          "enum": [
+                                            "display",
+                                            "window",
+                                            "viewport"
+                                          ],
+                                          "default": "display"
+                                        },
+                                        "fps": {
+                                          "type": "integer",
+                                          "description": "Capture frame rate for the `ffmpeg` engine.",
+                                          "default": 30,
+                                          "minimum": 1
+                                        }
+                                      }
+                                    }
                                   ]
                                 }
                               },
@@ -15241,9 +15449,107 @@
                                       "true",
                                       "false"
                                     ]
+                                  },
+                                  "engine": {
+                                    "title": "Recording engine",
+                                    "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                    "anyOf": [
+                                      {
+                                        "title": "Recording engine (simple)",
+                                        "type": "string",
+                                        "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                        "enum": [
+                                          "browser",
+                                          "ffmpeg"
+                                        ]
+                                      },
+                                      {
+                                        "title": "Recording engine (detailed)",
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "properties": {
+                                          "name": {
+                                            "type": "string",
+                                            "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                            "enum": [
+                                              "browser",
+                                              "ffmpeg"
+                                            ]
+                                          },
+                                          "target": {
+                                            "type": "string",
+                                            "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                            "enum": [
+                                              "display",
+                                              "window",
+                                              "viewport"
+                                            ],
+                                            "default": "display"
+                                          },
+                                          "fps": {
+                                            "type": "integer",
+                                            "description": "Capture frame rate for the `ffmpeg` engine.",
+                                            "default": 30,
+                                            "minimum": 1
+                                          }
+                                        }
+                                      }
+                                    ]
                                   }
                                 },
                                 "title": "Record (detailed)"
+                              },
+                              "engine": {
+                                "title": "Recording engine",
+                                "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+                                "anyOf": [
+                                  {
+                                    "title": "Recording engine (simple)",
+                                    "type": "string",
+                                    "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                    "enum": [
+                                      "browser",
+                                      "ffmpeg"
+                                    ]
+                                  },
+                                  {
+                                    "title": "Recording engine (detailed)",
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                                        "enum": [
+                                          "browser",
+                                          "ffmpeg"
+                                        ]
+                                      },
+                                      "target": {
+                                        "type": "string",
+                                        "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                                        "enum": [
+                                          "display",
+                                          "window",
+                                          "viewport"
+                                        ],
+                                        "default": "display"
+                                      },
+                                      "fps": {
+                                        "type": "integer",
+                                        "description": "Capture frame rate for the `ffmpeg` engine.",
+                                        "default": 30,
+                                        "minimum": 1
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           },
@@ -15254,6 +15560,18 @@
                               "path": "results.mp4",
                               "directory": "static/media",
                               "overwrite": "true"
+                            },
+                            {
+                              "path": "results.mp4",
+                              "engine": "ffmpeg"
+                            },
+                            {
+                              "path": "results.mp4",
+                              "engine": {
+                                "name": "ffmpeg",
+                                "target": "window",
+                                "fps": 60
+                              }
                             }
                           ]
                         }

--- a/src/common/src/schemas/output_schemas/test_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/test_v3.schema.json
@@ -6936,7 +6936,7 @@
                       {
                         "type": "boolean",
                         "title": "Record (boolean)",
-                        "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                        "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                       }
                     ],
                     "components": {
@@ -15410,7 +15410,7 @@
                             {
                               "type": "boolean",
                               "title": "Record (boolean)",
-                              "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+                              "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
                             }
                           ],
                           "components": {

--- a/src/common/src/schemas/src_schemas/record_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/record_v3.schema.json
@@ -12,7 +12,7 @@
     {
       "type": "boolean",
       "title": "Record (boolean)",
-      "description": "If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport."
+      "description": "If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record."
     }
   ],
   "components": {

--- a/src/common/src/schemas/src_schemas/record_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/record_v3.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "record",
-  "description": "Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+  "description": "Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
   "anyOf": [
     {
       "$ref": "#/components/schemas/string"
@@ -51,9 +51,61 @@
               "true",
               "false"
             ]
+          },
+          "engine": {
+            "$ref": "#/components/schemas/engine"
           }
         },
         "title": "Record (detailed)"
+      },
+      "engine": {
+        "title": "Recording engine",
+        "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
+        "anyOf": [
+          {
+            "title": "Recording engine (simple)",
+            "type": "string",
+            "description": "`browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+            "enum": [
+              "browser",
+              "ffmpeg"
+            ]
+          },
+          {
+            "title": "Recording engine (detailed)",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.",
+                "enum": [
+                  "browser",
+                  "ffmpeg"
+                ]
+              },
+              "target": {
+                "type": "string",
+                "description": "What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).",
+                "enum": [
+                  "display",
+                  "window",
+                  "viewport"
+                ],
+                "default": "display"
+              },
+              "fps": {
+                "type": "integer",
+                "description": "Capture frame rate for the `ffmpeg` engine.",
+                "default": 30,
+                "minimum": 1
+              }
+            }
+          }
+        ]
       }
     }
   },
@@ -64,6 +116,18 @@
       "path": "results.mp4",
       "directory": "static/media",
       "overwrite": "true"
+    },
+    {
+      "path": "results.mp4",
+      "engine": "ffmpeg"
+    },
+    {
+      "path": "results.mp4",
+      "engine": {
+        "name": "ffmpeg",
+        "target": "window",
+        "fps": 60
+      }
     }
   ]
 }

--- a/src/common/src/types/generated/record_v3.ts
+++ b/src/common/src/types/generated/record_v3.ts
@@ -21,7 +21,7 @@ export type RecordingEngine = RecordingEngineSimple | RecordingEngineDetailed;
  */
 export type RecordingEngineSimple = "browser" | "ffmpeg";
 /**
- * If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport.
+ * If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record.
  */
 export type RecordBoolean = boolean;
 

--- a/src/common/src/types/generated/record_v3.ts
+++ b/src/common/src/types/generated/record_v3.ts
@@ -5,13 +5,21 @@
  */
 
 /**
- * Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]
+ * Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]
  */
 export type Record = RecordSimple | RecordDetailed | RecordBoolean;
 /**
  * File path of the recording. Supports the `.mp4`, `.webm`, and `.gif` extensions. If not specified, the file name is the ID of the step, and the extension is `.mp4`.
  */
 export type RecordSimple = string;
+/**
+ * Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.
+ */
+export type RecordingEngine = RecordingEngineSimple | RecordingEngineDetailed;
+/**
+ * `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.
+ */
+export type RecordingEngineSimple = "browser" | "ffmpeg";
 /**
  * If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport.
  */
@@ -30,5 +38,20 @@ export interface RecordDetailed {
    * If `true`, overwrites the existing recording at `path` if it exists.
    */
   overwrite?: "true" | "false";
+  engine?: RecordingEngine;
   [k: string]: unknown;
+}
+export interface RecordingEngineDetailed {
+  /**
+   * Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.
+   */
+  name: "browser" | "ffmpeg";
+  /**
+   * What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).
+   */
+  target?: "display" | "window" | "viewport";
+  /**
+   * Capture frame rate for the `ffmpeg` engine.
+   */
+  fps?: number;
 }

--- a/src/common/src/types/generated/step_v3.ts
+++ b/src/common/src/types/generated/step_v3.ts
@@ -134,13 +134,21 @@ export type SaveCookieDetailed = {
   [k: string]: unknown;
 };
 /**
- * Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]
+ * Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]
  */
 export type Record1 = RecordSimple | RecordDetailed | RecordBoolean;
 /**
  * File path of the recording. Supports the `.mp4`, `.webm`, and `.gif` extensions. If not specified, the file name is the ID of the step, and the extension is `.mp4`.
  */
 export type RecordSimple = string;
+/**
+ * Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.
+ */
+export type RecordingEngine = RecordingEngineSimple | RecordingEngineDetailed;
+/**
+ * `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.
+ */
+export type RecordingEngineSimple = "browser" | "ffmpeg";
 /**
  * If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport.
  */
@@ -1270,7 +1278,22 @@ export interface RecordDetailed {
    * If `true`, overwrites the existing recording at `path` if it exists.
    */
   overwrite?: "true" | "false";
+  engine?: RecordingEngine;
   [k: string]: unknown;
+}
+export interface RecordingEngineDetailed {
+  /**
+   * Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.
+   */
+  name: "browser" | "ffmpeg";
+  /**
+   * What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).
+   */
+  target?: "display" | "window" | "viewport";
+  /**
+   * Capture frame rate for the `ffmpeg` engine.
+   */
+  fps?: number;
 }
 export interface Common11 {
   /**

--- a/src/common/src/types/generated/step_v3.ts
+++ b/src/common/src/types/generated/step_v3.ts
@@ -150,7 +150,7 @@ export type RecordingEngine = RecordingEngineSimple | RecordingEngineDetailed;
  */
 export type RecordingEngineSimple = "browser" | "ffmpeg";
 /**
- * If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport.
+ * If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record.
  */
 export type RecordBoolean = boolean;
 /**

--- a/src/common/src/types/generated/test_v3.ts
+++ b/src/common/src/types/generated/test_v3.ts
@@ -268,7 +268,7 @@ export type RecordingEngine = RecordingEngineSimple | RecordingEngineDetailed;
  */
 export type RecordingEngineSimple = "browser" | "ffmpeg";
 /**
- * If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport.
+ * If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record.
  */
 export type RecordBoolean = boolean;
 /**
@@ -570,7 +570,7 @@ export type RecordingEngine1 = RecordingEngineSimple1 | RecordingEngineDetailed1
  */
 export type RecordingEngineSimple1 = "browser" | "ffmpeg";
 /**
- * If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport.
+ * If `true`, starts recording — auto-selecting the `browser` engine for a visible Chrome context and the `ffmpeg` engine otherwise. If `false`, doesn't record.
  */
 export type RecordBoolean1 = boolean;
 /**

--- a/src/common/src/types/generated/test_v3.ts
+++ b/src/common/src/types/generated/test_v3.ts
@@ -252,13 +252,21 @@ export type SaveCookieDetailed =
       [k: string]: unknown;
     };
 /**
- * Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]
+ * Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]
  */
 export type Record1 = RecordSimple | RecordDetailed | RecordBoolean;
 /**
  * File path of the recording. Supports the `.mp4`, `.webm`, and `.gif` extensions. If not specified, the file name is the ID of the step, and the extension is `.mp4`.
  */
 export type RecordSimple = string;
+/**
+ * Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.
+ */
+export type RecordingEngine = RecordingEngineSimple | RecordingEngineDetailed;
+/**
+ * `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.
+ */
+export type RecordingEngineSimple = "browser" | "ffmpeg";
 /**
  * If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport.
  */
@@ -546,13 +554,21 @@ export type SaveCookieDetailed1 =
       [k: string]: unknown;
     };
 /**
- * Start recording the current browser viewport. Must be followed by a `stopRecord` step. Only runs in Chrome browsers when they are visible. Supported extensions: [ '.mp4', '.webm', '.gif' ]
+ * Start recording. Must be followed by a `stopRecord` step. The `browser` engine captures the Chrome viewport (works under concurrency); the `ffmpeg` engine captures the screen and supports any application. Supported extensions: [ '.mp4', '.webm', '.gif' ]
  */
 export type Record3 = RecordSimple1 | RecordDetailed1 | RecordBoolean1;
 /**
  * File path of the recording. Supports the `.mp4`, `.webm`, and `.gif` extensions. If not specified, the file name is the ID of the step, and the extension is `.mp4`.
  */
 export type RecordSimple1 = string;
+/**
+ * Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.
+ */
+export type RecordingEngine1 = RecordingEngineSimple1 | RecordingEngineDetailed1;
+/**
+ * `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.
+ */
+export type RecordingEngineSimple1 = "browser" | "ffmpeg";
 /**
  * If `true`, records the current browser viewport. If `false`, doesn't record the current browser viewport.
  */
@@ -1856,7 +1872,22 @@ export interface RecordDetailed {
    * If `true`, overwrites the existing recording at `path` if it exists.
    */
   overwrite?: "true" | "false";
+  engine?: RecordingEngine;
   [k: string]: unknown;
+}
+export interface RecordingEngineDetailed {
+  /**
+   * Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.
+   */
+  name: "browser" | "ffmpeg";
+  /**
+   * What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).
+   */
+  target?: "display" | "window" | "viewport";
+  /**
+   * Capture frame rate for the `ffmpeg` engine.
+   */
+  fps?: number;
 }
 export interface Common11 {
   /**
@@ -3413,7 +3444,22 @@ export interface RecordDetailed1 {
    * If `true`, overwrites the existing recording at `path` if it exists.
    */
   overwrite?: "true" | "false";
+  engine?: RecordingEngine1;
   [k: string]: unknown;
+}
+export interface RecordingEngineDetailed1 {
+  /**
+   * Recording engine. `browser` records the Chrome viewport (concurrency-safe); `ffmpeg` records the screen and supports any application.
+   */
+  name: "browser" | "ffmpeg";
+  /**
+   * What the `ffmpeg` engine captures. `display` records the full screen, `window` the active window, `viewport` the browser content area. Ignored by the `browser` engine, which always captures its tab. `window` and `viewport` are best-effort (captured full-screen, then cropped).
+   */
+  target?: "display" | "window" | "viewport";
+  /**
+   * Capture frame rate for the `ffmpeg` engine.
+   */
+  fps?: number;
 }
 export interface Common27 {
   /**

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -227,6 +227,48 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         }
       });
 
+      it("should validate a record step with an engine string shorthand", function () {
+        for (const engine of ["browser", "ffmpeg"]) {
+          const result = validate({
+            schemaKey: "step_v3",
+            object: { record: { path: "out.mp4", engine } },
+          });
+          expect(result.valid, `engine: ${engine} -> ${result.errors}`).to.be
+            .true;
+        }
+      });
+
+      it("should validate a record step with a detailed engine object", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            record: {
+              path: "out.mp4",
+              engine: { name: "ffmpeg", target: "window", fps: 60 },
+            },
+          },
+        });
+        expect(result.valid, result.errors).to.be.true;
+      });
+
+      it("should reject a record step with an invalid engine", function () {
+        for (const engine of [
+          "webkit",
+          { name: "vlc" },
+          { name: "ffmpeg", target: "tab" },
+          { name: "ffmpeg", fps: 1.5 },
+        ]) {
+          const result = validate({
+            schemaKey: "step_v3",
+            object: { record: { path: "out.mp4", engine } },
+          });
+          expect(
+            result.valid,
+            `expected invalid engine: ${JSON.stringify(engine)}`
+          ).to.be.false;
+        }
+      });
+
       it("should validate config_v3 concurrentRunners as a positive integer or true", function () {
         for (const concurrentRunners of [1, 4, true]) {
           const result = validate({

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -1853,7 +1853,7 @@ async function startAppiumServer(
     throw error;
   }
   log(config, "debug", `Appium is ready on port ${port}.`);
-  return { port, process: proc };
+  return { port, process: proc, display };
 }
 
 // Delay execution until Appium server is available.

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -38,6 +38,7 @@ import {
   browserCaptureTitle,
   browserDownloadDir,
   coerceRecordContextBrowser,
+  jobIsFfmpegRecording,
   computeEffectiveConcurrency,
   checkSystemBinary,
   xvfbDisplay,
@@ -685,11 +686,12 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   // recordings are only safe on Linux with per-runner Xvfb displays. Probe
   // Xvfb only when it could matter, then let computeEffectiveConcurrency
   // decide the effective limit.
-  const anyRecordStep = jobs.some((job: any) =>
-    job.context.steps?.some((step: any) => step.record !== undefined)
-  );
+  // Only ffmpeg-engine recordings need Xvfb; a browser-engine-only run
+  // shouldn't pay for an `Xvfb -help` spawn. Contexts are already coerced
+  // above, so resolveRecordPlan reflects the engine that will actually run.
+  const anyFfmpegRecording = jobs.some(jobIsFfmpegRecording);
   let xvfbAvailable = false;
-  if (anyRecordStep && process.platform === "linux") {
+  if (anyFfmpegRecording && process.platform === "linux") {
     xvfbAvailable = await checkSystemBinary("Xvfb");
   }
   const concurrency = computeEffectiveConcurrency({

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -43,6 +43,7 @@ import {
   checkSystemBinary,
   xvfbDisplay,
   startXvfb,
+  XVFB_SCREEN_SIZE,
 } from "./tests/ffmpegRecorder.js";
 import { loadVariables } from "./tests/loadVariables.js";
 import { saveCookie } from "./tests/saveCookie.js";
@@ -1431,7 +1432,12 @@ async function runContext({
       // renders on.
       if (portToDisplay) {
         const display = portToDisplay.get(appiumPort);
-        if (display) context.__display = display;
+        if (display) {
+          context.__display = display;
+          // The Xvfb displays are created at a known fixed size; record it so
+          // x11grab captures the full display (its default grabs only 640x480).
+          context.__displaySize = XVFB_SCREEN_SIZE;
+        }
       }
 
       // Define driver capabilities

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -34,6 +34,15 @@ import { wait } from "./tests/wait.js";
 import { saveScreenshot } from "./tests/saveScreenshot.js";
 import { startRecording } from "./tests/startRecording.js";
 import { stopRecording } from "./tests/stopRecording.js";
+import {
+  browserCaptureTitle,
+  browserDownloadDir,
+  coerceRecordContextBrowser,
+  computeEffectiveConcurrency,
+  checkSystemBinary,
+  xvfbDisplay,
+  startXvfb,
+} from "./tests/ffmpegRecorder.js";
 import { loadVariables } from "./tests/loadVariables.js";
 import { saveCookie } from "./tests/saveCookie.js";
 import { loadCookie } from "./tests/loadCookie.js";
@@ -198,7 +207,16 @@ function getDriverCapabilities({ runnerDetails, name, options }: { runnerDetails
         if (!chromium) break;
         // Set args
         args.push(`--enable-chrome-browser-cloud-management`);
-        args.push(`--auto-select-desktop-capture-source=RECORD_ME`);
+        // Auto-select the getDisplayMedia capture source by window title. A
+        // per-context title (set on document.title in startRecording) makes
+        // concurrent Chrome recordings safe: each browser process auto-selects
+        // only its own window. Falls back to the shared default for callers
+        // (warm-up, non-record contexts) that don't supply one.
+        args.push(
+          `--auto-select-desktop-capture-source=${
+            options.captureSourceTitle || "RECORD_ME"
+          }`
+        );
         if (options.headless) args.push("--headless", "--disable-gpu");
         if (process.platform === "linux") {
           args.push("--no-sandbox");
@@ -221,7 +239,9 @@ function getDriverCapabilities({ runnerDetails, name, options }: { runnerDetails
             // Reference: https://chromedriver.chromium.org/capabilities#h.p_ID_102
             args,
             prefs: {
-              "download.default_directory": os.tmpdir(),
+              // Per-context download dir keeps concurrent recordings from
+              // colliding on the same .webm filename in a shared temp dir.
+              "download.default_directory": options.downloadDir || os.tmpdir(),
               "download.prompt_for_download": false,
               "download.directory_upgrade": true,
             },
@@ -586,8 +606,8 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   // Resolve concurrency up front (defensive re-resolve: API callers can hand
   // runSpecs a config that never went through core setConfig, leaving
   // concurrentRunners as `true`). Drives both the worker pool and how many
-  // Appium servers to start.
-  const limit = resolveConcurrentRunners(config);
+  // Appium servers to start. Mutable: recording constraints may cap it below.
+  let limit = resolveConcurrentRunners(config);
 
   // Phase 1: pre-build the report skeleton and a flat list of context jobs
   // across all specs and tests. Slots are pre-assigned so report order always
@@ -644,24 +664,48 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
           usedContextIds.add(id);
           context.contextId = id;
         }
+        // Auto-resolution: when a record step has no explicit engine and the
+        // user never chose a browser, prefer the concurrency-safe browser
+        // engine by coercing to headed Chrome (when available). Done here,
+        // before the concurrency calc below, so each job's engine is settled.
+        // Non-record contexts keep runContext's normal browser defaulting.
+        const coercedBrowser = coerceRecordContextBrowser({
+          context,
+          availableApps: runnerDetails.availableApps,
+        });
+        if (coercedBrowser) context.browser = coercedBrowser;
         jobs.push({ spec, test, context, contexts: testReport.contexts, slot });
       });
     }
   }
 
-  if (
-    limit > 1 &&
-    jobs.some((job: any) =>
-      job.context.steps?.some((step: any) => step.record !== undefined)
-    )
-  ) {
-    // Concurrent headed recordings capture via getDisplayMedia and can grab
-    // the wrong window. Recording filenames in the temp dir can also collide.
+  // Recording concurrency. The browser (Chrome getDisplayMedia) engine is
+  // concurrency-safe via per-context capture titles, but the ffmpeg engine
+  // grabs the whole physical display and must own it — so concurrent ffmpeg
+  // recordings are only safe on Linux with per-runner Xvfb displays. Probe
+  // Xvfb only when it could matter, then let computeEffectiveConcurrency
+  // decide the effective limit.
+  const anyRecordStep = jobs.some((job: any) =>
+    job.context.steps?.some((step: any) => step.record !== undefined)
+  );
+  let xvfbAvailable = false;
+  if (anyRecordStep && process.platform === "linux") {
+    xvfbAvailable = await checkSystemBinary("Xvfb");
+  }
+  const concurrency = computeEffectiveConcurrency({
+    requestedLimit: limit,
+    jobs,
+    platform: process.platform,
+    xvfbAvailable,
+  });
+  limit = concurrency.limit;
+  if (concurrency.forcedSerial) {
     log(
       config,
       "warning",
-      "Tests include record steps while concurrentRunners is greater than 1. Concurrent recordings can capture the wrong window; set concurrentRunners to 1 for recording runs."
+      "Recording with the ffmpeg engine needs exclusive use of the display, so this run is executing serially (concurrentRunners=1). To record concurrently, use the Chrome browser engine (record: { engine: \"browser\" }) or, on Linux, install Xvfb."
     );
+    report.recordingForcedSerial = true;
   }
 
   // Start one Appium server per concurrent runner that will actually use a
@@ -672,10 +716,17 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   const driverJobCount = jobs.filter((job: any) =>
     isDriverRequired({ test: job.context })
   ).length;
-  let appiumServers: Array<{ port: number; process: any }> = [];
+  let appiumServers: Array<{ port: number; process: any; display?: string }> =
+    [];
   let appiumPool:
     | { acquire(): Promise<number>; release(port: number): void }
     | undefined;
+  // Per-server virtual displays (Linux Xvfb) for concurrent ffmpeg recording,
+  // and the port→display map so a context that acquires a server records the
+  // same display its browser renders on.
+  const xvfbProcesses: any[] = [];
+  const useXvfbDisplays = concurrency.xvfbContexts.length > 0;
+  let portToDisplay: Map<number, string> | undefined;
   if (driverJobCount > 0) {
     setAppiumHome({ cacheDir: config?.cacheDir });
     // Resolve appium's actual JS entrypoint via `require.resolve` (shim
@@ -703,7 +754,15 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     // come up, tearing down any already started so they don't leak.
     try {
       for (let i = 0; i < serverCount; i++) {
-        appiumServers.push(await startAppiumServer(appiumEntry, config));
+        let display: string | undefined;
+        if (useXvfbDisplays) {
+          display = xvfbDisplay(i);
+          xvfbProcesses.push(await startXvfb(display));
+          log(config, "debug", `Started Xvfb on ${display} for recording.`);
+        }
+        appiumServers.push(
+          await startAppiumServer(appiumEntry, config, display)
+        );
       }
     } catch (error) {
       for (const server of appiumServers) {
@@ -713,9 +772,23 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
           // best-effort
         }
       }
+      for (const xvfb of xvfbProcesses) {
+        try {
+          xvfb.kill();
+        } catch {
+          // best-effort
+        }
+      }
       throw error;
     }
     appiumPool = createAppiumPool(appiumServers.map((s) => s.port));
+    if (useXvfbDisplays) {
+      portToDisplay = new Map(
+        appiumServers
+          .filter((s) => s.display)
+          .map((s) => [s.port, s.display as string])
+      );
+    }
   }
 
   // Everything that uses the Appium servers runs inside this try so the
@@ -755,6 +828,7 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
           context: job.context,
           runnerDetails,
           appiumPool,
+          portToDisplay,
           metaValues,
           installAttempts,
           warmUpResults,
@@ -808,6 +882,14 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
       log(config, "debug", `Closing Appium server on port ${server.port}`);
       try {
         kill(server.process.pid);
+      } catch {
+        // Process may already be terminated
+      }
+    }
+    // Tear down any Xvfb virtual displays started for recording.
+    for (const xvfb of xvfbProcesses) {
+      try {
+        xvfb.kill();
       } catch {
         // Process may already be terminated
       }
@@ -1157,6 +1239,7 @@ async function runContext({
   context,
   runnerDetails,
   appiumPool,
+  portToDisplay,
   metaValues,
   installAttempts,
   warmUpResults,
@@ -1170,6 +1253,7 @@ async function runContext({
   appiumPool:
     | { acquire(): Promise<number>; release(port: number): void }
     | undefined;
+  portToDisplay?: Map<number, string>;
   metaValues: any;
   installAttempts: Map<string, "installed" | "failed" | "notInstallable">;
   warmUpResults: Map<string, "ok" | "failed">;
@@ -1340,9 +1424,22 @@ async function runContext({
       // Check out a server for this context's lifetime — released in the
       // finally so the next queued context can reuse it.
       appiumPort = await appiumPool!.acquire();
+      // If this server runs on a dedicated Xvfb display, record it on the
+      // context so the ffmpeg recorder captures the same display the browser
+      // renders on.
+      if (portToDisplay) {
+        const display = portToDisplay.get(appiumPort);
+        if (display) context.__display = display;
+      }
 
       // Define driver capabilities
       // TODO: Support custom apps
+      // Per-context recording identifiers so concurrent Chrome recordings
+      // auto-select their own window and download to their own dir.
+      const recordOptions = {
+        captureSourceTitle: browserCaptureTitle(context.contextId),
+        downloadDir: browserDownloadDir(context.contextId),
+      };
       let caps: any = getDriverCapabilities({
         runnerDetails: runnerDetails,
         name: context.browser.name,
@@ -1350,6 +1447,7 @@ async function runContext({
           width: context.browser?.window?.width || 1200,
           height: context.browser?.window?.height || 800,
           headless: context.browser?.headless !== false,
+          ...recordOptions,
         },
       });
       clog("debug", "CAPABILITIES:");
@@ -1373,6 +1471,7 @@ async function runContext({
               width: context.browser?.window?.width || 1200,
               height: context.browser?.window?.height || 800,
               headless: context.browser?.headless !== false,
+              ...recordOptions,
             },
           });
           driver = await driverStart(caps, appiumPort, 4, { cacheDir: config?.cacheDir });
@@ -1713,16 +1812,22 @@ async function runStep({
 // never create sessions on the same Appium instance.
 async function startAppiumServer(
   appiumEntry: string,
-  config: any
-): Promise<{ port: number; process: any }> {
+  config: any,
+  display?: string
+): Promise<{ port: number; process: any; display?: string }> {
   const port = await findFreePort();
   log(config, "debug", `Starting Appium on port ${port}`);
+  // When a virtual display is supplied (Linux Xvfb recording), launch the
+  // server with DISPLAY set so the browser it spawns (via chromedriver)
+  // renders on that display — which is what ffmpeg x11grab then captures.
+  const env = display ? { ...process.env, DISPLAY: display } : process.env;
   const proc: any = spawn(
     process.execPath,
     [appiumEntry, "-a", "127.0.0.1", "-p", String(port)],
     {
       windowsHide: true,
       cwd: path.join(__dirname, "../.."),
+      env,
     }
   );
   proc.on("error", (err: any) => {

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -212,19 +212,28 @@ async function resolveCropGeometry({
   if (target === "viewport") {
     const m = await driver.execute(() => {
       return {
-        x: (window as any).screenX,
-        y: (window as any).screenY,
-        w: (window as any).innerWidth,
-        h: (window as any).innerHeight,
+        sx: (window as any).screenX,
+        sy: (window as any).screenY,
+        iw: (window as any).innerWidth,
+        ih: (window as any).innerHeight,
+        ow: (window as any).outerWidth,
+        oh: (window as any).outerHeight,
         dpr: (window as any).devicePixelRatio || 1,
       };
     });
     const dpr = m.dpr || 1;
+    // screenX/screenY is the window's outer top-left, which sits above the
+    // browser chrome (tabs, address bar, infobars). Offset to the content
+    // area: by the side border on X, and by the top chrome height on Y
+    // (outerHeight - innerHeight, minus one border for the matching bottom
+    // edge). Otherwise the crop captures the chrome instead of the page.
+    const border = Math.max(0, (m.ow - m.iw) / 2);
+    const topChrome = Math.max(0, m.oh - m.ih - border);
     return {
-      x: Math.round(m.x * dpr),
-      y: Math.round(m.y * dpr),
-      w: Math.round(m.w * dpr),
-      h: Math.round(m.h * dpr),
+      x: Math.round((m.sx + border) * dpr),
+      y: Math.round((m.sy + topChrome) * dpr),
+      w: Math.round(m.iw * dpr),
+      h: Math.round(m.ih * dpr),
     };
   }
   if (target === "window") {

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -72,14 +72,16 @@ function resolveRecordPlan({
   return {
     name: engineName as "browser" | "ffmpeg",
     target: target || "display",
-    fps: fps || 30,
+    fps: fps ?? 30,
   };
 }
 
 function hasRecordStepWithoutEngine(context: any): boolean {
   const steps = Array.isArray(context?.steps) ? context.steps : [];
   return steps.some((s: any) => {
-    if (typeof s?.record === "undefined") return false;
+    // Falsy record (undefined, or an explicit `record: false`) is not an
+    // active recording step.
+    if (!s?.record) return false;
     return engineFields(s.record).name === undefined;
   });
 }
@@ -121,7 +123,7 @@ function buildCaptureArgs({
   outputPath: string;
   screenIndex?: string;
 }): string[] {
-  const rate = String(fps || 30);
+  const rate = String(fps ?? 30);
   let input: string[];
   switch (platform) {
     case "win32":
@@ -201,7 +203,7 @@ async function resolveCropGeometry({
 function jobIsFfmpegRecording(job: any): boolean {
   const steps = Array.isArray(job?.context?.steps) ? job.context.steps : [];
   return steps.some((s: any) => {
-    if (typeof s?.record === "undefined") return false;
+    if (!s?.record) return false; // skip undefined / `record: false`
     return resolveRecordPlan({ step: s, context: job.context }).name === "ffmpeg";
   });
 }

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -351,6 +351,10 @@ async function startXvfb(
   const num = display.replace(/^:/, "").split(".")[0];
   const w = opts.width ?? 1920;
   const h = opts.height ?? 1080;
+  // Capture the spawn time so a stale `/tmp/.X<N>-lock` (left by a dead Xvfb
+  // or another server) can't false-ready us — we only accept a lock created
+  // at/after our own start.
+  const startMs = Date.now();
   const proc: any = spawn(
     "Xvfb",
     [display, "-screen", "0", `${w}x${h}x24`, "-nolisten", "tcp"],
@@ -363,13 +367,18 @@ async function startXvfb(
   // Readiness signal: the X lock file `/tmp/.X<N>-lock`, which Xvfb creates
   // once it owns the display. We don't watch `/tmp/.X11-unix/X<N>` because some
   // environments (e.g. WSLg) back the display with an abstract socket that
-  // never appears there.
+  // never appears there. If the display is already in use, Xvfb exits with an
+  // error (caught by the exitCode check) rather than acquiring the lock.
   const lock = `/tmp/.X${num}-lock`;
   for (let i = 0; i < 50; i++) {
     if (spawnErr) throw spawnErr;
     if (proc.exitCode !== null)
       throw new Error(`Xvfb exited early on ${display} (code ${proc.exitCode})`);
-    if (fs.existsSync(lock)) return proc;
+    try {
+      if (fs.statSync(lock).mtimeMs >= startMs) return proc;
+    } catch {
+      /* lock not present yet */
+    }
     await new Promise((r) => setTimeout(r, 100));
   }
   try {

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -178,7 +178,21 @@ async function resolveCropGeometry({
   }
   if (target === "window") {
     const r = await driver.getWindowRect();
-    return { x: r.x, y: r.y, w: r.width, h: r.height };
+    // getWindowRect is in CSS pixels; the crop filter is in physical pixels,
+    // so scale by devicePixelRatio (as the viewport branch does). Falls back
+    // to 1 if the page can't report it.
+    let dpr = 1;
+    try {
+      dpr = (await driver.execute(() => (window as any).devicePixelRatio || 1)) || 1;
+    } catch {
+      dpr = 1;
+    }
+    return {
+      x: Math.round(r.x * dpr),
+      y: Math.round(r.y * dpr),
+      w: Math.round(r.width * dpr),
+      h: Math.round(r.height * dpr),
+    };
   }
   return null;
 }

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -3,10 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
 import { loadHeavyDep } from "../../runtime/loader.js";
+import { sanitizeFilesystemName } from "../utils.js";
 
 export {
   resolveRecordPlan,
   coerceRecordContextBrowser,
+  safeContextId,
   browserCaptureTitle,
   browserDownloadDir,
   buildCaptureArgs,
@@ -25,11 +27,22 @@ export {
 // sets document.title + reads the download) must agree, so both derive these
 // from the contextId here. Unique-per-context titles are what make concurrent
 // Chrome recordings safe — each browser auto-selects only its own window.
+// contextId can be author-supplied (a spec may set it), so it must be
+// sanitized before going into a filesystem path or a launch-flag value —
+// otherwise a value like "../x" could escape the temp dir.
+function safeContextId(contextId: any): string {
+  return sanitizeFilesystemName(String(contextId ?? "ctx"), "ctx");
+}
 function browserCaptureTitle(contextId: string): string {
-  return `RECORD_ME_${contextId}`;
+  return `RECORD_ME_${safeContextId(contextId)}`;
 }
 function browserDownloadDir(contextId: string): string {
-  return path.join(os.tmpdir(), "doc-detective", "recordings", String(contextId));
+  return path.join(
+    os.tmpdir(),
+    "doc-detective",
+    "recordings",
+    safeContextId(contextId)
+  );
 }
 
 type RecordPlan = { name: "browser" | "ffmpeg"; target: string; fps: number };

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -16,6 +16,8 @@ export {
   jobIsFfmpegRecording,
   computeEffectiveConcurrency,
   getFfmpegPath,
+  detectMacScreenIndex,
+  parseMacScreenIndex,
   checkSystemBinary,
   xvfbDisplay,
   startXvfb,
@@ -143,13 +145,15 @@ function buildCaptureArgs({
       input = ["-f", "gdigrab", "-framerate", rate, "-i", "desktop"];
       break;
     case "darwin":
+      // Default to screen index 0 (a camera-less host — e.g. CI — lists the
+      // screen at 0). startRecording detects the real index when it can.
       input = [
         "-f",
         "avfoundation",
         "-framerate",
         rate,
         "-i",
-        `${screenIndex ?? "1"}:none`,
+        `${screenIndex ?? "0"}:none`,
       ];
       break;
     case "linux":
@@ -267,6 +271,42 @@ async function getFfmpegPath(ctx: { cacheDir?: string } = {}): Promise<string> {
     );
   }
   return candidate;
+}
+
+// Parse the stderr of `ffmpeg -f avfoundation -list_devices true -i ""` for
+// the screen-capture device index. Only the video-devices section labels an
+// entry "Capture screen N", so this won't match audio devices. Returns the
+// index string (e.g. "0") or null if not found.
+function parseMacScreenIndex(listing: string): string | null {
+  const m = /\[(\d+)\]\s+Capture screen/i.exec(listing || "");
+  return m ? m[1] : null;
+}
+
+// macOS only: discover the avfoundation device index of the screen. Indices
+// shift with attached cameras (a camera-less host such as a CI runner lists
+// the screen at 0, not 1), so a hardcoded value frequently opens the wrong
+// device and ffmpeg exits immediately. Returns null if it can't be determined.
+async function detectMacScreenIndex(
+  ffmpegPath: string
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    let out = "";
+    try {
+      const proc = spawn(
+        ffmpegPath,
+        ["-f", "avfoundation", "-list_devices", "true", "-i", ""],
+        { stdio: ["ignore", "ignore", "pipe"] }
+      );
+      proc.stderr?.on("data", (d) => {
+        out += d.toString();
+      });
+      proc.on("error", () => resolve(null));
+      // ffmpeg exits non-zero for a list-only invocation; parse regardless.
+      proc.on("close", () => resolve(parseMacScreenIndex(out)));
+    } catch {
+      resolve(null);
+    }
+  });
 }
 
 // Probe for a system binary on PATH (e.g. Xvfb, which is not an npm package).

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
+import crypto from "node:crypto";
 import { loadHeavyDep } from "../../runtime/loader.js";
 import { sanitizeFilesystemName } from "../utils.js";
 
@@ -33,7 +34,16 @@ export {
 // sanitized before going into a filesystem path or a launch-flag value —
 // otherwise a value like "../x" could escape the temp dir.
 function safeContextId(contextId: any): string {
-  return sanitizeFilesystemName(String(contextId ?? "ctx"), "ctx");
+  const raw = String(contextId ?? "ctx");
+  const base = sanitizeFilesystemName(raw, "ctx");
+  // If sanitization didn't change anything, the id is already filesystem-safe
+  // and unique. If it did, distinct raw ids (e.g. "a/b" and "a\\b") could
+  // collapse to the same value — which would reintroduce the concurrency bug
+  // (shared capture title / download dir). Disambiguate with a short stable
+  // hash of the raw id so uniqueness survives sanitization.
+  if (base === raw) return base;
+  const hash = crypto.createHash("sha1").update(raw).digest("hex").slice(0, 8);
+  return `${base}-${hash}`;
 }
 function browserCaptureTitle(contextId: string): string {
   return `RECORD_ME_${safeContextId(contextId)}`;

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -11,6 +11,7 @@ export {
   browserDownloadDir,
   buildCaptureArgs,
   resolveCropGeometry,
+  jobIsFfmpegRecording,
   computeEffectiveConcurrency,
   getFfmpegPath,
   checkSystemBinary,

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -1,0 +1,301 @@
+import { spawn } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import { loadHeavyDep } from "../../runtime/loader.js";
+
+export {
+  resolveRecordPlan,
+  coerceRecordContextBrowser,
+  browserCaptureTitle,
+  browserDownloadDir,
+  buildCaptureArgs,
+  resolveCropGeometry,
+  computeEffectiveConcurrency,
+  getFfmpegPath,
+  checkSystemBinary,
+  xvfbDisplay,
+  startXvfb,
+};
+
+// The browser engine drives getDisplayMedia's auto-select via a per-context
+// window title and downloads the .webm to a per-context dir. tests.ts (which
+// builds Chrome's launch flag + download pref) and startRecording.ts (which
+// sets document.title + reads the download) must agree, so both derive these
+// from the contextId here. Unique-per-context titles are what make concurrent
+// Chrome recordings safe — each browser auto-selects only its own window.
+function browserCaptureTitle(contextId: string): string {
+  return `RECORD_ME_${contextId}`;
+}
+function browserDownloadDir(contextId: string): string {
+  return path.join(os.tmpdir(), "doc-detective", "recordings", String(contextId));
+}
+
+type RecordPlan = { name: "browser" | "ffmpeg"; target: string; fps: number };
+
+// Pull the engine fields out of a `record` step value. `record` may be a
+// boolean, a string path, or a detailed object; only the object form can
+// carry an `engine`, which itself is either a string shorthand or an object.
+function engineFields(record: any): {
+  name?: string;
+  target?: string;
+  fps?: number;
+} {
+  const engine =
+    record && typeof record === "object" ? record.engine : undefined;
+  if (typeof engine === "string") return { name: engine };
+  if (engine && typeof engine === "object")
+    return { name: engine.name, target: engine.target, fps: engine.fps };
+  return {};
+}
+
+// Normalize a record step into a concrete plan. An explicit engine always
+// wins; otherwise auto-resolve: a visible Chrome context uses the
+// concurrency-safe browser engine, everything else falls back to ffmpeg. The
+// context handed in here is already coerced (see coerceRecordContextBrowser),
+// so this stays a pure read.
+function resolveRecordPlan({
+  step,
+  context,
+}: {
+  step: any;
+  context: any;
+}): RecordPlan {
+  const { name, target, fps } = engineFields(step?.record);
+  let engineName = name;
+  if (!engineName) {
+    const b = context?.browser;
+    engineName =
+      b?.name === "chrome" && b?.headless === false ? "browser" : "ffmpeg";
+  }
+  return {
+    name: engineName as "browser" | "ffmpeg",
+    target: target || "display",
+    fps: fps || 30,
+  };
+}
+
+function hasRecordStepWithoutEngine(context: any): boolean {
+  const steps = Array.isArray(context?.steps) ? context.steps : [];
+  return steps.some((s: any) => {
+    if (typeof s?.record === "undefined") return false;
+    return engineFields(s.record).name === undefined;
+  });
+}
+
+// When a context has a record step with no explicit engine and the user
+// never chose a browser, prefer to make the browser engine viable by
+// coercing to headed Chrome (the browser engine can't record headless).
+// Returns the browser to assign, or null when no coercion applies.
+function coerceRecordContextBrowser({
+  context,
+  availableApps,
+}: {
+  context: any;
+  availableApps: any[];
+}): { name: string; headless: boolean } | null {
+  if (context?.browser) return null; // user specified a browser
+  if (!hasRecordStepWithoutEngine(context)) return null;
+  const chromeAvailable =
+    Array.isArray(availableApps) &&
+    availableApps.some((a: any) => a?.name === "chrome");
+  if (!chromeAvailable) return null;
+  return { name: "chrome", headless: false };
+}
+
+// Build the ffmpeg argument list for a full-display capture on the given
+// platform. window/viewport targets are realized later by cropping during
+// transcode, so capture is always full-screen here. Input options
+// (`-framerate`, `-f`, device) precede `-i`; output options follow it.
+function buildCaptureArgs({
+  platform,
+  fps,
+  displayEnv,
+  outputPath,
+  screenIndex,
+}: {
+  platform: string;
+  fps: number;
+  displayEnv?: string;
+  outputPath: string;
+  screenIndex?: string;
+}): string[] {
+  const rate = String(fps || 30);
+  let input: string[];
+  switch (platform) {
+    case "win32":
+      input = ["-f", "gdigrab", "-framerate", rate, "-i", "desktop"];
+      break;
+    case "darwin":
+      input = [
+        "-f",
+        "avfoundation",
+        "-framerate",
+        rate,
+        "-i",
+        `${screenIndex ?? "1"}:none`,
+      ];
+      break;
+    case "linux":
+      input = ["-f", "x11grab", "-framerate", rate, "-i", displayEnv || ":0.0"];
+      break;
+    default:
+      throw new Error(
+        `Screen recording isn't supported on platform '${platform}'.`
+      );
+  }
+  return ["-y", ...input, "-pix_fmt", "yuv420p", outputPath];
+}
+
+// Resolve the crop rectangle (in physical pixels) for a window/viewport
+// target. Returns null for the full-display target (no crop). Best-effort:
+// viewport geometry is derived from in-page metrics scaled by devicePixelRatio,
+// window geometry from the WebDriver window rect.
+async function resolveCropGeometry({
+  driver,
+  target,
+}: {
+  driver: any;
+  target: string;
+}): Promise<{ x: number; y: number; w: number; h: number } | null> {
+  if (target === "viewport") {
+    const m = await driver.execute(() => {
+      return {
+        x: (window as any).screenX,
+        y: (window as any).screenY,
+        w: (window as any).innerWidth,
+        h: (window as any).innerHeight,
+        dpr: (window as any).devicePixelRatio || 1,
+      };
+    });
+    const dpr = m.dpr || 1;
+    return {
+      x: Math.round(m.x * dpr),
+      y: Math.round(m.y * dpr),
+      w: Math.round(m.w * dpr),
+      h: Math.round(m.h * dpr),
+    };
+  }
+  if (target === "window") {
+    const r = await driver.getWindowRect();
+    return { x: r.x, y: r.y, w: r.width, h: r.height };
+  }
+  return null;
+}
+
+function jobIsFfmpegRecording(job: any): boolean {
+  const steps = Array.isArray(job?.context?.steps) ? job.context.steps : [];
+  return steps.some((s: any) => {
+    if (typeof s?.record === "undefined") return false;
+    return resolveRecordPlan({ step: s, context: job.context }).name === "ffmpeg";
+  });
+}
+
+// Decide the effective worker-pool limit given recording constraints. ffmpeg
+// screen capture needs exclusive use of the physical display, so concurrent
+// ffmpeg recordings are only safe on Linux with per-runner Xvfb displays;
+// elsewhere the run is forced serial. forcedSerial is true only when a
+// requested limit > 1 was actually capped (so callers warn precisely once).
+function computeEffectiveConcurrency({
+  requestedLimit,
+  jobs,
+  platform,
+  xvfbAvailable,
+}: {
+  requestedLimit: number;
+  jobs: any[];
+  platform: string;
+  xvfbAvailable: boolean;
+}): { limit: number; xvfbContexts: any[]; forcedSerial: boolean } {
+  const ffmpegJobs = (jobs || []).filter(jobIsFfmpegRecording);
+  if (ffmpegJobs.length === 0) {
+    return { limit: requestedLimit, xvfbContexts: [], forcedSerial: false };
+  }
+  if (platform === "linux" && xvfbAvailable) {
+    return {
+      limit: requestedLimit,
+      xvfbContexts: ffmpegJobs.map((j) => j.context),
+      forcedSerial: false,
+    };
+  }
+  return { limit: 1, xvfbContexts: [], forcedSerial: requestedLimit > 1 };
+}
+
+// Resolve the ffmpeg binary path lazily — @ffmpeg-installer/ffmpeg is a heavy
+// runtime dep that should only load when a recording step actually runs. The
+// ctx threads a user-overridden cacheDir through, matching the JIT installer.
+async function getFfmpegPath(ctx: { cacheDir?: string } = {}): Promise<string> {
+  const mod = await loadHeavyDep<any>("@ffmpeg-installer/ffmpeg", { ctx });
+  // The package's CJS entry exports an object with a .path field; under an
+  // ESM dynamic import we may get { default: { path }, path? }. Try both, then
+  // guard before handing it to a child process so a malformed install fails
+  // with an actionable message instead of a confusing deep node error.
+  const candidate = mod && (mod.path ?? mod.default?.path);
+  if (typeof candidate !== "string" || candidate.length === 0) {
+    throw new Error(
+      "ffmpeg binary path is missing or malformed in the installed @ffmpeg-installer/ffmpeg package. Try `doc-detective install runtime --force` to reinstall."
+    );
+  }
+  return candidate;
+}
+
+// Probe for a system binary on PATH (e.g. Xvfb, which is not an npm package).
+// Resolves true if the binary launches, false on ENOENT/spawn error.
+async function checkSystemBinary(name: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const proc = spawn(name, ["-help"], { stdio: "ignore" });
+      proc.on("error", () => resolve(false));
+      proc.on("close", () => resolve(true));
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+// X11 display name for the Nth concurrent runner. Offset by 99 to stay clear
+// of any real display (:0 = the desktop). Pure so it's unit-testable and the
+// server-start and capture paths agree.
+function xvfbDisplay(index: number): string {
+  return `:${99 + index}`;
+}
+
+// Start an Xvfb virtual framebuffer on `display` and resolve once its X socket
+// is up. Each concurrent ffmpeg-recording runner gets its own display so the
+// browser renders there and x11grab captures only that runner's screen —
+// making concurrent recording safe on Linux. Caller owns process teardown.
+async function startXvfb(
+  display: string,
+  opts: { width?: number; height?: number } = {}
+): Promise<any> {
+  const num = display.replace(/^:/, "").split(".")[0];
+  const w = opts.width ?? 1920;
+  const h = opts.height ?? 1080;
+  const proc: any = spawn(
+    "Xvfb",
+    [display, "-screen", "0", `${w}x${h}x24`, "-nolisten", "tcp"],
+    { stdio: "ignore" }
+  );
+  let spawnErr: any = null;
+  proc.on("error", (e: any) => {
+    spawnErr = e;
+  });
+  // Readiness signal: the X lock file `/tmp/.X<N>-lock`, which Xvfb creates
+  // once it owns the display. We don't watch `/tmp/.X11-unix/X<N>` because some
+  // environments (e.g. WSLg) back the display with an abstract socket that
+  // never appears there.
+  const lock = `/tmp/.X${num}-lock`;
+  for (let i = 0; i < 50; i++) {
+    if (spawnErr) throw spawnErr;
+    if (proc.exitCode !== null)
+      throw new Error(`Xvfb exited early on ${display} (code ${proc.exitCode})`);
+    if (fs.existsSync(lock)) return proc;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  try {
+    proc.kill();
+  } catch {
+    /* ignore */
+  }
+  throw new Error(`Xvfb did not become ready on ${display} within 5s.`);
+}

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -181,7 +181,7 @@ async function resolveCropGeometry({
     // getWindowRect is in CSS pixels; the crop filter is in physical pixels,
     // so scale by devicePixelRatio (as the viewport branch does). Falls back
     // to 1 if the page can't report it.
-    let dpr = 1;
+    let dpr: number;
     try {
       dpr = (await driver.execute(() => (window as any).devicePixelRatio || 1)) || 1;
     } catch {

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -6,6 +6,11 @@ import crypto from "node:crypto";
 import { loadHeavyDep } from "../../runtime/loader.js";
 import { sanitizeFilesystemName } from "../utils.js";
 
+// Fixed virtual-display size for the Linux Xvfb recording path. Used both to
+// start Xvfb and as the x11grab `-video_size`, so the capture matches the
+// display exactly (and window/viewport crops fit within it).
+const XVFB_SCREEN_SIZE = "1920x1080";
+
 export {
   resolveRecordPlan,
   coerceRecordContextBrowser,
@@ -25,11 +30,6 @@ export {
   XVFB_SCREEN_SIZE,
   detectX11ScreenSize,
 };
-
-// Fixed virtual-display size for the Linux Xvfb recording path. Used both to
-// start Xvfb and as the x11grab `-video_size`, so the capture matches the
-// display exactly (and window/viewport crops fit within it).
-const XVFB_SCREEN_SIZE = "1920x1080";
 
 // The browser engine drives getDisplayMedia's auto-select via a per-context
 // window title and downloads the .webm to a per-context dir. tests.ts (which

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -322,20 +322,34 @@ async function detectMacScreenIndex(
 ): Promise<string | null> {
   return new Promise((resolve) => {
     let out = "";
+    let settled = false;
+    let proc: any = null;
+    const done = (v: string | null) => {
+      if (settled) return;
+      settled = true;
+      try {
+        proc?.kill();
+      } catch {
+        /* ignore */
+      }
+      resolve(v);
+    };
     try {
-      const proc = spawn(
+      proc = spawn(
         ffmpegPath,
         ["-f", "avfoundation", "-list_devices", "true", "-i", ""],
         { stdio: ["ignore", "ignore", "pipe"] }
       );
-      proc.stderr?.on("data", (d) => {
+      proc.stderr?.on("data", (d: any) => {
         out += d.toString();
       });
-      proc.on("error", () => resolve(null));
+      proc.on("error", () => done(null));
       // ffmpeg exits non-zero for a list-only invocation; parse regardless.
-      proc.on("close", () => resolve(parseMacScreenIndex(out)));
+      proc.on("close", () => done(parseMacScreenIndex(out)));
+      // Bound the probe so a hung ffmpeg can't stall recording startup.
+      setTimeout(() => done(null), 5000);
     } catch {
-      resolve(null);
+      done(null);
     }
   });
 }
@@ -347,19 +361,33 @@ async function detectMacScreenIndex(
 async function detectX11ScreenSize(display?: string): Promise<string | null> {
   return new Promise((resolve) => {
     let out = "";
+    let settled = false;
+    let proc: any = null;
+    const done = (v: string | null) => {
+      if (settled) return;
+      settled = true;
+      try {
+        proc?.kill();
+      } catch {
+        /* ignore */
+      }
+      resolve(v);
+    };
     try {
       const env = display ? { ...process.env, DISPLAY: display } : process.env;
-      const proc = spawn("xdpyinfo", [], { env, stdio: ["ignore", "pipe", "ignore"] });
-      proc.stdout?.on("data", (d) => {
+      proc = spawn("xdpyinfo", [], { env, stdio: ["ignore", "pipe", "ignore"] });
+      proc.stdout?.on("data", (d: any) => {
         out += d.toString();
       });
-      proc.on("error", () => resolve(null));
+      proc.on("error", () => done(null));
       proc.on("close", () => {
         const m = /dimensions:\s+(\d+x\d+)\s+pixels/i.exec(out);
-        resolve(m ? m[1] : null);
+        done(m ? m[1] : null);
       });
+      // Bound the probe so a hung xdpyinfo can't stall recording startup.
+      setTimeout(() => done(null), 5000);
     } catch {
-      resolve(null);
+      done(null);
     }
   });
 }

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -22,7 +22,14 @@ export {
   checkSystemBinary,
   xvfbDisplay,
   startXvfb,
+  XVFB_SCREEN_SIZE,
+  detectX11ScreenSize,
 };
+
+// Fixed virtual-display size for the Linux Xvfb recording path. Used both to
+// start Xvfb and as the x11grab `-video_size`, so the capture matches the
+// display exactly (and window/viewport crops fit within it).
+const XVFB_SCREEN_SIZE = "1920x1080";
 
 // The browser engine drives getDisplayMedia's auto-select via a per-context
 // window title and downloads the .webm to a per-context dir. tests.ts (which
@@ -141,12 +148,14 @@ function buildCaptureArgs({
   displayEnv,
   outputPath,
   screenIndex,
+  screenSize,
 }: {
   platform: string;
   fps: number;
   displayEnv?: string;
   outputPath: string;
   screenIndex?: string;
+  screenSize?: string;
 }): string[] {
   const rate = String(fps ?? 30);
   let input: string[];
@@ -167,7 +176,19 @@ function buildCaptureArgs({
       ];
       break;
     case "linux":
-      input = ["-f", "x11grab", "-framerate", rate, "-i", displayEnv || ":0.0"];
+      // x11grab in the bundled ffmpeg defaults to a 640x480 grab when
+      // -video_size is omitted, capturing only a corner of the display. Pass
+      // the real screen size so the full display (and any window/viewport
+      // crop within it) is captured.
+      input = [
+        "-f",
+        "x11grab",
+        "-framerate",
+        rate,
+        ...(screenSize ? ["-video_size", screenSize] : []),
+        "-i",
+        displayEnv || ":0.0",
+      ];
       break;
     default:
       throw new Error(
@@ -319,6 +340,30 @@ async function detectMacScreenIndex(
   });
 }
 
+// Best-effort detection of an X11 display's screen size via xdpyinfo, e.g.
+// "1920x1080". Used to set x11grab's -video_size for a non-Xvfb (real
+// desktop) Linux display. Returns null if xdpyinfo is unavailable or the
+// output can't be parsed (the caller then omits -video_size).
+async function detectX11ScreenSize(display?: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    let out = "";
+    try {
+      const env = display ? { ...process.env, DISPLAY: display } : process.env;
+      const proc = spawn("xdpyinfo", [], { env, stdio: ["ignore", "pipe", "ignore"] });
+      proc.stdout?.on("data", (d) => {
+        out += d.toString();
+      });
+      proc.on("error", () => resolve(null));
+      proc.on("close", () => {
+        const m = /dimensions:\s+(\d+x\d+)\s+pixels/i.exec(out);
+        resolve(m ? m[1] : null);
+      });
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
 // Probe for a system binary on PATH (e.g. Xvfb, which is not an npm package).
 // Resolves true if the binary launches, false on ENOENT/spawn error.
 async function checkSystemBinary(name: string): Promise<boolean> {
@@ -349,8 +394,9 @@ async function startXvfb(
   opts: { width?: number; height?: number } = {}
 ): Promise<any> {
   const num = display.replace(/^:/, "").split(".")[0];
-  const w = opts.width ?? 1920;
-  const h = opts.height ?? 1080;
+  const [defW, defH] = XVFB_SCREEN_SIZE.split("x").map(Number);
+  const w = opts.width ?? defW;
+  const h = opts.height ?? defH;
   // Capture the spawn time so a stale `/tmp/.X<N>-lock` (left by a dead Xvfb
   // or another server) can't false-ready us — we only accept a lock created
   // at/after our own start.

--- a/src/core/tests/startRecording.ts
+++ b/src/core/tests/startRecording.ts
@@ -1,6 +1,15 @@
 import { validate } from "../../common/src/validate.js";
 import { log } from "../utils.js";
 import { instantiateCursor } from "./moveTo.js";
+import {
+  resolveRecordPlan,
+  browserCaptureTitle,
+  browserDownloadDir,
+  buildCaptureArgs,
+  resolveCropGeometry,
+  getFfmpegPath,
+} from "./ffmpegRecorder.js";
+import { spawn } from "node:child_process";
 import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
@@ -45,13 +54,6 @@ async function startRecording({ config, context, step, driver }: { config: any; 
     overwrite: step.record.overwrite || "false",
   };
 
-  // If headless is true, skip recording
-  if (context.browser?.headless) {
-    result.status = "SKIPPED";
-    result.description = `Recording isn't supported in headless mode.`;
-    return result;
-  }
-
   // Set file name
   let filePath = step.record.path;
   const baseName = path.basename(filePath, path.extname(filePath));
@@ -71,16 +73,39 @@ async function startRecording({ config, context, step, driver }: { config: any; 
     return result;
   }
 
-  if (
-    context?.browser?.name === "chrome" &&
-    context?.browser?.headless === false
-  ) {
-    // Chrome and Chromium
+  // Resolve which engine to use. The context's browser is already coerced by
+  // the runner (headed Chrome preferred when nothing was specified), so this
+  // is a pure read.
+  const plan = resolveRecordPlan({ step, context });
+
+  if (plan.name === "browser") {
+    // Browser engine: capture the Chrome viewport via getDisplayMedia +
+    // MediaRecorder. Concurrency-safe — each context auto-selects its own
+    // window by a unique title. Requires headed Chrome.
+    if (context.browser?.headless) {
+      result.status = "SKIPPED";
+      result.description = `Recording isn't supported in headless mode with the browser engine. Use the ffmpeg engine to record headless.`;
+      return result;
+    }
+    if (context.browser?.name !== "chrome") {
+      result.status = "SKIPPED";
+      result.description = `The browser recording engine requires Chrome. Use the ffmpeg engine for '${context.browser?.name}'.`;
+      return result;
+    }
+
+    const captureTitle = browserCaptureTitle(context.contextId);
+    const downloadDir = browserDownloadDir(context.contextId);
+    if (!fs.existsSync(downloadDir)) {
+      fs.mkdirSync(downloadDir, { recursive: true });
+    }
+    const downloadPath = path.join(downloadDir, `${baseName}.webm`);
+
     // Get document title
     const documentTitle = await driver.getTitle();
     const originalTab = await driver.getWindowHandle();
-    // Set document title to "RECORD_ME"
-    await driver.execute(() => (document.title = "RECORD_ME"));
+    // Set document title to the per-context capture title so the launch flag
+    // --auto-select-desktop-capture-source picks exactly this window.
+    await driver.execute((title: any) => (document.title = title), captureTitle);
     // Instantiate cursor
     await instantiateCursor(driver, { position: "center" });
     // Create new tab
@@ -195,16 +220,95 @@ async function startRecording({ config, context, step, driver }: { config: any; 
     result.recording = {
       type: "MediaRecorder",
       tab: recorderTab.handle,
-      downloadPath: path.join(os.tmpdir(), `${baseName}.webm`), // Where the recording will be downloaded.
+      downloadPath, // Where the recording will be downloaded.
       targetPath: filePath, // Where the recording will be saved.
     };
-  } else {
-    // Other context — recording not supported
-    result.status = "SKIPPED";
-    result.description = `Recording is not supported for this context.`;
     return result;
   }
 
-  // PASS
+  // ffmpeg engine: capture the screen with ffmpeg. Works for any application.
+  // window/viewport targets capture the full display and are cropped during
+  // stopRecording's transcode.
+
+  // A headless browser has no on-screen content to capture. ffmpeg headless
+  // recording is only meaningful against a virtual display (Linux Xvfb),
+  // threaded in as context.__display. Without one, skip — matching the
+  // long-standing "recording isn't supported headless" behavior.
+  if (context.browser?.headless && !context.__display) {
+    result.status = "SKIPPED";
+    result.description = `Recording isn't supported in headless mode without a virtual display (Xvfb).`;
+    return result;
+  }
+
+  let crop: any = null;
+  if (driver && plan.target !== "display") {
+    try {
+      crop = await resolveCropGeometry({ driver, target: plan.target });
+    } catch (err) {
+      log(
+        config,
+        "warning",
+        `Couldn't resolve ${plan.target} geometry for recording; capturing the full display. ${err}`
+      );
+    }
+  }
+
+  // Show the synthetic cursor in the page so automated actions are visible
+  // (WebDriver doesn't move the OS pointer).
+  if (driver) {
+    try {
+      await instantiateCursor(driver, { position: "center" });
+    } catch {
+      /* non-fatal */
+    }
+  }
+
+  const tempDir = path.join(os.tmpdir(), "doc-detective", "recordings");
+  if (!fs.existsSync(tempDir)) fs.mkdirSync(tempDir, { recursive: true });
+  const tempPath = path.join(tempDir, `${context.contextId || "ctx"}-${baseName}.mkv`);
+
+  let ffmpegPath: string;
+  try {
+    ffmpegPath = await getFfmpegPath({ cacheDir: config?.cacheDir });
+  } catch (err) {
+    result.status = "FAIL";
+    result.description = `Couldn't start recording: ${err}`;
+    log(config, "error", result.description);
+    return result;
+  }
+
+  const args = buildCaptureArgs({
+    platform: process.platform,
+    fps: plan.fps,
+    // Honor a per-context virtual display (Linux Xvfb) when threaded through.
+    displayEnv: context.__display || process.env.DISPLAY,
+    outputPath: tempPath,
+  });
+
+  const proc = spawn(ffmpegPath, args, { stdio: ["pipe", "ignore", "pipe"] });
+  let spawnError: any = null;
+  proc.on("error", (err) => {
+    spawnError = err;
+  });
+
+  // Give ffmpeg a moment to initialize, then make sure it didn't immediately
+  // fail (e.g. missing display, permission denied).
+  await new Promise((r) => setTimeout(r, 500));
+  if (spawnError || proc.exitCode !== null) {
+    result.status = "FAIL";
+    result.description = `Couldn't start ffmpeg recording.${
+      spawnError ? ` ${spawnError}` : ` ffmpeg exited with code ${proc.exitCode}.`
+    } On macOS, grant screen recording permission; on Linux, ensure a display (or Xvfb) is available.`;
+    log(config, "error", result.description);
+    return result;
+  }
+
+  result.recording = {
+    type: "ffmpeg",
+    process: proc,
+    tempPath,
+    targetPath: filePath,
+    crop,
+  };
   return result;
 }

--- a/src/core/tests/startRecording.ts
+++ b/src/core/tests/startRecording.ts
@@ -9,6 +9,7 @@ import {
   buildCaptureArgs,
   resolveCropGeometry,
   getFfmpegPath,
+  detectMacScreenIndex,
 } from "./ffmpegRecorder.js";
 import { spawn } from "node:child_process";
 import path from "node:path";
@@ -297,23 +298,38 @@ async function startRecording({ config, context, step, driver }: { config: any; 
     return result;
   }
 
+  // On macOS the avfoundation screen device index isn't fixed (it shifts with
+  // attached cameras), so detect it rather than guessing.
+  let screenIndex: string | undefined;
+  if (process.platform === "darwin") {
+    screenIndex = (await detectMacScreenIndex(ffmpegPath)) ?? undefined;
+  }
+
   const args = buildCaptureArgs({
     platform: process.platform,
     fps: plan.fps,
     // Honor a per-context virtual display (Linux Xvfb) when threaded through.
     displayEnv: context.__display || process.env.DISPLAY,
     outputPath: tempPath,
+    screenIndex,
   });
   log(
     config,
     "debug",
     `ffmpeg recording: platform=${process.platform} target=${plan.target}${
-      context.__display ? ` display=${context.__display}` : ""
-    } -> ${tempPath}`
+      screenIndex !== undefined ? ` screen=${screenIndex}` : ""
+    }${context.__display ? ` display=${context.__display}` : ""} -> ${tempPath}`
   );
 
   const proc = spawn(ffmpegPath, args, { stdio: ["pipe", "ignore", "pipe"] });
   let spawnError: any = null;
+  // Drain ffmpeg's stderr into a bounded tail: it both prevents the unread
+  // pipe from filling and blocking ffmpeg, and surfaces the real reason on a
+  // start failure (wrong device index, denied screen-recording permission…).
+  let stderrTail = "";
+  proc.stderr?.on("data", (d) => {
+    stderrTail = (stderrTail + d.toString()).slice(-2000);
+  });
   proc.on("error", (err) => {
     spawnError = err;
   });
@@ -325,7 +341,9 @@ async function startRecording({ config, context, step, driver }: { config: any; 
     result.status = "FAIL";
     result.description = `Couldn't start ffmpeg recording.${
       spawnError ? ` ${spawnError}` : ` ffmpeg exited with code ${proc.exitCode}.`
-    } On macOS, grant screen recording permission; on Linux, ensure a display (or Xvfb) is available.`;
+    } On macOS, grant screen recording permission; on Linux, ensure a display (or Xvfb) is available.${
+      stderrTail ? ` ffmpeg: ${stderrTail.trim().slice(-500)}` : ""
+    }`;
     log(config, "error", result.description);
     return result;
   }

--- a/src/core/tests/startRecording.ts
+++ b/src/core/tests/startRecording.ts
@@ -99,6 +99,15 @@ async function startRecording({ config, context, step, driver }: { config: any; 
       fs.mkdirSync(downloadDir, { recursive: true });
     }
     const downloadPath = path.join(downloadDir, `${baseName}.webm`);
+    // Remove any stale download from a previous crashed run — otherwise Chrome
+    // saves as "<name> (1).webm" and stopRecording waits on the wrong path.
+    if (fs.existsSync(downloadPath)) {
+      try {
+        fs.unlinkSync(downloadPath);
+      } catch {
+        /* best-effort */
+      }
+    }
 
     // Get document title
     const documentTitle = await driver.getTitle();
@@ -284,6 +293,13 @@ async function startRecording({ config, context, step, driver }: { config: any; 
     displayEnv: context.__display || process.env.DISPLAY,
     outputPath: tempPath,
   });
+  log(
+    config,
+    "debug",
+    `ffmpeg recording: platform=${process.platform} target=${plan.target}${
+      context.__display ? ` display=${context.__display}` : ""
+    } -> ${tempPath}`
+  );
 
   const proc = spawn(ffmpegPath, args, { stdio: ["pipe", "ignore", "pipe"] });
   let spawnError: any = null;

--- a/src/core/tests/startRecording.ts
+++ b/src/core/tests/startRecording.ts
@@ -32,6 +32,13 @@ async function startRecording({ config, context, step, driver }: { config: any; 
   // Accept coerced and defaulted values
   step = isValidStep.object;
 
+  // `record: false` explicitly disables recording — don't start one.
+  if (step.record === false) {
+    result.status = "SKIPPED";
+    result.description = "Recording is disabled (record: false).";
+    return result;
+  }
+
   // Convert boolean to string
   if (typeof step.record === "boolean") {
     step.record = { path: `${step.stepId}.mp4` };

--- a/src/core/tests/startRecording.ts
+++ b/src/core/tests/startRecording.ts
@@ -3,6 +3,7 @@ import { log } from "../utils.js";
 import { instantiateCursor } from "./moveTo.js";
 import {
   resolveRecordPlan,
+  safeContextId,
   browserCaptureTitle,
   browserDownloadDir,
   buildCaptureArgs,
@@ -281,7 +282,10 @@ async function startRecording({ config, context, step, driver }: { config: any; 
 
   const tempDir = path.join(os.tmpdir(), "doc-detective", "recordings");
   if (!fs.existsSync(tempDir)) fs.mkdirSync(tempDir, { recursive: true });
-  const tempPath = path.join(tempDir, `${context.contextId || "ctx"}-${baseName}.mkv`);
+  const tempPath = path.join(
+    tempDir,
+    `${safeContextId(context.contextId)}-${baseName}.mkv`
+  );
 
   let ffmpegPath: string;
   try {

--- a/src/core/tests/startRecording.ts
+++ b/src/core/tests/startRecording.ts
@@ -10,6 +10,7 @@ import {
   resolveCropGeometry,
   getFfmpegPath,
   detectMacScreenIndex,
+  detectX11ScreenSize,
 } from "./ffmpegRecorder.js";
 import { spawn } from "node:child_process";
 import path from "node:path";
@@ -305,13 +306,26 @@ async function startRecording({ config, context, step, driver }: { config: any; 
     screenIndex = (await detectMacScreenIndex(ffmpegPath)) ?? undefined;
   }
 
+  const displayEnv = context.__display || process.env.DISPLAY;
+  // On Linux, x11grab must be told the screen size or the bundled ffmpeg only
+  // grabs a 640x480 corner. Use the known Xvfb size when threaded, else detect
+  // the real display's size.
+  let screenSize: string | undefined;
+  if (process.platform === "linux") {
+    screenSize =
+      context.__displaySize ||
+      (await detectX11ScreenSize(displayEnv)) ||
+      undefined;
+  }
+
   const args = buildCaptureArgs({
     platform: process.platform,
     fps: plan.fps,
     // Honor a per-context virtual display (Linux Xvfb) when threaded through.
-    displayEnv: context.__display || process.env.DISPLAY,
+    displayEnv,
     outputPath: tempPath,
     screenIndex,
+    screenSize,
   });
   log(
     config,

--- a/src/core/tests/stopRecording.ts
+++ b/src/core/tests/stopRecording.ts
@@ -107,6 +107,12 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
         /* fall through to kill */
       }
       await new Promise<void>((resolve) => {
+        // Already exited (e.g. ffmpeg reacted to "q" before we got here) —
+        // don't wait on a "close" that will never fire again.
+        if (proc.exitCode !== null || proc.signalCode !== null) {
+          resolve();
+          return;
+        }
         let settled = false;
         const finish = () => {
           if (!settled) {
@@ -114,20 +120,22 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
             resolve();
           }
         };
-        proc.on("close", finish);
-        proc.on("exit", finish);
-        // ffmpeg should exit promptly after "q". If it doesn't, kill it — but
-        // still wait for the process to actually exit (and flush the .mkv)
-        // before transcoding, falling back to a hard finish only if the kill
-        // itself doesn't take effect.
-        setTimeout(() => {
+        // Normal path: ffmpeg exits after "q"; close clears the kill timer and
+        // we transcode the fully-flushed .mkv.
+        const killTimer = setTimeout(() => {
           try {
-            proc.kill();
+            proc.kill("SIGKILL");
           } catch {
             /* ignore */
           }
+          // Resolve on the post-kill close, or after a short grace if it never
+          // arrives. The .mkv survives a hard kill.
           setTimeout(finish, 2000);
         }, 15000);
+        proc.once("close", () => {
+          clearTimeout(killTimer);
+          finish();
+        });
       });
 
       await transcode({

--- a/src/core/tests/stopRecording.ts
+++ b/src/core/tests/stopRecording.ts
@@ -230,7 +230,9 @@ async function waitForStableFile(
     } catch {
       size = -1;
     }
-    if (size >= 0 && size === lastSize) {
+    // Require a non-empty, steady size: Chrome may pre-create the .webm
+    // before writing data, and transcoding an empty file fails.
+    if (size > 0 && size === lastSize) {
       stableReads++;
       if (stableReads >= 1) return true;
     } else {

--- a/src/core/tests/stopRecording.ts
+++ b/src/core/tests/stopRecording.ts
@@ -1,6 +1,6 @@
 import { validate } from "../../common/src/validate.js";
 import { log } from "../utils.js";
-import { execFile } from "node:child_process";
+import { spawn } from "node:child_process";
 import path from "node:path";
 import fs from "node:fs";
 import { getFfmpegPath } from "./ffmpegRecorder.js";
@@ -194,10 +194,13 @@ async function transcode({
   ffmpegArgs.push(`${targetPath}`);
   const ffmpegPath = await getFfmpegPath({ cacheDir: config?.cacheDir });
   await new Promise<void>((resolve, reject) => {
-    const child = execFile(ffmpegPath, ffmpegArgs);
+    // spawn (not execFile): a long/noisy ffmpeg transcode can emit megabytes
+    // of progress on stderr, which would overflow execFile's internal buffer
+    // (ERR_CHILD_PROCESS_STDIO_MAXBUFFER). We stream stderr into a bounded tail.
+    const child = spawn(ffmpegPath, ffmpegArgs);
     let stderr = "";
     child.stderr?.on("data", (d) => {
-      stderr += d.toString();
+      stderr = (stderr + d.toString()).slice(-2000);
     });
     child
       .on("close", (code) => {

--- a/src/core/tests/stopRecording.ts
+++ b/src/core/tests/stopRecording.ts
@@ -13,15 +13,15 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
     description: "Stopped recording.",
   };
 
-  // Validate step payload
+  // Validate step payload. (The stopRecord step carries no fields we read
+  // here — the recording state lives on driver.state — so we only assert
+  // validity and don't keep the coerced object.)
   const isValidStep = validate({ schemaKey: "step_v3", object: step });
   if (!isValidStep.valid) {
     result.status = "FAIL";
     result.description = `Invalid step definition: ${isValidStep.errors}`;
     return result;
   }
-  // Accept coerced and defaulted values
-  step = isValidStep.object;
 
   // Skip if recording is not started. Recording state is per-context (it
   // lives on driver.state), so concurrent contexts can't see each other's
@@ -116,15 +116,17 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
         };
         proc.on("close", finish);
         proc.on("exit", finish);
-        // ffmpeg should exit promptly after "q"; kill as a last resort. The
-        // .mkv intermediate survives a hard kill.
+        // ffmpeg should exit promptly after "q". If it doesn't, kill it — but
+        // still wait for the process to actually exit (and flush the .mkv)
+        // before transcoding, falling back to a hard finish only if the kill
+        // itself doesn't take effect.
         setTimeout(() => {
           try {
             proc.kill();
           } catch {
             /* ignore */
           }
-          finish();
+          setTimeout(finish, 2000);
         }, 15000);
       });
 
@@ -237,5 +239,8 @@ async function waitForStableFile(
     lastSize = size;
     await new Promise((r) => setTimeout(r, 500));
   }
-  return fs.existsSync(filePath);
+  // Timed out without the size ever holding steady — the file is missing or
+  // still being written. Report not-stable so the caller fails cleanly rather
+  // than transcoding a partial download.
+  return false;
 }

--- a/src/core/tests/stopRecording.ts
+++ b/src/core/tests/stopRecording.ts
@@ -183,7 +183,15 @@ async function transcode({
   const ffmpegArgs = ["-y", "-i", `${sourcePath}`, "-an", "-pix_fmt", "yuv420p"];
   const filters: string[] = [];
   if (crop) {
-    filters.push(`crop=${crop.w}:${crop.h}:${crop.x}:${crop.y}`);
+    // Clamp the crop to the captured frame using ffmpeg expressions (iw/ih),
+    // so a window/viewport rectangle larger than the captured display can't
+    // make the crop filter fail with "Invalid too big size". Commas inside
+    // min()/max() are escaped (\,) so they aren't read as filter separators.
+    const cw = `min(iw\\,${crop.w})`;
+    const ch = `min(ih\\,${crop.h})`;
+    const cx = `max(0\\,min(${crop.x}\\,iw-${cw}))`;
+    const cy = `max(0\\,min(${crop.y}\\,ih-${ch}))`;
+    filters.push(`crop=w=${cw}:h=${ch}:x=${cx}:y=${cy}`);
   }
   if (path.extname(targetPath) === ".gif") {
     filters.push("scale=iw:-1:flags=lanczos");

--- a/src/core/tests/stopRecording.ts
+++ b/src/core/tests/stopRecording.ts
@@ -3,27 +3,7 @@ import { log } from "../utils.js";
 import { execFile } from "node:child_process";
 import path from "node:path";
 import fs from "node:fs";
-import { loadHeavyDep } from "../../runtime/loader.js";
-
-// Resolve the ffmpeg binary path lazily — @ffmpeg-installer/ffmpeg is a
-// heavy runtime dep that should only be loaded when a stopRecording step
-// actually runs. The ctx is threaded through so a user-overridden
-// cacheDir is honored here just as it is by the JIT pre-flight installer.
-async function getFfmpegPath(ctx: { cacheDir?: string } = {}): Promise<string> {
-  const mod = await loadHeavyDep<any>("@ffmpeg-installer/ffmpeg", { ctx });
-  // The package's CJS entry exports an object with a .path field; in ESM
-  // dynamic import we get { default: { path }, path? } shape depending on
-  // bundler. Try both, then guard before handing it to execFile so a
-  // malformed install fails with an actionable message instead of a
-  // confusing "argument must be of type string" deep in node's exec.
-  const candidate = mod && (mod.path ?? mod.default?.path);
-  if (typeof candidate !== "string" || candidate.length === 0) {
-    throw new Error(
-      "ffmpeg binary path is missing or malformed in the installed @ffmpeg-installer/ffmpeg package. Try `doc-detective install runtime --force` to reinstall."
-    );
-  }
-  return candidate;
-}
+import { getFfmpegPath } from "./ffmpegRecorder.js";
 
 export { stopRecording };
 
@@ -55,7 +35,7 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
 
   try {
     if (recording.type === "MediaRecorder") {
-      // MediaRecorder
+      // Browser engine.
 
       // Switch to recording tab
       await driver.switchToWindow(recording.tab);
@@ -84,13 +64,12 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
       await driver.execute(() => {
         (window as any).recorder.stop();
       });
-      // Wait for file to be in download path
-      let waitCount = 0;
-      while (!fs.existsSync(recording.downloadPath) && waitCount < 60) {
-        await new Promise((r) => setTimeout(r, 1000));
-        waitCount++;
-      }
-      if (!fs.existsSync(recording.downloadPath)) {
+      // Wait for the download to appear AND finish writing. Chrome streams the
+      // blob to disk (and may use a .crdownload temp first), so existence
+      // alone isn't enough — transcoding a still-growing file makes ffmpeg
+      // fail. Wait for the size to hold steady across two reads.
+      const downloaded = await waitForStableFile(recording.downloadPath, 60);
+      if (!downloaded) {
         result.status = "FAIL";
         result.description = "Recording download timed out.";
         // Clear the state so the auto-stop in runContext doesn't re-invoke
@@ -108,37 +87,55 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
         await driver.switchToWindow(remainingHandles[0]);
       }
 
-      // Convert the file into the target format/location
-      const targetPath = `${recording.targetPath}`;
-      const downloadPath = `${recording.downloadPath}`;
-      const endMessage = `Finished processing file: ${recording.targetPath}`;
-      const ffmpegArgs = ["-y", "-i", downloadPath, "-pix_fmt", "yuv420p"];
-      if (path.extname(targetPath) === ".gif") {
-        ffmpegArgs.push("-vf", "scale=iw:-1:flags=lanczos");
-      }
-      ffmpegArgs.push(targetPath);
-      // Await transcoding to complete before returning
-      const ffmpegPath = await getFfmpegPath({ cacheDir: config?.cacheDir });
-      await new Promise<void>((resolve, reject) => {
-        execFile(ffmpegPath, ffmpegArgs)
-          .on("close", (code) => {
-            if (code === 0) {
-              // Only delete the downloaded file after successful transcoding
-              if (targetPath !== downloadPath) {
-                try { fs.unlinkSync(downloadPath); } catch { /* ignore */ }
-              }
-              log(config, "debug", endMessage);
-              resolve();
-            } else {
-              reject(new Error(`ffmpeg exited with code ${code}`));
-            }
-          })
-          .on("error", reject);
+      // Convert the downloaded .webm into the target format/location.
+      await transcode({
+        config,
+        sourcePath: recording.downloadPath,
+        targetPath: recording.targetPath,
+        deleteSource: true,
       });
       driver.state.recording = null;
-    } else {
-      // FFMPEG
-      // recording.stdin.write("q");
+    } else if (recording.type === "ffmpeg") {
+      // ffmpeg engine. Stop the capture gracefully (write "q" to stdin so the
+      // container is finalized), then transcode the temp .mkv into the target
+      // format, cropping to the requested window/viewport if one was resolved.
+      const proc = recording.process;
+      try {
+        proc.stdin?.write("q");
+        proc.stdin?.end?.();
+      } catch {
+        /* fall through to kill */
+      }
+      await new Promise<void>((resolve) => {
+        let settled = false;
+        const finish = () => {
+          if (!settled) {
+            settled = true;
+            resolve();
+          }
+        };
+        proc.on("close", finish);
+        proc.on("exit", finish);
+        // ffmpeg should exit promptly after "q"; kill as a last resort. The
+        // .mkv intermediate survives a hard kill.
+        setTimeout(() => {
+          try {
+            proc.kill();
+          } catch {
+            /* ignore */
+          }
+          finish();
+        }, 15000);
+      });
+
+      await transcode({
+        config,
+        sourcePath: recording.tempPath,
+        targetPath: recording.targetPath,
+        deleteSource: true,
+        crop: recording.crop,
+      });
+      driver.state.recording = null;
     }
   } catch (error) {
     // Couldn't stop recording
@@ -152,4 +149,93 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
 
   // PASS
   return result;
+}
+
+// Transcode a recording into the requested target format/location with
+// ffmpeg, applying an optional crop and the gif scale filter. Deletes the
+// source on success when requested (and when it isn't the target itself).
+async function transcode({
+  config,
+  sourcePath,
+  targetPath,
+  deleteSource,
+  crop,
+}: {
+  config: any;
+  sourcePath: string;
+  targetPath: string;
+  deleteSource: boolean;
+  crop?: { x: number; y: number; w: number; h: number } | null;
+}): Promise<void> {
+  // Drop audio (-an): doc recordings are visual, and the browser engine's
+  // captured opus track fails to mux into mp4 ("Too many packets buffered for
+  // output stream"). Silent video is the intended, reliable output.
+  const ffmpegArgs = ["-y", "-i", `${sourcePath}`, "-an", "-pix_fmt", "yuv420p"];
+  const filters: string[] = [];
+  if (crop) {
+    filters.push(`crop=${crop.w}:${crop.h}:${crop.x}:${crop.y}`);
+  }
+  if (path.extname(targetPath) === ".gif") {
+    filters.push("scale=iw:-1:flags=lanczos");
+  }
+  if (filters.length > 0) {
+    ffmpegArgs.push("-vf", filters.join(","));
+  }
+  ffmpegArgs.push(`${targetPath}`);
+  const ffmpegPath = await getFfmpegPath({ cacheDir: config?.cacheDir });
+  await new Promise<void>((resolve, reject) => {
+    const child = execFile(ffmpegPath, ffmpegArgs);
+    let stderr = "";
+    child.stderr?.on("data", (d) => {
+      stderr += d.toString();
+    });
+    child
+      .on("close", (code) => {
+        if (code === 0) {
+          if (deleteSource && sourcePath !== targetPath) {
+            try {
+              fs.unlinkSync(sourcePath);
+            } catch {
+              /* ignore */
+            }
+          }
+          log(config, "debug", `Finished processing file: ${targetPath}`);
+          resolve();
+        } else {
+          reject(
+            new Error(`ffmpeg exited with code ${code}: ${stderr.slice(-600)}`)
+          );
+        }
+      })
+      .on("error", reject);
+  });
+}
+
+// Wait for a file to exist and stop growing (size unchanged across two reads
+// ~500ms apart), up to `maxSeconds`. Returns true once stable, false on
+// timeout. Guards against transcoding a download that's still being written.
+async function waitForStableFile(
+  filePath: string,
+  maxSeconds: number
+): Promise<boolean> {
+  let lastSize = -1;
+  let stableReads = 0;
+  const deadline = maxSeconds * 2; // two checks per second
+  for (let i = 0; i < deadline; i++) {
+    let size = -1;
+    try {
+      size = fs.statSync(filePath).size;
+    } catch {
+      size = -1;
+    }
+    if (size >= 0 && size === lastSize) {
+      stableReads++;
+      if (stableReads >= 1) return true;
+    } else {
+      stableReads = 0;
+    }
+    lastSize = size;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return fs.existsSync(filePath);
 }

--- a/src/hints/context.ts
+++ b/src/hints/context.ts
@@ -144,6 +144,9 @@ export async function buildHintContext(
     outputDirGitignored,
     nodeMajor,
     hasRstFiles,
+    // Set by the runner on the results object when it forced serial execution
+    // for ffmpeg recording. Defensive read — results may be partial/absent.
+    recordingForcedSerial: options.results?.recordingForcedSerial === true,
   };
 }
 

--- a/src/hints/hints.ts
+++ b/src/hints/hints.ts
@@ -263,6 +263,24 @@ export const HINTS: Hint[] = [
   },
 
   // ------------------------------------------------------------------
+  // recordConcurrently (optimization & advanced)
+  // ------------------------------------------------------------------
+  {
+    id: "recordConcurrently",
+    priority: 50,
+    markdown: [
+      "This run executed serially because the ffmpeg recording engine needs exclusive use of the display. To keep `concurrentRunners` parallelism while recording, either record the Chrome viewport with the browser engine:",
+      "",
+      "```json",
+      '{ "record": { "engine": "browser" } }',
+      "```",
+      "",
+      "or, on Linux, install Xvfb so each runner records its own virtual display.",
+    ].join("\n"),
+    when: (ctx) => ctx.recordingForcedSerial,
+  },
+
+  // ------------------------------------------------------------------
   // setConcurrentRunners (optimization & advanced)
   // ------------------------------------------------------------------
   {

--- a/src/hints/types.ts
+++ b/src/hints/types.ts
@@ -163,6 +163,13 @@ export interface HintContext {
    * Python as a top-level interpreter. Powers `useRunCodeStep`.
    */
   hasNodeOrPythonInRunShell: boolean;
+  /**
+   * True when the runner capped `concurrentRunners` to 1 because the run used
+   * the ffmpeg recording engine (which needs exclusive use of the display) on
+   * a platform without per-runner virtual displays. Read directly from
+   * `results.recordingForcedSerial`. Powers `recordConcurrently`.
+   */
+  recordingForcedSerial: boolean;
 }
 
 export interface Hint {

--- a/test/core-artifacts/recording-permutations.spec.json
+++ b/test/core-artifacts/recording-permutations.spec.json
@@ -1,0 +1,417 @@
+{
+  "specId": "recording-permutations",
+  "description": "Validates each permutation of recording support that isn't already covered by recording.spec.json: the record value forms (boolean/false), both engines as a string shorthand, every ffmpeg target (display/window/viewport), custom fps, all output formats (mp4/webm/gif) per engine, and the engine-specific headless skip. ffmpeg permutations run on Windows (gdigrab) and macOS (avfoundation); the browser engine needs headed Chrome.",
+  "tests": [
+    {
+      "testId": "rec-perm-record-true",
+      "description": "record: true (boolean) auto-resolves to the browser engine on headed Chrome.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": true
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-record-false",
+      "description": "record: false disables recording — the step is skipped, not started.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac",
+            "linux"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": true
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": false
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-engine-string-browser",
+      "description": "engine string shorthand \"browser\".",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-engine-browser.mp4",
+            "engine": "browser",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-engine-string-ffmpeg",
+      "description": "engine string shorthand \"ffmpeg\" (default display target).",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-engine-ffmpeg.mp4",
+            "engine": "ffmpeg",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-ffmpeg-window",
+      "description": "ffmpeg engine, window target (full-screen capture cropped to the window).",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-window.mp4",
+            "engine": {
+              "name": "ffmpeg",
+              "target": "window"
+            },
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-ffmpeg-viewport",
+      "description": "ffmpeg engine, viewport target (cropped to the browser content area).",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-viewport.mp4",
+            "engine": {
+              "name": "ffmpeg",
+              "target": "viewport"
+            },
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-ffmpeg-fps",
+      "description": "ffmpeg engine with a custom capture frame rate.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-fps.mp4",
+            "engine": {
+              "name": "ffmpeg",
+              "target": "display",
+              "fps": 60
+            },
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-browser-gif",
+      "description": "browser engine output as a .gif.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-browser.gif",
+            "engine": "browser",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-ffmpeg-webm",
+      "description": "ffmpeg engine output as a .webm.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-ffmpeg.webm",
+            "engine": "ffmpeg",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-ffmpeg-gif",
+      "description": "ffmpeg engine output as a .gif.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-ffmpeg.gif",
+            "engine": "ffmpeg",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-ffmpeg-headless-skip",
+      "description": "ffmpeg engine in headless mode with no virtual display is skipped.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac",
+            "linux"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": true
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-headless.mp4",
+            "engine": "ffmpeg",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    }
+  ]
+}

--- a/test/core-artifacts/recording-permutations.spec.json
+++ b/test/core-artifacts/recording-permutations.spec.json
@@ -685,6 +685,110 @@
           "stopRecord": true
         }
       ]
+    },
+    {
+      "testId": "rec-perm-safari-ffmpeg",
+      "description": "Safari (macOS-only, non-Chrome) context with the ffmpeg engine — the ffmpeg engine is browser-agnostic.",
+      "runOn": [
+        {
+          "platforms": [
+            "mac"
+          ],
+          "browsers": {
+            "name": "safari"
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-safari-ffmpeg.mp4",
+            "engine": "ffmpeg",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 8000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-safari-auto",
+      "description": "Safari context with no explicit engine auto-resolves to ffmpeg (the browser engine is Chrome-only).",
+      "runOn": [
+        {
+          "platforms": [
+            "mac"
+          ],
+          "browsers": {
+            "name": "safari"
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-safari-auto.mp4",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 8000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-safari-browser-skip",
+      "description": "Safari context with the browser engine is skipped (the browser engine requires Chrome).",
+      "runOn": [
+        {
+          "platforms": [
+            "mac"
+          ],
+          "browsers": {
+            "name": "safari"
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-safari-browser.mp4",
+            "engine": "browser",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 8000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
     }
   ]
 }

--- a/test/core-artifacts/recording-permutations.spec.json
+++ b/test/core-artifacts/recording-permutations.spec.json
@@ -417,6 +417,274 @@
           "stopRecord": true
         }
       ]
+    },
+    {
+      "testId": "rec-perm-record-string",
+      "description": "record as a string path shorthand (auto-resolves to the browser engine on headed Chrome).",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": "rec-perm-string.mp4"
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-engine-object-browser",
+      "description": "engine as a detailed object { name: \"browser\" }.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-engine-obj-browser.mp4",
+            "engine": {
+              "name": "browser"
+            },
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-chrome-ffmpeg-object",
+      "description": "Chrome context with the ffmpeg engine as a detailed object { name: \"ffmpeg\", target: \"display\" } — records the screen while driving Chrome.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac",
+            "linux"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-chrome-ffmpeg-obj.mp4",
+            "engine": {
+              "name": "ffmpeg",
+              "target": "display"
+            },
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-firefox-ffmpeg",
+      "description": "Non-Chrome (Firefox) context with the ffmpeg engine — the ffmpeg engine is browser-agnostic.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "firefox",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-firefox-ffmpeg.mp4",
+            "engine": "ffmpeg",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 8000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-firefox-auto",
+      "description": "Firefox context with no explicit engine auto-resolves to ffmpeg (the browser engine is Chrome-only).",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "firefox",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-firefox-auto.mp4",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 8000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-firefox-browser-skip",
+      "description": "Firefox context with the browser engine is skipped (the browser engine requires Chrome).",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "firefox",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-firefox-browser.mp4",
+            "engine": "browser",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 8000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
+      "testId": "rec-perm-overwrite-false-skip",
+      "description": "A second recording to an existing path with overwrite:false is skipped.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "rec-perm-overwrite.mp4",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        },
+        {
+          "record": {
+            "path": "rec-perm-overwrite.mp4",
+            "overwrite": "false"
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
     }
   ]
 }

--- a/test/core-artifacts/recording-permutations.spec.json
+++ b/test/core-artifacts/recording-permutations.spec.json
@@ -1,6 +1,6 @@
 {
   "specId": "recording-permutations",
-  "description": "Validates each permutation of recording support that isn't already covered by recording.spec.json: the record value forms (boolean/false), both engines as a string shorthand, every ffmpeg target (display/window/viewport), custom fps, all output formats (mp4/webm/gif) per engine, and the engine-specific headless skip. ffmpeg permutations run on Windows (gdigrab) and macOS (avfoundation); the browser engine needs headed Chrome.",
+  "description": "Validates each permutation of recording support that isn't already covered by recording.spec.json: the record value forms (boolean/false), both engines as a string shorthand, every ffmpeg target (display/window/viewport), custom fps, all output formats (mp4/webm/gif) per engine, and the engine-specific headless skip. ffmpeg permutations run on Windows (gdigrab), macOS (avfoundation), and Linux (x11grab on a per-runner Xvfb display); the browser engine needs headed Chrome (Windows/macOS).",
   "tests": [
     {
       "testId": "rec-perm-record-true",
@@ -113,7 +113,8 @@
         {
           "platforms": [
             "windows",
-            "mac"
+            "mac",
+            "linux"
           ],
           "browsers": {
             "name": "chrome",
@@ -150,7 +151,8 @@
         {
           "platforms": [
             "windows",
-            "mac"
+            "mac",
+            "linux"
           ],
           "browsers": {
             "name": "chrome",
@@ -190,7 +192,8 @@
         {
           "platforms": [
             "windows",
-            "mac"
+            "mac",
+            "linux"
           ],
           "browsers": {
             "name": "chrome",
@@ -230,7 +233,8 @@
         {
           "platforms": [
             "windows",
-            "mac"
+            "mac",
+            "linux"
           ],
           "browsers": {
             "name": "chrome",
@@ -308,7 +312,8 @@
         {
           "platforms": [
             "windows",
-            "mac"
+            "mac",
+            "linux"
           ],
           "browsers": {
             "name": "chrome",
@@ -345,7 +350,8 @@
         {
           "platforms": [
             "windows",
-            "mac"
+            "mac",
+            "linux"
           ],
           "browsers": {
             "name": "chrome",
@@ -377,13 +383,12 @@
     },
     {
       "testId": "rec-perm-ffmpeg-headless-skip",
-      "description": "ffmpeg engine in headless mode with no virtual display is skipped.",
+      "description": "ffmpeg engine in headless mode is skipped on Windows/macOS (no virtual display). On Linux the per-runner Xvfb provides a display, so headless ffmpeg recording is supported there and this skip case doesn't apply.",
       "runOn": [
         {
           "platforms": [
             "windows",
-            "mac",
-            "linux"
+            "mac"
           ],
           "browsers": {
             "name": "chrome",

--- a/test/core-artifacts/recording.spec.json
+++ b/test/core-artifacts/recording.spec.json
@@ -1,13 +1,14 @@
 {
   "specId": "recording",
-  "description": "Tests for screen recording start/stop lifecycle. Uses the browser (Chrome getDisplayMedia) engine, which is concurrency-safe. The ffmpeg engine isn't exercised here because CI runners can't grant OS screen-recording permission (macOS avfoundation) or provide a display; it's covered by local E2E instead. Non-headless tests require a visible display and only run on Windows and macOS. Headless tests verify skip/guard behavior on all platforms.",
+  "description": "Tests for screen recording start/stop lifecycle. Covers both engines on a visible display: the browser (Chrome getDisplayMedia) engine, which is concurrency-safe, and the ffmpeg engine (gdigrab on Windows, avfoundation on macOS). Non-headless tests only run on Windows and macOS; headless tests verify skip/guard behavior on all platforms.",
   "tests": [
     {
-      "testId": "recording-ffmpeg-display-PROBE",
-      "description": "DIAGNOSTIC: ffmpeg-engine display capture on macOS CI (index vs TCC).",
+      "testId": "recording-ffmpeg-display",
+      "description": "Record the full display with the ffmpeg engine (gdigrab/avfoundation).",
       "runOn": [
         {
           "platforms": [
+            "windows",
             "mac"
           ],
           "browsers": {

--- a/test/core-artifacts/recording.spec.json
+++ b/test/core-artifacts/recording.spec.json
@@ -1,47 +1,7 @@
 {
   "specId": "recording",
-  "description": "Tests for screen recording start/stop lifecycle. The browser engine (default for headed Chrome) is concurrency-safe; the ffmpeg engine records the screen for any application (serial on Windows/macOS). Non-headless tests require a visible display and only run on Windows and macOS. Headless tests verify skip/guard behavior on all platforms.",
+  "description": "Tests for screen recording start/stop lifecycle. Uses the browser (Chrome getDisplayMedia) engine, which is concurrency-safe. The ffmpeg engine isn't exercised here because CI runners can't grant OS screen-recording permission (macOS avfoundation) or provide a display; it's covered by local E2E instead. Non-headless tests require a visible display and only run on Windows and macOS. Headless tests verify skip/guard behavior on all platforms.",
   "tests": [
-    {
-      "testId": "recording-ffmpeg-display",
-      "description": "Record the full display with the ffmpeg engine.",
-      "runOn": [
-        {
-          "platforms": [
-            "windows",
-            "mac"
-          ],
-          "browsers": {
-            "name": "chrome",
-            "headless": false
-          }
-        }
-      ],
-      "steps": [
-        {
-          "goTo": "http://localhost:8092"
-        },
-        {
-          "record": {
-            "path": "recording-ffmpeg-display.mp4",
-            "engine": {
-              "name": "ffmpeg",
-              "target": "display"
-            },
-            "overwrite": "true"
-          }
-        },
-        {
-          "find": {
-            "selector": "body",
-            "timeout": 5000
-          }
-        },
-        {
-          "stopRecord": true
-        }
-      ]
-    },
     {
       "testId": "recording-basic",
       "description": "Start and stop a basic recording.",

--- a/test/core-artifacts/recording.spec.json
+++ b/test/core-artifacts/recording.spec.json
@@ -3,6 +3,45 @@
   "description": "Tests for screen recording start/stop lifecycle. Uses the browser (Chrome getDisplayMedia) engine, which is concurrency-safe. The ffmpeg engine isn't exercised here because CI runners can't grant OS screen-recording permission (macOS avfoundation) or provide a display; it's covered by local E2E instead. Non-headless tests require a visible display and only run on Windows and macOS. Headless tests verify skip/guard behavior on all platforms.",
   "tests": [
     {
+      "testId": "recording-ffmpeg-display-PROBE",
+      "description": "DIAGNOSTIC: ffmpeg-engine display capture on macOS CI (index vs TCC).",
+      "runOn": [
+        {
+          "platforms": [
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "recording-ffmpeg-display.mp4",
+            "engine": {
+              "name": "ffmpeg",
+              "target": "display"
+            },
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
+    {
       "testId": "recording-basic",
       "description": "Start and stop a basic recording.",
       "runOn": [

--- a/test/core-artifacts/recording.spec.json
+++ b/test/core-artifacts/recording.spec.json
@@ -1,13 +1,56 @@
 {
   "specId": "recording",
-  "description": "Tests for screen recording start/stop lifecycle. Non-headless tests require Chrome with screen recording permissions and only run on Windows and macOS. Headless tests verify skip/guard behavior on all platforms.",
+  "description": "Tests for screen recording start/stop lifecycle. The browser engine (default for headed Chrome) is concurrency-safe; the ffmpeg engine records the screen for any application (serial on Windows/macOS). Non-headless tests require a visible display and only run on Windows and macOS. Headless tests verify skip/guard behavior on all platforms.",
   "tests": [
+    {
+      "testId": "recording-ffmpeg-display",
+      "description": "Record the full display with the ffmpeg engine.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "recording-ffmpeg-display.mp4",
+            "engine": {
+              "name": "ffmpeg",
+              "target": "display"
+            },
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": true
+        }
+      ]
+    },
     {
       "testId": "recording-basic",
       "description": "Start and stop a basic recording.",
       "runOn": [
         {
-          "platforms": ["windows", "mac"],
+          "platforms": [
+            "windows",
+            "mac"
+          ],
           "browsers": {
             "name": "chrome",
             "headless": false
@@ -40,7 +83,10 @@
       "description": "Start and stop recording with mp4 output.",
       "runOn": [
         {
-          "platforms": ["windows", "mac"],
+          "platforms": [
+            "windows",
+            "mac"
+          ],
           "browsers": {
             "name": "chrome",
             "headless": false
@@ -73,7 +119,11 @@
       "description": "Recording should be skipped in headless mode.",
       "runOn": [
         {
-          "platforms": ["windows", "mac", "linux"],
+          "platforms": [
+            "windows",
+            "mac",
+            "linux"
+          ],
           "browsers": {
             "name": "chrome",
             "headless": true
@@ -97,7 +147,11 @@
       "description": "Stopping a recording that was never started should be skipped.",
       "runOn": [
         {
-          "platforms": ["windows", "mac", "linux"],
+          "platforms": [
+            "windows",
+            "mac",
+            "linux"
+          ],
           "browsers": {
             "name": "chrome",
             "headless": true

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -6,6 +6,7 @@ import {
   browserDownloadDir,
   buildCaptureArgs,
   resolveCropGeometry,
+  jobIsFfmpegRecording,
   computeEffectiveConcurrency,
   checkSystemBinary,
   xvfbDisplay,
@@ -204,6 +205,24 @@ describe("ffmpegRecorder", function () {
       };
       const geo = await resolveCropGeometry({ driver, target: "window" });
       expect(geo).to.deep.equal({ x: 10, y: 12, w: 2048, h: 1536 });
+    });
+  });
+
+  describe("jobIsFfmpegRecording", function () {
+    it("is true only for jobs whose record step resolves to ffmpeg", function () {
+      const ffmpeg = {
+        context: { steps: [{ record: { engine: "ffmpeg" } }] },
+      };
+      const browser = {
+        context: {
+          browser: { name: "chrome", headless: false },
+          steps: [{ record: true }],
+        },
+      };
+      const none = { context: { steps: [{ goTo: "x" }] } };
+      expect(jobIsFfmpegRecording(ffmpeg)).to.equal(true);
+      expect(jobIsFfmpegRecording(browser)).to.equal(false);
+      expect(jobIsFfmpegRecording(none)).to.equal(false);
     });
   });
 

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -189,12 +189,21 @@ describe("ffmpegRecorder", function () {
       expect(geo).to.deep.equal({ x: 20, y: 40, w: 1600, h: 1200 });
     });
 
-    it("computes a window crop from getWindowRect", async function () {
+    it("computes a window crop from getWindowRect (dpr=1 when unavailable)", async function () {
       const driver = {
         getWindowRect: async () => ({ x: 5, y: 6, width: 1024, height: 768 }),
       };
       const geo = await resolveCropGeometry({ driver, target: "window" });
       expect(geo).to.deep.equal({ x: 5, y: 6, w: 1024, h: 768 });
+    });
+
+    it("scales the window crop by devicePixelRatio on HiDPI", async function () {
+      const driver = {
+        getWindowRect: async () => ({ x: 5, y: 6, width: 1024, height: 768 }),
+        execute: async () => 2,
+      };
+      const geo = await resolveCropGeometry({ driver, target: "window" });
+      expect(geo).to.deep.equal({ x: 10, y: 12, w: 2048, h: 1536 });
     });
   });
 

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -9,6 +9,7 @@ import {
   resolveCropGeometry,
   jobIsFfmpegRecording,
   computeEffectiveConcurrency,
+  parseMacScreenIndex,
   checkSystemBinary,
   xvfbDisplay,
 } from "../dist/core/tests/ffmpegRecorder.js";
@@ -314,6 +315,32 @@ describe("ffmpegRecorder", function () {
       });
       expect(r.limit).to.equal(1);
       expect(r.forcedSerial).to.equal(false);
+    });
+  });
+
+  describe("parseMacScreenIndex", function () {
+    it("finds the screen index on a camera-less host (screen at 0)", function () {
+      const listing = [
+        "[AVFoundation indev @ 0x1] AVFoundation video devices:",
+        "[AVFoundation indev @ 0x1] [0] Capture screen 0",
+        "[AVFoundation indev @ 0x1] AVFoundation audio devices:",
+        "[AVFoundation indev @ 0x1] [0] MacBook Pro Microphone",
+      ].join("\n");
+      expect(parseMacScreenIndex(listing)).to.equal("0");
+    });
+
+    it("finds the screen index past a camera (screen at 1)", function () {
+      const listing = [
+        "[AVFoundation indev] AVFoundation video devices:",
+        "[AVFoundation indev] [0] FaceTime HD Camera",
+        "[AVFoundation indev] [1] Capture screen 0",
+      ].join("\n");
+      expect(parseMacScreenIndex(listing)).to.equal("1");
+    });
+
+    it("returns null when no screen device is listed", function () {
+      expect(parseMacScreenIndex("[0] FaceTime HD Camera")).to.equal(null);
+      expect(parseMacScreenIndex("")).to.equal(null);
     });
   });
 

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -111,6 +111,14 @@ describe("ffmpegRecorder", function () {
       });
       expect(out).to.equal(null);
     });
+
+    it("does not coerce for an explicit record: false", function () {
+      const out = coerceRecordContextBrowser({
+        context: { steps: [{ record: false }] },
+        availableApps: chromeApps,
+      });
+      expect(out).to.equal(null);
+    });
   });
 
   describe("browser engine paths", function () {
@@ -220,9 +228,11 @@ describe("ffmpegRecorder", function () {
         },
       };
       const none = { context: { steps: [{ goTo: "x" }] } };
+      const disabled = { context: { steps: [{ record: false }] } };
       expect(jobIsFfmpegRecording(ffmpeg)).to.equal(true);
       expect(jobIsFfmpegRecording(browser)).to.equal(false);
       expect(jobIsFfmpegRecording(none)).to.equal(false);
+      expect(jobIsFfmpegRecording(disabled)).to.equal(false);
     });
   });
 

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -197,6 +197,29 @@ describe("ffmpegRecorder", function () {
       expect(args).to.include(":0.0");
     });
 
+    it("passes -video_size before -i on linux when a screen size is given", function () {
+      const args = buildCaptureArgs({
+        platform: "linux",
+        fps: 30,
+        displayEnv: ":99",
+        screenSize: "1920x1080",
+        outputPath: "out.mkv",
+      });
+      expect(args).to.include("-video_size");
+      expect(args).to.include("1920x1080");
+      expect(args.indexOf("-video_size")).to.be.lessThan(args.indexOf("-i"));
+    });
+
+    it("omits -video_size on linux when no screen size is given", function () {
+      const args = buildCaptureArgs({
+        platform: "linux",
+        fps: 30,
+        displayEnv: ":99",
+        outputPath: "out.mkv",
+      });
+      expect(args).to.not.include("-video_size");
+    });
+
     it("throws on an unsupported platform", function () {
       expect(() =>
         buildCaptureArgs({ platform: "sunos", fps: 30, outputPath: "o" })

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -1,0 +1,285 @@
+import { expect } from "chai";
+import {
+  resolveRecordPlan,
+  coerceRecordContextBrowser,
+  browserCaptureTitle,
+  browserDownloadDir,
+  buildCaptureArgs,
+  resolveCropGeometry,
+  computeEffectiveConcurrency,
+  checkSystemBinary,
+  xvfbDisplay,
+} from "../dist/core/tests/ffmpegRecorder.js";
+
+describe("ffmpegRecorder", function () {
+  describe("resolveRecordPlan", function () {
+    it("auto-resolves chrome + headed to the browser engine", function () {
+      const plan = resolveRecordPlan({
+        step: { record: true },
+        context: { browser: { name: "chrome", headless: false } },
+      });
+      expect(plan).to.deep.equal({
+        name: "browser",
+        target: "display",
+        fps: 30,
+      });
+    });
+
+    it("auto-resolves non-chrome, headless, or no browser to ffmpeg", function () {
+      for (const browser of [
+        { name: "firefox", headless: false },
+        { name: "chrome", headless: true },
+        undefined,
+      ]) {
+        const plan = resolveRecordPlan({
+          step: { record: true },
+          context: { browser },
+        });
+        expect(plan.name, JSON.stringify(browser)).to.equal("ffmpeg");
+      }
+    });
+
+    it("honors an explicit engine string shorthand with defaults filled", function () {
+      const plan = resolveRecordPlan({
+        step: { record: { path: "x.mp4", engine: "ffmpeg" } },
+        context: { browser: { name: "chrome", headless: false } },
+      });
+      expect(plan).to.deep.equal({ name: "ffmpeg", target: "display", fps: 30 });
+    });
+
+    it("honors an explicit engine object and fills remaining defaults", function () {
+      const plan = resolveRecordPlan({
+        step: { record: { engine: { name: "ffmpeg", target: "window" } } },
+        context: {},
+      });
+      expect(plan).to.deep.equal({ name: "ffmpeg", target: "window", fps: 30 });
+    });
+
+    it("normalizes string shorthand and object form to the same plan", function () {
+      const a = resolveRecordPlan({
+        step: { record: { engine: "ffmpeg" } },
+        context: {},
+      });
+      const b = resolveRecordPlan({
+        step: { record: { engine: { name: "ffmpeg" } } },
+        context: {},
+      });
+      expect(a).to.deep.equal(b);
+    });
+  });
+
+  describe("coerceRecordContextBrowser", function () {
+    const chromeApps = [{ name: "chrome" }, { name: "firefox" }];
+
+    it("coerces an unspecified browser to headed chrome when a record step lacks an engine and chrome is available", function () {
+      const out = coerceRecordContextBrowser({
+        context: { steps: [{ record: true }] },
+        availableApps: chromeApps,
+      });
+      expect(out).to.deep.equal({ name: "chrome", headless: false });
+    });
+
+    it("does not coerce when the browser was user-specified", function () {
+      const out = coerceRecordContextBrowser({
+        context: { browser: { name: "firefox" }, steps: [{ record: true }] },
+        availableApps: chromeApps,
+      });
+      expect(out).to.equal(null);
+    });
+
+    it("does not coerce when the record step specifies an engine", function () {
+      const out = coerceRecordContextBrowser({
+        context: { steps: [{ record: { engine: "ffmpeg" } }] },
+        availableApps: chromeApps,
+      });
+      expect(out).to.equal(null);
+    });
+
+    it("does not coerce when chrome is unavailable", function () {
+      const out = coerceRecordContextBrowser({
+        context: { steps: [{ record: true }] },
+        availableApps: [{ name: "firefox" }],
+      });
+      expect(out).to.equal(null);
+    });
+
+    it("does not coerce when there is no record step", function () {
+      const out = coerceRecordContextBrowser({
+        context: { steps: [{ goTo: "x" }] },
+        availableApps: chromeApps,
+      });
+      expect(out).to.equal(null);
+    });
+  });
+
+  describe("browser engine paths", function () {
+    it("derives a unique capture title per contextId", function () {
+      expect(browserCaptureTitle("chrome-2")).to.equal("RECORD_ME_chrome-2");
+      expect(browserCaptureTitle("a")).to.not.equal(browserCaptureTitle("b"));
+    });
+
+    it("derives a per-context download dir that varies by contextId", function () {
+      expect(browserDownloadDir("a")).to.not.equal(browserDownloadDir("b"));
+      expect(browserDownloadDir("a")).to.contain("a");
+    });
+  });
+
+  describe("buildCaptureArgs", function () {
+    it("builds gdigrab args on win32 with framerate before -i", function () {
+      const args = buildCaptureArgs({
+        platform: "win32",
+        fps: 30,
+        outputPath: "out.mkv",
+      });
+      expect(args).to.include("gdigrab");
+      expect(args).to.include("desktop");
+      expect(args).to.include("yuv420p");
+      expect(args[args.length - 1]).to.equal("out.mkv");
+      expect(args.indexOf("-framerate")).to.be.lessThan(args.indexOf("-i"));
+    });
+
+    it("builds avfoundation args on darwin honoring fps", function () {
+      const args = buildCaptureArgs({
+        platform: "darwin",
+        fps: 24,
+        outputPath: "out.mkv",
+      });
+      expect(args).to.include("avfoundation");
+      expect(args).to.include("24");
+    });
+
+    it("builds x11grab args on linux using the provided DISPLAY", function () {
+      const args = buildCaptureArgs({
+        platform: "linux",
+        fps: 30,
+        displayEnv: ":99",
+        outputPath: "out.mkv",
+      });
+      expect(args).to.include("x11grab");
+      expect(args).to.include(":99");
+    });
+
+    it("defaults the linux display to :0.0", function () {
+      const args = buildCaptureArgs({
+        platform: "linux",
+        fps: 30,
+        outputPath: "out.mkv",
+      });
+      expect(args).to.include(":0.0");
+    });
+
+    it("throws on an unsupported platform", function () {
+      expect(() =>
+        buildCaptureArgs({ platform: "sunos", fps: 30, outputPath: "o" })
+      ).to.throw();
+    });
+  });
+
+  describe("resolveCropGeometry", function () {
+    it("returns null for the display target", async function () {
+      const geo = await resolveCropGeometry({ driver: {}, target: "display" });
+      expect(geo).to.equal(null);
+    });
+
+    it("computes a viewport crop from window metrics scaled by DPR", async function () {
+      const driver = {
+        execute: async () => ({ x: 10, y: 20, w: 800, h: 600, dpr: 2 }),
+      };
+      const geo = await resolveCropGeometry({ driver, target: "viewport" });
+      expect(geo).to.deep.equal({ x: 20, y: 40, w: 1600, h: 1200 });
+    });
+
+    it("computes a window crop from getWindowRect", async function () {
+      const driver = {
+        getWindowRect: async () => ({ x: 5, y: 6, width: 1024, height: 768 }),
+      };
+      const geo = await resolveCropGeometry({ driver, target: "window" });
+      expect(geo).to.deep.equal({ x: 5, y: 6, w: 1024, h: 768 });
+    });
+  });
+
+  describe("computeEffectiveConcurrency", function () {
+    const ffmpegJob = {
+      context: { contextId: "ff", steps: [{ record: { engine: "ffmpeg" } }] },
+    };
+    const browserJob = {
+      context: {
+        browser: { name: "chrome", headless: false },
+        steps: [{ record: true }],
+      },
+    };
+    const plainJob = { context: { steps: [{ goTo: "x" }] } };
+
+    it("does not cap when there is no ffmpeg recording", function () {
+      const r = computeEffectiveConcurrency({
+        requestedLimit: 4,
+        jobs: [browserJob, plainJob],
+        platform: "win32",
+        xvfbAvailable: false,
+      });
+      expect(r).to.deep.equal({ limit: 4, xvfbContexts: [], forcedSerial: false });
+    });
+
+    it("forces serial for ffmpeg recording on win/mac", function () {
+      for (const platform of ["win32", "darwin"]) {
+        const r = computeEffectiveConcurrency({
+          requestedLimit: 4,
+          jobs: [ffmpegJob, plainJob],
+          platform,
+          xvfbAvailable: true,
+        });
+        expect(r.limit, platform).to.equal(1);
+        expect(r.forcedSerial, platform).to.equal(true);
+      }
+    });
+
+    it("keeps concurrency for ffmpeg recording on linux with xvfb", function () {
+      const r = computeEffectiveConcurrency({
+        requestedLimit: 4,
+        jobs: [ffmpegJob],
+        platform: "linux",
+        xvfbAvailable: true,
+      });
+      expect(r.limit).to.equal(4);
+      expect(r.forcedSerial).to.equal(false);
+      expect(r.xvfbContexts.length).to.equal(1);
+    });
+
+    it("forces serial for ffmpeg recording on linux without xvfb", function () {
+      const r = computeEffectiveConcurrency({
+        requestedLimit: 4,
+        jobs: [ffmpegJob],
+        platform: "linux",
+        xvfbAvailable: false,
+      });
+      expect(r.limit).to.equal(1);
+      expect(r.forcedSerial).to.equal(true);
+    });
+
+    it("does not flag forcedSerial when the requested limit was already 1", function () {
+      const r = computeEffectiveConcurrency({
+        requestedLimit: 1,
+        jobs: [ffmpegJob],
+        platform: "win32",
+        xvfbAvailable: false,
+      });
+      expect(r.limit).to.equal(1);
+      expect(r.forcedSerial).to.equal(false);
+    });
+  });
+
+  describe("xvfbDisplay", function () {
+    it("offsets displays past :0 and gives each runner a distinct display", function () {
+      expect(xvfbDisplay(0)).to.equal(":99");
+      expect(xvfbDisplay(1)).to.equal(":100");
+      expect(xvfbDisplay(0)).to.not.equal(xvfbDisplay(1));
+    });
+  });
+
+  describe("checkSystemBinary", function () {
+    it("returns false for a binary that does not exist", async function () {
+      const ok = await checkSystemBinary("definitely-not-a-real-binary-xyz");
+      expect(ok).to.equal(false);
+    });
+  });
+});

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -136,12 +136,20 @@ describe("ffmpegRecorder", function () {
 
     it("sanitizes a traversal contextId so it can't escape the temp dir", function () {
       expect(safeContextId("../../etc")).to.not.match(/[\\/]/);
-      expect(safeContextId("..")).to.equal("ctx");
-      expect(safeContextId("")).to.equal("ctx");
+      expect(safeContextId("..")).to.not.match(/[\\/]/);
+      expect(safeContextId("")).to.not.match(/[\\/]/);
       expect(browserCaptureTitle("../x")).to.not.match(/[\\/]/);
       // The download dir's leaf segment contains no path separator.
       const dir = browserDownloadDir("../../evil");
       expect(/recordings[\\/][^\\/]+$/.test(dir)).to.equal(true);
+    });
+
+    it("keeps distinct ids distinct after sanitization (no collision)", function () {
+      // Different raw ids that sanitize to the same base must not collide.
+      expect(safeContextId("a/b")).to.not.equal(safeContextId("a\\b"));
+      expect(safeContextId("..")).to.not.equal(safeContextId(""));
+      // A clean, already-safe id is left untouched (no hash noise).
+      expect(safeContextId("mac-chrome-2")).to.equal("mac-chrome-2");
     });
   });
 

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import {
   resolveRecordPlan,
   coerceRecordContextBrowser,
+  safeContextId,
   browserCaptureTitle,
   browserDownloadDir,
   buildCaptureArgs,
@@ -130,6 +131,16 @@ describe("ffmpegRecorder", function () {
     it("derives a per-context download dir that varies by contextId", function () {
       expect(browserDownloadDir("a")).to.not.equal(browserDownloadDir("b"));
       expect(browserDownloadDir("a")).to.contain("a");
+    });
+
+    it("sanitizes a traversal contextId so it can't escape the temp dir", function () {
+      expect(safeContextId("../../etc")).to.not.match(/[\\/]/);
+      expect(safeContextId("..")).to.equal("ctx");
+      expect(safeContextId("")).to.equal("ctx");
+      expect(browserCaptureTitle("../x")).to.not.match(/[\\/]/);
+      // The download dir's leaf segment contains no path separator.
+      const dir = browserDownloadDir("../../evil");
+      expect(/recordings[\\/][^\\/]+$/.test(dir)).to.equal(true);
     });
   });
 

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -233,12 +233,23 @@ describe("ffmpegRecorder", function () {
       expect(geo).to.equal(null);
     });
 
-    it("computes a viewport crop from window metrics scaled by DPR", async function () {
+    it("computes a viewport crop offset past the browser chrome and scaled by DPR", async function () {
+      // window at (10,20), 800x600 content inside an 800x700 outer window:
+      // side border = 0, top chrome = 700-600 = 100. Content top-left =
+      // (10, 120); scaled by dpr 2 => (20, 240), size 1600x1200.
       const driver = {
-        execute: async () => ({ x: 10, y: 20, w: 800, h: 600, dpr: 2 }),
+        execute: async () => ({
+          sx: 10,
+          sy: 20,
+          iw: 800,
+          ih: 600,
+          ow: 800,
+          oh: 700,
+          dpr: 2,
+        }),
       };
       const geo = await resolveCropGeometry({ driver, target: "viewport" });
-      expect(geo).to.deep.equal({ x: 20, y: 40, w: 1600, h: 1200 });
+      expect(geo).to.deep.equal({ x: 20, y: 240, w: 1600, h: 1200 });
     });
 
     it("computes a window crop from getWindowRect (dpr=1 when unavailable)", async function () {

--- a/test/hints.test.js
+++ b/test/hints.test.js
@@ -1329,6 +1329,7 @@ function fakeCtx(partial = {}) {
     hasCurlInRunShell: false,
     hasNodeOrPythonInRunShell: false,
     hasRstFiles: false,
+    recordingForcedSerial: false,
     ...partial,
   };
 }
@@ -1401,12 +1402,12 @@ describe("hints/index pickByPriority + priorityWeight", function () {
 
 describe("hints/hints (registry)", function () {
   it("every hint has stable id, body, predicate, and a numeric priority when set", function () {
-    // 28 active hints. `useFileTypesForRst` is commented out in the
+    // 29 active hints. `useFileTypesForRst` is commented out in the
     // registry but the `RST_EXTENSIONS` constant, the
     // `detectRstFiles` helper, and the `hasRstFiles` context field
     // are kept in place so the hint can be re-enabled without
     // re-plumbing.
-    expect(HINTS.length).to.equal(28);
+    expect(HINTS.length).to.equal(29);
     const ids = new Set();
     // Ids are camelCase, matching the convention used everywhere else
     // in the project (step names like `goTo`, config fields like
@@ -1876,6 +1877,13 @@ describe("hints/hints (registry)", function () {
     expect(
       h.when(fakeCtx({ totalContexts: 5, producedRecordings: true }))
     ).to.equal(false);
+  });
+
+  it("recordConcurrently: fires only when the run was forced serial for recording", function () {
+    const h = findHint("recordConcurrently");
+    expect(h.priority).to.equal(50);
+    expect(h.when(fakeCtx({ recordingForcedSerial: true }))).to.equal(true);
+    expect(h.when(fakeCtx({ recordingForcedSerial: false }))).to.equal(false);
   });
 
   it("extractBeforeAnySharedSetup: fires on ≥5 specs without beforeAny regardless of step types", function () {


### PR DESCRIPTION
## What & why

The `record` action only worked in **headed Chrome** and wasn't safe under `concurrentRunners > 1` (it only *warned* that concurrent recordings could grab the wrong window). This PR makes recording work for **any application** and **100% correct under concurrency**, via two engines selected by a new `engine` field on the record step.

`engine` follows the repo's progressive-disclosure pattern (like `find`): a string shorthand or a detailed object.

```jsonc
{ "record": "out.mp4" }                                  // auto: headed Chrome → browser, else ffmpeg
{ "record": { "path": "out.mp4", "engine": "ffmpeg" } }  // shorthand
{ "record": { "path": "out.mp4", "engine": { "name": "ffmpeg", "target": "window", "fps": 60 } } }
```

### Two engines
- **`browser`** (Chrome `getDisplayMedia`) — now **concurrency-safe**: each context auto-selects its own window via a unique `RECORD_ME_<contextId>` title and downloads to a per-context dir, so parallel recordings no longer capture the wrong window or collide on filenames. Replaces the old shared `--auto-select-desktop-capture-source=RECORD_ME` flag.
- **`ffmpeg`** (`gdigrab` / `avfoundation` / `x11grab`) — records the screen, so it works for **any application**. `target` selects `display` (default), `window`, or `viewport`; `window`/`viewport` capture full-screen then crop during transcode.

### Concurrency correctness
ffmpeg grabs the whole physical display, so it needs exclusive use of it:
- **Windows/macOS** → the run is forced serial when an ffmpeg record step is present (one-time warning + the new `recordConcurrently` hint pointing at the alternatives).
- **Linux** → each runner gets its own **Xvfb** virtual display (the Appium server is launched with `DISPLAY=:N`, and `context.__display` tells ffmpeg which display to capture), so recording stays concurrent **and works headless**.

### Other
- **Auto-resolution**: with no `engine`, prefer the browser engine by coercing an unspecified browser to headed Chrome; otherwise ffmpeg.
- **Preflight** verifies ffmpeg and probes for Xvfb on Linux.
- **Transcode** now drops audio (`-an`) — doc recordings are visual, and the captured opus track failed to mux into mp4 — and waits for the browser download to finish writing before transcoding (fixes a partial-file race that produced "ffmpeg exited with code 1").

Follow-up tracked in #342 (serialize only ffmpeg contexts instead of the whole run).

## Test plan
- **Unit** (TDD, red→green): `record.engine` schema validation; new `test/ffmpeg-recorder.test.js` covering `resolveRecordPlan`, the context-coercion helper, `buildCaptureArgs` per platform, crop geometry, `computeEffectiveConcurrency` matrix + `forcedSerial`, `xvfbDisplay`, and the per-context title/download-dir helpers; `recordConcurrently` hint predicate. All green (ffmpeg-recorder 27, hints 148, common 402).
- **E2E — Windows**: ffmpeg engine (display) and browser engine (`.mp4`, `.webm`) each produce valid video, 5/5 steps PASS; forced-serial warning + `recordingForcedSerial` flag confirmed with `--concurrentRunners 2`.
- **E2E — Linux (WSL Ubuntu, clean install)**: single ffmpeg (PASS), browser engine (PASS), and **concurrent ffmpeg with `concurrentRunners=2`** → debug log shows `Started Xvfb on :99` + `:100`, `Starting 2 Appium server(s)`, zero serialization, 10/10 steps PASS, two distinct valid recordings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added engine-based recording via `record.engine`, supporting shorthand (`browser`/`ffmpeg`) and detailed options (e.g., `target`, `fps`).
  * Updated `record: true` to auto-select `browser` when a visible Chrome context is available; otherwise uses `ffmpeg`.
  * Added a `recordConcurrently` hint for switching away from forced-serial recording.

* **Bug Fixes / Improvements**
  * Improved ffmpeg capture alignment and concurrency behavior using per-server virtual displays where available.
  * Enhanced browser and ffmpeg recording lifecycle: overwrite handling, safer tab control, and more reliable stop/transcode.

* **Documentation**
  * Updated the recording JSON schema and examples for the new `engine` option.

* **Tests**
  * Expanded validation, helper coverage, and recording specs (including an ffmpeg display diagnostic test).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->