### PR TITLE
feat(debug): cache, install, network, appium, provenance & findings sections for the diagnostic dump

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,6 +109,7 @@ async function runTestsHandler(args: any) {
         configPath: configPath,
         configError: err instanceof Error ? err : new Error(String(err)),
         outDir: defaultDebugDir(),
+        args,
       });
       // The env-var dump replaced a real test run; a broken config must
       // still fail the process so CI doesn't go green on an unran suite.
@@ -130,6 +131,7 @@ async function runTestsHandler(args: any) {
       configPath,
       configError: null,
       outDir: defaultDebugDir(),
+      args,
     });
     return;
   }

--- a/src/debug/appium.ts
+++ b/src/debug/appium.ts
@@ -30,8 +30,11 @@ const KNOWN_DRIVERS = ["appium-chromium-driver", "appium-geckodriver"];
 export interface AppiumDriverStatus {
   // npm package name.
   name: string;
-  // pkgName appears in extensions.yaml under `drivers:`.
-  registered: boolean;
+  // Whether pkgName appears in extensions.yaml under `drivers:`. `null` when
+  // the manifest wasn't read (absent / unreadable / APPIUM_HOME unset) — i.e.
+  // registration is genuinely unknown, NOT confirmed-absent. Kept tri-state
+  // so the JSON dump can't be misread as "confirmed not registered".
+  registered: boolean | null;
   // resolveHeavyDepPath finds the package (shim or cache).
   npmResolvable: boolean;
 }
@@ -101,17 +104,19 @@ export function collectAppiumDiagnostics(config: any): AppiumDiagnostics {
     }
   }
 
-  const appiumEntry = resolveHeavyDepPath("appium", ctx);
+  // Registration is only KNOWN when the manifest was read successfully;
+  // otherwise every driver's `registered` is null (unknown), not false.
+  const registrationKnown = extensionsManifestPresent && !manifestError;
   const registeredSet = new Set(registeredDrivers);
   const drivers: AppiumDriverStatus[] = KNOWN_DRIVERS.map((name) => ({
     name,
     npmResolvable: Boolean(resolveHeavyDepPath(name, ctx)),
-    registered: registeredSet.has(name),
+    registered: registrationKnown ? registeredSet.has(name) : null,
   }));
 
   return {
     appiumHome,
-    appiumInstalled: Boolean(appiumEntry),
+    appiumInstalled: Boolean(resolveHeavyDepPath("appium", ctx)),
     extensionsManifestPath,
     extensionsManifestPresent,
     manifestError,

--- a/src/debug/appium.ts
+++ b/src/debug/appium.ts
@@ -1,0 +1,121 @@
+// Appium registration collector for the diagnostic dump.
+//
+// Reconciles the two ways an Appium driver can be "there":
+//   - npm-resolvable: the driver package resolves from the shim node_modules
+//     or the runtime cache (resolveHeavyDepPath).
+//   - registered: Appium has it recorded in its extensions manifest
+//     (<APPIUM_HOME>/node_modules/.cache/appium/extensions.yaml) under the
+//     active APPIUM_HOME.
+// The mismatch ("I npm-installed it but Appium doesn't see it") is a real
+// support case, usually an APPIUM_HOME pointing at the wrong node_modules.
+//
+// Registration is read straight from extensions.yaml — the same manifest
+// Appium itself reads — rather than spawning `appium driver list`. That
+// command cold-loads Appium and does an npm update-check (network), so it's
+// slow and variable (8s+ cold vs <1s warm); a bounded probe would
+// intermittently time out and then mislabel every registered driver as
+// "not registered". The manifest is authoritative, offline, and instant, so
+// the dump has no subprocess at all.
+
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+import { setAppiumHome } from "../core/appium.js";
+import { resolveHeavyDepPath } from "../runtime/loader.js";
+
+// The driver packages doc-detective installs. Order matches the browsers we
+// support (Chrome via chromium, Firefox via gecko).
+const KNOWN_DRIVERS = ["appium-chromium-driver", "appium-geckodriver"];
+
+export interface AppiumDriverStatus {
+  // npm package name.
+  name: string;
+  // pkgName appears in extensions.yaml under `drivers:`.
+  registered: boolean;
+  // resolveHeavyDepPath finds the package (shim or cache).
+  npmResolvable: boolean;
+}
+
+export interface AppiumDiagnostics {
+  appiumHome: string | null;
+  appiumInstalled: boolean;
+  extensionsManifestPath: string | null;
+  extensionsManifestPresent: boolean;
+  // Set when the manifest exists but couldn't be read/parsed — registration
+  // is then unknown rather than known-empty.
+  manifestError?: string;
+  // The driver package names Appium has registered, straight from the
+  // manifest (surfaced for transparency).
+  registeredDrivers: string[];
+  drivers: AppiumDriverStatus[];
+}
+
+// Parse the `pkgName` of every driver recorded in an extensions.yaml
+// document. Falls back to the short driver key when an entry omits pkgName.
+// Pure (takes the YAML text) so it's unit-testable without a filesystem.
+export function registeredDriverPkgNames(manifestText: string): string[] {
+  const doc = YAML.parse(manifestText);
+  const drivers = doc?.drivers;
+  if (!drivers || typeof drivers !== "object") return [];
+  const names: string[] = [];
+  for (const key of Object.keys(drivers)) {
+    const entry = (drivers as Record<string, any>)[key];
+    const pkg = entry?.pkgName;
+    names.push(typeof pkg === "string" && pkg.length > 0 ? pkg : key);
+  }
+  return names;
+}
+
+export function collectAppiumDiagnostics(config: any): AppiumDiagnostics {
+  const ctx = { cacheDir: config?.cacheDir };
+  try {
+    setAppiumHome(ctx);
+  } catch {
+    // Best-effort — diagnostics must never crash.
+  }
+  const appiumHome = process.env.APPIUM_HOME || null;
+
+  // Appium records registered extensions in
+  // <APPIUM_HOME>/node_modules/.cache/appium/extensions.yaml.
+  const extensionsManifestPath = appiumHome
+    ? path.join(appiumHome, "node_modules", ".cache", "appium", "extensions.yaml")
+    : null;
+
+  let extensionsManifestPresent = false;
+  let manifestError: string | undefined;
+  let registeredDrivers: string[] = [];
+  if (extensionsManifestPath) {
+    try {
+      extensionsManifestPresent = fs.existsSync(extensionsManifestPath);
+    } catch {
+      extensionsManifestPresent = false;
+    }
+    if (extensionsManifestPresent) {
+      try {
+        registeredDrivers = registeredDriverPkgNames(
+          fs.readFileSync(extensionsManifestPath, "utf8")
+        );
+      } catch (err: any) {
+        manifestError = err?.message || String(err);
+      }
+    }
+  }
+
+  const appiumEntry = resolveHeavyDepPath("appium", ctx);
+  const registeredSet = new Set(registeredDrivers);
+  const drivers: AppiumDriverStatus[] = KNOWN_DRIVERS.map((name) => ({
+    name,
+    npmResolvable: Boolean(resolveHeavyDepPath(name, ctx)),
+    registered: registeredSet.has(name),
+  }));
+
+  return {
+    appiumHome,
+    appiumInstalled: Boolean(appiumEntry),
+    extensionsManifestPath,
+    extensionsManifestPresent,
+    manifestError,
+    registeredDrivers,
+    drivers,
+  };
+}

--- a/src/debug/appium.ts
+++ b/src/debug/appium.ts
@@ -71,6 +71,9 @@ export function registeredDriverPkgNames(manifestText: string): string[] {
 
 export function collectAppiumDiagnostics(config: any): AppiumDiagnostics {
   const ctx = { cacheDir: config?.cacheDir };
+  // Resolve APPIUM_HOME independently (the cache collector also does this in a
+  // full dump). Idempotent, so order doesn't matter — this collector is
+  // correct whether called standalone or after collectCacheStatus.
   try {
     setAppiumHome(ctx);
   } catch {

--- a/src/debug/cache.ts
+++ b/src/debug/cache.ts
@@ -1,0 +1,135 @@
+// Cache & runtime status collector for the diagnostic dump.
+//
+// Resolves the directories the lazy installer and runtime depend on
+// (cacheDir / runtimeDir / browsersDir / installed.json / APPIUM_HOME)
+// and reports, per location, whether it exists, is writable, and how much
+// disk space is free. A non-writable cacheDir is a common silent failure
+// mode for lazy installs, so surfacing it here lets the Findings layer
+// suggest `DOC_DETECTIVE_CACHE_DIR`.
+//
+// Read-only and crash-proof: every probe is wrapped so a permission error
+// on one path degrades to `writable: false` rather than aborting the dump.
+// (`getCacheDir` does create the cache root as a side effect — acceptable
+// here since the dump is explicitly probing the cache, and it matches how
+// every other consumer resolves the dir.)
+
+import fs from "node:fs";
+import path from "node:path";
+import {
+  getCacheDir,
+  getRuntimeDir,
+  getBrowsersDir,
+  getInstalledRecordPath,
+} from "../runtime/cacheDir.js";
+import { setAppiumHome } from "../core/appium.js";
+
+export interface CacheEntry {
+  label: string;
+  // null only for APPIUM_HOME when the env var is unset.
+  path: string | null;
+  exists: boolean;
+  // null when not applicable (unset path) — otherwise the result of a
+  // W_OK probe against the path (or its nearest existing parent).
+  writable: boolean | null;
+  // null when free space couldn't be determined (older Node without
+  // statfsSync, or a probe error). Bytes otherwise.
+  freeBytes: number | null;
+}
+
+export interface CacheStatus {
+  entries: CacheEntry[];
+  error?: string;
+}
+
+function safeExists(target: string): boolean {
+  try {
+    return fs.existsSync(target);
+  } catch {
+    return false;
+  }
+}
+
+// Probe W_OK on the path, or — when the path doesn't exist yet — on its
+// nearest existing ancestor, so "could doc-detective create/write here?"
+// is answered even for not-yet-created dirs.
+function isWritable(target: string): boolean {
+  try {
+    const probe = safeExists(target) ? target : path.dirname(target);
+    fs.accessSync(probe, fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function freeSpaceBytes(target: string): number | null {
+  try {
+    // statfsSync landed in Node 18.15 / 19.6; older runtimes lack it.
+    const statfsSync = (fs as unknown as { statfsSync?: (p: string) => unknown })
+      .statfsSync;
+    if (typeof statfsSync !== "function") return null;
+    const probe = safeExists(target) ? target : path.dirname(target);
+    const stats = statfsSync(probe) as { bavail?: number; bsize?: number };
+    if (typeof stats?.bavail !== "number" || typeof stats?.bsize !== "number") {
+      return null;
+    }
+    return stats.bavail * stats.bsize;
+  } catch {
+    return null;
+  }
+}
+
+function probeDir(label: string, p: string): CacheEntry {
+  return {
+    label,
+    path: p,
+    exists: safeExists(p),
+    writable: isWritable(p),
+    freeBytes: freeSpaceBytes(p),
+  };
+}
+
+export function collectCacheStatus(config: any): CacheStatus {
+  const ctx = { cacheDir: config?.cacheDir };
+  const entries: CacheEntry[] = [];
+  try {
+    entries.push(probeDir("cacheDir", getCacheDir(ctx)));
+    entries.push(probeDir("runtimeDir", getRuntimeDir(ctx)));
+    entries.push(probeDir("browsersDir", getBrowsersDir(ctx)));
+
+    // installed.json is a file, not a dir — report existence + whether its
+    // parent is writable (so "can the installer record here?" is answered),
+    // but no free-space figure.
+    const recordPath = getInstalledRecordPath(ctx);
+    entries.push({
+      label: "installed.json",
+      path: recordPath,
+      exists: safeExists(recordPath),
+      writable: isWritable(recordPath),
+      freeBytes: null,
+    });
+
+    // APPIUM_HOME is resolved by mutating process.env (setAppiumHome returns
+    // void), then read back. May be left unset if nothing resolves.
+    try {
+      setAppiumHome(ctx);
+    } catch {
+      // Best-effort — diagnostics must never crash.
+    }
+    const appiumHome = process.env.APPIUM_HOME;
+    if (typeof appiumHome === "string" && appiumHome.length > 0) {
+      entries.push(probeDir("APPIUM_HOME", appiumHome));
+    } else {
+      entries.push({
+        label: "APPIUM_HOME",
+        path: null,
+        exists: false,
+        writable: null,
+        freeBytes: null,
+      });
+    }
+  } catch (err: any) {
+    return { entries, error: err?.message || String(err) };
+  }
+  return { entries };
+}

--- a/src/debug/cache.ts
+++ b/src/debug/cache.ts
@@ -113,23 +113,26 @@ export function collectCacheStatus(config: any): CacheStatus {
     entries.push(probeDir("runtimeDir", getRuntimeDir(ctx)));
     entries.push(probeDir("browsersDir", getBrowsersDir(ctx)));
 
-    // installed.json is a file, not a dir — report existence + whether its
-    // parent is writable (so "can the installer record here?" is answered),
-    // but no free-space figure.
+    // installed.json is a file, not a dir — report existence + whether the
+    // installer could write the record here. writeInstalledRecord() writes via
+    // tmp-file + rename, which depends on the *directory* being writable (not
+    // the file), so probe the parent dir explicitly rather than the file path.
     const recordPath = getInstalledRecordPath(ctx);
     entries.push({
       label: "installed.json",
       path: recordPath,
       exists: safeExists(recordPath),
-      writable: isWritable(recordPath),
+      writable: isWritable(path.dirname(recordPath)),
       freeBytes: null,
     });
 
     // APPIUM_HOME is resolved by mutating process.env (setAppiumHome returns
-    // void), then read back. May be left unset if nothing resolves. This is
-    // idempotent and resolved independently here (the appium collector calls
-    // it too) so each collector is correct standalone and in any order — the
-    // second call in a full dump is a cheap no-op, not an ordering dependency.
+    // void), then read back. setAppiumHome always assigns a value (its legacy
+    // fallback sets one unconditionally), so the unset branch below only fires
+    // if the call threw and was swallowed above. Resolution is idempotent and
+    // done independently here (the appium collector calls it too) so each
+    // collector is correct standalone and in any order — the second call in a
+    // full dump is a cheap no-op, not an ordering dependency.
     try {
       setAppiumHome(ctx);
     } catch {

--- a/src/debug/cache.ts
+++ b/src/debug/cache.ts
@@ -126,7 +126,10 @@ export function collectCacheStatus(config: any): CacheStatus {
     });
 
     // APPIUM_HOME is resolved by mutating process.env (setAppiumHome returns
-    // void), then read back. May be left unset if nothing resolves.
+    // void), then read back. May be left unset if nothing resolves. This is
+    // idempotent and resolved independently here (the appium collector calls
+    // it too) so each collector is correct standalone and in any order — the
+    // second call in a full dump is a cheap no-op, not an ordering dependency.
     try {
       setAppiumHome(ctx);
     } catch {

--- a/src/debug/cache.ts
+++ b/src/debug/cache.ts
@@ -49,13 +49,27 @@ function safeExists(target: string): boolean {
   }
 }
 
-// Probe W_OK on the path, or — when the path doesn't exist yet — on its
-// nearest existing ancestor, so "could doc-detective create/write here?"
-// is answered even for not-yet-created dirs.
+// The target itself if it exists, otherwise the nearest existing ancestor —
+// so probes against a not-yet-created dir (e.g. <cache>/runtime/browsers,
+// whose parents may also be missing) answer "could doc-detective create and
+// write here?" instead of failing on the first non-existent level.
+function nearestExistingPath(target: string): string {
+  let current = target;
+  // Bounded by the path depth; stops at the filesystem root (dirname of a
+  // root returns the root itself).
+  for (let i = 0; i < 64; i++) {
+    if (safeExists(current)) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return current;
+    current = parent;
+  }
+  return current;
+}
+
+// Probe W_OK on the path (or its nearest existing ancestor).
 function isWritable(target: string): boolean {
   try {
-    const probe = safeExists(target) ? target : path.dirname(target);
-    fs.accessSync(probe, fs.constants.W_OK);
+    fs.accessSync(nearestExistingPath(target), fs.constants.W_OK);
     return true;
   } catch {
     return false;
@@ -68,8 +82,10 @@ function freeSpaceBytes(target: string): number | null {
     const statfsSync = (fs as unknown as { statfsSync?: (p: string) => unknown })
       .statfsSync;
     if (typeof statfsSync !== "function") return null;
-    const probe = safeExists(target) ? target : path.dirname(target);
-    const stats = statfsSync(probe) as { bavail?: number; bsize?: number };
+    const stats = statfsSync(nearestExistingPath(target)) as {
+      bavail?: number;
+      bsize?: number;
+    };
     if (typeof stats?.bavail !== "number" || typeof stats?.bsize !== "number") {
       return null;
     }

--- a/src/debug/command.ts
+++ b/src/debug/command.ts
@@ -70,6 +70,7 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
         configError: err instanceof Error ? err : new Error(String(err)),
         includeEnv,
         outDir,
+        args,
       });
       // Config is broken — exit non-zero so scripts/CI that gate on the
       // exit code don't treat a CONFIG INVALID dump as success. Mirrors
@@ -83,6 +84,7 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
       configError: null,
       includeEnv,
       outDir,
+      args,
     });
   },
 };

--- a/src/debug/findings.ts
+++ b/src/debug/findings.ts
@@ -35,14 +35,22 @@ const chromeUnavailable: Rule = (data) => {
   const chrome = findBrowser(data, "chrome");
   if (!chrome || !chrome.supported || chrome.available) return null;
   const driver = findDriver(data, "appium-chromium-driver");
-  // Only fire when the driver is actually the likely cause — suppress when
-  // it's confirmed resolvable AND registered.
+  // Suppress only when the driver is confirmed resolvable AND registered.
   if (driver && driver.npmResolvable && driver.registered === true) return null;
+  // Tailor the detail to what we actually know: a missing driver, a confirmed
+  // unregistered one, and an unknown-registration one (manifest absent) are
+  // distinct — saying "missing or not registered" for the unknown case would
+  // be wrong (the package resolved fine; only its registration is unverified).
+  const detail =
+    !driver || !driver.npmResolvable
+      ? "Chrome shows NOT AVAILABLE and its Appium driver (appium-chromium-driver) is missing, so browser tests can't run."
+      : driver.registered === false
+      ? "Chrome shows NOT AVAILABLE and appium-chromium-driver is installed but not registered under the active APPIUM_HOME."
+      : "Chrome shows NOT AVAILABLE. appium-chromium-driver is installed, but its registration is unknown (Appium manifest missing or unreadable).";
   return {
     severity: "error",
     title: "Chrome is not available",
-    detail:
-      "Chrome shows NOT AVAILABLE and its Appium driver (appium-chromium-driver) is missing or not registered, so browser tests can't run.",
+    detail,
     fix: "doc-detective install runtime",
   };
 };

--- a/src/debug/findings.ts
+++ b/src/debug/findings.ts
@@ -35,8 +35,9 @@ const chromeUnavailable: Rule = (data) => {
   const chrome = findBrowser(data, "chrome");
   if (!chrome || !chrome.supported || chrome.available) return null;
   const driver = findDriver(data, "appium-chromium-driver");
-  // Only fire when the driver is actually the likely cause.
-  if (driver && driver.npmResolvable && driver.registered) return null;
+  // Only fire when the driver is actually the likely cause — suppress when
+  // it's confirmed resolvable AND registered.
+  if (driver && driver.npmResolvable && driver.registered === true) return null;
   return {
     severity: "error",
     title: "Chrome is not available",
@@ -100,16 +101,12 @@ const proxyMaybeBlocking: Rule = (data) => {
 };
 
 // Driver resolves from npm but Appium doesn't list it → APPIUM_HOME mismatch.
-// Only meaningful when the extensions manifest was actually read — without
-// it, "not registered" is unknown, not a finding (a missing manifest would
-// otherwise false-flag every resolvable driver).
+// `registered === false` is the only firing case: `null` (manifest unread)
+// means registration is unknown, not a finding — a missing manifest must not
+// false-flag every resolvable driver.
 const driverNotRegistered: Rule = (data) => {
-  const registrationKnown = Boolean(
-    data.appium?.extensionsManifestPresent && !data.appium?.manifestError
-  );
-  if (!registrationKnown) return null;
   const stranded = (data.appium?.drivers || []).filter(
-    (d) => d.npmResolvable && !d.registered
+    (d) => d.npmResolvable && d.registered === false
   );
   if (stranded.length === 0) return null;
   return {

--- a/src/debug/findings.ts
+++ b/src/debug/findings.ts
@@ -1,0 +1,144 @@
+// Interpretation layer for the diagnostic dump.
+//
+// Pure functions over the already-collected DebugData (no I/O, no probing —
+// the data sections did that). Each rule turns a data condition into a
+// human-readable Finding with, where possible, the exact fix command. This
+// is what makes the dump self-service for support: instead of "Chrome NOT
+// AVAILABLE", the user sees "→ run `doc-detective install runtime`".
+//
+// Modeled on the hints philosophy in src/hints/: small, pure, concrete.
+// `import type` keeps this a compile-time-only dependency on index.ts, so
+// there's no runtime import cycle.
+
+import type { DebugData } from "./index.js";
+
+export interface Finding {
+  severity: "error" | "warning" | "info";
+  title: string;
+  detail: string;
+  fix?: string;
+}
+
+type Rule = (data: DebugData) => Finding | null;
+
+function findDriver(data: DebugData, pkg: string) {
+  return (data.appium?.drivers || []).find((d) => d.name === pkg);
+}
+
+function findBrowser(data: DebugData, name: string) {
+  return (data.browsers?.browsers || []).find((b) => b.name === name);
+}
+
+// Chrome can't run and its Appium driver is missing or unregistered → the
+// runtime install is incomplete.
+const chromeUnavailable: Rule = (data) => {
+  const chrome = findBrowser(data, "chrome");
+  if (!chrome || !chrome.supported || chrome.available) return null;
+  const driver = findDriver(data, "appium-chromium-driver");
+  // Only fire when the driver is actually the likely cause.
+  if (driver && driver.npmResolvable && driver.registered) return null;
+  return {
+    severity: "error",
+    title: "Chrome is not available",
+    detail:
+      "Chrome shows NOT AVAILABLE and its Appium driver (appium-chromium-driver) is missing or not registered, so browser tests can't run.",
+    fix: "doc-detective install runtime",
+  };
+};
+
+// Recorded install is older than the declared constraint, or the
+// doc-detective / doc-detective-common versions disagree → stale install.
+const staleInstall: Rule = (data) => {
+  const outdated = (data.install?.rows || []).filter((r) => r.outdated);
+  const lockstep = Boolean(data.docDetective?.lockstepWarning);
+  if (outdated.length === 0 && !lockstep) return null;
+  const reasons: string[] = [];
+  if (outdated.length > 0) {
+    reasons.push(
+      `outdated: ${outdated.map((r) => r.assetId).join(", ")}`
+    );
+  }
+  if (lockstep) reasons.push("doc-detective / doc-detective-common version mismatch");
+  return {
+    severity: "warning",
+    title: "Install looks stale",
+    detail: `${reasons.join("; ")}. A stale or mismatched install is a common source of hard-to-explain failures.`,
+    fix: "doc-detective install runtime",
+  };
+};
+
+// cacheDir not writable → lazy installs and recordings have nowhere to go.
+const cacheNotWritable: Rule = (data) => {
+  const entry = (data.cache?.entries || []).find((e) => e.label === "cacheDir");
+  if (!entry || entry.writable !== false) return null;
+  return {
+    severity: "error",
+    title: "Cache directory is not writable",
+    detail: `cacheDir (${entry.path}) is not writable, so doc-detective can't lazy-install browsers or runtime packages there.`,
+    fix: "set DOC_DETECTIVE_CACHE_DIR to a writable path",
+  };
+};
+
+// A proxy is configured and something the installer needs is missing — flag
+// the proxy as a likely lazy-install blocker (we don't probe reachability;
+// that's the opt-in --check-network work).
+const proxyMaybeBlocking: Rule = (data) => {
+  const hasProxy = (data.network?.variables || []).some((v) =>
+    /^(https?_proxy|all_proxy)$/i.test(v.name)
+  );
+  if (!hasProxy) return null;
+  const missingNpm = (data.install?.rows || []).some(
+    (r) => r.kind === "npm" && !r.installed
+  );
+  if (!missingNpm) return null;
+  return {
+    severity: "info",
+    title: "Proxy configured with missing runtime packages",
+    detail:
+      "A proxy is set and some runtime npm packages are not installed. If lazy installs fail, the proxy/registry is the likely cause — verify it's reachable and that proxy-agent is installed for @puppeteer/browsers downloads.",
+  };
+};
+
+// Driver resolves from npm but Appium doesn't list it → APPIUM_HOME mismatch.
+// Only meaningful when the extensions manifest was actually read — without
+// it, "not registered" is unknown, not a finding (a missing manifest would
+// otherwise false-flag every resolvable driver).
+const driverNotRegistered: Rule = (data) => {
+  const registrationKnown = Boolean(
+    data.appium?.extensionsManifestPresent && !data.appium?.manifestError
+  );
+  if (!registrationKnown) return null;
+  const stranded = (data.appium?.drivers || []).filter(
+    (d) => d.npmResolvable && !d.registered
+  );
+  if (stranded.length === 0) return null;
+  return {
+    severity: "warning",
+    title: "Appium driver installed but not registered",
+    detail: `${stranded
+      .map((d) => d.name)
+      .join(", ")} resolve from npm but Appium doesn't list them under the active APPIUM_HOME — usually an APPIUM_HOME pointing at the wrong node_modules.`,
+    fix: "doc-detective install runtime",
+  };
+};
+
+const RULES: Rule[] = [
+  chromeUnavailable,
+  staleInstall,
+  cacheNotWritable,
+  proxyMaybeBlocking,
+  driverNotRegistered,
+];
+
+export function computeFindings(data: DebugData): Finding[] {
+  const findings: Finding[] = [];
+  for (const rule of RULES) {
+    try {
+      const finding = rule(data);
+      if (finding) findings.push(finding);
+    } catch {
+      // A rule must never crash the dump; skip on error.
+    }
+  }
+  return findings;
+}

--- a/src/debug/findings.ts
+++ b/src/debug/findings.ts
@@ -92,8 +92,13 @@ const cacheNotWritable: Rule = (data) => {
 // the proxy as a likely lazy-install blocker (we don't probe reachability;
 // that's the opt-in --check-network work).
 const proxyMaybeBlocking: Rule = (data) => {
-  const hasProxy = (data.network?.variables || []).some((v) =>
-    /^(https?_proxy|all_proxy)$/i.test(v.name)
+  // Catch both the standard proxy env vars (HTTP(S)_PROXY / ALL_PROXY) and a
+  // proxy configured purely through npm (`npm config set proxy=…`), which
+  // surfaces in the network section as npm_config_proxy / npm_config_https_proxy.
+  const hasProxy = (data.network?.variables || []).some(
+    (v) =>
+      /^(https?_proxy|all_proxy)$/i.test(v.name) ||
+      /^npm_config_(https?_)?proxy$/i.test(v.name)
   );
   if (!hasProxy) return null;
   const missingNpm = (data.install?.rows || []).some(

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -36,8 +36,8 @@ import {
   renderDocument,
   type Section,
 } from "./render.js";
-import { getInstalledRecordPath } from "../runtime/cacheDir.js";
-import { status, type StatusRow } from "../runtime/installer.js";
+import { type StatusRow } from "../runtime/installer.js";
+import { collectInstallStatus, type InstallData } from "./install.js";
 import { collectCacheStatus, type CacheStatus } from "./cache.js";
 import { collectNetworkConfig, type NetworkConfig } from "./network.js";
 import { collectProvenance, type Provenance } from "./provenance.js";
@@ -143,12 +143,6 @@ interface ConfigData {
   redacted: unknown;
 }
 
-interface InstallData {
-  recordPath?: string;
-  rows?: StatusRow[];
-  error?: string;
-}
-
 export interface DebugData {
   generatedAt: string;
   system: SystemInfo;
@@ -203,17 +197,6 @@ async function collectDebugData(opts: PrintDebugOptions): Promise<DebugData> {
   };
   data.findings = computeFindings(data);
   return data;
-}
-
-// Diff installed.json against declared/expected versions. Wrapped so a
-// missing/corrupt cache degrades to an `error` marker instead of crashing.
-function collectInstallStatus(config: any): InstallData {
-  try {
-    const ctx = { cacheDir: config?.cacheDir };
-    return { recordPath: getInstalledRecordPath(ctx), rows: status(ctx) };
-  } catch (err: any) {
-    return { error: err?.message || String(err) };
-  }
 }
 
 // collectAppiumDiagnostics reads extensions.yaml (no subprocess) and guards

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -578,22 +578,20 @@ function renderAppiumSection(a: AppiumDiagnostics): Section {
   if (a.manifestError) {
     lines.push(`  ! could not read extensions.yaml: ${a.manifestError}`);
   }
-  // Registration is only KNOWN when the manifest was read successfully;
-  // without it, a resolvable driver's registration is genuinely unknown —
-  // don't claim "not registered".
-  const registrationKnown =
-    a.extensionsManifestPresent && !a.manifestError;
   lines.push("");
   lines.push("  drivers:");
   if (a.drivers.length === 0) lines.push("    <none>");
   for (const d of a.drivers) {
-    const classification = d.registered
-      ? "registered"
-      : !d.npmResolvable
-      ? "missing"
-      : registrationKnown
-      ? "resolvable but not registered"
-      : "resolvable (registration unknown — no manifest)";
+    // registered === null means the manifest wasn't read — registration is
+    // unknown, not confirmed-absent.
+    const classification =
+      d.registered === true
+        ? "registered"
+        : !d.npmResolvable
+        ? "missing"
+        : d.registered === false
+        ? "resolvable but not registered"
+        : "resolvable (registration unknown — no manifest)";
     lines.push(`    ${d.name.padEnd(24)} ${classification}`);
   }
   return renderSection("Appium registration", lines);

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -564,9 +564,11 @@ function renderAppiumSection(a: AppiumDiagnostics): Section {
   lines.push("");
   lines.push("  drivers:");
   if (a.drivers.length === 0) lines.push("    <none>");
+  // registered === null means the manifest wasn't read — registration is
+  // unknown, not confirmed-absent. That covers two distinct cases: the
+  // manifest is absent, or it's present but unreadable/unparsable.
+  const unknownReason = a.manifestError ? "manifest unreadable" : "no manifest";
   for (const d of a.drivers) {
-    // registered === null means the manifest wasn't read — registration is
-    // unknown, not confirmed-absent.
     const classification =
       d.registered === true
         ? "registered"
@@ -574,7 +576,7 @@ function renderAppiumSection(a: AppiumDiagnostics): Section {
         ? "missing"
         : d.registered === false
         ? "resolvable but not registered"
-        : "resolvable (registration unknown — no manifest)";
+        : `resolvable (registration unknown — ${unknownReason})`;
     lines.push(`    ${d.name.padEnd(24)} ${classification}`);
   }
   return renderSection("Appium registration", lines);

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -36,6 +36,16 @@ import {
   renderDocument,
   type Section,
 } from "./render.js";
+import { getInstalledRecordPath } from "../runtime/cacheDir.js";
+import { status, type StatusRow } from "../runtime/installer.js";
+import { collectCacheStatus, type CacheStatus } from "./cache.js";
+import { collectNetworkConfig, type NetworkConfig } from "./network.js";
+import { collectProvenance, type Provenance } from "./provenance.js";
+import {
+  collectAppiumDiagnostics,
+  type AppiumDiagnostics,
+} from "./appium.js";
+import { computeFindings, type Finding } from "./findings.js";
 
 export interface PrintDebugOptions {
   config: any;
@@ -60,6 +70,12 @@ export interface PrintDebugOptions {
    * omit it so calling `printDebug` never writes a file as a side effect.
    */
   outDir?: string;
+  /**
+   * The raw parsed CLI args (yargs argv). Used only by the Config provenance
+   * section to report which flags overrode the validated config. Optional so
+   * unit tests can call `printDebug` without synthesizing argv.
+   */
+  args?: any;
   print?: (line: string) => void;
 }
 
@@ -127,15 +143,27 @@ interface ConfigData {
   redacted: unknown;
 }
 
+interface InstallData {
+  recordPath?: string;
+  rows?: StatusRow[];
+  error?: string;
+}
+
 export interface DebugData {
   generatedAt: string;
   system: SystemInfo;
   docDetective: DocDetectiveData;
   tools: ToolResult[];
   browsers: BrowsersData;
+  install: InstallData;
+  appium: AppiumDiagnostics;
+  cache: CacheStatus;
   container: ContainerInfo;
+  network: NetworkConfig;
   environment: EnvData;
+  provenance: Provenance;
   config: ConfigData;
+  findings: Finding[];
 }
 
 // Secondary cap on browser-detection latency. Detection reads
@@ -149,20 +177,62 @@ const BROWSER_DETECTION_TIMEOUT_MS = 5000;
 
 async function collectDebugData(opts: PrintDebugOptions): Promise<DebugData> {
   const system = collectSystemInfo();
-  return {
+  const data: DebugData = {
     generatedAt: system.wallclockIso,
     system,
     docDetective: collectDocDetective(),
     tools: await probeAllTools(opts.config?.cacheDir),
     browsers: await collectBrowsers(opts.config),
+    install: collectInstallStatus(opts.config),
+    appium: collectAppiumStatus(opts.config),
+    cache: collectCacheStatus(opts.config),
     container: detectContainer(),
+    network: collectNetworkConfig(),
     environment: collectEnvVars(opts),
+    provenance: collectProvenance({
+      configPath: opts.configPath ?? null,
+      args: opts.args,
+    }),
     config: {
       configPath: opts.configPath ?? null,
       configError: opts.configError?.message,
       redacted: safeRedactConfig(opts.config),
     },
+    // Computed last: the Findings layer interprets the data sections above.
+    findings: [],
   };
+  data.findings = computeFindings(data);
+  return data;
+}
+
+// Diff installed.json against declared/expected versions. Wrapped so a
+// missing/corrupt cache degrades to an `error` marker instead of crashing.
+function collectInstallStatus(config: any): InstallData {
+  try {
+    const ctx = { cacheDir: config?.cacheDir };
+    return { recordPath: getInstalledRecordPath(ctx), rows: status(ctx) };
+  } catch (err: any) {
+    return { error: err?.message || String(err) };
+  }
+}
+
+// collectAppiumDiagnostics reads extensions.yaml (no subprocess) and guards
+// each step, but wrap the whole call so an unforeseen throw can't abort the
+// dump.
+function collectAppiumStatus(config: any): AppiumDiagnostics {
+  try {
+    return collectAppiumDiagnostics(config);
+  } catch (err: any) {
+    return {
+      appiumHome: null,
+      appiumInstalled: false,
+      extensionsManifestPath: null,
+      extensionsManifestPresent: false,
+      manifestError: err?.message || String(err),
+      registeredDrivers: [],
+      drivers: [],
+    };
+  }
 }
 
 function collectDocDetective(): DocDetectiveData {
@@ -416,15 +486,167 @@ function writeFileSafe(
 
 function renderText(data: DebugData, opts: PrintDebugOptions): string {
   const sections: Section[] = [
+    // Findings first — it's the summary a support engineer reads before
+    // scrolling into the raw data sections below.
+    renderFindingsSection(data.findings),
     renderSystemSection(data.system),
     renderDocDetectiveSection(data.docDetective),
     renderToolsSection(data.tools),
     renderBrowsersSection(data.browsers),
+    renderInstallSection(data.install),
+    renderAppiumSection(data.appium),
+    renderCacheSection(data.cache),
     renderContainerSection(data.container),
+    renderNetworkSection(data.network),
     renderEnvSection(data.environment),
+    renderProvenanceSection(data.provenance),
     renderConfigSection(data.config, opts.configError ?? null),
   ];
   return renderDocument(sections, data.generatedAt);
+}
+
+function renderFindingsSection(findings: Finding[]): Section {
+  if (findings.length === 0) {
+    return renderSection("Findings / next steps", ["  No problems detected."]);
+  }
+  const lines: string[] = [];
+  for (const f of findings) {
+    lines.push(`  [${f.severity.toUpperCase()}] ${f.title}`);
+    lines.push(`    ${f.detail}`);
+    if (f.fix) lines.push(`    fix: ${f.fix}`);
+    lines.push("");
+  }
+  if (lines[lines.length - 1] === "") lines.pop();
+  return renderSection("Findings / next steps", lines);
+}
+
+// Bytes → a compact human figure (MiB / GiB) for the cache free-space rows.
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "<unknown>";
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  const rounded = unit === 0 ? value : Math.round(value * 10) / 10;
+  return `${rounded} ${units[unit]}`;
+}
+
+function formatInstallRow(r: StatusRow): string {
+  const state = r.installed ? "installed" : "missing  ";
+  const version = r.installedVersion || "—";
+  const parts = [`${r.assetId.padEnd(24)} ${state}  ${version}`];
+  if (r.expectedVersion) parts.push(`expected ${r.expectedVersion}`);
+  if (r.latestKnownVersion) parts.push(`latest ${r.latestKnownVersion}`);
+  if (r.outdated) parts.push("OUTDATED");
+  return parts.join("  ");
+}
+
+function renderInstallSection(install: InstallData): Section {
+  if (install.error) {
+    return renderSection("Install status", [
+      `  <install status failed: ${install.error}>`,
+    ]);
+  }
+  const rows = install.rows || [];
+  const npm = rows.filter((r) => r.kind === "npm");
+  const browsers = rows.filter((r) => r.kind === "browser");
+  const lines: string[] = [];
+  lines.push(`  record: ${install.recordPath || "<unknown>"}`);
+  lines.push("");
+  lines.push("  npm packages:");
+  if (npm.length === 0) lines.push("    <none>");
+  for (const r of npm) lines.push(`    ${formatInstallRow(r)}`);
+  lines.push("");
+  lines.push("  browsers:");
+  if (browsers.length === 0) lines.push("    <none>");
+  for (const r of browsers) lines.push(`    ${formatInstallRow(r)}`);
+  return renderSection("Install status", lines);
+}
+
+function renderAppiumSection(a: AppiumDiagnostics): Section {
+  const lines: string[] = [];
+  lines.push(`  APPIUM_HOME:      ${a.appiumHome ?? "<unset>"}`);
+  lines.push(`  appium installed: ${a.appiumInstalled}`);
+  const manifest = a.extensionsManifestPresent ? "present" : "absent";
+  const manifestPath = a.extensionsManifestPath
+    ? `  (${a.extensionsManifestPath})`
+    : "";
+  lines.push(`  extensions.yaml:  ${manifest}${manifestPath}`);
+  if (a.manifestError) {
+    lines.push(`  ! could not read extensions.yaml: ${a.manifestError}`);
+  }
+  // Registration is only KNOWN when the manifest was read successfully;
+  // without it, a resolvable driver's registration is genuinely unknown —
+  // don't claim "not registered".
+  const registrationKnown =
+    a.extensionsManifestPresent && !a.manifestError;
+  lines.push("");
+  lines.push("  drivers:");
+  if (a.drivers.length === 0) lines.push("    <none>");
+  for (const d of a.drivers) {
+    const classification = d.registered
+      ? "registered"
+      : !d.npmResolvable
+      ? "missing"
+      : registrationKnown
+      ? "resolvable but not registered"
+      : "resolvable (registration unknown — no manifest)";
+    lines.push(`    ${d.name.padEnd(24)} ${classification}`);
+  }
+  return renderSection("Appium registration", lines);
+}
+
+function renderCacheSection(cache: CacheStatus): Section {
+  const lines: string[] = [];
+  if (cache.error) lines.push(`  ! cache probe error: ${cache.error}`);
+  for (const e of cache.entries) {
+    lines.push(`  ${e.label}:`);
+    lines.push(`    path:     ${e.path ?? "<unset>"}`);
+    lines.push(`    exists:   ${e.exists}`);
+    if (e.writable !== null) lines.push(`    writable: ${e.writable}`);
+    if (e.freeBytes !== null) {
+      lines.push(`    free:     ${formatBytes(e.freeBytes)}`);
+    }
+  }
+  return renderSection("Cache & runtime", lines);
+}
+
+function renderNetworkSection(net: NetworkConfig): Section {
+  const lines: string[] = [];
+  if (net.variables.length === 0) {
+    lines.push("  <no proxy / npm network env vars set>");
+  } else {
+    for (const { name, value } of net.variables) {
+      lines.push(`  ${name} = ${value}`);
+    }
+  }
+  return renderSection("Proxy / npm network", lines);
+}
+
+function renderProvenanceSection(p: Provenance): Section {
+  const lines: string[] = [];
+  lines.push(`  config file:          ${p.configPath || "<none>"}`);
+  lines.push(
+    `  DOC_DETECTIVE_CONFIG: ${
+      p.docDetectiveConfigApplied ? "applied (overrides file)" : "not set"
+    }`
+  );
+  lines.push(
+    `  DOC_DETECTIVE_API:    ${p.docDetectiveApiApplied ? "applied" : "not set"}`
+  );
+  lines.push("");
+  if (p.cliOverrides.length === 0) {
+    lines.push("  CLI overrides: <none>");
+  } else {
+    lines.push("  CLI overrides (override file + env):");
+    for (const o of p.cliOverrides) {
+      lines.push(`    --${o.flag} → config.${o.configKey}`);
+    }
+  }
+  return renderSection("Config provenance", lines);
 }
 
 function renderSystemSection(info: SystemInfo): Section {

--- a/src/debug/install.ts
+++ b/src/debug/install.ts
@@ -1,0 +1,28 @@
+// Install-status collector for the diagnostic dump.
+//
+// Diffs <cacheDir>/installed.json against the declared/expected versions via
+// the installer's own status() — the same matrix `doc-detective install`
+// reports (installed vs expected vs outdated, for npm packages and
+// browsers). Wrapped so a missing/corrupt cache degrades to an `error`
+// marker instead of crashing the dump.
+
+import {
+  getInstalledRecordPath,
+  type CacheDirContext,
+} from "../runtime/cacheDir.js";
+import { status, type StatusRow } from "../runtime/installer.js";
+
+export interface InstallData {
+  recordPath?: string;
+  rows?: StatusRow[];
+  error?: string;
+}
+
+export function collectInstallStatus(config: any): InstallData {
+  try {
+    const ctx: CacheDirContext = { cacheDir: config?.cacheDir };
+    return { recordPath: getInstalledRecordPath(ctx), rows: status(ctx) };
+  } catch (err: any) {
+    return { error: err?.message || String(err) };
+  }
+}

--- a/src/debug/network.ts
+++ b/src/debug/network.ts
@@ -45,7 +45,10 @@ export function collectNetworkConfig(
     if (typeof env[key] === "string") names.add(key);
   }
   // Sweep every npm_config_* var present (registry, proxy, strict-ssl,
-  // cafile, per-registry _authToken, …). Redaction handles the auth ones.
+  // cafile, per-registry _authToken, …). The prefix match is lowercased so
+  // uppercase variants (NPM_CONFIG_*) are caught too; keys keep their original
+  // casing, and redactValue/isSecretName are case-insensitive, so an
+  // _authToken key still redacts. Redaction handles the auth ones.
   for (const key of Object.keys(env)) {
     if (key.toLowerCase().startsWith("npm_config_")) names.add(key);
   }

--- a/src/debug/network.ts
+++ b/src/debug/network.ts
@@ -1,0 +1,59 @@
+// Proxy / npm network config collector for the diagnostic dump.
+//
+// The lazy installer shells out to `npm install` to fetch heavy deps and
+// browsers (see src/runtime/heavyDeps.ts — `@puppeteer/browsers` even pulls
+// `proxy-agent` so proxied downloads work). A misconfigured proxy or
+// registry is the single most common silent install failure, so the dump
+// always shows the relevant env vars.
+//
+// Every value goes through `redactValue`, which already flags
+// userinfo-bearing URLs (`https://user:tok@registry`) and `*authToken`-style
+// keys — so a registry or proxy with embedded credentials is redacted, not
+// leaked into a pasted bug report.
+
+import { redactValue } from "./redact.js";
+
+export interface NetworkVar {
+  name: string;
+  value: string;
+}
+
+export interface NetworkConfig {
+  variables: NetworkVar[];
+}
+
+// Proxy vars are conventionally set in either case; tools read both, so we
+// surface whichever the user actually set.
+const PROXY_KEYS = [
+  "HTTP_PROXY",
+  "http_proxy",
+  "HTTPS_PROXY",
+  "https_proxy",
+  "NO_PROXY",
+  "no_proxy",
+  "ALL_PROXY",
+  "all_proxy",
+];
+
+// Collect proxy + npm network env vars. Takes an explicit env map so the
+// behavior is unit-testable without mutating the real process environment.
+export function collectNetworkConfig(
+  env: NodeJS.ProcessEnv = process.env
+): NetworkConfig {
+  const names = new Set<string>();
+  for (const key of PROXY_KEYS) {
+    if (typeof env[key] === "string") names.add(key);
+  }
+  // Sweep every npm_config_* var present (registry, proxy, strict-ssl,
+  // cafile, per-registry _authToken, …). Redaction handles the auth ones.
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase().startsWith("npm_config_")) names.add(key);
+  }
+  const sorted = Array.from(names).sort();
+  return {
+    variables: sorted.map((name) => ({
+      name,
+      value: redactValue(name, env[name]),
+    })),
+  };
+}

--- a/src/debug/network.ts
+++ b/src/debug/network.ts
@@ -50,7 +50,12 @@ export function collectNetworkConfig(
   // casing, and redactValue/isSecretName are case-insensitive, so an
   // _authToken key still redacts. Redaction handles the auth ones.
   for (const key of Object.keys(env)) {
-    if (key.toLowerCase().startsWith("npm_config_")) names.add(key);
+    // Guard on a string value (same as the proxy loop) so a key present with
+    // an undefined value — e.g. a partial env object passed by a caller —
+    // doesn't surface as a misleading `npm_config_x = <unset>` entry.
+    if (typeof env[key] === "string" && key.toLowerCase().startsWith("npm_config_")) {
+      names.add(key);
+    }
   }
   const sorted = Array.from(names).sort();
   return {

--- a/src/debug/provenance.ts
+++ b/src/debug/provenance.ts
@@ -25,8 +25,12 @@ export interface Provenance {
   cliOverrides: CliOverride[];
 }
 
-// Replicates setConfig's reporters guard: `if (args.reporters != null)` then
-// only overrides when the normalized list is non-empty.
+// Replicates setConfig's reporters guard exactly: `if (args.reporters != null)`
+// then override only when `reporterList.length > 0`. Note setConfig does NOT
+// drop empty-string entries here (unlike --test / --spec), so `[""]` length 1
+// DOES override — `reportersPresent([""])` must return true to stay faithful.
+// Don't be tempted to filter empties: that would make provenance claim
+// "no override" while setConfig actually overrides with `[""]`.
 function reportersPresent(reporters: unknown): boolean {
   if (reporters == null) return false;
   const list = Array.isArray(reporters) ? reporters : [reporters];

--- a/src/debug/provenance.ts
+++ b/src/debug/provenance.ts
@@ -9,7 +9,8 @@
 // setConfig untouched and this logic pure / unit-testable.
 
 export interface CliOverride {
-  // The CLI flag the user passed (without leading dashes).
+  // The CLI flag spelling (without leading dashes) as declared in
+  // buildYargs — e.g. "dry-run", "cache-dir", "logLevel".
   flag: string;
   // The config key it overrides after validation.
   configKey: string;
@@ -24,58 +25,82 @@ export interface Provenance {
   cliOverrides: CliOverride[];
 }
 
-// The CLI overrides setConfig() applies, paired with the config key each
-// lands on. The `present` guard mirrors the exact truthiness check in the
-// corresponding setConfig override block so this report can't claim an
-// override that setConfig would have skipped. Keep in sync with the
-// override section of setConfig in src/utils.ts.
+// Replicates setConfig's reporters guard: `if (args.reporters != null)` then
+// only overrides when the normalized list is non-empty.
+function reportersPresent(reporters: unknown): boolean {
+  if (reporters == null) return false;
+  const list = Array.isArray(reporters) ? reporters : [reporters];
+  return list.length > 0;
+}
+
+// Replicates setConfig's --test / --spec guard: comma-split, trim, drop
+// empties, override only when at least one entry survives. A value like ","
+// or "  " trims to nothing and does NOT override, so it must not be reported.
+function commaListPresent(value: unknown): boolean {
+  if (typeof value !== "string" || value.length === 0) return false;
+  return (
+    value
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0).length > 0
+  );
+}
+
+// The CLI overrides setConfig() applies. `flag` is the declared yargs option
+// name (what the user types); `argKey` is the camelCased property yargs
+// exposes on argv; `configKey` is where it lands after validation. The
+// `present` guard mirrors the exact check in the corresponding setConfig
+// override block so this report can't claim an override setConfig skipped.
+//
+// This is a curated mirror of the override section of setConfig in
+// src/utils.ts — when a new user-facing flag is wired there, add it here too.
+// `test/debug.test.js` pins the flag list so any change is deliberate.
 const OVERRIDE_SPECS: Array<{
   flag: string;
+  argKey: string;
   configKey: string;
   present: (args: any) => boolean;
 }> = [
-  { flag: "input", configKey: "input", present: (a) => Boolean(a.input) },
-  { flag: "output", configKey: "output", present: (a) => Boolean(a.output) },
-  { flag: "logLevel", configKey: "logLevel", present: (a) => Boolean(a.logLevel) },
+  { flag: "input", argKey: "input", configKey: "input", present: (a) => Boolean(a.input) },
+  { flag: "output", argKey: "output", configKey: "output", present: (a) => Boolean(a.output) },
+  { flag: "logLevel", argKey: "logLevel", configKey: "logLevel", present: (a) => Boolean(a.logLevel) },
   {
-    flag: "allowUnsafe",
+    flag: "allow-unsafe",
+    argKey: "allowUnsafe",
     configKey: "allowUnsafeSteps",
     present: (a) => typeof a.allowUnsafe === "boolean",
   },
-  { flag: "dryRun", configKey: "dryRun", present: (a) => typeof a.dryRun === "boolean" },
-  { flag: "reporters", configKey: "reporters", present: (a) => a.reporters != null },
-  {
-    flag: "test",
-    configKey: "testFilter",
-    present: (a) => typeof a.test === "string" && a.test.length > 0,
-  },
-  {
-    flag: "spec",
-    configKey: "specFilter",
-    present: (a) => typeof a.spec === "string" && a.spec.length > 0,
-  },
+  { flag: "dry-run", argKey: "dryRun", configKey: "dryRun", present: (a) => typeof a.dryRun === "boolean" },
+  { flag: "reporters", argKey: "reporters", configKey: "reporters", present: (a) => reportersPresent(a.reporters) },
+  { flag: "test", argKey: "test", configKey: "testFilter", present: (a) => commaListPresent(a.test) },
+  { flag: "spec", argKey: "spec", configKey: "specFilter", present: (a) => commaListPresent(a.spec) },
   {
     flag: "hints",
+    argKey: "hints",
     configKey: "hints.enabled",
     present: (a) => typeof a.hints === "boolean",
   },
   {
-    flag: "autoUpdate",
+    flag: "auto-update",
+    argKey: "autoUpdate",
     configKey: "autoUpdate",
     present: (a) => typeof a.autoUpdate === "boolean",
   },
   {
-    flag: "autoScreenshot",
+    flag: "auto-screenshot",
+    argKey: "autoScreenshot",
     configKey: "autoScreenshot",
     present: (a) => typeof a.autoScreenshot === "boolean",
   },
   {
-    flag: "cacheDir",
+    flag: "cache-dir",
+    argKey: "cacheDir",
     configKey: "cacheDir",
     present: (a) => typeof a.cacheDir === "string" && a.cacheDir.length > 0,
   },
   {
-    flag: "concurrentRunners",
+    flag: "concurrent-runners",
+    argKey: "concurrentRunners",
     configKey: "concurrentRunners",
     present: (a) => typeof a.concurrentRunners === "string",
   },
@@ -102,10 +127,13 @@ export function collectProvenance(opts: {
   env?: NodeJS.ProcessEnv;
 }): Provenance {
   const env = opts.env ?? process.env;
+  // Empty-string env vars do NOT apply: getConfigFromEnv() /
+  // getResolvedTestsFromEnv() both gate on `if (!process.env.*)`, so an empty
+  // value is treated as unset. Match that with a non-empty (truthy) check.
   return {
     configPath: opts.configPath ?? null,
-    docDetectiveConfigApplied: typeof env.DOC_DETECTIVE_CONFIG === "string",
-    docDetectiveApiApplied: typeof env.DOC_DETECTIVE_API === "string",
+    docDetectiveConfigApplied: Boolean(env.DOC_DETECTIVE_CONFIG),
+    docDetectiveApiApplied: Boolean(env.DOC_DETECTIVE_API),
     cliOverrides: collectCliOverrides(opts.args),
   };
 }

--- a/src/debug/provenance.ts
+++ b/src/debug/provenance.ts
@@ -50,6 +50,17 @@ function commaListPresent(value: unknown): boolean {
   );
 }
 
+// Replicates setConfig's --concurrent-runners guard: the bare flag ("") and
+// "true" select CPU-count mode, otherwise the value must parse to a positive
+// integer; anything else (e.g. "abc", "0") logs a warning and does NOT
+// override, so it must not be reported.
+function concurrentRunnersPresent(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  if (value === "" || value.toLowerCase() === "true") return true;
+  const count = Number(value);
+  return Number.isInteger(count) && count >= 1;
+}
+
 // The CLI overrides setConfig() applies. `flag` is the declared yargs option
 // name (what the user types); `argKey` is the camelCased property yargs
 // exposes on argv; `configKey` is where it lands after validation. The
@@ -110,7 +121,7 @@ const OVERRIDE_SPECS: Array<{
     flag: "concurrent-runners",
     argKey: "concurrentRunners",
     configKey: "concurrentRunners",
-    present: (a) => typeof a.concurrentRunners === "string",
+    present: (a) => concurrentRunnersPresent(a.concurrentRunners),
   },
 ];
 

--- a/src/debug/provenance.ts
+++ b/src/debug/provenance.ts
@@ -1,0 +1,111 @@
+// Config provenance collector for the diagnostic dump.
+//
+// Answers "where did the effective config come from?" — the resolved config
+// file path, whether DOC_DETECTIVE_CONFIG / DOC_DETECTIVE_API were applied,
+// and which CLI flags overrode the validated config. This mirrors the
+// documented precedence chain (file → env → AJV → CLI) in setConfig
+// (src/utils.ts) WITHOUT threading new state out of setConfig: everything
+// here is derived from inputs the debug command already has, which keeps
+// setConfig untouched and this logic pure / unit-testable.
+
+export interface CliOverride {
+  // The CLI flag the user passed (without leading dashes).
+  flag: string;
+  // The config key it overrides after validation.
+  configKey: string;
+}
+
+export interface Provenance {
+  configPath: string | null;
+  // DOC_DETECTIVE_CONFIG is merged over file config (and overrides it).
+  docDetectiveConfigApplied: boolean;
+  // DOC_DETECTIVE_API short-circuits to the orchestration API path.
+  docDetectiveApiApplied: boolean;
+  cliOverrides: CliOverride[];
+}
+
+// The CLI overrides setConfig() applies, paired with the config key each
+// lands on. The `present` guard mirrors the exact truthiness check in the
+// corresponding setConfig override block so this report can't claim an
+// override that setConfig would have skipped. Keep in sync with the
+// override section of setConfig in src/utils.ts.
+const OVERRIDE_SPECS: Array<{
+  flag: string;
+  configKey: string;
+  present: (args: any) => boolean;
+}> = [
+  { flag: "input", configKey: "input", present: (a) => Boolean(a.input) },
+  { flag: "output", configKey: "output", present: (a) => Boolean(a.output) },
+  { flag: "logLevel", configKey: "logLevel", present: (a) => Boolean(a.logLevel) },
+  {
+    flag: "allowUnsafe",
+    configKey: "allowUnsafeSteps",
+    present: (a) => typeof a.allowUnsafe === "boolean",
+  },
+  { flag: "dryRun", configKey: "dryRun", present: (a) => typeof a.dryRun === "boolean" },
+  { flag: "reporters", configKey: "reporters", present: (a) => a.reporters != null },
+  {
+    flag: "test",
+    configKey: "testFilter",
+    present: (a) => typeof a.test === "string" && a.test.length > 0,
+  },
+  {
+    flag: "spec",
+    configKey: "specFilter",
+    present: (a) => typeof a.spec === "string" && a.spec.length > 0,
+  },
+  {
+    flag: "hints",
+    configKey: "hints.enabled",
+    present: (a) => typeof a.hints === "boolean",
+  },
+  {
+    flag: "autoUpdate",
+    configKey: "autoUpdate",
+    present: (a) => typeof a.autoUpdate === "boolean",
+  },
+  {
+    flag: "autoScreenshot",
+    configKey: "autoScreenshot",
+    present: (a) => typeof a.autoScreenshot === "boolean",
+  },
+  {
+    flag: "cacheDir",
+    configKey: "cacheDir",
+    present: (a) => typeof a.cacheDir === "string" && a.cacheDir.length > 0,
+  },
+  {
+    flag: "concurrentRunners",
+    configKey: "concurrentRunners",
+    present: (a) => typeof a.concurrentRunners === "string",
+  },
+];
+
+export function collectCliOverrides(args: any): CliOverride[] {
+  if (!args || typeof args !== "object") return [];
+  const out: CliOverride[] = [];
+  for (const spec of OVERRIDE_SPECS) {
+    let present = false;
+    try {
+      present = spec.present(args);
+    } catch {
+      present = false;
+    }
+    if (present) out.push({ flag: spec.flag, configKey: spec.configKey });
+  }
+  return out;
+}
+
+export function collectProvenance(opts: {
+  configPath?: string | null;
+  args?: any;
+  env?: NodeJS.ProcessEnv;
+}): Provenance {
+  const env = opts.env ?? process.env;
+  return {
+    configPath: opts.configPath ?? null,
+    docDetectiveConfigApplied: typeof env.DOC_DETECTIVE_CONFIG === "string",
+    docDetectiveApiApplied: typeof env.DOC_DETECTIVE_API === "string",
+    cliOverrides: collectCliOverrides(opts.args),
+  };
+}

--- a/src/debug/provenance.ts
+++ b/src/debug/provenance.ts
@@ -52,9 +52,13 @@ function commaListPresent(value: unknown): boolean {
 // `present` guard mirrors the exact check in the corresponding setConfig
 // override block so this report can't claim an override setConfig skipped.
 //
-// This is a curated mirror of the override section of setConfig in
-// src/utils.ts — when a new user-facing flag is wired there, add it here too.
-// `test/debug.test.js` pins the flag list so any change is deliberate.
+// NOTE: this list must be kept in sync with the override blocks in setConfig()
+// (src/utils.ts). `test/debug.test.js` pins the full set, but it only asserts
+// that the recognized flags fire correctly — it does NOT cross-reference
+// setConfig, so a new override added there without an entry here will silently
+// omit from provenance. Adding a setConfig override means adding it here AND
+// updating that pinned-list assertion. (CLAUDE.md's TDD-per-flag steps include
+// this.)
 const OVERRIDE_SPECS: Array<{
   flag: string;
   argKey: string;

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -1079,6 +1079,19 @@ describe("debug/provenance", function () {
     expect(collectCliOverrides({ spec: "," }).map((o) => o.flag)).to.not.include(
       "spec"
     );
+    // concurrent-runners: "" / "true" / positive int override; "abc"/"0" don't.
+    for (const v of ["", "true", "TRUE", "4"]) {
+      expect(
+        collectCliOverrides({ concurrentRunners: v }).map((o) => o.flag),
+        `value ${JSON.stringify(v)}`
+      ).to.include("concurrent-runners");
+    }
+    for (const v of ["abc", "0", "-1", "1.5"]) {
+      expect(
+        collectCliOverrides({ concurrentRunners: v }).map((o) => o.flag),
+        `value ${JSON.stringify(v)}`
+      ).to.not.include("concurrent-runners");
+    }
   });
 
   it("pins the full set of recognized override flags (keep in sync with setConfig)", function () {

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -1205,7 +1205,15 @@ describe("debug/cache", function () {
   });
 
   it("reports writable=false for a non-writable cache dir (POSIX)", function () {
-    if (process.platform === "win32") this.skip();
+    // Root bypasses the directory write-bit, so a 0500 dir still passes
+    // W_OK under UID 0 (common in CI containers) — skip there to keep the
+    // test implementation-dependent rather than environment-dependent.
+    if (
+      process.platform === "win32" ||
+      (typeof process.getuid === "function" && process.getuid() === 0)
+    ) {
+      this.skip();
+    }
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-cache-ro-"));
     try {
       fs.chmodSync(tmp, 0o500); // r-x, no write

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -990,3 +990,348 @@ describe("debug CLI smoke test", function () {
     }
   });
 });
+
+describe("debug/network", function () {
+  let collectNetworkConfig;
+  before(async function () {
+    ({ collectNetworkConfig } = await import("../dist/debug/network.js"));
+  });
+
+  it("lists proxy and npm_config_* vars, sorted", function () {
+    const out = collectNetworkConfig({
+      HTTPS_PROXY: "http://proxy.example:8080",
+      npm_config_registry: "https://registry.example/",
+      npm_config_strict_ssl: "true",
+      UNRELATED: "ignored",
+    });
+    const names = out.variables.map((v) => v.name);
+    expect(names).to.deep.equal([
+      "HTTPS_PROXY",
+      "npm_config_registry",
+      "npm_config_strict_ssl",
+    ]);
+    expect(names).to.not.include("UNRELATED");
+  });
+
+  it("redacts a registry URL that embeds credentials", function () {
+    const out = collectNetworkConfig({
+      npm_config_registry: "https://user:s3cr3t@registry.example/",
+    });
+    const reg = out.variables.find((v) => v.name === "npm_config_registry");
+    expect(reg.value).to.match(/\*{3}redacted/);
+    expect(reg.value).to.not.include("s3cr3t");
+  });
+
+  it("redacts a per-registry _authToken by name", function () {
+    const out = collectNetworkConfig({
+      "npm_config_//registry.example/:_authToken": "abc123tokenvalue",
+    });
+    expect(out.variables[0].value).to.match(/\*{3}redacted/);
+    expect(out.variables[0].value).to.not.include("abc123tokenvalue");
+  });
+
+  it("returns an empty list when no network vars are set", function () {
+    expect(collectNetworkConfig({}).variables).to.deep.equal([]);
+  });
+});
+
+describe("debug/provenance", function () {
+  let collectCliOverrides, collectProvenance;
+  before(async function () {
+    ({ collectCliOverrides, collectProvenance } = await import(
+      "../dist/debug/provenance.js"
+    ));
+  });
+
+  it("reports only the CLI flags actually present, mapped to config keys", function () {
+    const overrides = collectCliOverrides({
+      input: "docs",
+      test: "smoke,api",
+      dryRun: true,
+      // absent / empty values must NOT be reported
+      output: undefined,
+      spec: "",
+      logLevel: "",
+    });
+    const flags = overrides.map((o) => o.flag);
+    expect(flags).to.have.members(["input", "test", "dryRun"]);
+    expect(flags).to.not.include("output");
+    expect(flags).to.not.include("spec");
+    expect(flags).to.not.include("logLevel");
+    const testOverride = overrides.find((o) => o.flag === "test");
+    expect(testOverride.configKey).to.equal("testFilter");
+  });
+
+  it("returns [] for non-object args", function () {
+    expect(collectCliOverrides(undefined)).to.deep.equal([]);
+    expect(collectCliOverrides(null)).to.deep.equal([]);
+  });
+
+  it("reflects DOC_DETECTIVE_CONFIG / DOC_DETECTIVE_API and configPath", function () {
+    const applied = collectProvenance({
+      configPath: "/abs/.doc-detective.json",
+      args: { input: "x" },
+      env: { DOC_DETECTIVE_CONFIG: "{}", DOC_DETECTIVE_API: "{}" },
+    });
+    expect(applied.configPath).to.equal("/abs/.doc-detective.json");
+    expect(applied.docDetectiveConfigApplied).to.equal(true);
+    expect(applied.docDetectiveApiApplied).to.equal(true);
+    expect(applied.cliOverrides.map((o) => o.flag)).to.deep.equal(["input"]);
+
+    const none = collectProvenance({ configPath: null, args: {}, env: {} });
+    expect(none.configPath).to.equal(null);
+    expect(none.docDetectiveConfigApplied).to.equal(false);
+    expect(none.docDetectiveApiApplied).to.equal(false);
+    expect(none.cliOverrides).to.deep.equal([]);
+  });
+});
+
+describe("debug/cache", function () {
+  let collectCacheStatus;
+  let prevCacheEnv;
+  before(async function () {
+    ({ collectCacheStatus } = await import("../dist/debug/cache.js"));
+  });
+  beforeEach(function () {
+    // getCacheDir prefers DOC_DETECTIVE_CACHE_DIR over the passed config —
+    // clear it so the config.cacheDir under test is honored.
+    prevCacheEnv = process.env.DOC_DETECTIVE_CACHE_DIR;
+    delete process.env.DOC_DETECTIVE_CACHE_DIR;
+  });
+  afterEach(function () {
+    if (prevCacheEnv === undefined) delete process.env.DOC_DETECTIVE_CACHE_DIR;
+    else process.env.DOC_DETECTIVE_CACHE_DIR = prevCacheEnv;
+  });
+
+  it("reports path / exists / writable for the resolved cache dirs", function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-cache-status-"));
+    try {
+      const status = collectCacheStatus({ cacheDir: tmp });
+      const labels = status.entries.map((e) => e.label);
+      expect(labels).to.include.members([
+        "cacheDir",
+        "runtimeDir",
+        "browsersDir",
+        "installed.json",
+        "APPIUM_HOME",
+      ]);
+      const cacheDir = status.entries.find((e) => e.label === "cacheDir");
+      // getCacheDir created it, under the temp root, and it's writable.
+      expect(cacheDir.path).to.equal(tmp);
+      expect(cacheDir.exists).to.equal(true);
+      expect(cacheDir.writable).to.equal(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("reports writable=false for a non-writable cache dir (POSIX)", function () {
+    if (process.platform === "win32") this.skip();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-cache-ro-"));
+    try {
+      fs.chmodSync(tmp, 0o500); // r-x, no write
+      const status = collectCacheStatus({ cacheDir: tmp });
+      const cacheDir = status.entries.find((e) => e.label === "cacheDir");
+      expect(cacheDir.writable).to.equal(false);
+    } finally {
+      fs.chmodSync(tmp, 0o700);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("debug/appium", function () {
+  let registeredDriverPkgNames, collectAppiumDiagnostics;
+  before(async function () {
+    ({ registeredDriverPkgNames, collectAppiumDiagnostics } = await import(
+      "../dist/debug/appium.js"
+    ));
+  });
+
+  it("extracts driver pkgNames from an extensions.yaml manifest", function () {
+    const manifest = [
+      "drivers:",
+      "  gecko:",
+      "    pkgName: appium-geckodriver",
+      "    version: 2.2.6",
+      "  chromium:",
+      "    pkgName: appium-chromium-driver",
+      "    version: 2.2.5",
+      "plugins: {}",
+    ].join("\n");
+    const names = registeredDriverPkgNames(manifest);
+    expect(names).to.have.members([
+      "appium-geckodriver",
+      "appium-chromium-driver",
+    ]);
+  });
+
+  it("falls back to the short key when an entry omits pkgName", function () {
+    const names = registeredDriverPkgNames("drivers:\n  chromium:\n    version: 1");
+    expect(names).to.deep.equal(["chromium"]);
+  });
+
+  it("returns [] for a manifest with no drivers map", function () {
+    expect(registeredDriverPkgNames("plugins: {}")).to.deep.equal([]);
+  });
+
+  it("returns a drivers array and degrades cleanly when appium is absent", function () {
+    // No subprocess any more — pure fs reads against a cacheDir with no
+    // appium install; must not throw and must classify each known driver.
+    const diag = collectAppiumDiagnostics({
+      cacheDir: path.join(os.tmpdir(), "dd-no-appium-xyz"),
+    });
+    expect(diag.drivers.map((d) => d.name)).to.include.members([
+      "appium-chromium-driver",
+      "appium-geckodriver",
+    ]);
+    for (const d of diag.drivers) {
+      expect(d).to.have.property("registered").that.is.a("boolean");
+      expect(d).to.have.property("npmResolvable").that.is.a("boolean");
+    }
+    expect(diag).to.have.property("registeredDrivers").that.is.an("array");
+  });
+});
+
+describe("debug/findings", function () {
+  let computeFindings;
+  before(async function () {
+    ({ computeFindings } = await import("../dist/debug/findings.js"));
+  });
+
+  // Minimal DebugData skeleton; each test overrides only what its rule reads.
+  function baseData(overrides) {
+    return {
+      browsers: { browsers: [] },
+      appium: { drivers: [] },
+      install: { rows: [] },
+      cache: { entries: [] },
+      network: { variables: [] },
+      docDetective: {},
+      ...overrides,
+    };
+  }
+
+  it("flags Chrome unavailable with a missing chromium driver", function () {
+    const findings = computeFindings(
+      baseData({
+        browsers: {
+          browsers: [{ name: "chrome", supported: true, available: false }],
+        },
+        appium: {
+          drivers: [
+            { name: "appium-chromium-driver", registered: false, npmResolvable: false },
+          ],
+        },
+      })
+    );
+    const chrome = findings.find((f) => /Chrome is not available/.test(f.title));
+    expect(chrome).to.not.equal(undefined);
+    expect(chrome.severity).to.equal("error");
+    expect(chrome.fix).to.equal("doc-detective install runtime");
+  });
+
+  it("does NOT flag Chrome when it is available", function () {
+    const findings = computeFindings(
+      baseData({
+        browsers: {
+          browsers: [{ name: "chrome", supported: true, available: true }],
+        },
+      })
+    );
+    expect(findings.find((f) => /Chrome/.test(f.title))).to.equal(undefined);
+  });
+
+  it("flags an outdated install and an unregistered-but-resolvable driver", function () {
+    const findings = computeFindings(
+      baseData({
+        install: {
+          rows: [{ assetId: "webdriverio", kind: "npm", installed: true, outdated: true }],
+        },
+        appium: {
+          // Registration is only KNOWN when the manifest was read.
+          extensionsManifestPresent: true,
+          drivers: [
+            { name: "appium-geckodriver", registered: false, npmResolvable: true },
+          ],
+        },
+      })
+    );
+    expect(findings.find((f) => /stale/i.test(f.title))).to.not.equal(undefined);
+    const stranded = findings.find((f) => /not registered/i.test(f.title));
+    expect(stranded).to.not.equal(undefined);
+    expect(stranded.fix).to.equal("doc-detective install runtime");
+  });
+
+  it("does NOT flag unregistered drivers when the manifest is absent", function () {
+    // This is the regression that prompted the rewrite: a missing/unreadable
+    // manifest must not be treated as "not registered".
+    const findings = computeFindings(
+      baseData({
+        appium: {
+          extensionsManifestPresent: false,
+          drivers: [
+            { name: "appium-geckodriver", registered: false, npmResolvable: true },
+            { name: "appium-chromium-driver", registered: false, npmResolvable: true },
+          ],
+        },
+      })
+    );
+    expect(findings.find((f) => /not registered/i.test(f.title))).to.equal(
+      undefined
+    );
+  });
+
+  it("flags a non-writable cacheDir", function () {
+    const findings = computeFindings(
+      baseData({
+        cache: { entries: [{ label: "cacheDir", path: "/ro", writable: false }] },
+      })
+    );
+    const finding = findings.find((f) => /not writable/i.test(f.title));
+    expect(finding).to.not.equal(undefined);
+    expect(finding.fix).to.match(/DOC_DETECTIVE_CACHE_DIR/);
+  });
+
+  it("returns no findings for clean data", function () {
+    const findings = computeFindings(
+      baseData({
+        browsers: {
+          browsers: [{ name: "chrome", supported: true, available: true }],
+        },
+      })
+    );
+    expect(findings).to.deep.equal([]);
+  });
+});
+
+describe("debug/printDebug new sections end-to-end", function () {
+  let printDebug;
+  before(async function () {
+    ({ printDebug } = await import("../dist/debug/index.js"));
+  });
+
+  it("renders the new sections, with Findings first", async function () {
+    this.timeout(60000);
+    const out = [];
+    await printDebug({
+      config: { input: ".", logLevel: "info", environment: { platform: "linux" } },
+      configPath: null,
+      args: { input: ".", dryRun: true },
+      print: (line) => out.push(line),
+    });
+    const text = out.join("\n");
+    expect(text).to.include("-- Findings / next steps ");
+    expect(text).to.include("-- Install status ");
+    expect(text).to.include("-- Appium registration ");
+    expect(text).to.include("-- Cache & runtime ");
+    expect(text).to.include("-- Proxy / npm network ");
+    expect(text).to.include("-- Config provenance ");
+    // Findings is the first section, before System.
+    expect(text.indexOf("-- Findings / next steps ")).to.be.lessThan(
+      text.indexOf("-- System ")
+    );
+    // Provenance reflects the args we passed.
+    expect(text).to.match(/--dryRun → config\.dryRun/);
+  });
+});

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -1300,6 +1300,31 @@ describe("debug/findings", function () {
     expect(chrome.fix).to.equal("doc-detective install runtime");
   });
 
+  it("tailors the Chrome-unavailable detail to the driver's known state", function () {
+    const chromeDown = (driver) =>
+      computeFindings(
+        baseData({
+          browsers: {
+            browsers: [{ name: "chrome", supported: true, available: false }],
+          },
+          appium: { extensionsManifestPresent: true, drivers: driver ? [driver] : [] },
+        })
+      ).find((f) => /Chrome is not available/.test(f.title));
+
+    // Missing driver (not resolvable).
+    expect(
+      chromeDown({ name: "appium-chromium-driver", registered: false, npmResolvable: false }).detail
+    ).to.match(/is missing/);
+    // Installed but confirmed unregistered.
+    expect(
+      chromeDown({ name: "appium-chromium-driver", registered: false, npmResolvable: true }).detail
+    ).to.match(/installed but not registered/);
+    // Installed, registration unknown (manifest absent → registered null).
+    expect(
+      chromeDown({ name: "appium-chromium-driver", registered: null, npmResolvable: true }).detail
+    ).to.match(/registration is unknown/);
+  });
+
   it("does NOT flag Chrome when it is available", function () {
     const findings = computeFindings(
       baseData({

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -1377,6 +1377,18 @@ describe("debug/findings", function () {
     );
   });
 
+  it("flags an npm-only proxy (npm_config_proxy) with missing runtime packages", function () {
+    const findings = computeFindings(
+      baseData({
+        network: { variables: [{ name: "npm_config_proxy", value: "http://p:8080" }] },
+        install: {
+          rows: [{ assetId: "webdriverio", kind: "npm", installed: false, outdated: false }],
+        },
+      })
+    );
+    expect(findings.find((f) => /proxy/i.test(f.title))).to.not.equal(undefined);
+  });
+
   it("flags a non-writable cacheDir", function () {
     const findings = computeFindings(
       baseData({

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -1043,7 +1043,7 @@ describe("debug/provenance", function () {
     ));
   });
 
-  it("reports only the CLI flags actually present, mapped to config keys", function () {
+  it("reports only the CLI flags actually present, with real flag spellings", function () {
     const overrides = collectCliOverrides({
       input: "docs",
       test: "smoke,api",
@@ -1054,12 +1054,67 @@ describe("debug/provenance", function () {
       logLevel: "",
     });
     const flags = overrides.map((o) => o.flag);
-    expect(flags).to.have.members(["input", "test", "dryRun"]);
+    // dryRun is the camel argv key, but the reported flag is the real
+    // CLI spelling `--dry-run`.
+    expect(flags).to.have.members(["input", "test", "dry-run"]);
     expect(flags).to.not.include("output");
     expect(flags).to.not.include("spec");
     expect(flags).to.not.include("logLevel");
     const testOverride = overrides.find((o) => o.flag === "test");
     expect(testOverride.configKey).to.equal("testFilter");
+  });
+
+  it("matches setConfig's guards for reporters / test / spec edge cases", function () {
+    // reporters: [] does NOT override in setConfig (normalized list empty).
+    expect(
+      collectCliOverrides({ reporters: [] }).map((o) => o.flag)
+    ).to.not.include("reporters");
+    expect(
+      collectCliOverrides({ reporters: ["html"] }).map((o) => o.flag)
+    ).to.include("reporters");
+    // test / spec whose comma-split trims to nothing do NOT override.
+    expect(collectCliOverrides({ test: " , " }).map((o) => o.flag)).to.not.include(
+      "test"
+    );
+    expect(collectCliOverrides({ spec: "," }).map((o) => o.flag)).to.not.include(
+      "spec"
+    );
+  });
+
+  it("pins the full set of recognized override flags (keep in sync with setConfig)", function () {
+    // Every flag set at once → the complete list this collector recognizes.
+    // If setConfig gains/loses a user-facing override, update OVERRIDE_SPECS
+    // and this assertion together.
+    const all = collectCliOverrides({
+      input: "x",
+      output: "y",
+      logLevel: "info",
+      allowUnsafe: true,
+      dryRun: true,
+      reporters: ["html"],
+      test: "a",
+      spec: "b",
+      hints: true,
+      autoUpdate: true,
+      autoScreenshot: true,
+      cacheDir: "z",
+      concurrentRunners: "2",
+    });
+    expect(all.map((o) => o.flag)).to.deep.equal([
+      "input",
+      "output",
+      "logLevel",
+      "allow-unsafe",
+      "dry-run",
+      "reporters",
+      "test",
+      "spec",
+      "hints",
+      "auto-update",
+      "auto-screenshot",
+      "cache-dir",
+      "concurrent-runners",
+    ]);
   });
 
   it("returns [] for non-object args", function () {
@@ -1083,6 +1138,17 @@ describe("debug/provenance", function () {
     expect(none.docDetectiveConfigApplied).to.equal(false);
     expect(none.docDetectiveApiApplied).to.equal(false);
     expect(none.cliOverrides).to.deep.equal([]);
+  });
+
+  it("treats empty-string env vars as NOT applied (matches getConfigFromEnv)", function () {
+    // setConfig's env readers gate on `if (!process.env.*)`, so "" is unset.
+    const p = collectProvenance({
+      configPath: null,
+      args: {},
+      env: { DOC_DETECTIVE_CONFIG: "", DOC_DETECTIVE_API: "" },
+    });
+    expect(p.docDetectiveConfigApplied).to.equal(false);
+    expect(p.docDetectiveApiApplied).to.equal(false);
   });
 });
 
@@ -1186,7 +1252,10 @@ describe("debug/appium", function () {
       "appium-geckodriver",
     ]);
     for (const d of diag.drivers) {
-      expect(d).to.have.property("registered").that.is.a("boolean");
+      // registered is tri-state: true / false / null (manifest unread).
+      expect(d.registered === null || typeof d.registered === "boolean").to.equal(
+        true
+      );
       expect(d).to.have.property("npmResolvable").that.is.a("boolean");
     }
     expect(diag).to.have.property("registeredDrivers").that.is.an("array");
@@ -1270,9 +1339,10 @@ describe("debug/findings", function () {
       baseData({
         appium: {
           extensionsManifestPresent: false,
+          // Manifest unread → registration is null (unknown), not false.
           drivers: [
-            { name: "appium-geckodriver", registered: false, npmResolvable: true },
-            { name: "appium-chromium-driver", registered: false, npmResolvable: true },
+            { name: "appium-geckodriver", registered: null, npmResolvable: true },
+            { name: "appium-chromium-driver", registered: null, npmResolvable: true },
           ],
         },
       })
@@ -1331,7 +1401,7 @@ describe("debug/printDebug new sections end-to-end", function () {
     expect(text.indexOf("-- Findings / next steps ")).to.be.lessThan(
       text.indexOf("-- System ")
     );
-    // Provenance reflects the args we passed.
-    expect(text).to.match(/--dryRun → config\.dryRun/);
+    // Provenance reflects the args we passed (real CLI spelling).
+    expect(text).to.match(/--dry-run → config\.dryRun/);
   });
 });

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -1033,6 +1033,14 @@ describe("debug/network", function () {
   it("returns an empty list when no network vars are set", function () {
     expect(collectNetworkConfig({}).variables).to.deep.equal([]);
   });
+
+  it("ignores npm_config_* keys whose value is undefined", function () {
+    const out = collectNetworkConfig({
+      npm_config_registry: undefined,
+      npm_config_proxy: "http://p:8080",
+    });
+    expect(out.variables.map((v) => v.name)).to.deep.equal(["npm_config_proxy"]);
+  });
 });
 
 describe("debug/provenance", function () {


### PR DESCRIPTION
## What

Follow-up enhancements to the `doc-detective debug` diagnostic dump (introduced in #336). Adds six additive, read-only sections that target the install/cache complexity the dump exists to debug, plus an interpretation layer that turns the data into fix commands.

Each section is a typed `DebugData` field rendered through the existing `renderText()` → `Section[]` pipeline, so it also serializes into the `debug-<ts>.json` dump for free. Every collector is crash-proof (degrades to an `error`/`<unknown>` marker) and routes secret-bearing values through the existing `redactValue`/`redactObject` redaction layer.

### Sections

| # | Section | What it shows |
|---|---------|---------------|
| #2 | **Install status** | The installer's `status()` matrix — npm packages + browsers, installed vs expected vs `OUTDATED`, and the `installed.json` path. |
| #1 | **Cache & runtime** | Resolved `cacheDir` / `runtimeDir` / `browsersDir` / `installed.json` / `APPIUM_HOME` with exists, **writable**, and free-disk-space per location. |
| #6 | **Proxy / npm network** | Redacted `HTTP(S)_PROXY` / `NO_PROXY` + swept `npm_config_*` block — the #1 silent lazy-install failure mode. |
| #5 | **Config provenance** | Config file path, whether `DOC_DETECTIVE_CONFIG` / `DOC_DETECTIVE_API` applied, and which CLI flags overrode the validated config. |
| #4 | **Appium registration** | Reconciles npm-resolvable drivers against Appium's *registered* drivers (read from `extensions.yaml`): `registered` / `resolvable but not registered` / `missing`. |
| #3 | **Findings / next steps** | Pure rules over the collected `DebugData` that emit actionable fixes, rendered **first** as the support summary. |

## Why

The dump described the environment but stopped short of the two things that make install/cache bugs actually diagnosable: the resolved cache/runtime paths + install-status matrix the lazy installer works against, and an interpretation layer that says *what to do*. A user filing a bug can now paste one block that not only shows the state but flags the likely cause and the fix command (e.g. "Chrome unavailable → `doc-detective install runtime`"; "cacheDir not writable → set `DOC_DETECTIVE_CACHE_DIR`").

## Notes for reviewers

- **No schema changes** — this is all in `src/debug/*`. The `src/common` AJV schemas/types are untouched.
- **Config provenance keeps `setConfig` untouched.** Provenance is derived in the debug layer from inputs the command already has (configPath, `process.env`, parsed `args`), rather than threading new state out of `setConfig`. `args` is now passed into `printDebug` from all three call sites (the `debug` subcommand + both `DOC_DETECTIVE_DEBUG` paths in `cli.ts`).
- **Appium uses no subprocess.** The first revision spawned `appium driver list --installed`, but that command cold-loads Appium and does a network update-check (measured ~8.8s cold vs ~0.6s warm), so a bounded probe intermittently timed out and then mislabeled every registered driver as "not registered". It now reads `extensions.yaml` — Appium's own authoritative manifest, matched by `pkgName` — which is instant, offline, and deterministic. When the manifest is absent/unreadable, registration is reported as *unknown* rather than falsely "not registered", and the corresponding finding is suppressed.
- **Out of scope (own PRs):** the opt-in network-reachability probe (`--check-network`, #7) and browser-launch smoke test (`--probe-browser`, #8) — both have egress/process side effects.
- This is a `feat:`, so it will cut a **minor** release on merge.

## Testing

- `test/debug.test.js`: **71 passing**, 3 POSIX-only skips on Windows — covers each new collector/helper, the findings rules (including a regression test that a missing Appium manifest must not false-flag drivers), and an end-to-end section-presence + ordering check.
- Full main suite green except 7 pre-existing environmental failures (the documented port-8092 test-server collision in `core-screenshot` / `core-core` URL-fixture tests — unrelated to `src/debug`).
- Manually verified the live CLI: all sections render in order (Findings first), proxy/registry credentials are redacted (0 leaks), provenance reflects CLI overrides, and the Appium section runs in a steady ~770ms with drivers correctly shown as `registered`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced diagnostic output with comprehensive system, installation, cache, and network configuration details.
  * Added automated findings and recommendations based on diagnostic analysis to help troubleshoot common issues.
  * Improved debug dumps to include command-line argument provenance and configuration override tracking.

* **Tests**
  * Added comprehensive test coverage for new diagnostic modules and debug output functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->