### PR TITLE
fix(runner): skip run-folder creation when no artifacts are written

### DIFF
--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -21,6 +21,7 @@ import {
   rollUpResults,
   createAppiumPool,
   getRunOutputDir,
+  runArchivesArtifacts,
   sanitizeFilesystemName,
 } from "./utils.js";
 import axios from "axios";
@@ -571,7 +572,12 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   // reporter archives results beside any auto screenshots from the same run,
   // and so consumers can correlate results over time. Created after the
   // filter short-circuit above so a run that matched nothing leaves no folder.
-  const runDir = getRunOutputDir(config);
+  // Only create the folder when something will actually write into it (the
+  // runFolder reporter or autoScreenshot) — otherwise just resolve the path
+  // for the report stamp and leave no empty `.doc-detective/run-<id>/` behind.
+  const runDir = getRunOutputDir(config, {
+    create: runArchivesArtifacts(config),
+  });
   const runId = path.basename(runDir).replace(/^run-/, "");
   const report: any = {
     runId,

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -573,10 +573,13 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   // and so consumers can correlate results over time. Created after the
   // filter short-circuit above so a run that matched nothing leaves no folder.
   // Only create the folder when something will actually write into it (the
-  // runFolder reporter or autoScreenshot) — otherwise just resolve the path
-  // for the report stamp and leave no empty `.doc-detective/run-<id>/` behind.
+  // runFolder reporter, or autoScreenshot at any of config/spec/test level) —
+  // otherwise just resolve the path for the report stamp and leave no empty
+  // `.doc-detective/run-<id>/` behind. Pass the selected specs so per-spec/test
+  // autoScreenshot reserves the folder atomically up front rather than via the
+  // non-atomic memoized branch when the first screenshot fires.
   const runDir = getRunOutputDir(config, {
-    create: runArchivesArtifacts(config),
+    create: runArchivesArtifacts(config, specs),
   });
   const runId = path.basename(runDir).replace(/^run-/, "");
   const report: any = {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -695,7 +695,12 @@ function runArchivesArtifacts(config: any = {}, specs: any[] = []): boolean {
       .map((reporter) => reporter.trim())
       .filter((reporter) => reporter.length > 0);
     if (normalized.length > 0) {
-      return normalized.some((reporter) => reporter.toLowerCase() === "runfolder");
+      // Match both the `runFolder` shorthand and the internal
+      // `runFolderReporter` key, since outputResults honors either.
+      return normalized.some((reporter) => {
+        const name = reporter.toLowerCase();
+        return name === "runfolder" || name === "runfolderreporter";
+      });
     }
   }
   return true;

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -14,6 +14,7 @@ export {
   timestamp,
   getOrInitRunTimestamp,
   getRunOutputDir,
+  runOutputBaseDir,
   runArchivesArtifacts,
   replaceEnvs,
   spawnCommand,
@@ -587,34 +588,52 @@ function getOrInitRunTimestamp(config: any): string {
   return config.__runTimestamp;
 }
 
+// Resolve the directory the `.doc-detective/` run-artifact root sits under,
+// from a configured `output`. `output` is normally a directory, but reporters
+// also accept a file path (e.g. `results.json`), in which case the run folder
+// belongs *beside* the file, not inside it. An existing path is classified by
+// its real filesystem type; a not-yet-created path is treated as a file when
+// it carries an extension (e.g. `out/results.csv`) and as a directory
+// otherwise (e.g. `out/results`). Coerces defensively: a programmatic caller
+// could hand a non-string output (e.g. a PathLike).
+function runOutputBaseDir(output: any): string {
+  const base = String(output ?? ".") || ".";
+  try {
+    return fs.statSync(base).isDirectory() ? base : path.dirname(base);
+  } catch {
+    // Path doesn't exist yet — a trailing extension implies a file.
+    return path.extname(base) ? path.dirname(base) : base;
+  }
+}
+
 // Per-run artifact directory: `<output>/.doc-detective/run-<runId>/`, where
 // runId is the run timestamp — plus an ordinal suffix (`-2`, `-3`, …) on the
 // rare same-millisecond collision, so the effective runId stamped in the
 // report can carry that suffix. Memoized on the config object so auto
 // screenshots and the runFolder reporter all land in the same folder for the
-// duration of a run. If `config.output` points at a report file (reporters
-// accept `.json`/`.html` paths), the run folder is created next to it.
-// Creation is atomic (non-recursive mkdir, EEXIST → ordinal suffix) so two
-// runs starting in the same millisecond each get their own folder instead of
-// silently merging artifacts.
+// duration of a run. If `output` points at a file (see runOutputBaseDir), the
+// run folder is created next to it.
+//
+// When `create` is true, creation is atomic (non-recursive mkdir, EEXIST →
+// ordinal suffix) so two runs starting in the same millisecond each reserve
+// their own folder instead of silently merging artifacts. `create: false`
+// only resolves and memoizes the path without touching disk — used by runs
+// that won't write any artifacts (see runArchivesArtifacts / runSpecs). Any
+// run that *does* write reserves the folder atomically on its first call here,
+// so the non-atomic memoized branch below is never the one racing.
 function getRunOutputDir(
   config: any,
   { create = true }: { create?: boolean } = {}
 ): string {
   if (config?.__runOutputDir) {
-    // The path was decided on a prior call. If that call deferred creation
-    // (create: false) and this one writes, materialize the folder now.
+    // The path was decided (and, if a writer asked, atomically reserved) on a
+    // prior call. A recursive mkdir here is safe: either the folder already
+    // exists, or this is the first writer after a non-writing run deferred
+    // creation — in which case nothing else is racing this path.
     if (create) fs.mkdirSync(config.__runOutputDir, { recursive: true });
     return config.__runOutputDir;
   }
-  // Coerce defensively: a programmatic caller could hand us a non-string
-  // output (e.g. a PathLike), and the extension check / path ops below assume
-  // a string. Mirrors the String() coercion in runFolderReporter.
-  let base = String(config?.output || ".");
-  const reportFileExtensions = [".json", ".html", ".htm"];
-  if (reportFileExtensions.some((ext) => base.toLowerCase().endsWith(ext))) {
-    base = path.dirname(base);
-  }
+  const base = runOutputBaseDir(config?.output);
   const runsRoot = path.resolve(base, ".doc-detective");
   const runId = getOrInitRunTimestamp(config);
   let dir = path.join(runsRoot, `run-${runId}`);
@@ -648,12 +667,25 @@ function getRunOutputDir(
 // (`<output>/.doc-detective/run-<id>/`). The folder only holds runFolder
 // reporter archives and autoScreenshot images, so when neither is active the
 // runner skips creating it (see runSpecs) instead of leaving an empty folder
-// behind. An unset `reporters` falls back to the schema default
+// behind.
+//
+// autoScreenshot can be set globally on the config or per spec/test, so the
+// optional `specs` lets the runner account for the resolved test plan; the
+// test > spec > config precedence here mirrors resolveAutoScreenshot. Reporter
+// selection mirrors outputResults: only a *non-empty* `reporters` array is an
+// override — an empty or unset array falls back to the schema default
 // (`["terminal", "json", "runFolder"]`), which archives.
-function runArchivesArtifacts(config: any = {}): boolean {
+function runArchivesArtifacts(config: any = {}, specs: any[] = []): boolean {
   if (config?.autoScreenshot === true) return true;
+  for (const spec of specs ?? []) {
+    for (const test of spec?.tests ?? []) {
+      const resolved =
+        test?.autoScreenshot ?? spec?.autoScreenshot ?? config?.autoScreenshot;
+      if (resolved === true) return true;
+    }
+  }
   const reporters = config?.reporters;
-  if (Array.isArray(reporters)) {
+  if (Array.isArray(reporters) && reporters.length > 0) {
     return reporters.some(
       (reporter) =>
         typeof reporter === "string" && reporter.toLowerCase() === "runfolder"

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -14,6 +14,7 @@ export {
   timestamp,
   getOrInitRunTimestamp,
   getRunOutputDir,
+  runArchivesArtifacts,
   replaceEnvs,
   spawnCommand,
   inContainer,
@@ -596,8 +597,16 @@ function getOrInitRunTimestamp(config: any): string {
 // Creation is atomic (non-recursive mkdir, EEXIST → ordinal suffix) so two
 // runs starting in the same millisecond each get their own folder instead of
 // silently merging artifacts.
-function getRunOutputDir(config: any): string {
-  if (config?.__runOutputDir) return config.__runOutputDir;
+function getRunOutputDir(
+  config: any,
+  { create = true }: { create?: boolean } = {}
+): string {
+  if (config?.__runOutputDir) {
+    // The path was decided on a prior call. If that call deferred creation
+    // (create: false) and this one writes, materialize the folder now.
+    if (create) fs.mkdirSync(config.__runOutputDir, { recursive: true });
+    return config.__runOutputDir;
+  }
   // Coerce defensively: a programmatic caller could hand us a non-string
   // output (e.g. a PathLike), and the extension check / path ops below assume
   // a string. Mirrors the String() coercion in runFolderReporter.
@@ -607,24 +616,50 @@ function getRunOutputDir(config: any): string {
     base = path.dirname(base);
   }
   const runsRoot = path.resolve(base, ".doc-detective");
-  fs.mkdirSync(runsRoot, { recursive: true });
   const runId = getOrInitRunTimestamp(config);
   let dir = path.join(runsRoot, `run-${runId}`);
-  let suffix = 2;
-  // Non-recursive mkdir is the reservation: it throws EEXIST if another
-  // process already claimed the name, closing the check-then-create race an
-  // existsSync loop would leave open.
-  for (;;) {
-    try {
-      fs.mkdirSync(dir);
-      break;
-    } catch (error: any) {
-      if (error?.code !== "EEXIST") throw error;
-      dir = path.join(runsRoot, `run-${runId}-${suffix++}`);
+  // create: false just resolves and memoizes the path — no folder is left on
+  // disk. A run that neither archives results (runFolder reporter) nor writes
+  // auto screenshots has nothing to put here, so creating it would only leave
+  // an empty `.doc-detective/run-<id>/` behind. The eager-creation branch
+  // below still runs for the writers, and a later create:true call (via the
+  // memoized branch above) materializes the folder if a write does occur.
+  if (create) {
+    fs.mkdirSync(runsRoot, { recursive: true });
+    let suffix = 2;
+    // Non-recursive mkdir is the reservation: it throws EEXIST if another
+    // process already claimed the name, closing the check-then-create race an
+    // existsSync loop would leave open.
+    for (;;) {
+      try {
+        fs.mkdirSync(dir);
+        break;
+      } catch (error: any) {
+        if (error?.code !== "EEXIST") throw error;
+        dir = path.join(runsRoot, `run-${runId}-${suffix++}`);
+      }
     }
   }
   if (config) config.__runOutputDir = dir;
   return dir;
+}
+
+// Whether a run will write anything into its per-run artifact folder
+// (`<output>/.doc-detective/run-<id>/`). The folder only holds runFolder
+// reporter archives and autoScreenshot images, so when neither is active the
+// runner skips creating it (see runSpecs) instead of leaving an empty folder
+// behind. An unset `reporters` falls back to the schema default
+// (`["terminal", "json", "runFolder"]`), which archives.
+function runArchivesArtifacts(config: any = {}): boolean {
+  if (config?.autoScreenshot === true) return true;
+  const reporters = config?.reporters;
+  if (Array.isArray(reporters)) {
+    return reporters.some(
+      (reporter) =>
+        typeof reporter === "string" && reporter.toLowerCase() === "runfolder"
+    );
+  }
+  return true;
 }
 
 // Perform a native command in the current working directory.

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -657,20 +657,31 @@ function getRunOutputDir(
 // runner skips creating it (see runSpecs) instead of leaving an empty folder
 // behind.
 //
-// autoScreenshot can be set globally on the config or per spec/test, so the
-// optional `specs` lets the runner account for the resolved test plan; the
-// test > spec > config precedence here mirrors resolveAutoScreenshot. Reporter
-// selection mirrors outputResults: only a *non-empty* `reporters` array is an
-// override — an empty or unset array falls back to the schema default
-// (`["terminal", "json", "runFolder"]`), which archives.
+// autoScreenshot can be set globally on the config or per spec/test. When the
+// resolved `specs` are available, decide exactly as resolveAutoScreenshot does
+// — `Boolean(test ?? spec ?? config)`, test > spec > config — for *each*
+// selected test, so a per-test `false` that overrides a global `true` is
+// respected (no eager folder for a run where every test disables screenshots)
+// and a truthy non-boolean from an API caller still counts. Without specs
+// (programmatic/early callers), fall back to the global flag, Boolean-coerced.
+// Reporter selection mirrors outputResults: only a *non-empty* `reporters`
+// array is an override — an empty or unset array falls back to the schema
+// default (`["terminal", "json", "runFolder"]`), which archives.
 function runArchivesArtifacts(config: any = {}, specs: any[] = []): boolean {
-  if (config?.autoScreenshot === true) return true;
-  for (const spec of specs ?? []) {
-    for (const test of spec?.tests ?? []) {
-      const resolved =
-        test?.autoScreenshot ?? spec?.autoScreenshot ?? config?.autoScreenshot;
-      if (resolved === true) return true;
-    }
+  const list = Array.isArray(specs) ? specs : [];
+  if (list.length > 0) {
+    const writesScreenshot = list.some((spec: any) =>
+      (spec?.tests ?? []).some((test: any) =>
+        Boolean(
+          test?.autoScreenshot ??
+            spec?.autoScreenshot ??
+            config?.autoScreenshot
+        )
+      )
+    );
+    if (writesScreenshot) return true;
+  } else if (Boolean(config?.autoScreenshot)) {
+    return true;
   }
   const reporters = config?.reporters;
   if (Array.isArray(reporters)) {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -685,11 +685,19 @@ function runArchivesArtifacts(config: any = {}, specs: any[] = []): boolean {
     }
   }
   const reporters = config?.reporters;
-  if (Array.isArray(reporters) && reporters.length > 0) {
-    return reporters.some(
-      (reporter) =>
-        typeof reporter === "string" && reporter.toLowerCase() === "runfolder"
-    );
+  if (Array.isArray(reporters)) {
+    // Defense-in-depth: trim and drop empty entries before matching, so an
+    // env/CLI value that slipped past setConfig (e.g. [" runFolder ", ""])
+    // still resolves correctly. After normalizing, a non-empty list that
+    // omits runFolder is a genuine override; an empty (or all-blank) list
+    // falls through to the default set, which archives.
+    const normalized = reporters
+      .filter((reporter) => typeof reporter === "string")
+      .map((reporter) => reporter.trim())
+      .filter((reporter) => reporter.length > 0);
+    if (normalized.length > 0) {
+      return normalized.some((reporter) => reporter.toLowerCase() === "runfolder");
+    }
   }
   return true;
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -14,7 +14,6 @@ export {
   timestamp,
   getOrInitRunTimestamp,
   getRunOutputDir,
-  runOutputBaseDir,
   runArchivesArtifacts,
   replaceEnvs,
   spawnCommand,
@@ -588,31 +587,13 @@ function getOrInitRunTimestamp(config: any): string {
   return config.__runTimestamp;
 }
 
-// Resolve the directory the `.doc-detective/` run-artifact root sits under,
-// from a configured `output`. `output` is normally a directory, but reporters
-// also accept a file path (e.g. `results.json`), in which case the run folder
-// belongs *beside* the file, not inside it. An existing path is classified by
-// its real filesystem type; a not-yet-created path is treated as a file when
-// it carries an extension (e.g. `out/results.csv`) and as a directory
-// otherwise (e.g. `out/results`). Coerces defensively: a programmatic caller
-// could hand a non-string output (e.g. a PathLike).
-function runOutputBaseDir(output: any): string {
-  const base = String(output ?? ".") || ".";
-  try {
-    return fs.statSync(base).isDirectory() ? base : path.dirname(base);
-  } catch {
-    // Path doesn't exist yet — a trailing extension implies a file.
-    return path.extname(base) ? path.dirname(base) : base;
-  }
-}
-
 // Per-run artifact directory: `<output>/.doc-detective/run-<runId>/`, where
 // runId is the run timestamp — plus an ordinal suffix (`-2`, `-3`, …) on the
 // rare same-millisecond collision, so the effective runId stamped in the
 // report can carry that suffix. Memoized on the config object so auto
 // screenshots and the runFolder reporter all land in the same folder for the
-// duration of a run. If `output` points at a file (see runOutputBaseDir), the
-// run folder is created next to it.
+// duration of a run. If `config.output` points at a report file (reporters
+// accept `.json`/`.html` paths), the run folder is created next to it.
 //
 // When `create` is true, creation is atomic (non-recursive mkdir, EEXIST →
 // ordinal suffix) so two runs starting in the same millisecond each reserve
@@ -633,7 +614,14 @@ function getRunOutputDir(
     if (create) fs.mkdirSync(config.__runOutputDir, { recursive: true });
     return config.__runOutputDir;
   }
-  const base = runOutputBaseDir(config?.output);
+  // Coerce defensively: a programmatic caller could hand us a non-string
+  // output (e.g. a PathLike), and the extension check / path ops below assume
+  // a string. Mirrors the String() coercion in runFolderReporter.
+  let base = String(config?.output || ".");
+  const reportFileExtensions = [".json", ".html", ".htm"];
+  if (reportFileExtensions.some((ext) => base.toLowerCase().endsWith(ext))) {
+    base = path.dirname(base);
+  }
   const runsRoot = path.resolve(base, ".doc-detective");
   const runId = getOrInitRunTimestamp(config);
   let dir = path.join(runsRoot, `run-${runId}`);

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -664,9 +664,16 @@ function getRunOutputDir(
 // respected (no eager folder for a run where every test disables screenshots)
 // and a truthy non-boolean from an API caller still counts. Without specs
 // (programmatic/early callers), fall back to the global flag, Boolean-coerced.
-// Reporter selection mirrors outputResults: only a *non-empty* `reporters`
-// array is an override — an empty or unset array falls back to the schema
-// default (`["terminal", "json", "runFolder"]`), which archives.
+//
+// The reporter gate mirrors outputResults *exactly* so the gate never reserves
+// a folder the reporter won't write to (which would leave it empty). Like
+// outputResults: a non-empty `reporters` array is the override, otherwise the
+// default set (`["terminal", "json", "runFolder"]`) applies; tokens are matched
+// verbatim (no trimming — outputResults doesn't trim, so a padded `" runFolder "`
+// runs no reporter); the `runFolder` shorthand matches case-insensitively (its
+// switch lowercases) and the internal `runFolderReporter` key matches verbatim
+// (its default branch passes the token straight to the reporters map);
+// non-string (e.g. function) reporters are not the runFolder reporter.
 function runArchivesArtifacts(config: any = {}, specs: any[] = []): boolean {
   const list = Array.isArray(specs) ? specs : [];
   if (list.length > 0) {
@@ -683,27 +690,16 @@ function runArchivesArtifacts(config: any = {}, specs: any[] = []): boolean {
   } else if (Boolean(config?.autoScreenshot)) {
     return true;
   }
-  const reporters = config?.reporters;
-  if (Array.isArray(reporters)) {
-    // Defense-in-depth: trim and drop empty entries before matching, so an
-    // env/CLI value that slipped past setConfig (e.g. [" runFolder ", ""])
-    // still resolves correctly. After normalizing, a non-empty list that
-    // omits runFolder is a genuine override; an empty (or all-blank) list
-    // falls through to the default set, which archives.
-    const normalized = reporters
-      .filter((reporter) => typeof reporter === "string")
-      .map((reporter) => reporter.trim())
-      .filter((reporter) => reporter.length > 0);
-    if (normalized.length > 0) {
-      // Match both the `runFolder` shorthand and the internal
-      // `runFolderReporter` key, since outputResults honors either.
-      return normalized.some((reporter) => {
-        const name = reporter.toLowerCase();
-        return name === "runfolder" || name === "runfolderreporter";
-      });
-    }
-  }
-  return true;
+  const active =
+    Array.isArray(config?.reporters) && config.reporters.length > 0
+      ? config.reporters
+      : ["terminal", "json", "runFolder"];
+  return active.some(
+    (reporter: any) =>
+      typeof reporter === "string" &&
+      (reporter.toLowerCase() === "runfolder" ||
+        reporter === "runFolderReporter")
+  );
 }
 
 // Perform a native command in the current working directory.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 import { validate } from "./common/src/validate.js";
 import { resolvePaths, readFile } from "./core/index.js";
-import { getRunOutputDir } from "./core/utils.js";
+import { getRunOutputDir, runOutputBaseDir } from "./core/utils.js";
 import path from "node:path";
 import fs from "node:fs";
 import { spawn } from "node:child_process";
@@ -519,18 +519,10 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
     // path's `.doc-detective/` root. Results can originate outside the local
     // process (e.g. API runs), and a garbled or malicious runDir must not
     // redirect the write elsewhere. Otherwise derive a fresh run folder.
-    const expectedRunsRoot = (() => {
-      let base = outputPath || config.output || ".";
-      const reportFileExtensions = [".json", ".html", ".htm"];
-      if (
-        reportFileExtensions.some((ext) =>
-          String(base).toLowerCase().endsWith(ext)
-        )
-      ) {
-        base = path.dirname(base);
-      }
-      return path.resolve(base, ".doc-detective");
-    })();
+    const expectedRunsRoot = path.resolve(
+      runOutputBaseDir(outputPath || config.output || "."),
+      ".doc-detective"
+    );
     const stampedRunDir =
       typeof results?.runDir === "string" && results.runDir.length > 0
         ? path.resolve(results.runDir)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -444,25 +444,27 @@ async function setConfig({ configPath, args }: { configPath?: any; args: any }) 
 // the reporter also accepts a file path (e.g. `results.json`), in which case
 // the run folder belongs *beside* the file, not inside it.
 //
-// An existing path is authoritative — a real file (any extension) archives
-// beside it, a real directory (even a dotted one like `reports.v1`) archives
-// inside it. A not-yet-created path is ambiguous, so it mirrors
-// getRunOutputDir's report-extension allow-list rather than guessing from any
-// extension: this keeps the archive root from diverging from the stamped
-// runDir (a divergence would reject the stamp and break runId/runDir
-// correlation with autoScreenshots), and leaves a dotted directory name like
-// `reports.v1` classified as a directory. Scoped to the runFolder reporter —
-// the shared getRunOutputDir is unchanged, so autoScreenshot and report
-// stamping are unaffected.
+// A report-file extension (`.json`/`.html`/`.htm`) always resolves to the
+// parent, matching getRunOutputDir exactly — even for an existing directory
+// oddly named `reports.json` — so the archive root never diverges from the
+// stamped runDir (a divergence would reject the stamp and break runId/runDir
+// correlation with autoScreenshots). Any other path is then resolved by real
+// filesystem type: an existing file (any extension) archives beside it, an
+// existing or not-yet-created directory (including a dotted name like
+// `reports.v1`) archives inside it. Scoped to the runFolder reporter — the
+// shared getRunOutputDir is unchanged, so autoScreenshot and report stamping
+// are unaffected.
 function runFolderBaseDir(output: any): string {
   const base = String(output ?? ".") || ".";
+  const reportFileExtensions = [".json", ".html", ".htm"];
+  if (reportFileExtensions.some((ext) => base.toLowerCase().endsWith(ext))) {
+    return path.dirname(base);
+  }
   try {
     return fs.statSync(base).isDirectory() ? base : path.dirname(base);
   } catch {
-    const reportFileExtensions = [".json", ".html", ".htm"];
-    return reportFileExtensions.some((ext) => base.toLowerCase().endsWith(ext))
-      ? path.dirname(base)
-      : base;
+    // Not created yet — treat as a directory (matches getRunOutputDir).
+    return base;
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -448,7 +448,7 @@ async function setConfig({ configPath, args }: { configPath?: any; args: any }) 
 // parent, matching getRunOutputDir exactly — even for an existing directory
 // oddly named `reports.json` — so the archive root never diverges from the
 // stamped runDir (a divergence would reject the stamp and break runId/runDir
-// correlation with autoScreenshots). Any other path is then resolved by real
+// correlation with autoScreenshot). Any other path is then resolved by real
 // filesystem type: an existing file (any extension) archives beside it, an
 // existing or not-yet-created directory (including a dotted name like
 // `reports.v1`) archives inside it. Scoped to the runFolder reporter — the

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -441,21 +441,28 @@ async function setConfig({ configPath, args }: { configPath?: any; args: any }) 
 
 // Resolve the directory the runFolder reporter's `.doc-detective/` archive
 // root sits under, from its `output`. `output` is normally a directory, but
-// the reporter also accepts a file path (e.g. `results.json` or any other
-// file), in which case the run folder belongs *beside* the file, not inside
-// it. An existing path is classified by its real filesystem type; a
-// not-yet-created path is treated as a file when it carries an extension
-// (e.g. `out/results.csv`) and as a directory otherwise (e.g. `out/results`).
-// Scoped to the runFolder reporter — the shared getRunOutputDir keeps its own
-// (report-extension) handling so autoScreenshot and report stamping are
-// unaffected.
+// the reporter also accepts a file path (e.g. `results.json`), in which case
+// the run folder belongs *beside* the file, not inside it.
+//
+// An existing path is authoritative — a real file (any extension) archives
+// beside it, a real directory (even a dotted one like `reports.v1`) archives
+// inside it. A not-yet-created path is ambiguous, so it mirrors
+// getRunOutputDir's report-extension allow-list rather than guessing from any
+// extension: this keeps the archive root from diverging from the stamped
+// runDir (a divergence would reject the stamp and break runId/runDir
+// correlation with autoScreenshots), and leaves a dotted directory name like
+// `reports.v1` classified as a directory. Scoped to the runFolder reporter —
+// the shared getRunOutputDir is unchanged, so autoScreenshot and report
+// stamping are unaffected.
 function runFolderBaseDir(output: any): string {
   const base = String(output ?? ".") || ".";
   try {
     return fs.statSync(base).isDirectory() ? base : path.dirname(base);
   } catch {
-    // Path doesn't exist yet — a trailing extension implies a file.
-    return path.extname(base) ? path.dirname(base) : base;
+    const reportFileExtensions = [".json", ".html", ".htm"];
+    return reportFileExtensions.some((ext) => base.toLowerCase().endsWith(ext))
+      ? path.dirname(base)
+      : base;
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 import { validate } from "./common/src/validate.js";
 import { resolvePaths, readFile } from "./core/index.js";
-import { getRunOutputDir, runOutputBaseDir } from "./core/utils.js";
+import { getRunOutputDir } from "./core/utils.js";
 import path from "node:path";
 import fs from "node:fs";
 import { spawn } from "node:child_process";
@@ -439,6 +439,26 @@ async function setConfig({ configPath, args }: { configPath?: any; args: any }) 
   return config;
 }
 
+// Resolve the directory the runFolder reporter's `.doc-detective/` archive
+// root sits under, from its `output`. `output` is normally a directory, but
+// the reporter also accepts a file path (e.g. `results.json` or any other
+// file), in which case the run folder belongs *beside* the file, not inside
+// it. An existing path is classified by its real filesystem type; a
+// not-yet-created path is treated as a file when it carries an extension
+// (e.g. `out/results.csv`) and as a directory otherwise (e.g. `out/results`).
+// Scoped to the runFolder reporter — the shared getRunOutputDir keeps its own
+// (report-extension) handling so autoScreenshot and report stamping are
+// unaffected.
+function runFolderBaseDir(output: any): string {
+  const base = String(output ?? ".") || ".";
+  try {
+    return fs.statSync(base).isDirectory() ? base : path.dirname(base);
+  } catch {
+    // Path doesn't exist yet — a trailing extension implies a file.
+    return path.extname(base) ? path.dirname(base) : base;
+  }
+}
+
 // Internal reporters
 const reporters: Record<string, (config: any, outputPath: any, results: any, options: any) => Promise<any>> = {
   // HTML reporter: outputs results as a self-contained HTML file
@@ -519,10 +539,11 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
     // path's `.doc-detective/` root. Results can originate outside the local
     // process (e.g. API runs), and a garbled or malicious runDir must not
     // redirect the write elsewhere. Otherwise derive a fresh run folder.
-    const expectedRunsRoot = path.resolve(
-      runOutputBaseDir(outputPath || config.output || "."),
-      ".doc-detective"
-    );
+    // Resolve the output to a base directory once (file paths → parent), then
+    // both the confinement root and the fresh-folder fallback below derive
+    // from the same base, so a file-path output archives beside the file.
+    const baseDir = runFolderBaseDir(outputPath || config.output || ".");
+    const expectedRunsRoot = path.resolve(baseDir, ".doc-detective");
     const stampedRunDir =
       typeof results?.runDir === "string" && results.runDir.length > 0
         ? path.resolve(results.runDir)
@@ -546,9 +567,12 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
         useStampedRunDir = false;
       }
     }
+    // Pass the already-resolved directory so getRunOutputDir creates the run
+    // folder under it directly (it's a directory, so its report-extension
+    // handling is a no-op) — keeping the fallback consistent with baseDir.
     const runDir = useStampedRunDir
       ? stampedRunDir!
-      : getRunOutputDir({ output: outputPath || config.output || "." });
+      : getRunOutputDir({ output: baseDir });
     // When we reject the stamped runDir and write to a fresh folder, rewrite
     // runDir/runId in the archived JSON so the report describes the folder it
     // actually sits beside — otherwise consumers resolve `autoScreenshot`

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -115,27 +115,31 @@ describe("runArchivesArtifacts", function () {
     expect(runArchivesArtifacts({ reporters: [] })).to.equal(true);
   });
 
-  it("trims and drops empty reporter tokens before matching", function () {
-    // Defense-in-depth against an env/CLI value that bypassed setConfig.
-    expect(runArchivesArtifacts({ reporters: [" runFolder ", ""] })).to.equal(
-      true
-    );
-    // An all-blank list normalizes to empty → default fallback (archives).
-    expect(runArchivesArtifacts({ reporters: ["", "  "] })).to.equal(true);
-    // A non-empty list that omits runFolder after trimming is still an override.
-    expect(runArchivesArtifacts({ reporters: [" terminal ", ""] })).to.equal(
-      false
-    );
+  it("matches reporter tokens verbatim like outputResults (no trimming)", function () {
+    // outputResults matches tokens as-is, so a padded `" runFolder "` runs no
+    // reporter — the gate must agree, or it would reserve an empty folder.
+    expect(runArchivesArtifacts({ reporters: [" runFolder "] })).to.equal(false);
+    expect(runArchivesArtifacts({ reporters: ["runFolder"] })).to.equal(true);
+    // A non-empty list with only blank/non-matching tokens is still an
+    // override that excludes runFolder.
+    expect(runArchivesArtifacts({ reporters: ["", "  "] })).to.equal(false);
   });
 
-  it("recognizes the internal runFolderReporter key, not just the shorthand", function () {
-    // outputResults honors both names, so the gate must too.
+  it("does not treat a function reporter as the runFolder reporter", function () {
+    // outputResults runs function reporters as-is; none of them is the
+    // runFolder reporter, so a function-only override must not gate a folder.
+    expect(runArchivesArtifacts({ reporters: [() => {}] })).to.equal(false);
+  });
+
+  it("recognizes the internal runFolderReporter key verbatim, not just the shorthand", function () {
+    // outputResults resolves the exact `runFolderReporter` key via its default
+    // branch, but only verbatim — a padded or mis-cased variant runs nothing.
     expect(runArchivesArtifacts({ reporters: ["runFolderReporter"] })).to.equal(
       true
     );
     expect(
       runArchivesArtifacts({ reporters: ["terminal", " runFolderReporter "] })
-    ).to.equal(true);
+    ).to.equal(false);
   });
 
   it("is true when autoScreenshot is on even without the runFolder reporter", function () {

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -397,6 +397,27 @@ describe("runFolder reporter", function () {
     ).to.match(/^run-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z[\\/]/);
   });
 
+  it("keeps a report-extension output beside its parent even if it exists as a directory", async function () {
+    // A directory oddly named `reports.json` must resolve the same way
+    // getRunOutputDir does (strip the extension → parent), so the reporter's
+    // confinement root never diverges from the stamped runDir.
+    const dirOutput = path.join(tempBase, "reports.json");
+    fs.mkdirSync(dirOutput);
+    const written = await reporters.runFolderReporter(
+      {},
+      dirOutput,
+      { summary: {}, specs: [] },
+      { command: "runTests" }
+    );
+    // Archived beside `reports.json`, i.e. under <tempBase>/.doc-detective.
+    expect(
+      path.relative(path.resolve(tempBase, ".doc-detective"), written)
+    ).to.match(/^run-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z[\\/]/);
+    expect(
+      fs.existsSync(path.join(dirOutput, ".doc-detective"))
+    ).to.equal(false);
+  });
+
   it("treats a non-existent dotted output as a directory (matches getRunOutputDir)", async function () {
     // A not-yet-created path like `reports.v1` must stay a directory, so the
     // archive root agrees with the stamped runDir / autoScreenshot folder

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -1,8 +1,4 @@
-import {
-  getRunOutputDir,
-  runArchivesArtifacts,
-  runOutputBaseDir,
-} from "../dist/core/utils.js";
+import { getRunOutputDir, runArchivesArtifacts } from "../dist/core/utils.js";
 import { resolveTests, detectTests } from "../dist/core/index.js";
 import { generateSpecId } from "../dist/core/detectTests.js";
 import { resolveAutoScreenshot, runSpecs } from "../dist/core/tests.js";
@@ -65,16 +61,6 @@ describe("getRunOutputDir", function () {
     );
   });
 
-  it("creates the run folder next to any file-path output, not just reports", function () {
-    // Generalized file detection: a non-report extension is still a file, so
-    // the run folder belongs beside it, not inside it.
-    const config = { output: path.join(tempBase, "results.txt") };
-    const dir = getRunOutputDir(config);
-    expect(path.dirname(dir)).to.equal(
-      path.resolve(tempBase, ".doc-detective")
-    );
-  });
-
   it("coerces a non-string output instead of throwing", function () {
     // A programmatic caller could hand a PathLike; the extension check and
     // path ops assume a string, so it must be coerced defensively.
@@ -106,44 +92,6 @@ describe("getRunOutputDir", function () {
     const eager = getRunOutputDir(config);
     expect(eager).to.equal(lazy);
     expect(fs.existsSync(eager)).to.equal(true);
-  });
-});
-
-describe("runOutputBaseDir", function () {
-  let tempBase;
-
-  beforeEach(function () {
-    tempBase = fs.mkdtempSync(path.join(os.tmpdir(), "dd-base-dir-"));
-  });
-
-  afterEach(function () {
-    fs.rmSync(tempBase, { recursive: true, force: true });
-  });
-
-  it("returns an existing directory unchanged", function () {
-    expect(runOutputBaseDir(tempBase)).to.equal(tempBase);
-  });
-
-  it("returns the parent of an existing file", function () {
-    const file = path.join(tempBase, "results.log");
-    fs.writeFileSync(file, "x");
-    expect(runOutputBaseDir(file)).to.equal(tempBase);
-  });
-
-  it("treats a non-existent path with an extension as a file (uses parent)", function () {
-    // Generalizes beyond the old .json/.html/.htm allow-list.
-    const file = path.join(tempBase, "nested", "out.csv");
-    expect(runOutputBaseDir(file)).to.equal(path.join(tempBase, "nested"));
-  });
-
-  it("treats a non-existent extension-less path as a directory", function () {
-    const dir = path.join(tempBase, "nested", "results");
-    expect(runOutputBaseDir(dir)).to.equal(dir);
-  });
-
-  it("defaults to '.' for empty/undefined output", function () {
-    expect(runOutputBaseDir(undefined)).to.equal(".");
-    expect(runOutputBaseDir("")).to.equal(".");
   });
 });
 
@@ -384,6 +332,27 @@ describe("runFolder reporter", function () {
     expect(
       path.relative(path.resolve(tempBase, ".doc-detective"), written)
     ).to.match(/^run-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z[\\/]/);
+  });
+
+  it("archives beside a file-path output, not inside it (any extension)", async function () {
+    // The runFolder reporter accepts a file path — not just a directory — and
+    // not just report extensions. The archive belongs next to the file.
+    const fileOutput = path.join(tempBase, "results.log");
+    const written = await reporters.runFolderReporter(
+      {},
+      fileOutput,
+      { summary: {}, specs: [] },
+      { command: "runTests" }
+    );
+    // Written under <tempBase>/.doc-detective/, i.e. beside the file —
+    // never inside a `results.log/` directory.
+    expect(
+      path.relative(path.resolve(tempBase, ".doc-detective"), written)
+    ).to.match(/^run-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z[\\/]/);
+    expect(written).to.not.include(`results.log${path.sep}`);
+    expect(fs.existsSync(path.join(tempBase, "results.log", ".doc-detective"))).to.equal(
+      false
+    );
   });
 
   it("also writes an HTML report beside the JSON in the run folder", async function () {

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -1,4 +1,8 @@
-import { getRunOutputDir, runArchivesArtifacts } from "../dist/core/utils.js";
+import {
+  getRunOutputDir,
+  runArchivesArtifacts,
+  runOutputBaseDir,
+} from "../dist/core/utils.js";
 import { resolveTests, detectTests } from "../dist/core/index.js";
 import { generateSpecId } from "../dist/core/detectTests.js";
 import { resolveAutoScreenshot, runSpecs } from "../dist/core/tests.js";
@@ -61,6 +65,16 @@ describe("getRunOutputDir", function () {
     );
   });
 
+  it("creates the run folder next to any file-path output, not just reports", function () {
+    // Generalized file detection: a non-report extension is still a file, so
+    // the run folder belongs beside it, not inside it.
+    const config = { output: path.join(tempBase, "results.txt") };
+    const dir = getRunOutputDir(config);
+    expect(path.dirname(dir)).to.equal(
+      path.resolve(tempBase, ".doc-detective")
+    );
+  });
+
   it("coerces a non-string output instead of throwing", function () {
     // A programmatic caller could hand a PathLike; the extension check and
     // path ops assume a string, so it must be coerced defensively.
@@ -95,6 +109,44 @@ describe("getRunOutputDir", function () {
   });
 });
 
+describe("runOutputBaseDir", function () {
+  let tempBase;
+
+  beforeEach(function () {
+    tempBase = fs.mkdtempSync(path.join(os.tmpdir(), "dd-base-dir-"));
+  });
+
+  afterEach(function () {
+    fs.rmSync(tempBase, { recursive: true, force: true });
+  });
+
+  it("returns an existing directory unchanged", function () {
+    expect(runOutputBaseDir(tempBase)).to.equal(tempBase);
+  });
+
+  it("returns the parent of an existing file", function () {
+    const file = path.join(tempBase, "results.log");
+    fs.writeFileSync(file, "x");
+    expect(runOutputBaseDir(file)).to.equal(tempBase);
+  });
+
+  it("treats a non-existent path with an extension as a file (uses parent)", function () {
+    // Generalizes beyond the old .json/.html/.htm allow-list.
+    const file = path.join(tempBase, "nested", "out.csv");
+    expect(runOutputBaseDir(file)).to.equal(path.join(tempBase, "nested"));
+  });
+
+  it("treats a non-existent extension-less path as a directory", function () {
+    const dir = path.join(tempBase, "nested", "results");
+    expect(runOutputBaseDir(dir)).to.equal(dir);
+  });
+
+  it("defaults to '.' for empty/undefined output", function () {
+    expect(runOutputBaseDir(undefined)).to.equal(".");
+    expect(runOutputBaseDir("")).to.equal(".");
+  });
+});
+
 describe("runArchivesArtifacts", function () {
   it("is true when reporters include runFolder (case-insensitive)", function () {
     expect(runArchivesArtifacts({ reporters: ["terminal", "runFolder"] })).to.equal(
@@ -109,10 +161,40 @@ describe("runArchivesArtifacts", function () {
     ).to.equal(false);
   });
 
+  it("is true for an empty reporters array (mirrors the default fallback)", function () {
+    // outputResults falls back to the default reporter set (which includes
+    // runFolder) when reporters is empty, so this helper must agree.
+    expect(runArchivesArtifacts({ reporters: [] })).to.equal(true);
+  });
+
   it("is true when autoScreenshot is on even without the runFolder reporter", function () {
     expect(
       runArchivesArtifacts({ reporters: ["terminal"], autoScreenshot: true })
     ).to.equal(true);
+  });
+
+  it("is true when a spec enables autoScreenshot and runFolder is off", function () {
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal"] }, [
+        { autoScreenshot: true, tests: [{}] },
+      ])
+    ).to.equal(true);
+  });
+
+  it("is true when a test enables autoScreenshot and runFolder is off", function () {
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal"] }, [
+        { tests: [{ autoScreenshot: true }] },
+      ])
+    ).to.equal(true);
+  });
+
+  it("is false when no spec/test enables autoScreenshot and runFolder is off", function () {
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal"] }, [
+        { tests: [{ autoScreenshot: false }, {}] },
+      ])
+    ).to.equal(false);
   });
 
   it("is true when reporters are unset (the default set includes runFolder)", function () {
@@ -177,6 +259,20 @@ describe("runSpecs run-folder creation", function () {
     await runSpecs({
       resolvedTests: fixture({ reporters: ["terminal", "json", "runFolder"] }),
     });
+    const runsRoot = path.resolve(tempBase, ".doc-detective");
+    expect(fs.existsSync(runsRoot)).to.equal(true);
+    expect(
+      fs.readdirSync(runsRoot).some((name) => name.startsWith("run-"))
+    ).to.equal(true);
+  });
+
+  it("creates the run folder when a test enables autoScreenshot but runFolder is off", async function () {
+    // Per-spec/test autoScreenshot must still reserve the folder up front
+    // (atomic creation), even when global config.autoScreenshot is unset and
+    // the runFolder reporter is deselected.
+    const resolved = fixture({ reporters: ["terminal", "json"] });
+    resolved.specs[0].tests[0].autoScreenshot = true;
+    await runSpecs({ resolvedTests: resolved });
     const runsRoot = path.resolve(tempBase, ".doc-detective");
     expect(fs.existsSync(runsRoot)).to.equal(true);
     expect(

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -1,7 +1,8 @@
-import { getRunOutputDir } from "../dist/core/utils.js";
+import { getRunOutputDir, runArchivesArtifacts } from "../dist/core/utils.js";
 import { resolveTests, detectTests } from "../dist/core/index.js";
 import { generateSpecId } from "../dist/core/detectTests.js";
-import { resolveAutoScreenshot } from "../dist/core/tests.js";
+import { resolveAutoScreenshot, runSpecs } from "../dist/core/tests.js";
+import { getEnvironment } from "../dist/core/config.js";
 import { reporters } from "../dist/utils.js";
 import { buildHtml } from "../dist/reporters/htmlReporter.js";
 import path from "node:path";
@@ -69,6 +70,118 @@ describe("getRunOutputDir", function () {
       path.resolve(tempBase, ".doc-detective")
     );
     expect(fs.existsSync(dir)).to.equal(true);
+  });
+
+  it("returns the run folder path without creating it when create is false", function () {
+    const config = { output: tempBase };
+    const dir = getRunOutputDir(config, { create: false });
+    expect(path.dirname(dir)).to.equal(
+      path.resolve(tempBase, ".doc-detective")
+    );
+    expect(path.basename(dir)).to.match(RUN_ID_RE);
+    // No folder — not even the .doc-detective root — should touch disk.
+    expect(fs.existsSync(path.resolve(tempBase, ".doc-detective"))).to.equal(
+      false
+    );
+  });
+
+  it("creates the memoized folder when a later create:true call writes", function () {
+    const config = { output: tempBase };
+    const lazy = getRunOutputDir(config, { create: false });
+    expect(fs.existsSync(lazy)).to.equal(false);
+    const eager = getRunOutputDir(config);
+    expect(eager).to.equal(lazy);
+    expect(fs.existsSync(eager)).to.equal(true);
+  });
+});
+
+describe("runArchivesArtifacts", function () {
+  it("is true when reporters include runFolder (case-insensitive)", function () {
+    expect(runArchivesArtifacts({ reporters: ["terminal", "runFolder"] })).to.equal(
+      true
+    );
+    expect(runArchivesArtifacts({ reporters: ["RUNFOLDER"] })).to.equal(true);
+  });
+
+  it("is false when reporters are set but exclude runFolder", function () {
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal", "json", "html"] })
+    ).to.equal(false);
+  });
+
+  it("is true when autoScreenshot is on even without the runFolder reporter", function () {
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal"], autoScreenshot: true })
+    ).to.equal(true);
+  });
+
+  it("is true when reporters are unset (the default set includes runFolder)", function () {
+    expect(runArchivesArtifacts({})).to.equal(true);
+    expect(runArchivesArtifacts()).to.equal(true);
+  });
+});
+
+describe("runSpecs run-folder creation", function () {
+  this.timeout(120000);
+  let tempBase;
+
+  beforeEach(function () {
+    tempBase = fs.mkdtempSync(path.join(os.tmpdir(), "dd-run-create-"));
+  });
+
+  afterEach(function () {
+    fs.rmSync(tempBase, { recursive: true, force: true });
+  });
+
+  // One spec / test / context with a single non-driver step so no browser or
+  // Appium server is needed.
+  function fixture(extraConfig = {}) {
+    return {
+      config: {
+        logLevel: "silent",
+        telemetry: { send: false },
+        environment: getEnvironment(),
+        concurrentRunners: 1,
+        output: tempBase,
+        ...extraConfig,
+      },
+      specs: [
+        {
+          specId: "spec-1",
+          tests: [
+            {
+              testId: "spec-1-test-1",
+              contexts: [
+                {
+                  contextId: "spec-1-test-1-context-1",
+                  steps: [{ stepId: "s1", runShell: "echo hi" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  it("does not create a run folder when the runFolder reporter is deselected", async function () {
+    await runSpecs({
+      resolvedTests: fixture({ reporters: ["terminal", "json"] }),
+    });
+    expect(fs.existsSync(path.resolve(tempBase, ".doc-detective"))).to.equal(
+      false
+    );
+  });
+
+  it("creates a run folder when the runFolder reporter is active", async function () {
+    await runSpecs({
+      resolvedTests: fixture({ reporters: ["terminal", "json", "runFolder"] }),
+    });
+    const runsRoot = path.resolve(tempBase, ".doc-detective");
+    expect(fs.existsSync(runsRoot)).to.equal(true);
+    expect(
+      fs.readdirSync(runsRoot).some((name) => name.startsWith("run-"))
+    ).to.equal(true);
   });
 });
 

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -167,6 +167,19 @@ describe("runArchivesArtifacts", function () {
     expect(runArchivesArtifacts({ reporters: [] })).to.equal(true);
   });
 
+  it("trims and drops empty reporter tokens before matching", function () {
+    // Defense-in-depth against an env/CLI value that bypassed setConfig.
+    expect(runArchivesArtifacts({ reporters: [" runFolder ", ""] })).to.equal(
+      true
+    );
+    // An all-blank list normalizes to empty → default fallback (archives).
+    expect(runArchivesArtifacts({ reporters: ["", "  "] })).to.equal(true);
+    // A non-empty list that omits runFolder after trimming is still an override.
+    expect(runArchivesArtifacts({ reporters: [" terminal ", ""] })).to.equal(
+      false
+    );
+  });
+
   it("is true when autoScreenshot is on even without the runFolder reporter", function () {
     expect(
       runArchivesArtifacts({ reporters: ["terminal"], autoScreenshot: true })

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -150,6 +150,28 @@ describe("runArchivesArtifacts", function () {
     ).to.equal(true);
   });
 
+  it("respects a test-level autoScreenshot:false override of a global true", function () {
+    // resolveAutoScreenshot is test > spec > config, so a per-test false
+    // disables screenshots even when config.autoScreenshot is true — the run
+    // writes nothing, so it must not eagerly create the folder.
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal"], autoScreenshot: true }, [
+        { tests: [{ autoScreenshot: false }] },
+      ])
+    ).to.equal(false);
+  });
+
+  it("Boolean-coerces a truthy non-boolean autoScreenshot (API callers)", function () {
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal"], autoScreenshot: "true" })
+    ).to.equal(true);
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal"] }, [
+        { tests: [{ autoScreenshot: "yes" }] },
+      ])
+    ).to.equal(true);
+  });
+
   it("is false when no spec/test enables autoScreenshot and runFolder is off", function () {
     expect(
       runArchivesArtifacts({ reporters: ["terminal"] }, [
@@ -225,6 +247,20 @@ describe("runSpecs run-folder creation", function () {
     expect(
       fs.readdirSync(runsRoot).some((name) => name.startsWith("run-"))
     ).to.equal(true);
+  });
+
+  it("does not create a run folder when a test disables autoScreenshot despite a global true", async function () {
+    // config.autoScreenshot:true but the only test overrides to false → no
+    // screenshots fire, and with runFolder off nothing should be archived.
+    const resolved = fixture({
+      reporters: ["terminal", "json"],
+      autoScreenshot: true,
+    });
+    resolved.specs[0].tests[0].autoScreenshot = false;
+    await runSpecs({ resolvedTests: resolved });
+    expect(fs.existsSync(path.resolve(tempBase, ".doc-detective"))).to.equal(
+      false
+    );
   });
 
   it("creates the run folder when a test enables autoScreenshot but runFolder is off", async function () {

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -128,6 +128,16 @@ describe("runArchivesArtifacts", function () {
     );
   });
 
+  it("recognizes the internal runFolderReporter key, not just the shorthand", function () {
+    // outputResults honors both names, so the gate must too.
+    expect(runArchivesArtifacts({ reporters: ["runFolderReporter"] })).to.equal(
+      true
+    );
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal", " runFolderReporter "] })
+    ).to.equal(true);
+  });
+
   it("is true when autoScreenshot is on even without the runFolder reporter", function () {
     expect(
       runArchivesArtifacts({ reporters: ["terminal"], autoScreenshot: true })
@@ -370,25 +380,37 @@ describe("runFolder reporter", function () {
     ).to.match(/^run-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z[\\/]/);
   });
 
-  it("archives beside a file-path output, not inside it (any extension)", async function () {
+  it("archives beside an existing file-path output, not inside it (any extension)", async function () {
     // The runFolder reporter accepts a file path — not just a directory — and
-    // not just report extensions. The archive belongs next to the file.
+    // an existing file of any extension archives next to it, not inside a
+    // directory named after it.
     const fileOutput = path.join(tempBase, "results.log");
+    fs.writeFileSync(fileOutput, "x");
     const written = await reporters.runFolderReporter(
       {},
       fileOutput,
       { summary: {}, specs: [] },
       { command: "runTests" }
     );
-    // Written under <tempBase>/.doc-detective/, i.e. beside the file —
-    // never inside a `results.log/` directory.
     expect(
       path.relative(path.resolve(tempBase, ".doc-detective"), written)
     ).to.match(/^run-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z[\\/]/);
-    expect(written).to.not.include(`results.log${path.sep}`);
-    expect(fs.existsSync(path.join(tempBase, "results.log", ".doc-detective"))).to.equal(
-      false
+  });
+
+  it("treats a non-existent dotted output as a directory (matches getRunOutputDir)", async function () {
+    // A not-yet-created path like `reports.v1` must stay a directory, so the
+    // archive root agrees with the stamped runDir / autoScreenshot folder
+    // instead of diverging to the parent.
+    const dirOutput = path.join(tempBase, "reports.v1");
+    const written = await reporters.runFolderReporter(
+      {},
+      dirOutput,
+      { summary: {}, specs: [] },
+      { command: "runTests" }
     );
+    expect(
+      path.relative(path.resolve(dirOutput, ".doc-detective"), written)
+    ).to.match(/^run-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z[\\/]/);
   });
 
   it("also writes an HTML report beside the JSON in the run folder", async function () {


### PR DESCRIPTION
## What

`runSpecs` called `getRunOutputDir(config)` unconditionally, which eagerly created `<output>/.doc-detective/run-<timestamp>/` on **every** run — even when the `runFolder` reporter was deselected and `autoScreenshot` was off. Nothing ever wrote into that folder, so each such run left an empty scratch directory behind.

This gates folder creation on whether the run will actually write artifacts there.

## Changes

- **`runArchivesArtifacts(config)`** — new pure helper in `src/core/utils.ts`. Returns `true` only when the run will write into the per-run folder: `autoScreenshot` is on, or `reporters` includes `runFolder` (case-insensitive). An unset `reporters` falls back to the schema default (`["terminal","json","runFolder"]`), which archives — so default-config runs are unchanged.
- **`getRunOutputDir(config, { create })`** — added a `create` option. With `create: false` it resolves and memoizes the path without touching disk (not even the `.doc-detective` root). Writers (autoScreenshot, `runFolderReporter`) still call it with the default `create: true`; the memoized branch materializes the folder if a write happens after a deferred call. The atomic same-millisecond reservation loop is preserved on the creating path.
- **`runSpecs`** now calls `getRunOutputDir(config, { create: runArchivesArtifacts(config) })`. The report still gets `runId`/`runDir` stamped for correlation; the folder just isn't created when nothing will write to it.

## Why

Removing the `runFolder` reporter (or running with a reporter set that excludes it) should not litter the output tree with empty `.doc-detective/run-*/` folders. Default behavior — and the runFolder/autoScreenshot archive paths — are unchanged.

## Testing

Red → green TDD. New tests in `test/run-artifacts.test.js`:

- `getRunOutputDir` with `create: false` returns the path but leaves no folder on disk; a later `create: true` call materializes the memoized folder.
- `runArchivesArtifacts` — runFolder present/absent, case-insensitivity, `autoScreenshot` override, unset-reporters default.
- `runSpecs` integration — **no** `.doc-detective` folder when `runFolder` is deselected; folder **is** created when it's active.

All run-artifacts tests pass, plus the related concurrency / htmlReporter / dryRun / utils / hints suites stay green.

## Note for reviewers

`runId`/`runDir` are still stamped on the report even when the folder isn't created (they document where artifacts *would* go, and existing consumers/tests expect the fields present). Happy to omit them in the non-archiving case instead if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Run output directories are now created only when artifacts are expected to be written, preventing empty `run-*` folders after early exits.
  * Artifact archiving is now gated by `autoScreenshot` and reporter selection, including consistent precedence across config, reporter tokens, and per-spec/test overrides.
  * The run folder reporter now uses improved output-base handling to place archives under the correct runs root for reused or stamped run directories.
* **Tests**
  * Expanded coverage for conditional run-folder creation, archive-gating logic, case/whitespace matching behavior, and output-base path classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->