### PR TITLE
feat(record): autoRecord + multiple overlapping recordings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,26 @@ Always use **red → green** test-driven development. For every behavior change:
 
 Don't write implementation code before the failing test exists, and don't batch many changes behind a single test. The ["TDD cycle per flag"](#tdd-cycle-per-flag) section below shows the canonical red→green sequence applied to a new CLI flag.
 
+## Feature fixtures (required)
+
+Unit tests are necessary but not sufficient. When you add or change a **user-facing feature** (a new step type, action option, config/CLI flag, engine, output format, etc.), also author **Doc Detective fixtures** that exercise the feature end-to-end through the real runner — and cover **every permutation** of it, not just the happy path.
+
+"Every permutation" means each meaningfully distinct shape the feature can take, for example:
+
+- Each value form a field accepts (boolean / string / object), including the disabling/no-op form (`false`).
+- Each enumerated option (every engine, target, format, mode).
+- Each precedence level (config vs. spec vs. test overrides).
+- The interaction with related features (overlap, fallback, conflict, skip paths).
+- The graceful-degradation / guard paths (unsupported platform, headless, missing dependency).
+
+Fixtures live in [test/core-artifacts/](test/core-artifacts) as `*.spec.json` files and run inside the single combined `runTests()` pass driven by [test/core-core.test.js](test/core-core.test.js), which asserts no spec **fails**. So every fixture must resolve to **PASS** or **SKIPPED** (never FAIL):
+
+- Gate display/engine-specific permutations with `runOn` (platforms + headed/headless) so each runs only where it can succeed, and lands as `SKIPPED` elsewhere. Recording fixtures are the worked example: ffmpeg permutations run on Windows/macOS/Linux headed; browser-engine permutations only on headed Chrome (Windows/macOS).
+- Permutations that are *meant* to be skipped or guarded (headless skip, name conflict, `record: false`) belong in fixtures too — assert the SKIPPED behavior, don't omit it.
+- When a behavior needs a precise assertion the "no spec fails" gate can't express (e.g. a preflight that must skip a test for a specific reason), add a focused `it(...)` in `test/core-core.test.js` alongside the fixture.
+
+See [test/core-artifacts/recording.spec.json](test/core-artifacts/recording.spec.json), [recording-permutations.spec.json](test/core-artifacts/recording-permutations.spec.json), and [autorecord.spec.json](test/core-artifacts/autorecord.spec.json) for the canonical pattern (one spec per feature; one test per permutation; `runOn`-gated; PASS/SKIPPED only).
+
 ## Commit messages (required)
 
 All commits must follow [Conventional Commits](https://www.conventionalcommits.org/). This is enforced locally by a husky `commit-msg` hook and on PRs by [.github/workflows/commitlint.yml](.github/workflows/commitlint.yml). Non-conforming commits are rejected.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Unit tests are necessary but not sufficient. When you add or change a **user-fac
 
 "Every permutation" means each meaningfully distinct shape the feature can take, for example:
 
-- Each value form a field accepts (boolean / string / object), including the disabling/no-op form (`false`).
+- Each shape a field's value can take (boolean / string / object), including the disabling / no-op form (`false`).
 - Each enumerated option (every engine, target, format, mode).
 - Each precedence level (config vs. spec vs. test overrides).
 - The interaction with related features (overlap, fallback, conflict, skip paths).

--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -7453,7 +7453,7 @@
                                                   {
                                                     "type": "boolean",
                                                     "title": "stopRecord (boolean)",
-                                                    "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                                    "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                                                   },
                                                   {
                                                     "type": "null",
@@ -16553,7 +16553,7 @@
                                     {
                                       "type": "boolean",
                                       "title": "stopRecord (boolean)",
-                                      "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                      "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                                     },
                                     {
                                       "type": "null",

--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -7102,6 +7102,14 @@
                                                           "false"
                                                         ]
                                                       },
+                                                      "name": {
+                                                        "type": "string",
+                                                        "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                        "pattern": "\\S",
+                                                        "transform": [
+                                                          "trim"
+                                                        ]
+                                                      },
                                                       "engine": {
                                                         "title": "Recording engine",
                                                         "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -7195,6 +7203,14 @@
                                                           "enum": [
                                                             "true",
                                                             "false"
+                                                          ]
+                                                        },
+                                                        "name": {
+                                                          "type": "string",
+                                                          "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                          "pattern": "\\S",
+                                                          "transform": [
+                                                            "trim"
                                                           ]
                                                         },
                                                         "engine": {
@@ -7432,13 +7448,52 @@
                                               "stopRecord": {
                                                 "$schema": "http://json-schema.org/draft-07/schema#",
                                                 "title": "stopRecord",
-                                                "description": "Stop the current recording.",
-                                                "type": [
-                                                  "boolean",
-                                                  "null"
+                                                "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+                                                "anyOf": [
+                                                  {
+                                                    "type": "boolean",
+                                                    "title": "stopRecord (boolean)",
+                                                    "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                                  },
+                                                  {
+                                                    "type": "null",
+                                                    "title": "stopRecord (null)",
+                                                    "description": "Stops the most recently started active recording (LIFO)."
+                                                  },
+                                                  {
+                                                    "type": "string",
+                                                    "title": "stopRecord (name)",
+                                                    "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                                    "pattern": "\\S",
+                                                    "transform": [
+                                                      "trim"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "title": "stopRecord (detailed)",
+                                                    "additionalProperties": false,
+                                                    "required": [
+                                                      "name"
+                                                    ],
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string",
+                                                        "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                                        "pattern": "\\S",
+                                                        "transform": [
+                                                          "trim"
+                                                        ]
+                                                      }
+                                                    }
+                                                  }
                                                 ],
                                                 "examples": [
-                                                  true
+                                                  true,
+                                                  "demo",
+                                                  {
+                                                    "name": "demo"
+                                                  }
                                                 ]
                                               }
                                             },
@@ -9732,6 +9787,11 @@
     },
     "autoScreenshot": {
       "description": "If `true`, captures a screenshot after every step that runs in a browser, in addition to any explicit `screenshot` steps. Images are saved in the per-run artifact directory (`<output>/.doc-detective/run-<runId>/`) at paths derived from spec, test, and context IDs plus the step's order, action, and ID (for example, `screenshots/<specId>/<testId>/<contextId>/01-goTo-s4f2a91c.png`), so the same step lands on the same relative path in every run's folder for run-over-run comparison. Specs and tests can override this value with their own `autoScreenshot` fields (test level wins over spec level, which wins over config level). Equivalent to `--auto-screenshot` on the CLI.",
+      "type": "boolean",
+      "default": false
+    },
+    "autoRecord": {
+      "description": "If `true`, records a video of every test context that runs in a browser, in addition to any explicit `record` steps. The recording wraps the whole context (it starts before the first step and stops after the last) and always uses the `ffmpeg` engine. Videos are saved in the per-run artifact directory (`<output>/.doc-detective/run-<runId>/`) at paths derived from spec, test, and context IDs (for example, `recordings/<specId>/<testId>/<contextId>.mp4`), so the same context lands on the same relative path in every run's folder for run-over-run comparison. Specs and tests can override this value with their own `autoRecord` fields (test level wins over spec level, which wins over config level). Equivalent to `--auto-record` on the CLI.",
       "type": "boolean",
       "default": false
     },
@@ -16142,6 +16202,14 @@
                                             "false"
                                           ]
                                         },
+                                        "name": {
+                                          "type": "string",
+                                          "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                          "pattern": "\\S",
+                                          "transform": [
+                                            "trim"
+                                          ]
+                                        },
                                         "engine": {
                                           "title": "Recording engine",
                                           "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -16235,6 +16303,14 @@
                                             "enum": [
                                               "true",
                                               "false"
+                                            ]
+                                          },
+                                          "name": {
+                                            "type": "string",
+                                            "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                            "pattern": "\\S",
+                                            "transform": [
+                                              "trim"
                                             ]
                                           },
                                           "engine": {
@@ -16472,13 +16548,52 @@
                                 "stopRecord": {
                                   "$schema": "http://json-schema.org/draft-07/schema#",
                                   "title": "stopRecord",
-                                  "description": "Stop the current recording.",
-                                  "type": [
-                                    "boolean",
-                                    "null"
+                                  "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean",
+                                      "title": "stopRecord (boolean)",
+                                      "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                    },
+                                    {
+                                      "type": "null",
+                                      "title": "stopRecord (null)",
+                                      "description": "Stops the most recently started active recording (LIFO)."
+                                    },
+                                    {
+                                      "type": "string",
+                                      "title": "stopRecord (name)",
+                                      "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                      "pattern": "\\S",
+                                      "transform": [
+                                        "trim"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "title": "stopRecord (detailed)",
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                          "pattern": "\\S",
+                                          "transform": [
+                                            "trim"
+                                          ]
+                                        }
+                                      }
+                                    }
                                   ],
                                   "examples": [
-                                    true
+                                    true,
+                                    "demo",
+                                    {
+                                      "name": "demo"
+                                    }
                                   ]
                                 }
                               },

--- a/src/common/src/schemas/output_schemas/record_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/record_v3.schema.json
@@ -38,6 +38,14 @@
             "false"
           ]
         },
+        "name": {
+          "type": "string",
+          "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+          "pattern": "\\S",
+          "transform": [
+            "trim"
+          ]
+        },
         "engine": {
           "title": "Recording engine",
           "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -131,6 +139,14 @@
             "enum": [
               "true",
               "false"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+            "pattern": "\\S",
+            "transform": [
+              "trim"
             ]
           },
           "engine": {

--- a/src/common/src/schemas/output_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/report_v3.schema.json
@@ -625,6 +625,10 @@
                 "type": "boolean",
                 "description": "If `true`, captures a screenshot after every step in this spec's tests that runs in a browser. Overrides the config-level `autoScreenshot`; individual tests can override this value with their own `autoScreenshot`. When unset, defers to the config level."
               },
+              "autoRecord": {
+                "type": "boolean",
+                "description": "If `true`, records a video of every browser context in this spec's tests. Overrides the config-level `autoRecord`; individual tests can override this value with their own `autoRecord`. When unset, defers to the config level."
+              },
               "tests": {
                 "description": "[Tests](test) to perform.",
                 "type": "array",
@@ -657,6 +661,10 @@
                         "autoScreenshot": {
                           "type": "boolean",
                           "description": "If `true`, captures a screenshot after every step in this test that runs in a browser. Overrides `autoScreenshot` set at the spec or config level. When unset, defers to the spec level, then the config level."
+                        },
+                        "autoRecord": {
+                          "type": "boolean",
+                          "description": "If `true`, records a video of every browser context in this test. Overrides `autoRecord` set at the spec or config level. When unset, defers to the spec level, then the config level."
                         },
                         "runOn": {
                           "type": "array",
@@ -7514,6 +7522,14 @@
                                                   "false"
                                                 ]
                                               },
+                                              "name": {
+                                                "type": "string",
+                                                "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                "pattern": "\\S",
+                                                "transform": [
+                                                  "trim"
+                                                ]
+                                              },
                                               "engine": {
                                                 "title": "Recording engine",
                                                 "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -7607,6 +7623,14 @@
                                                   "enum": [
                                                     "true",
                                                     "false"
+                                                  ]
+                                                },
+                                                "name": {
+                                                  "type": "string",
+                                                  "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                  "pattern": "\\S",
+                                                  "transform": [
+                                                    "trim"
                                                   ]
                                                 },
                                                 "engine": {
@@ -7844,13 +7868,52 @@
                                       "stopRecord": {
                                         "$schema": "http://json-schema.org/draft-07/schema#",
                                         "title": "stopRecord",
-                                        "description": "Stop the current recording.",
-                                        "type": [
-                                          "boolean",
-                                          "null"
+                                        "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+                                        "anyOf": [
+                                          {
+                                            "type": "boolean",
+                                            "title": "stopRecord (boolean)",
+                                            "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                          },
+                                          {
+                                            "type": "null",
+                                            "title": "stopRecord (null)",
+                                            "description": "Stops the most recently started active recording (LIFO)."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "title": "stopRecord (name)",
+                                            "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                            "pattern": "\\S",
+                                            "transform": [
+                                              "trim"
+                                            ]
+                                          },
+                                          {
+                                            "type": "object",
+                                            "title": "stopRecord (detailed)",
+                                            "additionalProperties": false,
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "properties": {
+                                              "name": {
+                                                "type": "string",
+                                                "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                                "pattern": "\\S",
+                                                "transform": [
+                                                  "trim"
+                                                ]
+                                              }
+                                            }
+                                          }
                                         ],
                                         "examples": [
-                                          true
+                                          true,
+                                          "demo",
+                                          {
+                                            "name": "demo"
+                                          }
                                         ]
                                       }
                                     },
@@ -15988,6 +16051,14 @@
                                                         "false"
                                                       ]
                                                     },
+                                                    "name": {
+                                                      "type": "string",
+                                                      "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                      "pattern": "\\S",
+                                                      "transform": [
+                                                        "trim"
+                                                      ]
+                                                    },
                                                     "engine": {
                                                       "title": "Recording engine",
                                                       "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -16081,6 +16152,14 @@
                                                         "enum": [
                                                           "true",
                                                           "false"
+                                                        ]
+                                                      },
+                                                      "name": {
+                                                        "type": "string",
+                                                        "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                        "pattern": "\\S",
+                                                        "transform": [
+                                                          "trim"
                                                         ]
                                                       },
                                                       "engine": {
@@ -16318,13 +16397,52 @@
                                             "stopRecord": {
                                               "$schema": "http://json-schema.org/draft-07/schema#",
                                               "title": "stopRecord",
-                                              "description": "Stop the current recording.",
-                                              "type": [
-                                                "boolean",
-                                                "null"
+                                              "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+                                              "anyOf": [
+                                                {
+                                                  "type": "boolean",
+                                                  "title": "stopRecord (boolean)",
+                                                  "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                                },
+                                                {
+                                                  "type": "null",
+                                                  "title": "stopRecord (null)",
+                                                  "description": "Stops the most recently started active recording (LIFO)."
+                                                },
+                                                {
+                                                  "type": "string",
+                                                  "title": "stopRecord (name)",
+                                                  "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                                  "pattern": "\\S",
+                                                  "transform": [
+                                                    "trim"
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "title": "stopRecord (detailed)",
+                                                  "additionalProperties": false,
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string",
+                                                      "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                                      "pattern": "\\S",
+                                                      "transform": [
+                                                        "trim"
+                                                      ]
+                                                    }
+                                                  }
+                                                }
                                               ],
                                               "examples": [
-                                                true
+                                                true,
+                                                "demo",
+                                                {
+                                                  "name": "demo"
+                                                }
                                               ]
                                             }
                                           },

--- a/src/common/src/schemas/output_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/report_v3.schema.json
@@ -7873,7 +7873,7 @@
                                           {
                                             "type": "boolean",
                                             "title": "stopRecord (boolean)",
-                                            "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                            "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                                           },
                                           {
                                             "type": "null",
@@ -16402,7 +16402,7 @@
                                                 {
                                                   "type": "boolean",
                                                   "title": "stopRecord (boolean)",
-                                                  "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                                  "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                                                 },
                                                 {
                                                   "type": "null",

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -7466,7 +7466,7 @@
                                                       {
                                                         "type": "boolean",
                                                         "title": "stopRecord (boolean)",
-                                                        "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                                        "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                                                       },
                                                       {
                                                         "type": "null",
@@ -16566,7 +16566,7 @@
                                         {
                                           "type": "boolean",
                                           "title": "stopRecord (boolean)",
-                                          "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                          "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                                         },
                                         {
                                           "type": "null",
@@ -26344,7 +26344,7 @@
                                           {
                                             "type": "boolean",
                                             "title": "stopRecord (boolean)",
-                                            "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                            "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                                           },
                                           {
                                             "type": "null",
@@ -34873,7 +34873,7 @@
                                                 {
                                                   "type": "boolean",
                                                   "title": "stopRecord (boolean)",
-                                                  "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                                  "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                                                 },
                                                 {
                                                   "type": "null",

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -7115,6 +7115,14 @@
                                                               "false"
                                                             ]
                                                           },
+                                                          "name": {
+                                                            "type": "string",
+                                                            "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                            "pattern": "\\S",
+                                                            "transform": [
+                                                              "trim"
+                                                            ]
+                                                          },
                                                           "engine": {
                                                             "title": "Recording engine",
                                                             "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -7208,6 +7216,14 @@
                                                               "enum": [
                                                                 "true",
                                                                 "false"
+                                                              ]
+                                                            },
+                                                            "name": {
+                                                              "type": "string",
+                                                              "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                              "pattern": "\\S",
+                                                              "transform": [
+                                                                "trim"
                                                               ]
                                                             },
                                                             "engine": {
@@ -7445,13 +7461,52 @@
                                                   "stopRecord": {
                                                     "$schema": "http://json-schema.org/draft-07/schema#",
                                                     "title": "stopRecord",
-                                                    "description": "Stop the current recording.",
-                                                    "type": [
-                                                      "boolean",
-                                                      "null"
+                                                    "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "boolean",
+                                                        "title": "stopRecord (boolean)",
+                                                        "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                                      },
+                                                      {
+                                                        "type": "null",
+                                                        "title": "stopRecord (null)",
+                                                        "description": "Stops the most recently started active recording (LIFO)."
+                                                      },
+                                                      {
+                                                        "type": "string",
+                                                        "title": "stopRecord (name)",
+                                                        "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                                        "pattern": "\\S",
+                                                        "transform": [
+                                                          "trim"
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "title": "stopRecord (detailed)",
+                                                        "additionalProperties": false,
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "properties": {
+                                                          "name": {
+                                                            "type": "string",
+                                                            "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                                            "pattern": "\\S",
+                                                            "transform": [
+                                                              "trim"
+                                                            ]
+                                                          }
+                                                        }
+                                                      }
                                                     ],
                                                     "examples": [
-                                                      true
+                                                      true,
+                                                      "demo",
+                                                      {
+                                                        "name": "demo"
+                                                      }
                                                     ]
                                                   }
                                                 },
@@ -9745,6 +9800,11 @@
         },
         "autoScreenshot": {
           "description": "If `true`, captures a screenshot after every step that runs in a browser, in addition to any explicit `screenshot` steps. Images are saved in the per-run artifact directory (`<output>/.doc-detective/run-<runId>/`) at paths derived from spec, test, and context IDs plus the step's order, action, and ID (for example, `screenshots/<specId>/<testId>/<contextId>/01-goTo-s4f2a91c.png`), so the same step lands on the same relative path in every run's folder for run-over-run comparison. Specs and tests can override this value with their own `autoScreenshot` fields (test level wins over spec level, which wins over config level). Equivalent to `--auto-screenshot` on the CLI.",
+          "type": "boolean",
+          "default": false
+        },
+        "autoRecord": {
+          "description": "If `true`, records a video of every test context that runs in a browser, in addition to any explicit `record` steps. The recording wraps the whole context (it starts before the first step and stops after the last) and always uses the `ffmpeg` engine. Videos are saved in the per-run artifact directory (`<output>/.doc-detective/run-<runId>/`) at paths derived from spec, test, and context IDs (for example, `recordings/<specId>/<testId>/<contextId>.mp4`), so the same context lands on the same relative path in every run's folder for run-over-run comparison. Specs and tests can override this value with their own `autoRecord` fields (test level wins over spec level, which wins over config level). Equivalent to `--auto-record` on the CLI.",
           "type": "boolean",
           "default": false
         },
@@ -16155,6 +16215,14 @@
                                                 "false"
                                               ]
                                             },
+                                            "name": {
+                                              "type": "string",
+                                              "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                              "pattern": "\\S",
+                                              "transform": [
+                                                "trim"
+                                              ]
+                                            },
                                             "engine": {
                                               "title": "Recording engine",
                                               "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -16248,6 +16316,14 @@
                                                 "enum": [
                                                   "true",
                                                   "false"
+                                                ]
+                                              },
+                                              "name": {
+                                                "type": "string",
+                                                "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                "pattern": "\\S",
+                                                "transform": [
+                                                  "trim"
                                                 ]
                                               },
                                               "engine": {
@@ -16485,13 +16561,52 @@
                                     "stopRecord": {
                                       "$schema": "http://json-schema.org/draft-07/schema#",
                                       "title": "stopRecord",
-                                      "description": "Stop the current recording.",
-                                      "type": [
-                                        "boolean",
-                                        "null"
+                                      "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean",
+                                          "title": "stopRecord (boolean)",
+                                          "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                        },
+                                        {
+                                          "type": "null",
+                                          "title": "stopRecord (null)",
+                                          "description": "Stops the most recently started active recording (LIFO)."
+                                        },
+                                        {
+                                          "type": "string",
+                                          "title": "stopRecord (name)",
+                                          "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                          "pattern": "\\S",
+                                          "transform": [
+                                            "trim"
+                                          ]
+                                        },
+                                        {
+                                          "type": "object",
+                                          "title": "stopRecord (detailed)",
+                                          "additionalProperties": false,
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "type": "string",
+                                              "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                              "pattern": "\\S",
+                                              "transform": [
+                                                "trim"
+                                              ]
+                                            }
+                                          }
+                                        }
                                       ],
                                       "examples": [
-                                        true
+                                        true,
+                                        "demo",
+                                        {
+                                          "name": "demo"
+                                        }
                                       ]
                                     }
                                   },
@@ -18981,6 +19096,10 @@
                 "type": "boolean",
                 "description": "If `true`, captures a screenshot after every step in this spec's tests that runs in a browser. Overrides the config-level `autoScreenshot`; individual tests can override this value with their own `autoScreenshot`. When unset, defers to the config level."
               },
+              "autoRecord": {
+                "type": "boolean",
+                "description": "If `true`, records a video of every browser context in this spec's tests. Overrides the config-level `autoRecord`; individual tests can override this value with their own `autoRecord`. When unset, defers to the config level."
+              },
               "tests": {
                 "description": "[Tests](test) to perform.",
                 "type": "array",
@@ -19013,6 +19132,10 @@
                         "autoScreenshot": {
                           "type": "boolean",
                           "description": "If `true`, captures a screenshot after every step in this test that runs in a browser. Overrides `autoScreenshot` set at the spec or config level. When unset, defers to the spec level, then the config level."
+                        },
+                        "autoRecord": {
+                          "type": "boolean",
+                          "description": "If `true`, records a video of every browser context in this test. Overrides `autoRecord` set at the spec or config level. When unset, defers to the spec level, then the config level."
                         },
                         "runOn": {
                           "type": "array",
@@ -25870,6 +25993,14 @@
                                                   "false"
                                                 ]
                                               },
+                                              "name": {
+                                                "type": "string",
+                                                "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                "pattern": "\\S",
+                                                "transform": [
+                                                  "trim"
+                                                ]
+                                              },
                                               "engine": {
                                                 "title": "Recording engine",
                                                 "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -25963,6 +26094,14 @@
                                                   "enum": [
                                                     "true",
                                                     "false"
+                                                  ]
+                                                },
+                                                "name": {
+                                                  "type": "string",
+                                                  "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                  "pattern": "\\S",
+                                                  "transform": [
+                                                    "trim"
                                                   ]
                                                 },
                                                 "engine": {
@@ -26200,13 +26339,52 @@
                                       "stopRecord": {
                                         "$schema": "http://json-schema.org/draft-07/schema#",
                                         "title": "stopRecord",
-                                        "description": "Stop the current recording.",
-                                        "type": [
-                                          "boolean",
-                                          "null"
+                                        "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+                                        "anyOf": [
+                                          {
+                                            "type": "boolean",
+                                            "title": "stopRecord (boolean)",
+                                            "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                          },
+                                          {
+                                            "type": "null",
+                                            "title": "stopRecord (null)",
+                                            "description": "Stops the most recently started active recording (LIFO)."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "title": "stopRecord (name)",
+                                            "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                            "pattern": "\\S",
+                                            "transform": [
+                                              "trim"
+                                            ]
+                                          },
+                                          {
+                                            "type": "object",
+                                            "title": "stopRecord (detailed)",
+                                            "additionalProperties": false,
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "properties": {
+                                              "name": {
+                                                "type": "string",
+                                                "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                                "pattern": "\\S",
+                                                "transform": [
+                                                  "trim"
+                                                ]
+                                              }
+                                            }
+                                          }
                                         ],
                                         "examples": [
-                                          true
+                                          true,
+                                          "demo",
+                                          {
+                                            "name": "demo"
+                                          }
                                         ]
                                       }
                                     },
@@ -34344,6 +34522,14 @@
                                                         "false"
                                                       ]
                                                     },
+                                                    "name": {
+                                                      "type": "string",
+                                                      "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                      "pattern": "\\S",
+                                                      "transform": [
+                                                        "trim"
+                                                      ]
+                                                    },
                                                     "engine": {
                                                       "title": "Recording engine",
                                                       "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -34437,6 +34623,14 @@
                                                         "enum": [
                                                           "true",
                                                           "false"
+                                                        ]
+                                                      },
+                                                      "name": {
+                                                        "type": "string",
+                                                        "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                                        "pattern": "\\S",
+                                                        "transform": [
+                                                          "trim"
                                                         ]
                                                       },
                                                       "engine": {
@@ -34674,13 +34868,52 @@
                                             "stopRecord": {
                                               "$schema": "http://json-schema.org/draft-07/schema#",
                                               "title": "stopRecord",
-                                              "description": "Stop the current recording.",
-                                              "type": [
-                                                "boolean",
-                                                "null"
+                                              "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+                                              "anyOf": [
+                                                {
+                                                  "type": "boolean",
+                                                  "title": "stopRecord (boolean)",
+                                                  "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                                },
+                                                {
+                                                  "type": "null",
+                                                  "title": "stopRecord (null)",
+                                                  "description": "Stops the most recently started active recording (LIFO)."
+                                                },
+                                                {
+                                                  "type": "string",
+                                                  "title": "stopRecord (name)",
+                                                  "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                                  "pattern": "\\S",
+                                                  "transform": [
+                                                    "trim"
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "title": "stopRecord (detailed)",
+                                                  "additionalProperties": false,
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string",
+                                                      "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                                      "pattern": "\\S",
+                                                      "transform": [
+                                                        "trim"
+                                                      ]
+                                                    }
+                                                  }
+                                                }
                                               ],
                                               "examples": [
-                                                true
+                                                true,
+                                                "demo",
+                                                {
+                                                  "name": "demo"
+                                                }
                                               ]
                                             }
                                           },

--- a/src/common/src/schemas/output_schemas/spec_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/spec_v3.schema.json
@@ -597,6 +597,10 @@
       "type": "boolean",
       "description": "If `true`, captures a screenshot after every step in this spec's tests that runs in a browser. Overrides the config-level `autoScreenshot`; individual tests can override this value with their own `autoScreenshot`. When unset, defers to the config level."
     },
+    "autoRecord": {
+      "type": "boolean",
+      "description": "If `true`, records a video of every browser context in this spec's tests. Overrides the config-level `autoRecord`; individual tests can override this value with their own `autoRecord`. When unset, defers to the config level."
+    },
     "tests": {
       "description": "[Tests](test) to perform.",
       "type": "array",
@@ -629,6 +633,10 @@
               "autoScreenshot": {
                 "type": "boolean",
                 "description": "If `true`, captures a screenshot after every step in this test that runs in a browser. Overrides `autoScreenshot` set at the spec or config level. When unset, defers to the spec level, then the config level."
+              },
+              "autoRecord": {
+                "type": "boolean",
+                "description": "If `true`, records a video of every browser context in this test. Overrides `autoRecord` set at the spec or config level. When unset, defers to the spec level, then the config level."
               },
               "runOn": {
                 "type": "array",
@@ -7486,6 +7494,14 @@
                                         "false"
                                       ]
                                     },
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                      "pattern": "\\S",
+                                      "transform": [
+                                        "trim"
+                                      ]
+                                    },
                                     "engine": {
                                       "title": "Recording engine",
                                       "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -7579,6 +7595,14 @@
                                         "enum": [
                                           "true",
                                           "false"
+                                        ]
+                                      },
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                        "pattern": "\\S",
+                                        "transform": [
+                                          "trim"
                                         ]
                                       },
                                       "engine": {
@@ -7816,13 +7840,52 @@
                             "stopRecord": {
                               "$schema": "http://json-schema.org/draft-07/schema#",
                               "title": "stopRecord",
-                              "description": "Stop the current recording.",
-                              "type": [
-                                "boolean",
-                                "null"
+                              "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+                              "anyOf": [
+                                {
+                                  "type": "boolean",
+                                  "title": "stopRecord (boolean)",
+                                  "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                },
+                                {
+                                  "type": "null",
+                                  "title": "stopRecord (null)",
+                                  "description": "Stops the most recently started active recording (LIFO)."
+                                },
+                                {
+                                  "type": "string",
+                                  "title": "stopRecord (name)",
+                                  "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                  "pattern": "\\S",
+                                  "transform": [
+                                    "trim"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "title": "stopRecord (detailed)",
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                      "pattern": "\\S",
+                                      "transform": [
+                                        "trim"
+                                      ]
+                                    }
+                                  }
+                                }
                               ],
                               "examples": [
-                                true
+                                true,
+                                "demo",
+                                {
+                                  "name": "demo"
+                                }
                               ]
                             }
                           },
@@ -15960,6 +16023,14 @@
                                               "false"
                                             ]
                                           },
+                                          "name": {
+                                            "type": "string",
+                                            "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                            "pattern": "\\S",
+                                            "transform": [
+                                              "trim"
+                                            ]
+                                          },
                                           "engine": {
                                             "title": "Recording engine",
                                             "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -16053,6 +16124,14 @@
                                               "enum": [
                                                 "true",
                                                 "false"
+                                              ]
+                                            },
+                                            "name": {
+                                              "type": "string",
+                                              "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                              "pattern": "\\S",
+                                              "transform": [
+                                                "trim"
                                               ]
                                             },
                                             "engine": {
@@ -16290,13 +16369,52 @@
                                   "stopRecord": {
                                     "$schema": "http://json-schema.org/draft-07/schema#",
                                     "title": "stopRecord",
-                                    "description": "Stop the current recording.",
-                                    "type": [
-                                      "boolean",
-                                      "null"
+                                    "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+                                    "anyOf": [
+                                      {
+                                        "type": "boolean",
+                                        "title": "stopRecord (boolean)",
+                                        "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                      },
+                                      {
+                                        "type": "null",
+                                        "title": "stopRecord (null)",
+                                        "description": "Stops the most recently started active recording (LIFO)."
+                                      },
+                                      {
+                                        "type": "string",
+                                        "title": "stopRecord (name)",
+                                        "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                        "pattern": "\\S",
+                                        "transform": [
+                                          "trim"
+                                        ]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "title": "stopRecord (detailed)",
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "properties": {
+                                          "name": {
+                                            "type": "string",
+                                            "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                            "pattern": "\\S",
+                                            "transform": [
+                                              "trim"
+                                            ]
+                                          }
+                                        }
+                                      }
                                     ],
                                     "examples": [
-                                      true
+                                      true,
+                                      "demo",
+                                      {
+                                        "name": "demo"
+                                      }
                                     ]
                                   }
                                 },

--- a/src/common/src/schemas/output_schemas/spec_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/spec_v3.schema.json
@@ -7845,7 +7845,7 @@
                                 {
                                   "type": "boolean",
                                   "title": "stopRecord (boolean)",
-                                  "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                  "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                                 },
                                 {
                                   "type": "null",
@@ -16374,7 +16374,7 @@
                                       {
                                         "type": "boolean",
                                         "title": "stopRecord (boolean)",
-                                        "description": "If `true`, stops the most recently started active recording (LIFO)."
+                                        "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                                       },
                                       {
                                         "type": "null",

--- a/src/common/src/schemas/output_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/step_v3.schema.json
@@ -6278,6 +6278,14 @@
                         "false"
                       ]
                     },
+                    "name": {
+                      "type": "string",
+                      "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                      "pattern": "\\S",
+                      "transform": [
+                        "trim"
+                      ]
+                    },
                     "engine": {
                       "title": "Recording engine",
                       "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -6371,6 +6379,14 @@
                         "enum": [
                           "true",
                           "false"
+                        ]
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                        "pattern": "\\S",
+                        "transform": [
+                          "trim"
                         ]
                       },
                       "engine": {
@@ -6608,13 +6624,52 @@
             "stopRecord": {
               "$schema": "http://json-schema.org/draft-07/schema#",
               "title": "stopRecord",
-              "description": "Stop the current recording.",
-              "type": [
-                "boolean",
-                "null"
+              "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "title": "stopRecord (boolean)",
+                  "description": "If `true`, stops the most recently started active recording (LIFO)."
+                },
+                {
+                  "type": "null",
+                  "title": "stopRecord (null)",
+                  "description": "Stops the most recently started active recording (LIFO)."
+                },
+                {
+                  "type": "string",
+                  "title": "stopRecord (name)",
+                  "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                  "pattern": "\\S",
+                  "transform": [
+                    "trim"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "stopRecord (detailed)",
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                      "pattern": "\\S",
+                      "transform": [
+                        "trim"
+                      ]
+                    }
+                  }
+                }
               ],
               "examples": [
-                true
+                true,
+                "demo",
+                {
+                  "name": "demo"
+                }
               ]
             }
           },

--- a/src/common/src/schemas/output_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/step_v3.schema.json
@@ -6629,7 +6629,7 @@
                 {
                   "type": "boolean",
                   "title": "stopRecord (boolean)",
-                  "description": "If `true`, stops the most recently started active recording (LIFO)."
+                  "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                 },
                 {
                   "type": "null",

--- a/src/common/src/schemas/output_schemas/stopRecord_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/stopRecord_v3.schema.json
@@ -6,7 +6,7 @@
     {
       "type": "boolean",
       "title": "stopRecord (boolean)",
-      "description": "If `true`, stops the most recently started active recording (LIFO)."
+      "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
     },
     {
       "type": "null",

--- a/src/common/src/schemas/output_schemas/stopRecord_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/stopRecord_v3.schema.json
@@ -1,12 +1,51 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "stopRecord",
-  "description": "Stop the current recording.",
-  "type": [
-    "boolean",
-    "null"
+  "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+  "anyOf": [
+    {
+      "type": "boolean",
+      "title": "stopRecord (boolean)",
+      "description": "If `true`, stops the most recently started active recording (LIFO)."
+    },
+    {
+      "type": "null",
+      "title": "stopRecord (null)",
+      "description": "Stops the most recently started active recording (LIFO)."
+    },
+    {
+      "type": "string",
+      "title": "stopRecord (name)",
+      "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+      "pattern": "\\S",
+      "transform": [
+        "trim"
+      ]
+    },
+    {
+      "type": "object",
+      "title": "stopRecord (detailed)",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+          "pattern": "\\S",
+          "transform": [
+            "trim"
+          ]
+        }
+      }
+    }
   ],
   "examples": [
-    true
+    true,
+    "demo",
+    {
+      "name": "demo"
+    }
   ]
 }

--- a/src/common/src/schemas/output_schemas/test_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/test_v3.schema.json
@@ -25,6 +25,10 @@
       "type": "boolean",
       "description": "If `true`, captures a screenshot after every step in this test that runs in a browser. Overrides `autoScreenshot` set at the spec or config level. When unset, defers to the spec level, then the config level."
     },
+    "autoRecord": {
+      "type": "boolean",
+      "description": "If `true`, records a video of every browser context in this test. Overrides `autoRecord` set at the spec or config level. When unset, defers to the spec level, then the config level."
+    },
     "runOn": {
       "type": "array",
       "description": "Contexts to run the test in. Overrides contexts defined at the config and spec levels.",
@@ -6881,6 +6885,14 @@
                               "false"
                             ]
                           },
+                          "name": {
+                            "type": "string",
+                            "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                            "pattern": "\\S",
+                            "transform": [
+                              "trim"
+                            ]
+                          },
                           "engine": {
                             "title": "Recording engine",
                             "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -6974,6 +6986,14 @@
                               "enum": [
                                 "true",
                                 "false"
+                              ]
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                              "pattern": "\\S",
+                              "transform": [
+                                "trim"
                               ]
                             },
                             "engine": {
@@ -7211,13 +7231,52 @@
                   "stopRecord": {
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "title": "stopRecord",
-                    "description": "Stop the current recording.",
-                    "type": [
-                      "boolean",
-                      "null"
+                    "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+                    "anyOf": [
+                      {
+                        "type": "boolean",
+                        "title": "stopRecord (boolean)",
+                        "description": "If `true`, stops the most recently started active recording (LIFO)."
+                      },
+                      {
+                        "type": "null",
+                        "title": "stopRecord (null)",
+                        "description": "Stops the most recently started active recording (LIFO)."
+                      },
+                      {
+                        "type": "string",
+                        "title": "stopRecord (name)",
+                        "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                        "pattern": "\\S",
+                        "transform": [
+                          "trim"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "title": "stopRecord (detailed)",
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                            "pattern": "\\S",
+                            "transform": [
+                              "trim"
+                            ]
+                          }
+                        }
+                      }
                     ],
                     "examples": [
-                      true
+                      true,
+                      "demo",
+                      {
+                        "name": "demo"
+                      }
                     ]
                   }
                 },
@@ -15355,6 +15414,14 @@
                                     "false"
                                   ]
                                 },
+                                "name": {
+                                  "type": "string",
+                                  "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                  "pattern": "\\S",
+                                  "transform": [
+                                    "trim"
+                                  ]
+                                },
                                 "engine": {
                                   "title": "Recording engine",
                                   "description": "Recording engine to use. Either a string shorthand selecting the engine with defaults, or an object for full control. If unset, defaults to the `browser` engine when a visible Chrome context is available and to `ffmpeg` otherwise.",
@@ -15448,6 +15515,14 @@
                                     "enum": [
                                       "true",
                                       "false"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+                                    "pattern": "\\S",
+                                    "transform": [
+                                      "trim"
                                     ]
                                   },
                                   "engine": {
@@ -15685,13 +15760,52 @@
                         "stopRecord": {
                           "$schema": "http://json-schema.org/draft-07/schema#",
                           "title": "stopRecord",
-                          "description": "Stop the current recording.",
-                          "type": [
-                            "boolean",
-                            "null"
+                          "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "title": "stopRecord (boolean)",
+                              "description": "If `true`, stops the most recently started active recording (LIFO)."
+                            },
+                            {
+                              "type": "null",
+                              "title": "stopRecord (null)",
+                              "description": "Stops the most recently started active recording (LIFO)."
+                            },
+                            {
+                              "type": "string",
+                              "title": "stopRecord (name)",
+                              "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                              "pattern": "\\S",
+                              "transform": [
+                                "trim"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "title": "stopRecord (detailed)",
+                              "additionalProperties": false,
+                              "required": [
+                                "name"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+                                  "pattern": "\\S",
+                                  "transform": [
+                                    "trim"
+                                  ]
+                                }
+                              }
+                            }
                           ],
                           "examples": [
-                            true
+                            true,
+                            "demo",
+                            {
+                              "name": "demo"
+                            }
                           ]
                         }
                       },

--- a/src/common/src/schemas/output_schemas/test_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/test_v3.schema.json
@@ -7236,7 +7236,7 @@
                       {
                         "type": "boolean",
                         "title": "stopRecord (boolean)",
-                        "description": "If `true`, stops the most recently started active recording (LIFO)."
+                        "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                       },
                       {
                         "type": "null",
@@ -15765,7 +15765,7 @@
                             {
                               "type": "boolean",
                               "title": "stopRecord (boolean)",
-                              "description": "If `true`, stops the most recently started active recording (LIFO)."
+                              "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
                             },
                             {
                               "type": "null",

--- a/src/common/src/schemas/src_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/config_v3.schema.json
@@ -424,6 +424,11 @@
       "type": "boolean",
       "default": false
     },
+    "autoRecord": {
+      "description": "If `true`, records a video of every test context that runs in a browser, in addition to any explicit `record` steps. The recording wraps the whole context (it starts before the first step and stops after the last) and always uses the `ffmpeg` engine. Videos are saved in the per-run artifact directory (`<output>/.doc-detective/run-<runId>/`) at paths derived from spec, test, and context IDs (for example, `recordings/<specId>/<testId>/<contextId>.mp4`), so the same context lands on the same relative path in every run's folder for run-over-run comparison. Specs and tests can override this value with their own `autoRecord` fields (test level wins over spec level, which wins over config level). Equivalent to `--auto-record` on the CLI.",
+      "type": "boolean",
+      "default": false
+    },
     "autoUpdate": {
       "description": "If `true` (default), the CLI checks for a newer published `doc-detective` on startup and self-updates before running tests. Updates happen for global (`npm i -g`) and `npx` installs only — local installs (where `doc-detective` is a project dep) get an informational message instead, since auto-updating would mutate the user's lockfile. CI environments and the `DOC_DETECTIVE_SKIP_AUTO_UPDATE=1` env var also skip the check. Set to `false` to pin to the installed version. Equivalent to `--no-auto-update` on the CLI.",
       "type": "boolean",

--- a/src/common/src/schemas/src_schemas/record_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/record_v3.schema.json
@@ -52,6 +52,14 @@
               "false"
             ]
           },
+          "name": {
+            "type": "string",
+            "description": "Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: \"<name>\"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.",
+            "pattern": "\\S",
+            "transform": [
+              "trim"
+            ]
+          },
           "engine": {
             "$ref": "#/components/schemas/engine"
           }

--- a/src/common/src/schemas/src_schemas/spec_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/spec_v3.schema.json
@@ -39,6 +39,10 @@
       "type": "boolean",
       "description": "If `true`, captures a screenshot after every step in this spec's tests that runs in a browser. Overrides the config-level `autoScreenshot`; individual tests can override this value with their own `autoScreenshot`. When unset, defers to the config level."
     },
+    "autoRecord": {
+      "type": "boolean",
+      "description": "If `true`, records a video of every browser context in this spec's tests. Overrides the config-level `autoRecord`; individual tests can override this value with their own `autoRecord`. When unset, defers to the config level."
+    },
     "tests": {
       "description": "[Tests](test) to perform.",
       "type": "array",

--- a/src/common/src/schemas/src_schemas/stopRecord_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/stopRecord_v3.schema.json
@@ -6,7 +6,7 @@
     {
       "type": "boolean",
       "title": "stopRecord (boolean)",
-      "description": "If `true`, stops the most recently started active recording (LIFO)."
+      "description": "If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`)."
     },
     {
       "type": "null",

--- a/src/common/src/schemas/src_schemas/stopRecord_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/stopRecord_v3.schema.json
@@ -1,9 +1,51 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "stopRecord",
-  "description": "Stop the current recording.",
-  "type": ["boolean", "null"],
+  "description": "Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: \"<name>\"`) or an object (`stopRecord: { name: \"<name>\" }`).",
+  "anyOf": [
+    {
+      "type": "boolean",
+      "title": "stopRecord (boolean)",
+      "description": "If `true`, stops the most recently started active recording (LIFO)."
+    },
+    {
+      "type": "null",
+      "title": "stopRecord (null)",
+      "description": "Stops the most recently started active recording (LIFO)."
+    },
+    {
+      "type": "string",
+      "title": "stopRecord (name)",
+      "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+      "pattern": "\\S",
+      "transform": [
+        "trim"
+      ]
+    },
+    {
+      "type": "object",
+      "title": "stopRecord (detailed)",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the recording to stop. Matches the `name` given to a `record` step.",
+          "pattern": "\\S",
+          "transform": [
+            "trim"
+          ]
+        }
+      }
+    }
+  ],
   "examples": [
-    true
+    true,
+    "demo",
+    {
+      "name": "demo"
+    }
   ]
 }

--- a/src/common/src/schemas/src_schemas/test_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/test_v3.schema.json
@@ -25,6 +25,10 @@
       "type": "boolean",
       "description": "If `true`, captures a screenshot after every step in this test that runs in a browser. Overrides `autoScreenshot` set at the spec or config level. When unset, defers to the spec level, then the config level."
     },
+    "autoRecord": {
+      "type": "boolean",
+      "description": "If `true`, records a video of every browser context in this test. Overrides `autoRecord` set at the spec or config level. When unset, defers to the spec level, then the config level."
+    },
     "runOn": {
       "type": "array",
       "description": "Contexts to run the test in. Overrides contexts defined at the config and spec levels.",

--- a/src/common/src/types/generated/config_v3.ts
+++ b/src/common/src/types/generated/config_v3.ts
@@ -151,6 +151,10 @@ export interface Config {
    */
   autoScreenshot?: boolean;
   /**
+   * If `true`, records a video of every test context that runs in a browser, in addition to any explicit `record` steps. The recording wraps the whole context (it starts before the first step and stops after the last) and always uses the `ffmpeg` engine. Videos are saved in the per-run artifact directory (`<output>/.doc-detective/run-<runId>/`) at paths derived from spec, test, and context IDs (for example, `recordings/<specId>/<testId>/<contextId>.mp4`), so the same context lands on the same relative path in every run's folder for run-over-run comparison. Specs and tests can override this value with their own `autoRecord` fields (test level wins over spec level, which wins over config level). Equivalent to `--auto-record` on the CLI.
+   */
+  autoRecord?: boolean;
+  /**
    * If `true` (default), the CLI checks for a newer published `doc-detective` on startup and self-updates before running tests. Updates happen for global (`npm i -g`) and `npx` installs only — local installs (where `doc-detective` is a project dep) get an informational message instead, since auto-updating would mutate the user's lockfile. CI environments and the `DOC_DETECTIVE_SKIP_AUTO_UPDATE=1` env var also skip the check. Set to `false` to pin to the installed version. Equivalent to `--no-auto-update` on the CLI.
    */
   autoUpdate?: boolean;

--- a/src/common/src/types/generated/record_v3.ts
+++ b/src/common/src/types/generated/record_v3.ts
@@ -38,6 +38,10 @@ export interface RecordDetailed {
    * If `true`, overwrites the existing recording at `path` if it exists.
    */
   overwrite?: "true" | "false";
+  /**
+   * Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: "<name>"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.
+   */
+  name?: string;
   engine?: RecordingEngine;
   [k: string]: unknown;
 }

--- a/src/common/src/types/generated/report_v3.ts
+++ b/src/common/src/types/generated/report_v3.ts
@@ -77,6 +77,10 @@ export interface Specification {
    */
   autoScreenshot?: boolean;
   /**
+   * If `true`, records a video of every browser context in this spec's tests. Overrides the config-level `autoRecord`; individual tests can override this value with their own `autoRecord`. When unset, defers to the config level.
+   */
+  autoRecord?: boolean;
+  /**
    * [Tests](test) to perform.
    *
    * @minItems 1

--- a/src/common/src/types/generated/resolvedTests_v3.ts
+++ b/src/common/src/types/generated/resolvedTests_v3.ts
@@ -188,6 +188,10 @@ export interface Config {
    */
   autoScreenshot?: boolean;
   /**
+   * If `true`, records a video of every test context that runs in a browser, in addition to any explicit `record` steps. The recording wraps the whole context (it starts before the first step and stops after the last) and always uses the `ffmpeg` engine. Videos are saved in the per-run artifact directory (`<output>/.doc-detective/run-<runId>/`) at paths derived from spec, test, and context IDs (for example, `recordings/<specId>/<testId>/<contextId>.mp4`), so the same context lands on the same relative path in every run's folder for run-over-run comparison. Specs and tests can override this value with their own `autoRecord` fields (test level wins over spec level, which wins over config level). Equivalent to `--auto-record` on the CLI.
+   */
+  autoRecord?: boolean;
+  /**
    * If `true` (default), the CLI checks for a newer published `doc-detective` on startup and self-updates before running tests. Updates happen for global (`npm i -g`) and `npx` installs only — local installs (where `doc-detective` is a project dep) get an informational message instead, since auto-updating would mutate the user's lockfile. CI environments and the `DOC_DETECTIVE_SKIP_AUTO_UPDATE=1` env var also skip the check. Set to `false` to pin to the installed version. Equivalent to `--no-auto-update` on the CLI.
    */
   autoUpdate?: boolean;
@@ -515,6 +519,10 @@ export interface Specification {
    * If `true`, captures a screenshot after every step in this spec's tests that runs in a browser. Overrides the config-level `autoScreenshot`; individual tests can override this value with their own `autoScreenshot`. When unset, defers to the config level.
    */
   autoScreenshot?: boolean;
+  /**
+   * If `true`, records a video of every browser context in this spec's tests. Overrides the config-level `autoRecord`; individual tests can override this value with their own `autoRecord`. When unset, defers to the config level.
+   */
+  autoRecord?: boolean;
   /**
    * [Tests](test) to perform.
    *

--- a/src/common/src/types/generated/spec_v3.ts
+++ b/src/common/src/types/generated/spec_v3.ts
@@ -52,6 +52,10 @@ export interface Specification {
    */
   autoScreenshot?: boolean;
   /**
+   * If `true`, records a video of every browser context in this spec's tests. Overrides the config-level `autoRecord`; individual tests can override this value with their own `autoRecord`. When unset, defers to the config level.
+   */
+  autoRecord?: boolean;
+  /**
    * [Tests](test) to perform.
    *
    * @minItems 1

--- a/src/common/src/types/generated/step_v3.ts
+++ b/src/common/src/types/generated/step_v3.ts
@@ -154,9 +154,21 @@ export type RecordingEngineSimple = "browser" | "ffmpeg";
  */
 export type RecordBoolean = boolean;
 /**
- * Stop the current recording.
+ * Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: "<name>"`) or an object (`stopRecord: { name: "<name>" }`).
  */
-export type StopRecord1 = boolean | null;
+export type StopRecord1 = StopRecordBoolean | StopRecordNull | StopRecordName | StopRecordDetailed;
+/**
+ * If `true`, stops the most recently started active recording (LIFO).
+ */
+export type StopRecordBoolean = boolean;
+/**
+ * Stops the most recently started active recording (LIFO).
+ */
+export type StopRecordNull = null;
+/**
+ * Name of the recording to stop. Matches the `name` given to a `record` step.
+ */
+export type StopRecordName = string;
 /**
  * Load environment variables from the specified `.env` file.
  */
@@ -1278,6 +1290,10 @@ export interface RecordDetailed {
    * If `true`, overwrites the existing recording at `path` if it exists.
    */
   overwrite?: "true" | "false";
+  /**
+   * Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: "<name>"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.
+   */
+  name?: string;
   engine?: RecordingEngine;
   [k: string]: unknown;
 }
@@ -1369,6 +1385,12 @@ export interface SourceLocation11 {
 export interface StopRecord {
   stopRecord: StopRecord1;
   [k: string]: unknown;
+}
+export interface StopRecordDetailed {
+  /**
+   * Name of the recording to stop. Matches the `name` given to a `record` step.
+   */
+  name: string;
 }
 export interface Common12 {
   /**

--- a/src/common/src/types/generated/step_v3.ts
+++ b/src/common/src/types/generated/step_v3.ts
@@ -158,7 +158,7 @@ export type RecordBoolean = boolean;
  */
 export type StopRecord1 = StopRecordBoolean | StopRecordNull | StopRecordName | StopRecordDetailed;
 /**
- * If `true`, stops the most recently started active recording (LIFO).
+ * If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`).
  */
 export type StopRecordBoolean = boolean;
 /**

--- a/src/common/src/types/generated/stopRecord_v3.ts
+++ b/src/common/src/types/generated/stopRecord_v3.ts
@@ -5,6 +5,25 @@
  */
 
 /**
- * Stop the current recording.
+ * Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: "<name>"`) or an object (`stopRecord: { name: "<name>" }`).
  */
-export type StopRecord = boolean | null;
+export type StopRecord = StopRecordBoolean | StopRecordNull | StopRecordName | StopRecordDetailed;
+/**
+ * If `true`, stops the most recently started active recording (LIFO).
+ */
+export type StopRecordBoolean = boolean;
+/**
+ * Stops the most recently started active recording (LIFO).
+ */
+export type StopRecordNull = null;
+/**
+ * Name of the recording to stop. Matches the `name` given to a `record` step.
+ */
+export type StopRecordName = string;
+
+export interface StopRecordDetailed {
+  /**
+   * Name of the recording to stop. Matches the `name` given to a `record` step.
+   */
+  name: string;
+}

--- a/src/common/src/types/generated/stopRecord_v3.ts
+++ b/src/common/src/types/generated/stopRecord_v3.ts
@@ -9,7 +9,7 @@
  */
 export type StopRecord = StopRecordBoolean | StopRecordNull | StopRecordName | StopRecordDetailed;
 /**
- * If `true`, stops the most recently started active recording (LIFO).
+ * If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`).
  */
 export type StopRecordBoolean = boolean;
 /**

--- a/src/common/src/types/generated/test_v3.ts
+++ b/src/common/src/types/generated/test_v3.ts
@@ -280,7 +280,7 @@ export type RecordBoolean = boolean;
  */
 export type StopRecord1 = StopRecordBoolean | StopRecordNull | StopRecordName | StopRecordDetailed;
 /**
- * If `true`, stops the most recently started active recording (LIFO).
+ * If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`).
  */
 export type StopRecordBoolean = boolean;
 /**
@@ -594,7 +594,7 @@ export type RecordBoolean1 = boolean;
  */
 export type StopRecord3 = StopRecordBoolean1 | StopRecordNull1 | StopRecordName1 | StopRecordDetailed1;
 /**
- * If `true`, stops the most recently started active recording (LIFO).
+ * If `true`, stops the most recently started active recording (LIFO). If `false`, does nothing — an explicit no-op (mirrors `record: false`).
  */
 export type StopRecordBoolean1 = boolean;
 /**

--- a/src/common/src/types/generated/test_v3.ts
+++ b/src/common/src/types/generated/test_v3.ts
@@ -31,6 +31,10 @@ export type Test = {
    */
   autoScreenshot?: boolean;
   /**
+   * If `true`, records a video of every browser context in this test. Overrides `autoRecord` set at the spec or config level. When unset, defers to the spec level, then the config level.
+   */
+  autoRecord?: boolean;
+  /**
    * Contexts to run the test in. Overrides contexts defined at the config and spec levels.
    */
   runOn?: Context[];
@@ -272,9 +276,21 @@ export type RecordingEngineSimple = "browser" | "ffmpeg";
  */
 export type RecordBoolean = boolean;
 /**
- * Stop the current recording.
+ * Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: "<name>"`) or an object (`stopRecord: { name: "<name>" }`).
  */
-export type StopRecord1 = boolean | null;
+export type StopRecord1 = StopRecordBoolean | StopRecordNull | StopRecordName | StopRecordDetailed;
+/**
+ * If `true`, stops the most recently started active recording (LIFO).
+ */
+export type StopRecordBoolean = boolean;
+/**
+ * Stops the most recently started active recording (LIFO).
+ */
+export type StopRecordNull = null;
+/**
+ * Name of the recording to stop. Matches the `name` given to a `record` step.
+ */
+export type StopRecordName = string;
 /**
  * Load environment variables from the specified `.env` file.
  */
@@ -574,9 +590,21 @@ export type RecordingEngineSimple1 = "browser" | "ffmpeg";
  */
 export type RecordBoolean1 = boolean;
 /**
- * Stop the current recording.
+ * Stop a recording started by an earlier `record` step. With no target (`true`/`null`), stops the most recently started recording that is still active (LIFO). To stop a specific recording when several overlap, target it by name with a string (`stopRecord: "<name>"`) or an object (`stopRecord: { name: "<name>" }`).
  */
-export type StopRecord3 = boolean | null;
+export type StopRecord3 = StopRecordBoolean1 | StopRecordNull1 | StopRecordName1 | StopRecordDetailed1;
+/**
+ * If `true`, stops the most recently started active recording (LIFO).
+ */
+export type StopRecordBoolean1 = boolean;
+/**
+ * Stops the most recently started active recording (LIFO).
+ */
+export type StopRecordNull1 = null;
+/**
+ * Name of the recording to stop. Matches the `name` given to a `record` step.
+ */
+export type StopRecordName1 = string;
 /**
  * Load environment variables from the specified `.env` file.
  */
@@ -1872,6 +1900,10 @@ export interface RecordDetailed {
    * If `true`, overwrites the existing recording at `path` if it exists.
    */
   overwrite?: "true" | "false";
+  /**
+   * Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: "<name>"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.
+   */
+  name?: string;
   engine?: RecordingEngine;
   [k: string]: unknown;
 }
@@ -1963,6 +1995,12 @@ export interface SourceLocation11 {
 export interface StopRecord {
   stopRecord: StopRecord1;
   [k: string]: unknown;
+}
+export interface StopRecordDetailed {
+  /**
+   * Name of the recording to stop. Matches the `name` given to a `record` step.
+   */
+  name: string;
 }
 export interface Common12 {
   /**
@@ -3444,6 +3482,10 @@ export interface RecordDetailed1 {
    * If `true`, overwrites the existing recording at `path` if it exists.
    */
   overwrite?: "true" | "false";
+  /**
+   * Identifier for this recording. A later `stopRecord` step can target it by name (`stopRecord: "<name>"`), which is how you stop a specific recording when several overlap. Names must be unique among recordings that are active at the same time. If omitted, the recording is anonymous and is stopped LIFO by an untargeted `stopRecord`.
+   */
+  name?: string;
   engine?: RecordingEngine1;
   [k: string]: unknown;
 }
@@ -3535,6 +3577,12 @@ export interface SourceLocation27 {
 export interface StopRecord2 {
   stopRecord: StopRecord3;
   [k: string]: unknown;
+}
+export interface StopRecordDetailed1 {
+  /**
+   * Name of the recording to stop. Matches the `name` given to a `record` step.
+   */
+  name: string;
 }
 export interface Common28 {
   /**

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -269,6 +269,114 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         }
       });
 
+      it("should validate a config_v3 object with autoRecord set", function () {
+        const result = validate({
+          schemaKey: "config_v3",
+          object: { autoRecord: true },
+        });
+
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+        expect(result.object.autoRecord).to.equal(true);
+      });
+
+      it("should default autoRecord to false when unset", function () {
+        const result = validate({
+          schemaKey: "config_v3",
+          object: {},
+        });
+
+        expect(result.valid).to.be.true;
+        expect(result.object.autoRecord).to.equal(false);
+      });
+
+      it("should reject a config_v3 object whose autoRecord is not a boolean", function () {
+        const result = validate({
+          schemaKey: "config_v3",
+          object: { autoRecord: "yes" },
+        });
+
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+        expect(result.errors).to.include("autoRecord");
+      });
+
+      it("should validate spec_v3 and test_v3 objects with autoRecord overrides", function () {
+        const result = validate({
+          schemaKey: "spec_v3",
+          object: {
+            autoRecord: true,
+            tests: [
+              {
+                autoRecord: false,
+                steps: [{ goTo: { url: "https://example.com" } }],
+              },
+            ],
+          },
+        });
+
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+        expect(result.object.autoRecord).to.equal(true);
+        expect(result.object.tests[0].autoRecord).to.equal(false);
+      });
+
+      it("should not default autoRecord on specs or tests when unset", function () {
+        const result = validate({
+          schemaKey: "spec_v3",
+          object: {
+            tests: [{ steps: [{ goTo: { url: "https://example.com" } }] }],
+          },
+        });
+
+        expect(result.valid).to.be.true;
+        expect(result.object.autoRecord).to.equal(undefined);
+        expect(result.object.tests[0].autoRecord).to.equal(undefined);
+      });
+
+      it("should validate a record step with a name", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: { record: { path: "out.mp4", name: "demo" } },
+        });
+        expect(result.valid, result.errors).to.be.true;
+        expect(result.object.record.name).to.equal("demo");
+      });
+
+      it("should reject a record step whose name is whitespace-only", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: { record: { path: "out.mp4", name: "   " } },
+        });
+        expect(result.valid).to.be.false;
+      });
+
+      it("should validate stopRecord as boolean, null, a name string, or a name object", function () {
+        for (const stopRecord of [true, null, "demo", { name: "demo" }]) {
+          const result = validate({
+            schemaKey: "step_v3",
+            object: { stopRecord },
+          });
+          expect(
+            result.valid,
+            `stopRecord: ${JSON.stringify(stopRecord)} -> ${result.errors}`
+          ).to.be.true;
+        }
+      });
+
+      it("should reject stopRecord with an empty name or extra properties", function () {
+        for (const stopRecord of [{ name: "" }, { name: "demo", extra: 1 }]) {
+          const result = validate({
+            schemaKey: "step_v3",
+            object: { stopRecord },
+          });
+          expect(
+            result.valid,
+            `expected invalid stopRecord: ${JSON.stringify(stopRecord)}`
+          ).to.be.false;
+        }
+      });
+
       it("should validate config_v3 concurrentRunners as a positive integer or true", function () {
         for (const concurrentRunners of [1, 4, true]) {
           const result = validate({

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -1243,7 +1243,11 @@ function buildAutoRecordStep({
   context: any;
 }): any | null {
   if (!isDriverRequired({ test: context })) return null;
-  const runDir = getRunOutputDir(config);
+  // Compute the path only — don't create the run folder here. runSpecs reserves
+  // it up front when runArchivesArtifacts is true (autoRecord counts), and the
+  // recording's own startRecording mkdirs the target dir when it actually
+  // writes, so a headless run that skips recording leaves no empty folder.
+  const runDir = getRunOutputDir(config, { create: false });
   const fileName = `${capPathSegment(
     sanitizeFilesystemName(String(context.contextId ?? ""), "context")
   )}.mp4`;

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -714,8 +714,13 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
         if (resolveAutoRecord({ config, spec, test })) {
           const autoStep = buildAutoRecordStep({ config, spec, test, context });
           if (autoStep) {
-            if (!Array.isArray(context.steps)) context.steps = [];
-            context.steps.unshift(autoStep);
+            // Idempotent: strip any prior synthetic step before prepending, so a
+            // resolved context that's reused (e.g. runSpecs invoked twice) can't
+            // accumulate duplicate autoRecord captures targeting the same file.
+            const authored = Array.isArray(context.steps)
+              ? context.steps.filter((s: any) => !s?.__autoRecord)
+              : [];
+            context.steps = [autoStep, ...authored];
             autoRecordInjected = true;
           }
         }

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -44,6 +44,9 @@ import {
   xvfbDisplay,
   startXvfb,
   XVFB_SCREEN_SIZE,
+  isRecordingActive,
+  recordStepName,
+  detectRecordingNameConflict,
 } from "./tests/ffmpegRecorder.js";
 import { loadVariables } from "./tests/loadVariables.js";
 import { saveCookie } from "./tests/saveCookie.js";
@@ -84,6 +87,8 @@ export {
   getDefaultBrowser,
   isSupportedContext,
   resolveAutoScreenshot,
+  resolveAutoRecord,
+  buildAutoRecordStep,
 };
 // exports.appiumStart = appiumStart;
 // exports.appiumIsReady = appiumIsReady;
@@ -616,6 +621,10 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   // matches input order, no matter what order concurrent contexts finish in.
   log(config, "info", "Running test specs.");
   const jobs: any[] = [];
+  // Set when at least one context gets a synthetic autoRecord (ffmpeg) step.
+  // It opts the run into overlapping ffmpeg captures (parallel anyway) rather
+  // than the safe-serial default reserved for explicit-only ffmpeg recordings.
+  let autoRecordInjected = false;
   for (const spec of specs) {
     log(config, "debug", `SPEC: ${spec.specId}`);
     // Create-if-missing: specIds (and testIds) aren't guaranteed unique
@@ -640,6 +649,26 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
         contexts: new Array(test.contexts.length),
       };
       specReport.tests.push(testReport);
+      // Preflight: a `record` step that reuses a recording `name` while one is
+      // still active makes a later `stopRecord: "<name>"` ambiguous. Catch it
+      // statically and skip the whole test (across all its contexts) with a
+      // warning, rather than failing mid-run. Scan every context's authored
+      // steps (runOn overrides can differ) and skip if any conflicts.
+      let recordingNameConflict: string | null = null;
+      for (const c of test.contexts) {
+        const conflict = detectRecordingNameConflict(c?.steps);
+        if (conflict) {
+          recordingNameConflict = conflict;
+          break;
+        }
+      }
+      if (recordingNameConflict) {
+        log(
+          config,
+          "warning",
+          `Skipping test '${test.testId}': recording name '${recordingNameConflict}' is reused while a recording with that name is still active. Names must be unique among recordings that overlap in time.`
+        );
+      }
       // Track contextIds within this test so the deterministic fallback below
       // can suffix collisions, mirroring resolveTests' deriveContextId.
       const usedContextIds = new Set<string>(
@@ -665,6 +694,30 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
           }
           usedContextIds.add(id);
           context.contextId = id;
+        }
+        // Preflight conflict: record a SKIPPED context and don't enqueue a job.
+        if (recordingNameConflict) {
+          testReport.contexts[slot] = {
+            contextId: context.contextId,
+            platform: context.platform,
+            browser: context.browser,
+            result: "SKIPPED",
+            resultDescription: `Skipped — recording name '${recordingNameConflict}' is reused while still active; names must be unique among overlapping recordings.`,
+            steps: [],
+          };
+          return;
+        }
+        // autoRecord: prepend a synthetic full-context ffmpeg recording step
+        // (even when the author also has explicit record steps — overlapping is
+        // intended). Done before the concurrency calc below so the synthetic
+        // ffmpeg recording is counted by jobIsFfmpegRecording.
+        if (resolveAutoRecord({ config, spec, test })) {
+          const autoStep = buildAutoRecordStep({ config, spec, test, context });
+          if (autoStep) {
+            if (!Array.isArray(context.steps)) context.steps = [];
+            context.steps.unshift(autoStep);
+            autoRecordInjected = true;
+          }
         }
         // Auto-resolution: when a record step has no explicit engine and the
         // user never chose a browser, prefer the concurrency-safe browser
@@ -700,6 +753,8 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     jobs,
     platform: process.platform,
     xvfbAvailable,
+    // autoRecord runs opt into overlapping captures rather than forced-serial.
+    allowOverlappingCaptures: autoRecordInjected,
   });
   limit = concurrency.limit;
   if (concurrency.forcedSerial) {
@@ -709,6 +764,12 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
       "Recording with the ffmpeg engine needs exclusive use of the display, so this run is executing serially (concurrentRunners=1). To record concurrently, use the Chrome browser engine (record: { engine: \"browser\" }) or, on Linux, install Xvfb."
     );
     report.recordingForcedSerial = true;
+  } else if (concurrency.overlappingCaptures && limit > 1) {
+    log(
+      config,
+      "warning",
+      "autoRecord is running ffmpeg recordings concurrently on a shared display, so the captured videos will overlap (each context records the whole screen). For isolated concurrent recordings, run on Linux with Xvfb installed."
+    );
   }
 
   // Start one Appium server per concurrent runner that will actually use a
@@ -1119,6 +1180,60 @@ function resolveAutoScreenshot({
   return Boolean(
     test?.autoScreenshot ?? spec?.autoScreenshot ?? config?.autoScreenshot
   );
+}
+
+// Effective autoRecord setting for a test: same precedence as autoScreenshot
+// (test > spec > config; unset levels defer down the chain).
+function resolveAutoRecord({
+  config,
+  spec,
+  test,
+}: {
+  config: any;
+  spec: any;
+  test: any;
+}): boolean {
+  return Boolean(test?.autoRecord ?? spec?.autoRecord ?? config?.autoRecord);
+}
+
+// Build the synthetic full-context recording step for an autoRecord run, or
+// null when the context shouldn't be recorded (no driver-required authored
+// steps). Always uses the ffmpeg engine, and a deterministic path under the
+// run's artifact folder (recordings/<specId>/<testId>/<contextId>.mp4) so the
+// same context lands on the same relative path every run for comparison. The
+// `__autoRecord` marker tags the started handle as synthetic so an untargeted
+// user `stopRecord` won't end it (only end-of-context cleanup does).
+function buildAutoRecordStep({
+  config,
+  spec,
+  test,
+  context,
+}: {
+  config: any;
+  spec: any;
+  test: any;
+  context: any;
+}): any | null {
+  if (!isDriverRequired({ test: context })) return null;
+  const runDir = getRunOutputDir(config);
+  const fileName = `${capPathSegment(
+    sanitizeFilesystemName(String(context.contextId ?? ""), "context")
+  )}.mp4`;
+  const recordPath = path.join(
+    runDir,
+    "recordings",
+    capPathSegment(sanitizeFilesystemName(String(spec.specId ?? ""), "spec")),
+    capPathSegment(sanitizeFilesystemName(String(test.testId ?? ""), "test")),
+    fileName
+  );
+  return {
+    record: { path: recordPath, overwrite: "true", engine: "ffmpeg" },
+    description: "Automatic full-context recording",
+    stepId: `${sanitizeFilesystemName(String(test.testId ?? ""), "test")}~autorecord`,
+    // Internal marker — the runStep record dispatch flags the started handle as
+    // synthetic so it survives untargeted stopRecord and is swept by cleanup.
+    __autoRecord: true,
+  };
 }
 
 // Directory/file segments built from IDs are capped so deeply nested doc
@@ -1645,35 +1760,22 @@ async function runContext({
       }
     }
 
-    // If recording, stop recording
-    if (driver?.state?.recording) {
-      const stopRecordStep = {
-        stopRecord: true,
-        description: "Stopping recording",
-        stepId: randomUUID(),
-      };
-      const stepResult = await runStep({
-        config: config,
-        context: context,
-        step: stopRecordStep,
-        driver: driver,
-        options: {
-          openApiDefinitions: context.openApi || [],
-        },
-      });
-      stepResult.result = stepResult.status;
-      stepResult.resultDescription = stepResult.description;
-      delete stepResult.status;
-      delete stepResult.description;
-
-      // Add step result to report
-      const stepReport = {
-        ...stopRecordStep,
-        ...stepResult,
-      };
-      contextReport.steps.push(stepReport);
-    }
+    // Stop every recording still active at the end of the context (the
+    // synthetic autoRecord capture plus any explicit record steps the author
+    // didn't stop). Each produces an ordered stopRecord step report.
+    await stopAllRecordings({ config, context, driver, contextReport });
   } finally {
+    // Safety net: if the context threw before the normal sweep above, recordings
+    // are still active. Stop them now — while the driver session is still alive
+    // (the deleteSession below would otherwise kill the browser/ffmpeg capture
+    // and leak the process). On the normal path the set is already empty, so
+    // this is a no-op. Best-effort: a stop failure here must not mask the
+    // original error.
+    try {
+      await stopAllRecordings({ config, context, driver, contextReport });
+    } catch (error: any) {
+      clog("error", `Failed to stop recordings during cleanup: ${error?.message ?? error}`);
+    }
     // Close driver. In a finally so an unexpected throw can't leak a session
     // while sibling contexts keep running.
     if (driver) {
@@ -1693,6 +1795,64 @@ async function runContext({
 
   contextReport.result = rollUpResults(contextReport.steps);
   return contextReport;
+}
+
+// Stop every recording still active on the driver, pushing an ordered
+// stopRecord step report for each. Drains the per-context stack (LIFO) by
+// synthesizing `{ stopRecord: true, __stopAny: true }` steps — `__stopAny`
+// lets the generic stop also end the synthetic autoRecord recording (a plain
+// user `stopRecord: true` deliberately skips it). Each stop removes its handle
+// even on failure, so the loop always makes progress; an explicit iteration
+// cap is a belt-and-suspenders guard against a handle that somehow refuses to
+// drop. Each synthesized stop is isolated so one failure doesn't abort the
+// rest. Safe to call when nothing is active (no-op).
+async function stopAllRecordings({
+  config,
+  context,
+  driver,
+  contextReport,
+}: {
+  config: any;
+  context: any;
+  driver: any;
+  contextReport: any;
+}): Promise<void> {
+  if (!Array.isArray(driver?.state?.recordings)) return;
+  let guard = driver.state.recordings.length + 1;
+  while (driver.state.recordings.length > 0 && guard-- > 0) {
+    const stopRecordStep: any = {
+      stopRecord: true,
+      __stopAny: true,
+      description: "Stopping recording",
+      stepId: randomUUID(),
+    };
+    try {
+      const stepResult = await runStep({
+        config,
+        context,
+        step: stopRecordStep,
+        driver,
+        options: { openApiDefinitions: context.openApi || [] },
+      });
+      stepResult.result = stepResult.status;
+      stepResult.resultDescription = stepResult.description;
+      delete stepResult.status;
+      delete stepResult.description;
+      // Don't leak the internal routing marker into the report.
+      delete stopRecordStep.__stopAny;
+      contextReport.steps.push({ ...stopRecordStep, ...stepResult });
+    } catch (error: any) {
+      // A throw from runStep would otherwise strand the remaining handles.
+      // Drop the top handle so the loop can't spin, and record the failure.
+      delete stopRecordStep.__stopAny;
+      driver.state.recordings.pop();
+      contextReport.steps.push({
+        ...stopRecordStep,
+        result: "FAIL",
+        resultDescription: `Couldn't stop recording. ${error?.message ?? error}`,
+      });
+    }
+  }
 }
 
 // Run a specific step
@@ -1761,7 +1921,17 @@ async function runStep({
       step: step,
       driver: driver,
     });
-    driver.state.recording = actionResult.recording ?? null;
+    // Push the started recording onto the per-context stack so several can
+    // overlap. Carry the step's `id`/`name` so a later stopRecord can target
+    // it (by name) and end-of-context cleanup can identify the synthetic one.
+    if (actionResult.recording) {
+      if (!Array.isArray(driver.state.recordings)) driver.state.recordings = [];
+      const handle = actionResult.recording;
+      handle.id = handle.id ?? randomUUID();
+      handle.name = handle.name ?? recordStepName(step.record);
+      if (step.__autoRecord) handle.synthetic = true;
+      driver.state.recordings.push(handle);
+    }
   } else if (typeof step.runCode !== "undefined") {
     actionResult = await runCode({ config: config, step: step });
   } else if (typeof step.runShell !== "undefined") {
@@ -1787,7 +1957,7 @@ async function runStep({
     };
   }
   // If recording, wait until browser is loaded, then instantiate cursor
-  if (driver?.state?.recording) {
+  if (isRecordingActive(driver)) {
     const currentUrl = await driver.getUrl();
     if (currentUrl !== driver.state.url) {
       driver.state.url = currentUrl;
@@ -1922,9 +2092,12 @@ async function driverStart(
         connectionRetryTimeout: 120000, // 2 minutes
         waitforTimeout: 120000, // 2 minutes
       });
-      // Per-context mutable state. `recording` lives here (not on config)
-      // so concurrent contexts can't clobber each other's recordings.
-      driver.state = { url: "", x: null, y: null, recording: null };
+      // Per-context mutable state. `recordings` lives here (not on config)
+      // so concurrent contexts can't clobber each other's recordings. It is a
+      // stack of active recording handles (LIFO) so several can overlap within
+      // one context (e.g. an autoRecord full-context capture plus an explicit
+      // record/stopRecord sub-section).
+      driver.state = { url: "", x: null, y: null, recordings: [] };
       return driver;
     } catch (err: any) {
       lastError = err;

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -1243,10 +1243,11 @@ function buildAutoRecordStep({
   context: any;
 }): any | null {
   if (!isDriverRequired({ test: context })) return null;
-  // Compute the path only — don't create the run folder here. runSpecs reserves
-  // it up front when runArchivesArtifacts is true (autoRecord counts), and the
-  // recording's own startRecording mkdirs the target dir when it actually
-  // writes, so a headless run that skips recording leaves no empty folder.
+  // Compute the path only — runSpecs reserves the run folder up front when
+  // runArchivesArtifacts is true (autoRecord counts), so creating it here would
+  // be redundant. (startRecording also mkdirs the recording's target dir up
+  // front, so an enabled autoRecord run reserves the folder regardless — same as
+  // autoScreenshot.)
   const runDir = getRunOutputDir(config, { create: false });
   const fileName = `${capPathSegment(
     sanitizeFilesystemName(String(context.contextId ?? ""), "context")

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -753,13 +753,27 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   if (anyFfmpegRecording && process.platform === "linux") {
     xvfbAvailable = await checkSystemBinary("Xvfb");
   }
+  // "Parallel anyway" is an autoRecord-only opt-in: only bypass the forced-serial
+  // safeguard when every ffmpeg recording in the run is a synthetic autoRecord
+  // capture. If any explicit (author-written) record step would run as ffmpeg,
+  // keep the safe serial default so those recordings aren't silently
+  // parallelized (which would clobber each other on a shared display).
+  const hasExplicitFfmpegRecording = jobs.some((job: any) =>
+    jobIsFfmpegRecording({
+      context: {
+        ...job.context,
+        steps: Array.isArray(job.context?.steps)
+          ? job.context.steps.filter((s: any) => !s?.__autoRecord)
+          : [],
+      },
+    })
+  );
   const concurrency = computeEffectiveConcurrency({
     requestedLimit: limit,
     jobs,
     platform: process.platform,
     xvfbAvailable,
-    // autoRecord runs opt into overlapping captures rather than forced-serial.
-    allowOverlappingCaptures: autoRecordInjected,
+    allowOverlappingCaptures: autoRecordInjected && !hasExplicitFfmpegRecording,
   });
   limit = concurrency.limit;
   if (concurrency.forcedSerial) {
@@ -1777,6 +1791,9 @@ async function runContext({
     // this is a no-op. Best-effort: a stop failure here must not mask the
     // original error.
     try {
+      // On the normal path the step loop above already drained every recording,
+      // so this is a no-op; it only does work when the context threw before the
+      // in-loop sweep, finalizing recordings before deleteSession kills them.
       await stopAllRecordings({ config, context, driver, contextReport });
     } catch (error: any) {
       clog("error", `Failed to stop recordings during cleanup: ${error?.message ?? error}`);

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -395,6 +395,14 @@ function jobIsFfmpegRecording(job: any): boolean {
     if (!s?.record || s.record === false) continue; // not a start
     const plan = resolveRecordPlan({ step: s, context });
     if (plan.name === "ffmpeg") return true;
+    // plan.name === "browser": an explicit browser-engine record on a context
+    // that can't run one (headless or non-Chrome) is SKIPPED by startRecording,
+    // so it neither occupies the single browser slot nor falls back to ffmpeg —
+    // don't let it force serial/Xvfb. (Auto-engine on such contexts already
+    // resolves to ffmpeg above.)
+    const supportsBrowser =
+      context?.browser?.name === "chrome" && !context?.browser?.headless;
+    if (!supportsBrowser) continue;
     // A second concurrent browser-engine recording falls back to ffmpeg.
     if (activeBrowser.length > 0) return true;
     activeBrowser.push(recordStepName(s.record));

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -119,7 +119,10 @@ function detectRecordingNameConflict(steps: any[]): string | null {
     if (!step || typeof step !== "object") continue;
     const isStart =
       typeof step.record !== "undefined" && step.record !== false;
-    const isStop = typeof step.stopRecord !== "undefined";
+    // `stopRecord: false` is a no-op (see stopRecording), so it doesn't free a
+    // name in the simulation.
+    const isStop =
+      typeof step.stopRecord !== "undefined" && step.stopRecord !== false;
     if (isStart) {
       const name = recordStepName(step.record);
       if (name !== undefined && active.includes(name)) return name;
@@ -363,12 +366,40 @@ async function resolveCropGeometry({
   return null;
 }
 
+// True when a context will run at least one ffmpeg capture — either an
+// explicit ffmpeg-engine recording, or a browser-engine recording that will
+// fall back to ffmpeg at runtime because another browser recording is already
+// active (only one browser-engine recording can run per context). Simulating
+// the record/stopRecord sequence here keeps the concurrency planner in sync
+// with startRecording's runtime fallback, so a fallback ffmpeg capture still
+// gets the serial/Xvfb safeguards. Pure read — context browsers are already
+// coerced before this runs.
 function jobIsFfmpegRecording(job: any): boolean {
-  const steps = Array.isArray(job?.context?.steps) ? job.context.steps : [];
-  return steps.some((s: any) => {
-    if (!s?.record) return false; // skip undefined / `record: false`
-    return resolveRecordPlan({ step: s, context: job.context }).name === "ffmpeg";
-  });
+  const context = job?.context;
+  const steps = Array.isArray(context?.steps) ? context.steps : [];
+  // Names of active browser-engine recordings (LIFO), to detect overlap.
+  const activeBrowser: Array<string | undefined> = [];
+  for (const s of steps) {
+    const isStop =
+      typeof s?.stopRecord !== "undefined" && s.stopRecord !== false;
+    if (isStop) {
+      const target = stopRecordTargetName(s.stopRecord);
+      if (target !== undefined) {
+        const idx = activeBrowser.lastIndexOf(target);
+        if (idx !== -1) activeBrowser.splice(idx, 1);
+      } else if (activeBrowser.length > 0) {
+        activeBrowser.pop();
+      }
+      continue;
+    }
+    if (!s?.record || s.record === false) continue; // not a start
+    const plan = resolveRecordPlan({ step: s, context });
+    if (plan.name === "ffmpeg") return true;
+    // A second concurrent browser-engine recording falls back to ffmpeg.
+    if (activeBrowser.length > 0) return true;
+    activeBrowser.push(recordStepName(s.record));
+  }
+  return false;
 }
 
 // Decide the effective worker-pool limit given recording constraints. ffmpeg

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -29,7 +29,113 @@ export {
   startXvfb,
   XVFB_SCREEN_SIZE,
   detectX11ScreenSize,
+  isRecordingActive,
+  recordStepName,
+  stopRecordTargetName,
+  selectRecordingToStop,
+  detectRecordingNameConflict,
 };
+
+// True when the driver has at least one in-progress recording. Recordings now
+// live in `driver.state.recordings` (an array of handles); this keeps the many
+// "is a recording running?" reads (cursor handling, per-key typing, etc.) a
+// one-liner that's robust to a missing/uninitialized state.
+function isRecordingActive(driver: any): boolean {
+  return (
+    Array.isArray(driver?.state?.recordings) &&
+    driver.state.recordings.length > 0
+  );
+}
+
+// Pull the optional `name` off a `record` step value. Only the detailed-object
+// form carries a name; boolean/string shorthands are anonymous (undefined).
+function recordStepName(record: any): string | undefined {
+  if (record && typeof record === "object" && typeof record.name === "string") {
+    const trimmed = record.name.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  return undefined;
+}
+
+// Pull the optional target name off a `stopRecord` step value. A string is the
+// name directly; an object carries `{ name }`. boolean/null are untargeted
+// (LIFO) and return undefined.
+function stopRecordTargetName(stopRecord: any): string | undefined {
+  if (typeof stopRecord === "string") {
+    const trimmed = stopRecord.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (
+    stopRecord &&
+    typeof stopRecord === "object" &&
+    typeof stopRecord.name === "string"
+  ) {
+    const trimmed = stopRecord.name.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  return undefined;
+}
+
+// Choose which active recording a `stopRecord` step should stop.
+// - A targeted stop (`stopRecord: "name"` / `{ name }`) returns the active
+//   recording with that name, searched across the whole set (overlap need not
+//   be nested). The Phase-1 preflight guarantees names are unique among
+//   simultaneously-active recordings, so a first match is unambiguous.
+// - An untargeted stop (`true`/`null`) is LIFO: the most-recently-started
+//   active recording. By default it skips the synthetic autoRecord recording
+//   so a stray user `stopRecord` can't prematurely end the full-context
+//   capture; end-of-context cleanup passes `includeSynthetic` to drain
+//   everything (including the synthetic one).
+// Returns the handle to stop, or undefined when nothing matches.
+function selectRecordingToStop(
+  recordings: any[],
+  stopRecord: any,
+  { includeSynthetic = false }: { includeSynthetic?: boolean } = {}
+): any {
+  if (!Array.isArray(recordings) || recordings.length === 0) return undefined;
+  const target = stopRecordTargetName(stopRecord);
+  if (target !== undefined) {
+    return recordings.find((r) => r && r.name === target);
+  }
+  for (let i = recordings.length - 1; i >= 0; i--) {
+    const r = recordings[i];
+    if (includeSynthetic || !r?.synthetic) return r;
+  }
+  return undefined;
+}
+
+// Statically simulate the set of active named recordings across a test's steps
+// to catch an ambiguous overlap: a `record` step that (re)uses a `name` while a
+// recording with that same name is still active. Sequential reuse (record "a",
+// stopRecord "a", record "a") is fine — the name is freed by the stop.
+// Anonymous recordings never conflict. Returns the first conflicting name, or
+// null when there is no conflict. Pure — used by the Phase-1 preflight to skip
+// (and warn about) the offending test before any step runs.
+function detectRecordingNameConflict(steps: any[]): string | null {
+  if (!Array.isArray(steps)) return null;
+  // Stack of active recordings (names; undefined for anonymous), LIFO.
+  const active: Array<string | undefined> = [];
+  for (const step of steps) {
+    if (!step || typeof step !== "object") continue;
+    const isStart =
+      typeof step.record !== "undefined" && step.record !== false;
+    const isStop = typeof step.stopRecord !== "undefined";
+    if (isStart) {
+      const name = recordStepName(step.record);
+      if (name !== undefined && active.includes(name)) return name;
+      active.push(name);
+    } else if (isStop) {
+      const target = stopRecordTargetName(step.stopRecord);
+      if (target !== undefined) {
+        const idx = active.lastIndexOf(target);
+        if (idx !== -1) active.splice(idx, 1);
+      } else if (active.length > 0) {
+        active.pop();
+      }
+    }
+  }
+  return null;
+}
 
 // The browser engine drives getDisplayMedia's auto-select via a per-context
 // window title and downloads the .webm to a per-context dir. tests.ts (which
@@ -275,21 +381,45 @@ function computeEffectiveConcurrency({
   jobs,
   platform,
   xvfbAvailable,
+  allowOverlappingCaptures = false,
 }: {
   requestedLimit: number;
   jobs: any[];
   platform: string;
   xvfbAvailable: boolean;
-}): { limit: number; xvfbContexts: any[]; forcedSerial: boolean } {
+  // When true (autoRecord runs), don't force the run serial on a shared
+  // display — let ffmpeg captures overlap. Each concurrent context then
+  // captures the same screen (duplicate/overlapping video), which the
+  // autoRecord caller has opted into. Without it, the safe default below
+  // forces serial so explicit-record users never silently get overlapping
+  // captures.
+  allowOverlappingCaptures?: boolean;
+}): {
+  limit: number;
+  xvfbContexts: any[];
+  forcedSerial: boolean;
+  overlappingCaptures?: boolean;
+} {
   const ffmpegJobs = (jobs || []).filter(jobIsFfmpegRecording);
   if (ffmpegJobs.length === 0) {
     return { limit: requestedLimit, xvfbContexts: [], forcedSerial: false };
   }
   if (platform === "linux" && xvfbAvailable) {
+    // Each runner records its own Xvfb display → truly isolated, real parallel.
     return {
       limit: requestedLimit,
       xvfbContexts: ffmpegJobs.map((j) => j.context),
       forcedSerial: false,
+    };
+  }
+  if (allowOverlappingCaptures) {
+    // "Parallel anyway": keep the requested limit even though captures share
+    // the physical display and will overlap.
+    return {
+      limit: requestedLimit,
+      xvfbContexts: [],
+      forcedSerial: false,
+      overlappingCaptures: true,
     };
   }
   return { limit: 1, xvfbContexts: [], forcedSerial: requestedLimit > 1 };

--- a/src/core/tests/findElement.ts
+++ b/src/core/tests/findElement.ts
@@ -7,6 +7,7 @@ import {
 import { typeKeys } from "./typeKeys.js";
 import { moveTo } from "./moveTo.js";
 import { wait } from "./wait.js";
+import { isRecordingActive } from "./ffmpegRecorder.js";
 
 export { findElement };
 
@@ -147,7 +148,7 @@ async function findElement({ config, step, driver, click }: { config: any; step:
   }
 
   // If recording, wait until page is loaded and instantiate cursor
-  if (driver?.state?.recording) {
+  if (isRecordingActive(driver)) {
     await wait({ config: config, step: { wait: 2000 }, driver: driver });
   }
   // PASS

--- a/src/core/tests/saveScreenshot.ts
+++ b/src/core/tests/saveScreenshot.ts
@@ -347,21 +347,19 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
     await driver.pause(100);
   }
 
+  // Hide the synthetic cursor during capture so it isn't baked into the image,
+  // then always restore it in `finally` — otherwise a capture failure mid-way
+  // would leave the pointer hidden for every later step in a recording.
+  const recordingActive = isRecordingActive(driver);
   try {
-    // If recording is true, hide cursor
-    if (isRecordingActive(driver)) {
+    if (recordingActive) {
       await driver.execute(() => {
-        (document.querySelector("dd-mouse-pointer") as any).style.display = "none";
+        const pointer = document.querySelector("dd-mouse-pointer") as any;
+        if (pointer) pointer.style.display = "none";
       });
     }
     // Save screenshot
     await driver.saveScreenshot(filePath);
-    // If recording is true, show cursor
-    if (isRecordingActive(driver)) {
-      await driver.execute(() => {
-        (document.querySelector("dd-mouse-pointer") as any).style.display = "block";
-      });
-    }
   } catch (error) {
     // Couldn't save screenshot
     result.status = "FAIL";
@@ -371,6 +369,13 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
       fs.unlinkSync(filePath);
     }
     return result;
+  } finally {
+    if (recordingActive) {
+      await driver.execute(() => {
+        const pointer = document.querySelector("dd-mouse-pointer") as any;
+        if (pointer) pointer.style.display = "block";
+      });
+    }
   }
 
   // If crop is set, found bounds of element and crop image

--- a/src/core/tests/saveScreenshot.ts
+++ b/src/core/tests/saveScreenshot.ts
@@ -10,6 +10,7 @@ import {
 import path from "node:path";
 import fs from "node:fs";
 import { loadHeavyDep } from "../../runtime/loader.js";
+import { isRecordingActive } from "./ffmpegRecorder.js";
 
 // pngjs, sharp, and pixelmatch are all heavy runtime deps. Lazy-load each
 // the first time a screenshot step needs it. Use `typeof import('…')`
@@ -348,7 +349,7 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
 
   try {
     // If recording is true, hide cursor
-    if (driver?.state?.recording) {
+    if (isRecordingActive(driver)) {
       await driver.execute(() => {
         (document.querySelector("dd-mouse-pointer") as any).style.display = "none";
       });
@@ -356,7 +357,7 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
     // Save screenshot
     await driver.saveScreenshot(filePath);
     // If recording is true, show cursor
-    if (driver?.state?.recording) {
+    if (isRecordingActive(driver)) {
       await driver.execute(() => {
         (document.querySelector("dd-mouse-pointer") as any).style.display = "block";
       });

--- a/src/core/tests/saveScreenshot.ts
+++ b/src/core/tests/saveScreenshot.ts
@@ -371,10 +371,17 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
     return result;
   } finally {
     if (recordingActive) {
-      await driver.execute(() => {
-        const pointer = document.querySelector("dd-mouse-pointer") as any;
-        if (pointer) pointer.style.display = "block";
-      });
+      // Best-effort: a throw here (e.g. an unstable session) must not override a
+      // successful screenshot result or mask the caught error above — exceptions
+      // in `finally` take precedence over returns.
+      try {
+        await driver.execute(() => {
+          const pointer = document.querySelector("dd-mouse-pointer") as any;
+          if (pointer) pointer.style.display = "block";
+        });
+      } catch {
+        /* cursor restore is non-essential */
+      }
     }
   }
 

--- a/src/core/tests/startRecording.ts
+++ b/src/core/tests/startRecording.ts
@@ -87,13 +87,21 @@ async function startRecording({ config, context, step, driver }: { config: any; 
   // With overlapping recordings, two could target the same output before
   // either file exists (the existsSync check above can't catch that). Refuse to
   // start a recording whose target is already claimed by an active one.
-  const normalizedTarget = path.resolve(filePath);
+  // Case-fold on case-insensitive filesystems (Windows/macOS) so `out.mp4` and
+  // `Out.mp4` — which resolve to the same file — are caught by this guard.
+  const normalizeActiveTarget = (p: string) => {
+    const resolved = path.resolve(p);
+    return process.platform === "win32" || process.platform === "darwin"
+      ? resolved.toLowerCase()
+      : resolved;
+  };
+  const normalizedTarget = normalizeActiveTarget(filePath);
   if (
     Array.isArray(driver?.state?.recordings) &&
     driver.state.recordings.some(
       (r: any) =>
         typeof r?.targetPath === "string" &&
-        path.resolve(r.targetPath) === normalizedTarget
+        normalizeActiveTarget(r.targetPath) === normalizedTarget
     )
   ) {
     result.status = "SKIPPED";

--- a/src/core/tests/startRecording.ts
+++ b/src/core/tests/startRecording.ts
@@ -13,6 +13,7 @@ import {
   detectX11ScreenSize,
 } from "./ffmpegRecorder.js";
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
@@ -80,6 +81,23 @@ async function startRecording({ config, context, step, driver }: { config: any; 
     // File already exists
     result.status = "SKIPPED";
     result.description = `File already exists: ${filePath}`;
+    return result;
+  }
+
+  // With overlapping recordings, two could target the same output before
+  // either file exists (the existsSync check above can't catch that). Refuse to
+  // start a recording whose target is already claimed by an active one.
+  const normalizedTarget = path.resolve(filePath);
+  if (
+    Array.isArray(driver?.state?.recordings) &&
+    driver.state.recordings.some(
+      (r: any) =>
+        typeof r?.targetPath === "string" &&
+        path.resolve(r.targetPath) === normalizedTarget
+    )
+  ) {
+    result.status = "SKIPPED";
+    result.description = `Recording target is already in use by an active recording: ${filePath}`;
     return result;
   }
 
@@ -301,9 +319,12 @@ async function startRecording({ config, context, step, driver }: { config: any; 
 
   const tempDir = path.join(os.tmpdir(), "doc-detective", "recordings");
   if (!fs.existsSync(tempDir)) fs.mkdirSync(tempDir, { recursive: true });
+  // A short unique suffix keeps two same-context recordings that share a
+  // baseName (e.g. overlapping ffmpeg captures) from writing/transcoding/
+  // deleting the same intermediate .mkv.
   const tempPath = path.join(
     tempDir,
-    `${safeContextId(context.contextId)}-${baseName}.mkv`
+    `${safeContextId(context.contextId)}-${baseName}-${randomUUID().slice(0, 8)}.mkv`
   );
 
   let ffmpegPath: string;

--- a/src/core/tests/startRecording.ts
+++ b/src/core/tests/startRecording.ts
@@ -86,7 +86,24 @@ async function startRecording({ config, context, step, driver }: { config: any; 
   // Resolve which engine to use. The context's browser is already coerced by
   // the runner (headed Chrome preferred when nothing was specified), so this
   // is a pure read.
-  const plan = resolveRecordPlan({ step, context });
+  let plan = resolveRecordPlan({ step, context });
+
+  // The browser engine owns a dedicated recorder tab and switches the active
+  // window, so only one browser-engine recording can run per context. If one
+  // is already active and this would be a second, don't fail — fall back to
+  // the ffmpeg engine with a `viewport` target (cropped to the browser content
+  // area, approximating the browser-engine capture) and warn.
+  const hasActiveBrowserRecording =
+    Array.isArray(driver?.state?.recordings) &&
+    driver.state.recordings.some((r: any) => r?.type === "MediaRecorder");
+  if (plan.name === "browser" && hasActiveBrowserRecording) {
+    log(
+      config,
+      "warning",
+      "A browser-engine recording is already active in this context; recording this one with the ffmpeg engine (viewport target) instead, since only one browser-engine recording can run at a time."
+    );
+    plan = { name: "ffmpeg", target: "viewport", fps: plan.fps };
+  }
 
   if (plan.name === "browser") {
     // Browser engine: capture the Chrome viewport via getDisplayMedia +

--- a/src/core/tests/stopRecording.ts
+++ b/src/core/tests/stopRecording.ts
@@ -49,9 +49,15 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
   if (!recording) {
     result.status = "SKIPPED";
     const target = stopRecordTargetName(step.stopRecord);
-    result.description = target
-      ? `No active recording named '${target}'.`
-      : `Recording isn't started.`;
+    if (target !== undefined) {
+      result.description = `No active recording named '${target}'.`;
+    } else if (recordings.length > 0) {
+      // An untargeted stop found only the synthetic autoRecord recording, which
+      // it deliberately skips — say so rather than the misleading "isn't started".
+      result.description = `No user-stoppable recording is active; an automatic (autoRecord) recording is still running and stops at the end of the context.`;
+    } else {
+      result.description = `Recording isn't started.`;
+    }
     return result;
   }
 

--- a/src/core/tests/stopRecording.ts
+++ b/src/core/tests/stopRecording.ts
@@ -3,7 +3,11 @@ import { log } from "../utils.js";
 import { spawn } from "node:child_process";
 import path from "node:path";
 import fs from "node:fs";
-import { getFfmpegPath } from "./ffmpegRecorder.js";
+import {
+  getFfmpegPath,
+  selectRecordingToStop,
+  stopRecordTargetName,
+} from "./ffmpegRecorder.js";
 
 export { stopRecording };
 
@@ -23,15 +27,32 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
     return result;
   }
 
-  // Skip if recording is not started. Recording state is per-context (it
-  // lives on driver.state), so concurrent contexts can't see each other's
-  // recordings.
-  const recording = driver?.state?.recording;
+  // Resolve which active recording to stop. Recordings are per-context (they
+  // live on driver.state.recordings), so concurrent contexts can't see each
+  // other's recordings. `__stopAny` (set by end-of-context cleanup) lets a
+  // generic stop also drain the synthetic autoRecord recording.
+  const recordings: any[] = Array.isArray(driver?.state?.recordings)
+    ? driver.state.recordings
+    : [];
+  const recording = selectRecordingToStop(recordings, step.stopRecord, {
+    includeSynthetic: step?.__stopAny === true,
+  });
   if (!recording) {
     result.status = "SKIPPED";
-    result.description = `Recording isn't started.`;
+    const target = stopRecordTargetName(step.stopRecord);
+    result.description = target
+      ? `No active recording named '${target}'.`
+      : `Recording isn't started.`;
     return result;
   }
+
+  // Remove this specific handle from the active set regardless of how the stop
+  // below resolves — a failed stop must not leave a dead handle that the
+  // end-of-context cleanup would retry forever.
+  const dropHandle = () => {
+    const idx = recordings.indexOf(recording);
+    if (idx !== -1) recordings.splice(idx, 1);
+  };
 
   try {
     if (recording.type === "MediaRecorder") {
@@ -56,7 +77,7 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
         if (remainingHandles.length > 0) {
           await driver.switchToWindow(remainingHandles[0]);
         }
-        driver.state.recording = null;
+        dropHandle();
         return result;
       }
 
@@ -74,7 +95,7 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
         result.description = "Recording download timed out.";
         // Clear the state so the auto-stop in runContext doesn't re-invoke
         // a doomed second stop (the recorder was already told to stop).
-        driver.state.recording = null;
+        dropHandle();
         return result;
       }
       // Close recording tab and switch back to the original content tab
@@ -94,7 +115,7 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
         targetPath: recording.targetPath,
         deleteSource: true,
       });
-      driver.state.recording = null;
+      dropHandle();
     } else if (recording.type === "ffmpeg") {
       // ffmpeg engine. Stop the capture gracefully (write "q" to stdin so the
       // container is finalized), then transcode the temp .mkv into the target
@@ -145,15 +166,15 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
         deleteSource: true,
         crop: recording.crop,
       });
-      driver.state.recording = null;
+      dropHandle();
     }
   } catch (error) {
     // Couldn't stop recording
     result.status = "FAIL";
     result.description = `Couldn't stop recording. ${error}`;
-    // Clear the state so the auto-stop in runContext doesn't re-invoke a
+    // Drop the handle so the auto-stop in runContext doesn't re-invoke a
     // doomed second stop.
-    driver.state.recording = null;
+    dropHandle();
     return result;
   }
 

--- a/src/core/tests/stopRecording.ts
+++ b/src/core/tests/stopRecording.ts
@@ -262,9 +262,11 @@ async function transcode({
   });
 }
 
-// Wait for a file to exist and stop growing (size unchanged across two reads
-// ~500ms apart), up to `maxSeconds`. Returns true once stable, false on
-// timeout. Guards against transcoding a download that's still being written.
+// Wait for a file to exist and stop growing (size unchanged across three reads
+// ~500ms apart, i.e. ~1s of stability), up to `maxSeconds`. Returns true once
+// stable, false on timeout. Guards against transcoding a download that's still
+// being written — concurrent recordings make a mid-write size plateau (the OS
+// flushing in chunks) more likely, so a single agreeing read isn't enough.
 async function waitForStableFile(
   filePath: string,
   maxSeconds: number
@@ -283,7 +285,7 @@ async function waitForStableFile(
     // before writing data, and transcoding an empty file fails.
     if (size > 0 && size === lastSize) {
       stableReads++;
-      if (stableReads >= 1) return true;
+      if (stableReads >= 2) return true;
     } else {
       stableReads = 0;
     }

--- a/src/core/tests/stopRecording.ts
+++ b/src/core/tests/stopRecording.ts
@@ -27,6 +27,15 @@ async function stopRecording({ config, step, driver }: { config: any; step: any;
     return result;
   }
 
+  // `stopRecord: false` is an explicit no-op (mirrors `record: false`): it must
+  // not stop anything. Runtime dispatch keys on property presence, so guard the
+  // value here rather than in the schema (the boolean form stays valid).
+  if (step.stopRecord === false) {
+    result.status = "SKIPPED";
+    result.description = "Recording stop is disabled (stopRecord: false).";
+    return result;
+  }
+
   // Resolve which active recording to stop. Recordings are per-context (they
   // live on driver.state.recordings), so concurrent contexts can't see each
   // other's recordings. `__stopAny` (set by end-of-context cleanup) lets a

--- a/src/core/tests/typeKeys.ts
+++ b/src/core/tests/typeKeys.ts
@@ -3,6 +3,7 @@ import {
   findElementByCriteria,
 } from "./findStrategies.js";
 import { loadHeavyDep } from "../../runtime/loader.js";
+import { isRecordingActive } from "./ffmpegRecorder.js";
 
 export { typeKeys };
 
@@ -166,7 +167,7 @@ async function typeKeys({ config, step, driver }: { config: any; step: any; driv
   }
 
   // Split into array of strings, each containing a single key
-  if (driver?.state?.recording) {
+  if (isRecordingActive(driver)) {
     let keys: any[] = [];
     step.type.keys.forEach((key: any) => {
       if (key.startsWith("$") && key.endsWith("$")) {
@@ -211,7 +212,7 @@ async function typeKeys({ config, step, driver }: { config: any; step: any; driv
 
   // Run action
   try {
-    if (driver?.state?.recording) {
+    if (isRecordingActive(driver)) {
       // Type keys one at a time
       for (let i = 0; i < step.type.keys.length; i++) {
         await driver.keys(step.type.keys[i]);

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -652,10 +652,10 @@ function getRunOutputDir(
 }
 
 // Whether a run will write anything into its per-run artifact folder
-// (`<output>/.doc-detective/run-<id>/`). The folder only holds runFolder
-// reporter archives and autoScreenshot images, so when neither is active the
-// runner skips creating it (see runSpecs) instead of leaving an empty folder
-// behind.
+// (`<output>/.doc-detective/run-<id>/`). The folder holds runFolder reporter
+// archives, autoScreenshot images, and autoRecord videos, so when none is
+// active the runner skips creating it (see runSpecs) instead of leaving an
+// empty folder behind.
 //
 // autoScreenshot can be set globally on the config or per spec/test. When the
 // resolved `specs` are available, decide exactly as resolveAutoScreenshot does
@@ -677,17 +677,23 @@ function getRunOutputDir(
 function runArchivesArtifacts(config: any = {}, specs: any[] = []): boolean {
   const list = Array.isArray(specs) ? specs : [];
   if (list.length > 0) {
-    const writesScreenshot = list.some((spec: any) =>
-      (spec?.tests ?? []).some((test: any) =>
-        Boolean(
-          test?.autoScreenshot ??
-            spec?.autoScreenshot ??
-            config?.autoScreenshot
-        )
+    // autoScreenshot images and autoRecord videos both land in the run folder.
+    // Resolve each exactly as resolveAutoScreenshot/resolveAutoRecord do
+    // (test > spec > config) per selected test, so a per-test `false` that
+    // overrides a global `true` is respected.
+    const writesArtifact = list.some((spec: any) =>
+      (spec?.tests ?? []).some(
+        (test: any) =>
+          Boolean(
+            test?.autoScreenshot ??
+              spec?.autoScreenshot ??
+              config?.autoScreenshot
+          ) ||
+          Boolean(test?.autoRecord ?? spec?.autoRecord ?? config?.autoRecord)
       )
     );
-    if (writesScreenshot) return true;
-  } else if (Boolean(config?.autoScreenshot)) {
+    if (writesArtifact) return true;
+  } else if (Boolean(config?.autoScreenshot) || Boolean(config?.autoRecord)) {
     return true;
   }
   const active =

--- a/src/debug/provenance.ts
+++ b/src/debug/provenance.ts
@@ -112,6 +112,12 @@ const OVERRIDE_SPECS: Array<{
     present: (a) => typeof a.autoScreenshot === "boolean",
   },
   {
+    flag: "auto-record",
+    argKey: "autoRecord",
+    configKey: "autoRecord",
+    present: (a) => typeof a.autoRecord === "boolean",
+  },
+  {
     flag: "cache-dir",
     argKey: "cacheDir",
     configKey: "cacheDir",

--- a/src/hints/hints.ts
+++ b/src/hints/hints.ts
@@ -92,6 +92,27 @@ export const HINTS: Hint[] = [
   },
 
   // ------------------------------------------------------------------
+  // enableAutoRecord (feature discovery)
+  // ------------------------------------------------------------------
+  {
+    id: "enableAutoRecord",
+    priority: 40,
+    markdown: [
+      "Want a video of every run? Enable `--auto-record` to record each browser context end-to-end with the ffmpeg engine.",
+      "",
+      "Videos are archived per run under `.doc-detective/run-<runId>/` alongside test results, so you can replay exactly what happened.",
+      "",
+      "```bash",
+      "doc-detective --auto-record",
+      "```",
+    ].join("\n"),
+    when: (ctx) =>
+      ctx.usedBrowserContexts.size > 0 &&
+      !ctx.producedRecordings &&
+      !ctx.config?.autoRecord,
+  },
+
+  // ------------------------------------------------------------------
   // enableAutoScreenshot (feature discovery)
   // ------------------------------------------------------------------
   {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,6 +127,11 @@ function buildYargs(args: any): any {
         "Capture a screenshot after every browser-based step. Images are saved in the per-run artifact folder (<output>/.doc-detective/run-<runId>/) at paths derived from spec/test/context IDs plus each step's order, action, and ID, so the same step lands on the same relative path in every run's folder for run-over-run comparison. Use --no-auto-screenshot to override a config file that enables it.",
       type: "boolean",
     })
+    .option("auto-record", {
+      description:
+        "Record a video of every browser-based test context, in addition to any explicit record steps. The recording wraps the whole context and always uses the ffmpeg engine. Videos are saved in the per-run artifact folder (<output>/.doc-detective/run-<runId>/) at paths derived from spec/test/context IDs, so the same context lands on the same relative path in every run's folder for run-over-run comparison. Use --no-auto-record to override a config file that enables it.",
+      type: "boolean",
+    })
     .option("auto-update", {
       description:
         "Check the npm registry on startup for a newer doc-detective and self-update before running. Use --no-auto-update (or set autoUpdate: false in config) to pin to the installed version.",
@@ -394,6 +399,9 @@ async function setConfig({ configPath, args }: { configPath?: any; args: any }) 
   }
   if (typeof args.autoScreenshot === "boolean") {
     config.autoScreenshot = args.autoScreenshot;
+  }
+  if (typeof args.autoRecord === "boolean") {
+    config.autoRecord = args.autoRecord;
   }
   if (typeof args.cacheDir === "string" && args.cacheDir.length > 0) {
     // Assignment-only per the documented setConfig contract (the standard

--- a/test/core-artifacts/autorecord.spec.json
+++ b/test/core-artifacts/autorecord.spec.json
@@ -1,0 +1,169 @@
+{
+  "specId": "autorecord",
+  "description": "Exercises autoRecord and the multiple-overlapping-recordings model end-to-end: a synthetic full-context ffmpeg recording (autoRecord), a synthetic recording overlapping an explicit named recording stopped by name, the browser-engine-to-ffmpeg fallback when a second browser recording would overlap, and the static name-conflict preflight that skips a test before it runs. Recording tests need a visible display (Windows/macOS, and Linux via the per-runner Xvfb display); the browser engine additionally requires headed Chrome (Windows/macOS).",
+  "tests": [
+    {
+      "testId": "autorecord-full-context",
+      "description": "autoRecord (test-level) injects a synthetic full-context ffmpeg recording that is auto-stopped at the end of the context.",
+      "autoRecord": true,
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac",
+            "linux"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        }
+      ]
+    },
+    {
+      "testId": "autorecord-overlap-named",
+      "description": "A synthetic autoRecord (ffmpeg) recording overlaps an explicit, named browser-engine recording; the explicit one is stopped by name mid-context while the synthetic one runs to the end.",
+      "autoRecord": true,
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "autorecord-section.webm",
+            "name": "section",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": "section"
+        }
+      ]
+    },
+    {
+      "testId": "autorecord-browser-fallback",
+      "description": "A second concurrent browser-engine recording falls back to the ffmpeg engine (viewport target) instead of failing; both recordings are stopped by name.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "autorecord-fallback-first.webm",
+            "name": "first",
+            "engine": "browser",
+            "overwrite": "true"
+          }
+        },
+        {
+          "record": {
+            "path": "autorecord-fallback-second.mp4",
+            "name": "second",
+            "engine": "browser",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": "second"
+        },
+        {
+          "stopRecord": "first"
+        }
+      ]
+    },
+    {
+      "testId": "autorecord-name-conflict-skipped",
+      "description": "Reusing a recording name while one with that name is still active is caught by the static preflight, which skips the whole test (all contexts) before any step runs — so this needs no display and runs everywhere.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac",
+            "linux"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": true
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "autorecord-dup-1.mp4",
+            "name": "dup",
+            "engine": "ffmpeg",
+            "overwrite": "true"
+          }
+        },
+        {
+          "record": {
+            "path": "autorecord-dup-2.mp4",
+            "name": "dup",
+            "engine": "ffmpeg",
+            "overwrite": "true"
+          }
+        },
+        {
+          "find": {
+            "selector": "body",
+            "timeout": 5000
+          }
+        },
+        {
+          "stopRecord": "dup"
+        }
+      ]
+    }
+  ]
+}

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -147,6 +147,45 @@ describe("Run tests successfully", function () {
     }
   });
 
+  it("autoRecord/record name conflict skips the whole test before any step runs", async function () {
+    // A `record` step that reuses a recording `name` while one with that name
+    // is still active is caught by the static Phase-1 preflight, which skips
+    // the test (all contexts) with a clear reason — no driver is started, so
+    // this is deterministic on every platform.
+    const conflictSpec = {
+      tests: [
+        {
+          testId: "dup-name-conflict",
+          steps: [
+            { goTo: "http://localhost:8092" },
+            { record: { path: "dup-1.mp4", name: "dup", engine: "ffmpeg", overwrite: "true" } },
+            { record: { path: "dup-2.mp4", name: "dup", engine: "ffmpeg", overwrite: "true" } },
+            { stopRecord: "dup" },
+          ],
+        },
+      ],
+    };
+    const tempFilePath = path.resolve("./test/temp-record-name-conflict.json");
+    fs.writeFileSync(tempFilePath, JSON.stringify(conflictSpec, null, 2));
+    const config = { input: tempFilePath, logLevel: "silent" };
+    let result;
+    try {
+      result = await runTests(config);
+      assert.equal(result.summary.specs.fail, 0, "conflict must not fail the spec");
+      assert.ok(result.summary.tests.skipped >= 1, "the conflicting test should be skipped");
+      assert.equal(result.summary.tests.pass, 0, "the conflicting test must not pass");
+      const ctx = result.specs[0].tests[0].contexts[0];
+      assert.equal(ctx.result, "SKIPPED");
+      assert.match(
+        ctx.resultDescription,
+        /recording name 'dup'/,
+        `expected the skip reason to name the conflict, got: ${ctx.resultDescription}`
+      );
+    } finally {
+      fs.unlinkSync(tempFilePath);
+    }
+  });
+
   it("runShell regression test returns WARNING when variation exceeds threshold", async () => {
     // Create a test file path
     const outputFilePath = path.resolve("./test/temp-regression-output.txt");

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -172,7 +172,7 @@ describe("Run tests successfully", function () {
     try {
       result = await runTests(config);
       assert.equal(result.summary.specs.fail, 0, "conflict must not fail the spec");
-      assert.ok(result.summary.tests.skipped >= 1, "the conflicting test should be skipped");
+      assert.equal(result.summary.tests.skipped, 1, "exactly the one conflicting test should be skipped");
       assert.equal(result.summary.tests.pass, 0, "the conflicting test must not pass");
       const ctx = result.specs[0].tests[0].contexts[0];
       assert.equal(ctx.result, "SKIPPED");
@@ -180,6 +180,77 @@ describe("Run tests successfully", function () {
         ctx.resultDescription,
         /recording name 'dup'/,
         `expected the skip reason to name the conflict, got: ${ctx.resultDescription}`
+      );
+    } finally {
+      fs.unlinkSync(tempFilePath);
+    }
+  });
+
+  // autoRecord precedence (config > spec > test) end-to-end through runTests.
+  // The synthetic full-context recording carries this exact description, so its
+  // presence/absence in the executed steps proves whether autoRecord resolved
+  // true for the context. Headless here: the ffmpeg capture itself SKIPs without
+  // a display, but the synthetic step is still injected and reported, which is
+  // all these assertions need.
+  const AUTO_RECORD_DESC = "Automatic full-context recording";
+  const hasSyntheticRecord = (result) => {
+    const steps = result?.specs?.[0]?.tests?.[0]?.contexts?.[0]?.steps || [];
+    return steps.some(
+      (s) => s.description === AUTO_RECORD_DESC && typeof s.record !== "undefined"
+    );
+  };
+
+  it("autoRecord config-level injects a synthetic recording end-to-end", async function () {
+    this.retries(2); // browser startup between sequential runTests calls can be flaky
+    const spec = {
+      tests: [
+        {
+          steps: [
+            { goTo: "http://localhost:8092" },
+            { find: { selector: "body", timeout: 5000 } },
+          ],
+        },
+      ],
+    };
+    const tempFilePath = path.resolve("./test/temp-autorecord-config.json");
+    fs.writeFileSync(tempFilePath, JSON.stringify(spec, null, 2));
+    // autoRecord set ONLY at the config level (no spec/test fields).
+    const config = { input: tempFilePath, logLevel: "silent", autoRecord: true };
+    try {
+      const result = await runTests(config);
+      assert.equal(result.summary.specs.fail, 0);
+      assert.ok(
+        hasSyntheticRecord(result),
+        "config-level autoRecord should inject the synthetic recording step"
+      );
+    } finally {
+      fs.unlinkSync(tempFilePath);
+    }
+  });
+
+  it("autoRecord test-level false overrides spec-level true end-to-end", async function () {
+    this.retries(2);
+    const spec = {
+      autoRecord: true, // spec level on
+      tests: [
+        {
+          autoRecord: false, // test level wins → no synthetic recording
+          steps: [
+            { goTo: "http://localhost:8092" },
+            { find: { selector: "body", timeout: 5000 } },
+          ],
+        },
+      ],
+    };
+    const tempFilePath = path.resolve("./test/temp-autorecord-precedence.json");
+    fs.writeFileSync(tempFilePath, JSON.stringify(spec, null, 2));
+    const config = { input: tempFilePath, logLevel: "silent" };
+    try {
+      const result = await runTests(config);
+      assert.equal(result.summary.specs.fail, 0);
+      assert.ok(
+        !hasSyntheticRecord(result),
+        "test-level autoRecord:false should override spec-level true (no synthetic recording)"
       );
     } finally {
       fs.unlinkSync(tempFilePath);

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -1118,6 +1118,7 @@ describe("debug/provenance", function () {
       hints: true,
       autoUpdate: true,
       autoScreenshot: true,
+      autoRecord: true,
       cacheDir: "z",
       concurrentRunners: "2",
     });
@@ -1133,6 +1134,7 @@ describe("debug/provenance", function () {
       "hints",
       "auto-update",
       "auto-screenshot",
+      "auto-record",
       "cache-dir",
       "concurrent-runners",
     ]);

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -12,6 +12,11 @@ import {
   parseMacScreenIndex,
   checkSystemBinary,
   xvfbDisplay,
+  isRecordingActive,
+  recordStepName,
+  stopRecordTargetName,
+  selectRecordingToStop,
+  detectRecordingNameConflict,
 } from "../dist/core/tests/ffmpegRecorder.js";
 
 describe("ffmpegRecorder", function () {
@@ -357,6 +362,153 @@ describe("ffmpegRecorder", function () {
       });
       expect(r.limit).to.equal(1);
       expect(r.forcedSerial).to.equal(false);
+    });
+
+    it("allows overlapping captures (parallel anyway) when opted in on win/mac", function () {
+      for (const platform of ["win32", "darwin"]) {
+        const r = computeEffectiveConcurrency({
+          requestedLimit: 4,
+          jobs: [ffmpegJob, plainJob],
+          platform,
+          xvfbAvailable: false,
+          allowOverlappingCaptures: true,
+        });
+        expect(r.limit, platform).to.equal(4);
+        expect(r.forcedSerial, platform).to.equal(false);
+        expect(r.overlappingCaptures, platform).to.equal(true);
+      }
+    });
+
+    it("still forces serial for ffmpeg without the overlap opt-in (no regression)", function () {
+      const r = computeEffectiveConcurrency({
+        requestedLimit: 4,
+        jobs: [ffmpegJob],
+        platform: "win32",
+        xvfbAvailable: false,
+        allowOverlappingCaptures: false,
+      });
+      expect(r.limit).to.equal(1);
+      expect(r.forcedSerial).to.equal(true);
+    });
+
+    it("prefers Xvfb isolation over overlap even when overlap is allowed", function () {
+      const r = computeEffectiveConcurrency({
+        requestedLimit: 4,
+        jobs: [ffmpegJob],
+        platform: "linux",
+        xvfbAvailable: true,
+        allowOverlappingCaptures: true,
+      });
+      expect(r.limit).to.equal(4);
+      expect(r.forcedSerial).to.equal(false);
+      expect(r.xvfbContexts.length).to.equal(1);
+      expect(r.overlappingCaptures).to.equal(undefined);
+    });
+  });
+
+  describe("isRecordingActive", function () {
+    it("is false for missing/empty recordings and true for >=1", function () {
+      expect(isRecordingActive(undefined)).to.equal(false);
+      expect(isRecordingActive({})).to.equal(false);
+      expect(isRecordingActive({ state: {} })).to.equal(false);
+      expect(isRecordingActive({ state: { recordings: [] } })).to.equal(false);
+      expect(isRecordingActive({ state: { recordings: [{ id: "a" }] } })).to.equal(
+        true
+      );
+    });
+  });
+
+  describe("recordStepName / stopRecordTargetName", function () {
+    it("reads record name only from the detailed object form", function () {
+      expect(recordStepName(true)).to.equal(undefined);
+      expect(recordStepName("out.mp4")).to.equal(undefined);
+      expect(recordStepName({ path: "out.mp4" })).to.equal(undefined);
+      expect(recordStepName({ name: "demo" })).to.equal("demo");
+      expect(recordStepName({ name: "  demo  " })).to.equal("demo");
+      expect(recordStepName({ name: "   " })).to.equal(undefined);
+    });
+
+    it("reads stopRecord target from a string or { name }", function () {
+      expect(stopRecordTargetName(true)).to.equal(undefined);
+      expect(stopRecordTargetName(null)).to.equal(undefined);
+      expect(stopRecordTargetName("demo")).to.equal("demo");
+      expect(stopRecordTargetName({ name: "demo" })).to.equal("demo");
+      expect(stopRecordTargetName({ name: "" })).to.equal(undefined);
+    });
+  });
+
+  describe("selectRecordingToStop", function () {
+    const synth = { id: "s", synthetic: true };
+    const a = { id: "a", name: "a" };
+    const b = { id: "b", name: "b" };
+
+    it("LIFO returns the most-recent non-synthetic recording", function () {
+      expect(selectRecordingToStop([synth, a, b], true)).to.equal(b);
+      expect(selectRecordingToStop([synth, a], null)).to.equal(a);
+    });
+
+    it("LIFO skips the synthetic recording (returns undefined when only synthetic)", function () {
+      expect(selectRecordingToStop([synth], true)).to.equal(undefined);
+    });
+
+    it("includeSynthetic lets LIFO stop the synthetic recording (cleanup path)", function () {
+      expect(
+        selectRecordingToStop([synth], true, { includeSynthetic: true })
+      ).to.equal(synth);
+    });
+
+    it("targets a recording by name anywhere in the set", function () {
+      expect(selectRecordingToStop([synth, a, b], "a")).to.equal(a);
+      expect(selectRecordingToStop([synth, a, b], { name: "b" })).to.equal(b);
+      expect(selectRecordingToStop([synth, a, b], "missing")).to.equal(undefined);
+    });
+
+    it("returns undefined for an empty set", function () {
+      expect(selectRecordingToStop([], true)).to.equal(undefined);
+    });
+  });
+
+  describe("detectRecordingNameConflict", function () {
+    it("flags a name reused while still active", function () {
+      const steps = [
+        { record: { path: "a.mp4", name: "demo" } },
+        { record: { path: "b.mp4", name: "demo" } },
+      ];
+      expect(detectRecordingNameConflict(steps)).to.equal("demo");
+    });
+
+    it("allows sequential reuse once the first is stopped", function () {
+      const steps = [
+        { record: { path: "a.mp4", name: "demo" } },
+        { stopRecord: "demo" },
+        { record: { path: "b.mp4", name: "demo" } },
+      ];
+      expect(detectRecordingNameConflict(steps)).to.equal(null);
+    });
+
+    it("allows overlapping recordings with distinct names", function () {
+      const steps = [
+        { record: { path: "a.mp4", name: "a" } },
+        { record: { path: "b.mp4", name: "b" } },
+        { stopRecord: "a" },
+        { stopRecord: "b" },
+      ];
+      expect(detectRecordingNameConflict(steps)).to.equal(null);
+    });
+
+    it("never conflicts on anonymous recordings, and LIFO stop frees the stack", function () {
+      const steps = [
+        { record: true },
+        { record: true },
+        { stopRecord: true },
+        { record: true },
+      ];
+      expect(detectRecordingNameConflict(steps)).to.equal(null);
+    });
+
+    it("returns null for non-array / empty input", function () {
+      expect(detectRecordingNameConflict(undefined)).to.equal(null);
+      expect(detectRecordingNameConflict([])).to.equal(null);
     });
   });
 

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -293,6 +293,38 @@ describe("ffmpegRecorder", function () {
       expect(jobIsFfmpegRecording(none)).to.equal(false);
       expect(jobIsFfmpegRecording(disabled)).to.equal(false);
     });
+
+    it("counts a context whose second browser recording will fall back to ffmpeg", function () {
+      // Two overlapping browser-engine recordings: the second falls back to
+      // ffmpeg at runtime, so the planner must treat the context as ffmpeg.
+      const overlap = {
+        context: {
+          browser: { name: "chrome", headless: false },
+          steps: [
+            { record: { name: "a", engine: "browser" } },
+            { record: { name: "b", engine: "browser" } },
+            { stopRecord: "b" },
+            { stopRecord: "a" },
+          ],
+        },
+      };
+      expect(jobIsFfmpegRecording(overlap)).to.equal(true);
+    });
+
+    it("does not count sequential (non-overlapping) browser recordings as ffmpeg", function () {
+      const sequential = {
+        context: {
+          browser: { name: "chrome", headless: false },
+          steps: [
+            { record: { name: "a", engine: "browser" } },
+            { stopRecord: "a" },
+            { record: { name: "b", engine: "browser" } },
+            { stopRecord: "b" },
+          ],
+        },
+      };
+      expect(jobIsFfmpegRecording(sequential)).to.equal(false);
+    });
   });
 
   describe("computeEffectiveConcurrency", function () {
@@ -509,6 +541,16 @@ describe("ffmpegRecorder", function () {
     it("returns null for non-array / empty input", function () {
       expect(detectRecordingNameConflict(undefined)).to.equal(null);
       expect(detectRecordingNameConflict([])).to.equal(null);
+    });
+
+    it("does not treat stopRecord: false as freeing the name", function () {
+      // stopRecord: false is a no-op, so the first "dup" is still active.
+      const steps = [
+        { record: { path: "a.mp4", name: "dup" } },
+        { stopRecord: false },
+        { record: { path: "b.mp4", name: "dup" } },
+      ];
+      expect(detectRecordingNameConflict(steps)).to.equal("dup");
     });
   });
 

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -311,6 +311,32 @@ describe("ffmpegRecorder", function () {
       expect(jobIsFfmpegRecording(overlap)).to.equal(true);
     });
 
+    it("does not count browser recordings that startRecording would skip (headless/non-chrome)", function () {
+      // Explicit browser-engine records on a context that can't run one are
+      // SKIPPED at runtime, so two of them must NOT be classified as an ffmpeg
+      // fallback (which would wrongly force serial/Xvfb).
+      const headless = {
+        context: {
+          browser: { name: "chrome", headless: true },
+          steps: [
+            { record: { name: "a", engine: "browser" } },
+            { record: { name: "b", engine: "browser" } },
+          ],
+        },
+      };
+      const firefox = {
+        context: {
+          browser: { name: "firefox", headless: false },
+          steps: [
+            { record: { name: "a", engine: "browser" } },
+            { record: { name: "b", engine: "browser" } },
+          ],
+        },
+      };
+      expect(jobIsFfmpegRecording(headless)).to.equal(false);
+      expect(jobIsFfmpegRecording(firefox)).to.equal(false);
+    });
+
     it("does not count sequential (non-overlapping) browser recordings as ffmpeg", function () {
       const sequential = {
         context: {

--- a/test/hints.test.js
+++ b/test/hints.test.js
@@ -1402,12 +1402,12 @@ describe("hints/index pickByPriority + priorityWeight", function () {
 
 describe("hints/hints (registry)", function () {
   it("every hint has stable id, body, predicate, and a numeric priority when set", function () {
-    // 29 active hints. `useFileTypesForRst` is commented out in the
+    // 30 active hints. `useFileTypesForRst` is commented out in the
     // registry but the `RST_EXTENSIONS` constant, the
     // `detectRstFiles` helper, and the `hasRstFiles` context field
     // are kept in place so the hint can be re-enabled without
     // re-plumbing.
-    expect(HINTS.length).to.equal(29);
+    expect(HINTS.length).to.equal(30);
     const ids = new Set();
     // Ids are camelCase, matching the convention used everywhere else
     // in the project (step names like `goTo`, config fields like
@@ -1688,6 +1688,51 @@ describe("hints/hints (registry)", function () {
           producedScreenshots: false,
           producedAutoScreenshots: true,
           config: {},
+        })
+      )
+    ).to.equal(false);
+  });
+
+  it("enableAutoRecord: fires for browser runs with no recordings and autoRecord off", function () {
+    const h = findHint("enableAutoRecord");
+    expect(h.priority).to.equal(40);
+    expect(
+      h.when(
+        fakeCtx({
+          usedBrowserContexts: new Set(["chrome"]),
+          producedRecordings: false,
+          config: {},
+        })
+      )
+    ).to.equal(true);
+    // Negative: no browser contexts in the run.
+    expect(
+      h.when(
+        fakeCtx({
+          usedBrowserContexts: new Set(),
+          producedRecordings: false,
+          config: {},
+        })
+      )
+    ).to.equal(false);
+    // Negative: the run already produced a recording (incl. an autoRecord one,
+    // which lands as a real record step → producedRecordings true).
+    expect(
+      h.when(
+        fakeCtx({
+          usedBrowserContexts: new Set(["chrome"]),
+          producedRecordings: true,
+          config: {},
+        })
+      )
+    ).to.equal(false);
+    // Negative: autoRecord is already enabled.
+    expect(
+      h.when(
+        fakeCtx({
+          usedBrowserContexts: new Set(["chrome"]),
+          producedRecordings: false,
+          config: { autoRecord: true },
         })
       )
     ).to.equal(false);

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -199,6 +199,31 @@ describe("runArchivesArtifacts", function () {
     ).to.equal(false);
   });
 
+  it("is true when autoRecord is on even without the runFolder reporter", function () {
+    // autoRecord videos land in the run folder, so it must be archived too.
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal"], autoRecord: true })
+    ).to.equal(true);
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal"] }, [
+        { autoRecord: true, tests: [{}] },
+      ])
+    ).to.equal(true);
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal"] }, [
+        { tests: [{ autoRecord: true }] },
+      ])
+    ).to.equal(true);
+  });
+
+  it("respects a test-level autoRecord:false override of a global true", function () {
+    expect(
+      runArchivesArtifacts({ reporters: ["terminal"], autoRecord: true }, [
+        { tests: [{ autoRecord: false }] },
+      ])
+    ).to.equal(false);
+  });
+
   it("is true when reporters are unset (the default set includes runFolder)", function () {
     expect(runArchivesArtifacts({})).to.equal(true);
     expect(runArchivesArtifacts()).to.equal(true);

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -361,9 +361,21 @@ describe("resolveAutoRecord precedence", function () {
 });
 
 describe("buildAutoRecordStep", function () {
-  const config = { logLevel: "silent" };
+  // getRunOutputDir() creates the run folder, so give it a temp output to keep
+  // artifacts out of the repo CWD.
+  let tempOutput;
+  let config;
   const spec = { specId: "docs/guide.md" };
   const test = { testId: "docs/guide.md~abc123" };
+
+  beforeEach(function () {
+    tempOutput = fs.mkdtempSync(path.join(os.tmpdir(), "dd-auto-record-"));
+    config = { logLevel: "silent", output: tempOutput };
+  });
+
+  afterEach(function () {
+    fs.rmSync(tempOutput, { recursive: true, force: true });
+  });
 
   it("builds a synthetic ffmpeg record step with a deterministic path for a driver context", function () {
     const context = {

--- a/test/run-artifacts.test.js
+++ b/test/run-artifacts.test.js
@@ -1,7 +1,11 @@
 import { getRunOutputDir } from "../dist/core/utils.js";
 import { resolveTests, detectTests } from "../dist/core/index.js";
 import { generateSpecId } from "../dist/core/detectTests.js";
-import { resolveAutoScreenshot } from "../dist/core/tests.js";
+import {
+  resolveAutoScreenshot,
+  resolveAutoRecord,
+  buildAutoRecordStep,
+} from "../dist/core/tests.js";
 import { reporters } from "../dist/utils.js";
 import { buildHtml } from "../dist/reporters/htmlReporter.js";
 import path from "node:path";
@@ -314,6 +318,74 @@ describe("resolveAutoScreenshot precedence", function () {
         test: { autoScreenshot: false },
       })
     ).to.equal(false);
+  });
+});
+
+describe("resolveAutoRecord precedence", function () {
+  it("defers down the chain when levels are unset (test > spec > config)", function () {
+    expect(
+      resolveAutoRecord({ config: { autoRecord: true }, spec: {}, test: {} })
+    ).to.equal(true);
+    expect(resolveAutoRecord({ config: {}, spec: {}, test: {} })).to.equal(false);
+    // Spec overrides config.
+    expect(
+      resolveAutoRecord({
+        config: { autoRecord: false },
+        spec: { autoRecord: true },
+        test: {},
+      })
+    ).to.equal(true);
+    expect(
+      resolveAutoRecord({
+        config: { autoRecord: true },
+        spec: { autoRecord: false },
+        test: {},
+      })
+    ).to.equal(false);
+    // Test overrides spec and config.
+    expect(
+      resolveAutoRecord({
+        config: { autoRecord: false },
+        spec: { autoRecord: false },
+        test: { autoRecord: true },
+      })
+    ).to.equal(true);
+    expect(
+      resolveAutoRecord({
+        config: { autoRecord: true },
+        spec: { autoRecord: true },
+        test: { autoRecord: false },
+      })
+    ).to.equal(false);
+  });
+});
+
+describe("buildAutoRecordStep", function () {
+  const config = { logLevel: "silent" };
+  const spec = { specId: "docs/guide.md" };
+  const test = { testId: "docs/guide.md~abc123" };
+
+  it("builds a synthetic ffmpeg record step with a deterministic path for a driver context", function () {
+    const context = {
+      contextId: "windows-chrome",
+      steps: [{ goTo: { url: "https://example.com" } }],
+    };
+    const step = buildAutoRecordStep({ config, spec, test, context });
+    expect(step, "expected a synthetic step").to.not.equal(null);
+    expect(step.record.engine).to.equal("ffmpeg");
+    expect(step.record.overwrite).to.equal("true");
+    expect(step.__autoRecord).to.equal(true);
+    // Deterministic path ending in recordings/<spec>/<test>/<context>.mp4.
+    const normalized = step.record.path.split(path.sep).join("/");
+    expect(normalized).to.match(/recordings\/.+\/.+\/windows-chrome\.mp4$/);
+  });
+
+  it("returns null when the context has no driver-required steps", function () {
+    const context = {
+      contextId: "default",
+      steps: [{ httpRequest: { url: "https://api.example.com" } }],
+    };
+    expect(buildAutoRecordStep({ config, spec, test, context })).to.equal(null);
   });
 });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -375,6 +375,34 @@ describe("Util tests", function () {
     expect(configAbsent.autoScreenshot).to.equal(false);
   });
 
+  it("Yargs parses --auto-record / --no-auto-record as boolean", function () {
+    const on = setArgs(["node", "runTests.js", "--auto-record"]);
+    expect(on.autoRecord).to.equal(true);
+
+    const off = setArgs(["node", "runTests.js", "--no-auto-record"]);
+    expect(off.autoRecord).to.equal(false);
+
+    const absent = setArgs(["node", "runTests.js", "--input", "."]);
+    expect(absent.autoRecord).to.equal(undefined);
+  });
+
+  it("setConfig stores --auto-record on config.autoRecord and applies schema default when absent", async function () {
+    this.timeout(5000);
+    const argsOn = setArgs(["node", "runTests.js", "--auto-record"]);
+    const configOn = await setConfig({ configPath: null, args: argsOn });
+    expect(configOn.autoRecord).to.equal(true);
+
+    const argsOff = setArgs(["node", "runTests.js", "--no-auto-record"]);
+    const configOff = await setConfig({ configPath: null, args: argsOff });
+    expect(configOff.autoRecord).to.equal(false);
+
+    // Schema default is false; absent flag yields false via AJV useDefaults.
+    const argsAbsent = setArgs(["node", "runTests.js", "--input", "."]);
+    expect(argsAbsent.autoRecord).to.equal(undefined);
+    const configAbsent = await setConfig({ configPath: null, args: argsAbsent });
+    expect(configAbsent.autoRecord).to.equal(false);
+  });
+
   it("Yargs parses --cache-dir as a string", function () {
     const set = setArgs(["node", "runTests.js", "--cache-dir", "/tmp/ddc"]);
     expect(set.cacheDir).to.equal("/tmp/ddc");


### PR DESCRIPTION
## What & why

Adds **`autoRecord`** — a zero-config knob that records every browser-based test context end-to-end, mirroring the existing `autoScreenshot`. Enable it once (config/spec/test field or `--auto-record`) and each context's video lands in the per-run artifact folder at a deterministic `recordings/<spec>/<test>/<context>.mp4` path for run-over-run comparison.

Making this robust required upgrading the recording subsystem to support **multiple overlapping recordings** in a single context — the synthetic full-context capture can coexist with author-written `record`/`stopRecord` sub-sections.

## Feature wiring (mirrors `autoScreenshot`)

- `autoRecord` boolean at config/spec/test levels (test > spec > config precedence).
- `--auto-record` / `--no-auto-record` CLI flag + `setConfig` override.
- Debug provenance entry for the flag.
- `enableAutoRecord` post-run hint (feature discovery).

## Recording subsystem changes

- **State model:** `driver.state.recording` (single) → `driver.state.recordings` (a LIFO stack of handles). New `isRecordingActive()` helper; all "is recording active?" reads migrated. Single-recording behavior is byte-identical.
- **Named recordings + targeting:** `record` gains an optional `name`; `stopRecord` now accepts `true`/`null` (LIFO, skipping the synthetic capture), a name string, or `{ name }` to stop a specific recording anywhere in the active set.
- **Preflight:** reusing a recording `name` while one is still active is caught statically and skips that test across all contexts with a warning, instead of failing mid-run.
- **Browser-engine guard:** a second concurrent browser-engine recording transparently falls back to the ffmpeg engine with a `viewport` target (with a warning) — the browser engine can only own one recorder tab per context.
- **Clean exit:** `stopAllRecordings` drains every active recording at end-of-context **and** in the `finally`, so videos are finalized even when a context throws before its normal stop.
- **Concurrency ("parallel anyway"):** autoRecord runs are no longer forced serial. Linux + Xvfb still gives true per-runner isolation; elsewhere the run stays parallel and warns that concurrent ffmpeg captures share (and overlap on) the physical display.

## Schema changes (additive, backward compatible)

- `record_v3`: optional `name`.
- `stopRecord_v3`: widened from `boolean | null` to `boolean | null | string | { name }`.
- `autoRecord` added to `config_v3` / `spec_v3` / `test_v3`. Generated types regenerated via `npm run build:common`.

## Tests

- New/updated unit coverage: schema validation, `isRecordingActive`, `recordStepName`, `stopRecordTargetName`, `selectRecordingToStop`, `detectRecordingNameConflict`, `computeEffectiveConcurrency` (overlap branch + no-regression guard), `resolveAutoRecord` precedence, `buildAutoRecordStep`, CLI parse/`setConfig`/provenance, and the `enableAutoRecord` hint.
- Full suite green except pre-existing environmental failures (shared test-server port 8092 collision and remote-URL fetch tests) — the dedicated recording specs pass and produce video artifacts.

## Reviewer notes

- The synthetic autoRecord recording is **excluded** from untargeted LIFO `stopRecord`; only end-of-context cleanup ends it. This prevents a stray `stopRecord: true` from prematurely cutting the full-context video.
- On macOS/Windows, concurrent autoRecord captures overlap (same physical screen) by design — true isolation needs Linux + Xvfb.
- The `src/common` coverage ratchet currently fails ~0.3% against a stale 100% baseline; this is **pre-existing on `main`** (uncovered `detectTests.ts` Heretto lines), confirmed by measuring the base with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `autoRecord` option to automatically record browser-based test contexts (config/spec/test levels) and updated run output artifacts accordingly.
  * Added `record.name` to identify recordings; enhanced `stopRecord` to stop a specific recording by name (including string/object forms).
  * Added `--auto-record/--no-auto-record` CLI support and a new hint to enable auto-recording when appropriate.
* **Bug Fixes**
  * Auto-record now safely handles name conflicts by skipping affected tests ahead of execution.
  * Improved recording overlap/concurrency behavior and more robust recording stop/cleanup, including stricter file-stability checks.
* **Documentation**
  * Added guidance for required feature fixtures.
* **Tests**
  * Expanded validation, unit, and end-to-end coverage for auto-recording, naming, targeting, and conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->