### PR TITLE
feat(assertions): convert all step actions to the unified expression model

### DIFF
--- a/src/core/tests/checkLink.ts
+++ b/src/core/tests/checkLink.ts
@@ -1,19 +1,13 @@
 import { validate } from "../../common/src/validate.js";
-import { isRelativeUrl, appendQueryParams, rollUpResults } from "../utils.js";
+import { isRelativeUrl, appendQueryParams } from "../utils.js";
+import {
+  buildConditionContext,
+  evaluateImplicitAssertions,
+} from "../routing.js";
+import type { ImplicitAssertionSpec } from "../routing.js";
 import axios from "axios";
 
 export { checkLink };
-
-// One articulated assertion record. See runShell.ts and
-// docs/design/dynamic-routing-roadmap.md ("Assertions") for the locked shape.
-interface AssertionRecord {
-  statement: string;
-  source: "implicit" | "custom";
-  result: "PASS" | "FAIL" | "WARNING" | "SKIPPED";
-  expected?: any;
-  actual?: any;
-  description?: string;
-}
 
 const DEFAULT_HEADERS: Record<string, string> = {
   "User-Agent":
@@ -247,11 +241,17 @@ async function checkLink({ config, step }: { config: any; step: any }) {
     return result;
   }
 
-  // Implicit assertion: statusCode ∈ statusCodes. Always applicable (statusCodes
-  // is defaulted), always evaluated (a status came back), so there's no
-  // all-SKIPPED ambiguity. The step result is the roll-up of the emitted
-  // assertions.
-  const assertions: AssertionRecord[] = [];
+  // Unified assertion model: the single implicit check is a `$$` runtime
+  // EXPRESSION evaluated by the shared engine (see runShell.ts for the
+  // exemplar). checkLink exposes the resolved status code as a computed output
+  // so the spec is a trivial expression over it — and so `$$outputs.statusCode`
+  // is referenceable in conditions / custom assertions.
+  //
+  // statusCode ∈ statusCodes is always applicable (statusCodes is defaulted)
+  // and always evaluated (a status came back), so there's no all-SKIPPED
+  // ambiguity. The step result is the roll-up the shared engine returns.
+  result.outputs = { statusCode: last.statusCode };
+
   const statusCodePass =
     step.checkLink.statusCodes.indexOf(last.statusCode) >= 0;
   const statusCodeDescription = statusCodePass
@@ -259,17 +259,20 @@ async function checkLink({ config, step }: { config: any; step: any }) {
     : `Returned ${last.statusCode}. Expected one of ${JSON.stringify(
         step.checkLink.statusCodes
       )}`;
-  assertions.push({
-    statement: `statusCode in ${JSON.stringify(step.checkLink.statusCodes)}`,
-    source: "implicit",
-    result: statusCodePass ? "PASS" : "FAIL",
-    expected: step.checkLink.statusCodes,
-    actual: last.statusCode,
-    description: statusCodeDescription,
-  });
 
+  const specs: ImplicitAssertionSpec[] = [
+    {
+      statement: `$$outputs.statusCode oneOf ${JSON.stringify(
+        step.checkLink.statusCodes
+      )}`,
+      severity: "fail",
+    },
+  ];
+
+  const ctx = buildConditionContext({ outputs: result.outputs });
+  const { assertions, status } = await evaluateImplicitAssertions(specs, ctx);
   result.assertions = assertions;
-  result.status = rollUpResults(assertions);
+  result.status = status;
   result.description = statusCodeDescription;
 
   return result;

--- a/src/core/tests/click.ts
+++ b/src/core/tests/click.ts
@@ -43,7 +43,14 @@ async function clickElement({ config, step, driver }: { config: any; step: any; 
     click: true,
   });
 
+  // Unified model: click delegates element EXISTENCE (the implicit verification)
+  // to find, and the actual click is performed inside find as a sub-effect =
+  // EXECUTION. So click owns no spec of its own; it PROPAGATES find's computed
+  // outputs (incl. `found`), its existence assertion(s), and the rolled-up
+  // status verbatim. found→PASS, not-found→FAIL, click-fails→FAIL all carry
+  // through unchanged.
   result.outputs = findResult.outputs;
+  result.assertions = findResult.assertions;
   result.status = findResult.status;
   result.description = findResult.description;
 

--- a/src/core/tests/dragAndDrop.ts
+++ b/src/core/tests/dragAndDrop.ts
@@ -1,10 +1,25 @@
 import { validate } from "../../common/src/validate.js";
 import { findElement } from "./findElement.js";
 import { log } from "../utils.js";
+import {
+  buildConditionContext,
+  evaluateImplicitAssertions,
+} from "../routing.js";
+import type { ImplicitAssertionSpec } from "../routing.js";
 
 export { dragAndDropElement };
 
 // Drag and drop an element from source to target.
+//
+// Unified assertion model: the EXISTENCE of the source AND target elements are
+// the two implicit verifications — exposed as `outputs.sourceFound` and
+// `outputs.targetFound` and asserted (in order) via the trivial expressions
+// `$$outputs.sourceFound == true` then `$$outputs.targetFound == true` through
+// the shared engine. Because the engine short-circuits, a missing source records
+// sourceFound FAIL and targetFound SKIPPED. The drag operation itself (the
+// WebDriver.io attempt + HTML5 fallback) is EXECUTION: a failure there sets FAIL
+// with NO extra assertion record. Backward-compat: either element missing →
+// FAIL; drag failure → FAIL; success → PASS.
 async function dragAndDropElement({ config, step, driver }: { config: any; step: any; driver: any }) {
   async function HTML5DragDrop({ driver, sourceElement, targetElement }: { driver: any; sourceElement: any; targetElement: any }) {
     await driver.execute(
@@ -106,12 +121,28 @@ async function dragAndDropElement({ config, step, driver }: { config: any; step:
       findElement({ config, step: targetFindStep, driver }),
     ]);
 
-    // Check if source or target element search failed
-    if (sourceResult.status === "FAIL") {
-      return sourceResult;
-    }
-    if (targetResult.status === "FAIL") {
-      return targetResult;
+    // Expose distinct existence outputs, then evaluate the two ordered specs
+    // through the shared engine. Short-circuit semantics mean a missing source
+    // records sourceFound FAIL and targetFound SKIPPED.
+    result.outputs.sourceFound = sourceResult.outputs?.found === true;
+    result.outputs.targetFound = targetResult.outputs?.found === true;
+    const specs: ImplicitAssertionSpec[] = [
+      { statement: "$$outputs.sourceFound == true", severity: "fail" },
+      { statement: "$$outputs.targetFound == true", severity: "fail" },
+    ];
+    const { assertions, status } = await evaluateImplicitAssertions(
+      specs,
+      buildConditionContext({ outputs: result.outputs })
+    );
+    result.assertions = assertions;
+    result.status = status;
+
+    // Either element missing → FAIL: stop before the drag EXECUTION.
+    if (status === "FAIL") {
+      result.description = `Couldn't find ${
+        result.outputs.sourceFound ? "target" : "source"
+      } element.`;
+      return result;
     }
     sourceElement = sourceResult.outputs.rawElement;
     targetElement = targetResult.outputs.rawElement;

--- a/src/core/tests/findElement.ts
+++ b/src/core/tests/findElement.ts
@@ -8,8 +8,39 @@ import { typeKeys } from "./typeKeys.js";
 import { moveTo } from "./moveTo.js";
 import { wait } from "./wait.js";
 import { isRecordingActive } from "./ffmpegRecorder.js";
+import {
+  buildConditionContext,
+  evaluateImplicitAssertions,
+} from "../routing.js";
+import type { ImplicitAssertionSpec } from "../routing.js";
 
 export { findElement };
+
+// Unified assertion model: element EXISTENCE is the single implicit
+// verification. Whether an element matching ALL of the requested criteria
+// (selector/text/id/testId/class/attribute/aria AND-logic, or the shorthand
+// string path) was located is computed and EXPOSED as `outputs.found`, so the
+// implicit check is a trivial expression over it (`$$outputs.found == true`).
+// `outputs.found` and `result.assertions` are part of find's CONTRACT for
+// downstream consumers (conditions / custom assertions). `outputs.element.*`
+// and `outputs.rawElement` are preserved exactly as before. The interactions
+// the action performs (`moveTo` / `click` / `type` sub-effects) remain
+// EXECUTION, not assertions: a failure there sets FAIL with NO extra assertion
+// record, preserving prior behavior.
+//
+// Evaluate the single existence spec through the shared engine and set
+// `result.assertions` + `result.status`. On the success path this runs once,
+// after which sub-effects can still flip the status to FAIL (execution error).
+async function finalizeFound({ result }: { result: any }) {
+  const specs: ImplicitAssertionSpec[] = [
+    { statement: "$$outputs.found == true", severity: "fail" },
+  ];
+  const ctx = buildConditionContext({ outputs: result.outputs });
+  const { assertions, status } = await evaluateImplicitAssertions(specs, ctx);
+  result.assertions = assertions;
+  result.status = status;
+  return result;
+}
 
 // Find a single element
 async function findElement({ config, step, driver, click }: { config: any; step: any; driver: any; click?: any }) {
@@ -38,12 +69,14 @@ async function findElement({ config, step, driver, click }: { config: any; step:
     if (element) {
       result.description += ` Found element by ${foundBy}.`;
       result.outputs = await setElementOutputs({ element });
-      return result;
+      result.outputs.found = true;
+      return await finalizeFound({ result });
     } else {
-      // No matching elements
-      result.status = "FAIL";
+      // No matching elements: expose found=false and still evaluate so the
+      // existence assertion FAILs (don't early-return before the spec).
       result.description = "No elements matched selector or text.";
-      return result;
+      result.outputs.found = false;
+      return await finalizeFound({ result });
     }
   }
   // Apply default values
@@ -82,22 +115,26 @@ async function findElement({ config, step, driver, click }: { config: any; step:
   });
 
   if (!foundElement) {
-    result.status = "FAIL";
     result.description = error || "No elements matched criteria.";
-    return result;
+    result.outputs.found = false;
+    return await finalizeFound({ result });
   }
   element = foundElement;
   result.description += ` Found element by ${foundBy}.`;
 
   // No matching elements
   if (!element.elementId) {
-    result.status = "FAIL";
     result.description = "No elements matched selector and/or text.";
-    return result;
+    result.outputs.found = false;
+    return await finalizeFound({ result });
   }
 
   // Set element in outputs
   result.outputs = await setElementOutputs({ element });
+  result.outputs.found = true;
+  // Evaluate the existence assertion now (PASS). Sub-effects below remain
+  // EXECUTION and may still set FAIL with no extra record.
+  await finalizeFound({ result });
 
   // Move to element
   if (step.find.moveTo) {

--- a/src/core/tests/httpRequest.ts
+++ b/src/core/tests/httpRequest.ts
@@ -399,32 +399,30 @@ async function httpRequest({ config, step, openApiDefinitions = [] }: { config: 
       step.httpRequest.openApi?.validateAgainstSchema === "both") &&
     operation.schemas.response
   ) {
-    {
-      const ajv = new Ajv({
-        strictSchema: false,
-        useDefaults: true,
-        allErrors: true,
-        allowUnionTypes: true,
-        coerceTypes: false,
-      });
-      const validateFn = ajv.compile(operation.schemas.response);
-      const valid = validateFn(response.data);
-      result.outputs.responseSchemaValid = !!valid;
-      specs.push({
-        statement: `$$outputs.responseSchemaValid == true`,
-        severity: "fail",
-      });
-      if (valid) {
-        descriptions.push(`Response data matched the OpenAPI schema.`);
-      } else {
-        descriptions.push(
-          `Response data didn't match the OpenAPI schema. ${JSON.stringify(
-            validateFn.errors,
-            null,
-            2
-          )}`
-        );
-      }
+    const ajv = new Ajv({
+      strictSchema: false,
+      useDefaults: true,
+      allErrors: true,
+      allowUnionTypes: true,
+      coerceTypes: false,
+    });
+    const validateFn = ajv.compile(operation.schemas.response);
+    const valid = validateFn(response.data);
+    result.outputs.responseSchemaValid = !!valid;
+    specs.push({
+      statement: `$$outputs.responseSchemaValid == true`,
+      severity: "fail",
+    });
+    if (valid) {
+      descriptions.push(`Response data matched the OpenAPI schema.`);
+    } else {
+      descriptions.push(
+        `Response data didn't match the OpenAPI schema. ${JSON.stringify(
+          validateFn.errors,
+          null,
+          2
+        )}`
+      );
     }
   }
 
@@ -432,11 +430,19 @@ async function httpRequest({ config, step, openApiDefinitions = [] }: { config: 
   // false. Structurally-complex check -> compute the boolean, EXPOSE it as
   // `outputs.noUnexpectedFields`, assert a trivial expression over it.
   if (!step.httpRequest.allowAdditionalFields) {
-    const dataComparison = objectExistsInObject(
-      step.httpRequest.response.body,
-      response.data
-    );
-    const noUnexpectedFields = dataComparison.result.status !== "FAIL";
+    // `response.body` normally defaults to `{}` via the response-default spread
+    // above, but a step that explicitly sets `response.body` to undefined/null
+    // (or a non-object) would let undefined reach objectExistsInObject, whose
+    // `Object.keys(expected)` would throw. With no expected fields there are no
+    // unexpected fields to flag, so treat that as a PASS (noUnexpectedFields =
+    // true) — matching the prior outcome (FAIL only when there ARE unexpected
+    // fields).
+    const expectedBody = step.httpRequest.response?.body;
+    const noUnexpectedFields =
+      expectedBody && typeof expectedBody === "object"
+        ? objectExistsInObject(expectedBody, response.data).result.status !==
+          "FAIL"
+        : true;
     result.outputs.noUnexpectedFields = noUnexpectedFields;
     specs.push({
       statement: `$$outputs.noUnexpectedFields == true`,

--- a/src/core/tests/httpRequest.ts
+++ b/src/core/tests/httpRequest.ts
@@ -9,21 +9,14 @@ import {
   log,
   calculateFractionalDifference,
   replaceEnvs,
-  rollUpResults,
 } from "../utils.js";
+import {
+  buildConditionContext,
+  evaluateImplicitAssertions,
+} from "../routing.js";
+import type { ImplicitAssertionSpec } from "../routing.js";
 
 export { httpRequest };
-
-// One articulated assertion record. See runShell.ts and
-// docs/design/dynamic-routing-roadmap.md ("Assertions") for the locked shape.
-interface AssertionRecord {
-  statement: string;
-  source: "implicit" | "custom";
-  result: "PASS" | "FAIL" | "WARNING" | "SKIPPED";
-  expected?: any;
-  actual?: any;
-  description?: string;
-}
 
 async function httpRequest({ config, step, openApiDefinitions = [] }: { config: any; step: any; openApiDefinitions?: any[] }) {
   let result: any = { status: "", description: "", outputs: {} };
@@ -247,33 +240,37 @@ async function httpRequest({ config, step, openApiDefinitions = [] }: { config: 
   };
 
   // ---------------------------------------------------------------------------
-  // Articulated implicit assertions.
+  // Unified assertion model.
   //
-  // The runner emits one AssertionRecord per verification check, IN THEIR
-  // ORIGINAL ORDER, preserving the prior short-circuit/early-return behavior and
-  // exact PASS/FAIL/WARNING outcomes. Once a check FAILs we stop *evaluating*
-  // successors (their inputs may not be meaningful) but still REPORT each
-  // applicable-but-not-reached check as a SKIPPED record. A check is APPLICABLE
-  // only when its feature is configured; non-applicable checks are omitted.
-  // The step result is the roll-up of the emitted assertions
-  // (FAIL > WARNING > all-SKIPPED > PASS). The leading statusCode check is
-  // always applicable and always evaluated when a status came back, so an
-  // all-SKIPPED roll-up can't happen on a normal request.
+  // Each implicit verification check is a `$$` runtime EXPRESSION evaluated by
+  // the shared engine (`evaluateImplicitAssertions`), exactly like runShell.ts.
+  // We do NOT compute PASS/FAIL inline. Instead we (1) compute any derived
+  // inputs the expressions reference and EXPOSE them as outputs (simple value
+  // checks become direct expressions; structurally-complex checks compute a
+  // boolean/number with the EXISTING logic and assert a trivial expression over
+  // the exposed output), (2) build the ordered list of APPLICABLE specs IN THE
+  // SAME ORDER as before, then (3) hand them to the shared engine, which does
+  // the in-order evaluation, FAIL short-circuit (later applicable checks become
+  // SKIPPED), and FAIL > WARNING > SKIPPED > PASS roll-up. The exposed computed
+  // outputs are also a deliberate user-facing capability (referenceable in
+  // conditions / custom assertions).
   //
   // Execution errors (NOT assertions) still return FAIL with NO records:
   //   - invalid step / OpenAPI resolution failures (handled above);
   //   - request-body schema validation failure (no request is made);
   //   - total network failure with no response at all (no status came back).
+  //
+  // File side effects (write/overwrite) are preserved exactly and run
+  // unconditionally whenever `path` is set, independent of the assertion model.
   // ---------------------------------------------------------------------------
-  const assertions: AssertionRecord[] = [];
-  let shortCircuited = false;
+  const specs: ImplicitAssertionSpec[] = [];
   const descriptions: string[] = [];
 
-  // (1) Request body matches OpenAPI schema. APPLICABLE only when
+  // Request body matches OpenAPI schema. APPLICABLE only when
   // validateAgainstSchema is request/both and a request schema exists. This runs
-  // BEFORE the request is made, so a failure here is an execution error: no
-  // request is performed and no response/outputs exist -> FAIL, no records
-  // (preserves the prior early return).
+  // BEFORE the request is made, so it is a PREFLIGHT / execution gate, NOT an
+  // assertion: a failure means no request is performed and there are no
+  // response/outputs -> FAIL, no records (preserves the prior early return).
   if (
     (step.httpRequest.openApi?.validateAgainstSchema === "request" ||
       step.httpRequest.openApi?.validateAgainstSchema === "both") &&
@@ -289,12 +286,6 @@ async function httpRequest({ config, step, openApiDefinitions = [] }: { config: 
     const validateFn = ajv.compile(operation.schemas.request);
     const valid = validateFn(step.httpRequest.request.body);
     if (valid) {
-      assertions.push({
-        statement: "request body matches OpenAPI schema",
-        source: "implicit",
-        result: "PASS",
-        description: `Request body matched the OpenAPI schema.`,
-      });
       descriptions.push(`Request body matched the OpenAPI schema.`);
     } else {
       // Preserve prior behavior: execution error, FAIL, no assertion records.
@@ -358,8 +349,9 @@ async function httpRequest({ config, step, openApiDefinitions = [] }: { config: 
     response.headers = step.httpRequest?.response?.headers;
   }
 
-  // (2) statusCode ∈ statusCodes. Always applicable (statusCodes is defaulted)
-  // and always evaluated (a status came back).
+  // (1) statusCode ∈ statusCodes. Always applicable (statusCodes is defaulted)
+  // and always evaluated (a status came back). Simple value check -> DIRECT
+  // expression over the already-exposed `outputs.response.statusCode`.
   if (step.httpRequest.statusCodes) {
     const statusPass =
       step.httpRequest.statusCodes.indexOf(response.status) >= 0;
@@ -368,75 +360,46 @@ async function httpRequest({ config, step, openApiDefinitions = [] }: { config: 
       : `Returned ${response.status}. Expected one of ${JSON.stringify(
           step.httpRequest.statusCodes
         )}.`;
-    assertions.push({
-      statement: `statusCode in ${JSON.stringify(step.httpRequest.statusCodes)}`,
-      source: "implicit",
-      result: statusPass ? "PASS" : "FAIL",
-      expected: step.httpRequest.statusCodes,
-      actual: response.status,
-      description: statusDescription,
+    specs.push({
+      statement: `$$outputs.response.statusCode oneOf ${JSON.stringify(
+        step.httpRequest.statusCodes
+      )}`,
+      severity: "fail",
     });
     descriptions.push(statusDescription);
-    if (!statusPass) shortCircuited = true;
   }
 
-  // (3) Required response fields present. APPLICABLE only when
-  // response.required is non-empty.
+  // (2) Required response fields present. APPLICABLE only when
+  // response.required is non-empty. Structurally-complex check -> compute the
+  // boolean with the EXISTING logic, EXPOSE it as `outputs.requiredFieldsPresent`,
+  // and assert a trivial expression over it.
   if (step.httpRequest.response?.required?.length > 0) {
-    const requiredStatement = `response fields present: ${JSON.stringify(
-      step.httpRequest.response.required
-    )}`;
-    if (shortCircuited) {
-      assertions.push({
-        statement: requiredStatement,
-        source: "implicit",
-        result: "SKIPPED",
-        expected: step.httpRequest.response.required,
-      });
-    } else {
-      const missingFields: string[] = [];
-      for (const fieldPath of step.httpRequest.response.required) {
-        if (!fieldExistsAtPath(response.data, fieldPath)) {
-          missingFields.push(fieldPath);
-        }
+    const missingFields: string[] = [];
+    for (const fieldPath of step.httpRequest.response.required) {
+      if (!fieldExistsAtPath(response.data, fieldPath)) {
+        missingFields.push(fieldPath);
       }
-      if (missingFields.length > 0) {
-        const desc = `Missing required fields: ${missingFields.join(", ")}`;
-        assertions.push({
-          statement: requiredStatement,
-          source: "implicit",
-          result: "FAIL",
-          expected: step.httpRequest.response.required,
-          description: desc,
-        });
-        descriptions.push(desc);
-        shortCircuited = true;
-      } else {
-        assertions.push({
-          statement: requiredStatement,
-          source: "implicit",
-          result: "PASS",
-          expected: step.httpRequest.response.required,
-        });
-      }
+    }
+    result.outputs.requiredFieldsPresent = missingFields.length === 0;
+    specs.push({
+      statement: `$$outputs.requiredFieldsPresent == true`,
+      severity: "fail",
+    });
+    if (missingFields.length > 0) {
+      descriptions.push(`Missing required fields: ${missingFields.join(", ")}`);
     }
   }
 
-  // (4) Response body matches OpenAPI schema. APPLICABLE only when
+  // (3) Response body matches OpenAPI schema. APPLICABLE only when
   // validateAgainstSchema is response/both and a response schema exists.
+  // Structurally-complex check -> compute the boolean, EXPOSE it as
+  // `outputs.responseSchemaValid`, assert a trivial expression over it.
   if (
     (step.httpRequest.openApi?.validateAgainstSchema === "response" ||
       step.httpRequest.openApi?.validateAgainstSchema === "both") &&
     operation.schemas.response
   ) {
-    const responseSchemaStatement = "response body matches OpenAPI schema";
-    if (shortCircuited) {
-      assertions.push({
-        statement: responseSchemaStatement,
-        source: "implicit",
-        result: "SKIPPED",
-      });
-    } else {
+    {
       const ajv = new Ajv({
         strictSchema: false,
         useDefaults: true,
@@ -446,204 +409,139 @@ async function httpRequest({ config, step, openApiDefinitions = [] }: { config: 
       });
       const validateFn = ajv.compile(operation.schemas.response);
       const valid = validateFn(response.data);
+      result.outputs.responseSchemaValid = !!valid;
+      specs.push({
+        statement: `$$outputs.responseSchemaValid == true`,
+        severity: "fail",
+      });
       if (valid) {
-        assertions.push({
-          statement: responseSchemaStatement,
-          source: "implicit",
-          result: "PASS",
-          description: `Response data matched the OpenAPI schema.`,
-        });
         descriptions.push(`Response data matched the OpenAPI schema.`);
       } else {
-        const desc = `Response data didn't match the OpenAPI schema. ${JSON.stringify(
-          validateFn.errors,
-          null,
-          2
-        )}`;
-        assertions.push({
-          statement: responseSchemaStatement,
-          source: "implicit",
-          result: "FAIL",
-          description: desc,
-        });
-        descriptions.push(desc);
-        shortCircuited = true;
+        descriptions.push(
+          `Response data didn't match the OpenAPI schema. ${JSON.stringify(
+            validateFn.errors,
+            null,
+            2
+          )}`
+        );
       }
     }
   }
 
-  // (5) No unexpected fields. APPLICABLE only when allowAdditionalFields is
-  // false.
+  // (4) No unexpected fields. APPLICABLE only when allowAdditionalFields is
+  // false. Structurally-complex check -> compute the boolean, EXPOSE it as
+  // `outputs.noUnexpectedFields`, assert a trivial expression over it.
   if (!step.httpRequest.allowAdditionalFields) {
-    const noExtraStatement = "no unexpected response fields";
-    if (shortCircuited) {
-      assertions.push({
-        statement: noExtraStatement,
-        source: "implicit",
-        result: "SKIPPED",
-      });
-    } else {
+    const dataComparison = objectExistsInObject(
+      step.httpRequest.response.body,
+      response.data
+    );
+    const noUnexpectedFields = dataComparison.result.status !== "FAIL";
+    result.outputs.noUnexpectedFields = noUnexpectedFields;
+    specs.push({
+      statement: `$$outputs.noUnexpectedFields == true`,
+      severity: "fail",
+    });
+    if (!noUnexpectedFields) {
+      descriptions.push(`Response contained unexpected fields.`);
+    }
+  }
+
+  // (5) Response body type matches + body match. APPLICABLE only when
+  // response.body is defined. Structurally-complex check -> compute a single
+  // boolean (`bodyMatches`: true iff the type matches AND the existing
+  // object-subset / string-equality comparison passes), EXPOSE it as
+  // `outputs.bodyMatches`, assert a trivial expression over it.
+  if (typeof step.httpRequest.response?.body !== "undefined") {
+    let bodyMatches: boolean;
+    // Check if response body is the same type
+    if (
+      typeof step.httpRequest.response.body !== typeof response.data ||
+      (typeof step.httpRequest.response.body === "object" &&
+        Array.isArray(step.httpRequest.response.body) !==
+          Array.isArray(response.data))
+    ) {
+      bodyMatches = false;
+      descriptions.push(
+        `Expected response body type didn't match actual response body type.`
+      );
+    } else if (typeof step.httpRequest.response.body === "string") {
+      // SANCTIONED (Phase 4a.2a): a matching string body used to `return result`
+      // here, short-circuiting the response.headers check and `path` file save.
+      // That early return was intentionally removed so those checks run too.
+      bodyMatches = step.httpRequest.response.body === response.data;
+      if (!bodyMatches) {
+        descriptions.push(
+          `Expected response body didn't match actual response body.`
+        );
+      }
+    } else if (typeof step.httpRequest.response.body === "object") {
       const dataComparison = objectExistsInObject(
         step.httpRequest.response.body,
         response.data
       );
-      if (dataComparison.result.status === "FAIL") {
-        const desc = `Response contained unexpected fields.`;
-        assertions.push({
-          statement: noExtraStatement,
-          source: "implicit",
-          result: "FAIL",
-          description: desc,
-        });
-        descriptions.push(desc);
-        shortCircuited = true;
-      } else {
-        assertions.push({
-          statement: noExtraStatement,
-          source: "implicit",
-          result: "PASS",
-        });
-      }
-    }
-  }
-
-  // (6) Response body type matches + body match. APPLICABLE only when
-  // response.body is defined.
-  if (typeof step.httpRequest.response?.body !== "undefined") {
-    const bodyStatement = "response.body matches expected";
-    if (shortCircuited) {
-      assertions.push({
-        statement: bodyStatement,
-        source: "implicit",
-        result: "SKIPPED",
-        expected: step.httpRequest.response.body,
-      });
-    } else {
-      // Check if response body is the same type
-      if (
-        typeof step.httpRequest.response.body !== typeof response.data ||
-        (typeof step.httpRequest.response.body === "object" &&
-          Array.isArray(step.httpRequest.response.body) !==
-            Array.isArray(response.data))
-      ) {
-        const desc = `Expected response body type didn't match actual response body type.`;
-        assertions.push({
-          statement: bodyStatement,
-          source: "implicit",
-          result: "FAIL",
-          expected: step.httpRequest.response.body,
-          actual: response.data,
-          description: desc,
-        });
-        descriptions.push(desc);
-        shortCircuited = true;
-      } else if (typeof step.httpRequest.response.body === "string") {
-        // SANCTIONED (Phase 4a.2a): a matching string body used to `return result`
-        // here, short-circuiting the response.headers check and `path` file save.
-        // That early return was intentionally removed so those checks run too.
-        const bodyPass = step.httpRequest.response.body === response.data;
-        const desc = bodyPass
-          ? undefined
-          : `Expected response body didn't match actual response body.`;
-        assertions.push({
-          statement: bodyStatement,
-          source: "implicit",
-          result: bodyPass ? "PASS" : "FAIL",
-          expected: step.httpRequest.response.body,
-          actual: response.data,
-          ...(desc ? { description: desc } : {}),
-        });
-        if (desc) {
-          descriptions.push(desc);
-          shortCircuited = true;
-        }
-      } else if (typeof step.httpRequest.response.body === "object") {
-        const dataComparison = objectExistsInObject(
-          step.httpRequest.response.body,
-          response.data
+      bodyMatches = dataComparison.result.status === "PASS";
+      if (bodyMatches) {
+        descriptions.push(
+          `Expected response body was present in actual response body.`
         );
-        if (dataComparison.result.status === "PASS") {
-          const desc = `Expected response body was present in actual response body.`;
-          assertions.push({
-            statement: bodyStatement,
-            source: "implicit",
-            result: "PASS",
-            expected: step.httpRequest.response.body,
-            description: desc,
-          });
-          descriptions.push(desc);
-        } else {
-          assertions.push({
-            statement: bodyStatement,
-            source: "implicit",
-            result: "FAIL",
-            expected: step.httpRequest.response.body,
-            actual: response.data,
-            description: dataComparison.result.description,
-          });
-          descriptions.push(dataComparison.result.description);
-          shortCircuited = true;
-        }
+      } else {
+        descriptions.push(dataComparison.result.description);
       }
+    } else {
+      // Same primitive type but not string/object (number/boolean): the prior
+      // type-match branch fell through without an explicit comparison, treating
+      // it as a (vacuous) pass. Preserve that.
+      bodyMatches = true;
     }
+    result.outputs.bodyMatches = bodyMatches;
+    specs.push({
+      statement: `$$outputs.bodyMatches == true`,
+      severity: "fail",
+    });
   }
 
-  // (7) Response headers subset. APPLICABLE only when response.headers is
-  // non-empty.
+  // (6) Response headers subset. APPLICABLE only when response.headers is
+  // non-empty. Structurally-complex check -> compute the boolean, EXPOSE it as
+  // `outputs.headersMatch`, assert a trivial expression over it.
   if (
     typeof step.httpRequest.response?.headers !== "undefined" &&
     JSON.stringify(step.httpRequest.response?.headers) != "{}"
   ) {
-    const headersStatement = "response.headers contains expected";
-    if (shortCircuited) {
-      assertions.push({
-        statement: headersStatement,
-        source: "implicit",
-        result: "SKIPPED",
-        expected: step.httpRequest.response.headers,
-      });
+    // Preprocess headers to lowercase
+    const headers: any = {};
+    Object.keys(step.httpRequest.response.headers).forEach((key: any) => {
+      headers[key.toLowerCase()] = step.httpRequest.response.headers[key];
+    });
+    const responseHeaders: any = {};
+    Object.keys(response.headers).forEach((key: any) => {
+      responseHeaders[key.toLowerCase()] = response.headers[key];
+    });
+    const dataComparison = objectExistsInObject(headers, responseHeaders);
+    const headersMatch = dataComparison.result.status === "PASS";
+    result.outputs.headersMatch = headersMatch;
+    specs.push({
+      statement: `$$outputs.headersMatch == true`,
+      severity: "fail",
+    });
+    if (headersMatch) {
+      descriptions.push(
+        `Expected response headers were present in actual response headers.`
+      );
     } else {
-      // Preprocess headers to lowercase
-      const headers: any = {};
-      Object.keys(step.httpRequest.response.headers).forEach((key: any) => {
-        headers[key.toLowerCase()] = step.httpRequest.response.headers[key];
-      });
-      const responseHeaders: any = {};
-      Object.keys(response.headers).forEach((key: any) => {
-        responseHeaders[key.toLowerCase()] = response.headers[key];
-      });
-      const dataComparison = objectExistsInObject(headers, responseHeaders);
-      if (dataComparison.result.status === "PASS") {
-        const desc = `Expected response headers were present in actual response headers.`;
-        assertions.push({
-          statement: headersStatement,
-          source: "implicit",
-          result: "PASS",
-          expected: step.httpRequest.response.headers,
-          description: desc,
-        });
-        descriptions.push(desc);
-      } else {
-        assertions.push({
-          statement: headersStatement,
-          source: "implicit",
-          result: "FAIL",
-          expected: step.httpRequest.response.headers,
-          description: dataComparison.result.description,
-        });
-        descriptions.push(dataComparison.result.description);
-        shortCircuited = true;
-      }
+      descriptions.push(dataComparison.result.description);
     }
   }
 
-  // (8) Saved-file variation ≤ maxVariation. APPLICABLE only when path is set.
-  // Exceeding the tolerance is a WARNING (not a FAIL). The file-write/overwrite
-  // side effects are preserved exactly as before and run whenever the file
-  // exists, regardless of short-circuit; only the *assertion record* honors
-  // short-circuit (applicable-but-not-reached -> SKIPPED).
+  // (7) Saved-file variation ≤ maxVariation. APPLICABLE only when path is set
+  // AND an existing file is being compared against. Exceeding the tolerance is a
+  // WARNING (not a FAIL). The file-write/overwrite side effects are preserved
+  // exactly as before and run unconditionally whenever `path` is set; the
+  // assertion is gated on there being a prior file (the "file didn't exist yet
+  // -> write, NO variation assertion" path emits no spec). When applicable the
+  // computed `fractionalDiff` is EXPOSED as `outputs.variation` and the spec is
+  // `$$outputs.variation <= maxVariation` at WARNING severity.
   if (step.httpRequest.path) {
-    const variationStatement = `saved-file variation <= ${step.httpRequest.maxVariation}`;
     const dir = path.dirname(step.httpRequest.path);
     // If `dir` doesn't exist, create it
     if (!fs.existsSync(dir)) {
@@ -677,6 +575,16 @@ async function httpRequest({ config, step, openApiDefinitions = [] }: { config: 
       );
       log(config, "debug", `Fractional difference: ${fractionalDiff}`);
 
+      // Expose the computed variation as the output the expression references,
+      // and emit the WARNING-severity spec. The shared engine records WARNING
+      // (not FAIL) when it evaluates false, matching prior behavior.
+      result.outputs.variation = fractionalDiff;
+      specs.push({
+        statement: `$$outputs.variation <= ${step.httpRequest.maxVariation}`,
+        severity: "warning",
+      });
+
+      // File side effects (write/overwrite) are unchanged from prior behavior.
       if (fractionalDiff > step.httpRequest.maxVariation) {
         if (step.httpRequest.overwrite == "aboveVariation") {
           // Overwrite file
@@ -686,57 +594,29 @@ async function httpRequest({ config, step, openApiDefinitions = [] }: { config: 
           );
           descriptions.push(`Saved response to file.`);
         }
-        const desc = `The difference between the existing saved response and the new response (${fractionalDiff.toFixed(
-          2
-        )}) is greater than the max accepted variation (${
-          step.httpRequest.maxVariation
-        }).`;
-        if (shortCircuited) {
-          assertions.push({
-            statement: variationStatement,
-            source: "implicit",
-            result: "SKIPPED",
-            expected: step.httpRequest.maxVariation,
-          });
-        } else {
-          assertions.push({
-            statement: variationStatement,
-            source: "implicit",
-            result: "WARNING",
-            expected: step.httpRequest.maxVariation,
-            actual: fractionalDiff,
-            description: desc,
-          });
-          descriptions.push(desc);
-        }
+        descriptions.push(
+          `The difference between the existing saved response and the new response (${fractionalDiff.toFixed(
+            2
+          )}) is greater than the max accepted variation (${
+            step.httpRequest.maxVariation
+          }).`
+        );
       } else {
         if (step.httpRequest.overwrite == "true") {
           // Overwrite file
           fs.writeFileSync(filePath, JSON.stringify(response.data, null, 2));
           descriptions.push(`Saved response to file.`);
         }
-        if (shortCircuited) {
-          assertions.push({
-            statement: variationStatement,
-            source: "implicit",
-            result: "SKIPPED",
-            expected: step.httpRequest.maxVariation,
-          });
-        } else {
-          assertions.push({
-            statement: variationStatement,
-            source: "implicit",
-            result: "PASS",
-            expected: step.httpRequest.maxVariation,
-            actual: fractionalDiff,
-          });
-        }
       }
     }
   }
 
+  // Evaluate the applicable specs through the shared engine against the current
+  // step's outputs (response + the derived booleans/variation).
+  const ctx = buildConditionContext({ outputs: result.outputs });
+  const { assertions, status } = await evaluateImplicitAssertions(specs, ctx);
   result.assertions = assertions;
-  result.status = rollUpResults(assertions);
+  result.status = status;
   result.description = descriptions.join(" ").trim();
   return result;
 }

--- a/src/core/tests/runBrowserScript.ts
+++ b/src/core/tests/runBrowserScript.ts
@@ -5,6 +5,11 @@ import {
   serializeBrowserResult,
   matchesExpectedOutput,
 } from "../utils.js";
+import {
+  buildConditionContext,
+  evaluateImplicitAssertions,
+} from "../routing.js";
+import type { ImplicitAssertionSpec } from "../routing.js";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -96,18 +101,53 @@ async function runBrowserScript({
   result.outputs.result = returnValue;
   const serialized = serializeBrowserResult(returnValue);
 
-  // Evaluate expected output (substring or /regex/) against the serialized value.
+  // Unified assertion model: implicit verifications are `$$` runtime
+  // EXPRESSIONS evaluated by the shared engine. Script EXECUTION errors (no
+  // driver/`execute`, throw/timeout, invalid step, fs error) are handled above
+  // / below as FAIL with NO assertion records. Here we (1) compute any derived
+  // inputs the expressions reference and EXPOSE them as outputs, (2) build the
+  // ordered list of APPLICABLE specs, then (3) hand them to the shared engine.
+  //
+  // Applicable set: output match (only when `output` is set); saved-file
+  // variation (only when `path` is set AND an existing file is being compared
+  // against). With neither, there are zero applicable specs and the roll-up of
+  // an empty record list is PASS. File write/overwrite SIDE EFFECTS are
+  // preserved exactly and run unconditionally whenever `path` is set,
+  // independent of the assertion model.
+  const specs: ImplicitAssertionSpec[] = [];
+  const descriptions: string[] = [];
+
+  // (a) Expected output match — APPLICABLE only when `output` is set. The
+  // existing substring / regex match (`matchesExpectedOutput`) is computed here
+  // and EXPOSED as a boolean output so the spec is a simple equality and
+  // `$$outputs.outputMatches` is referenceable downstream.
   if (step.runBrowserScript.output) {
-    if (!matchesExpectedOutput(serialized, step.runBrowserScript.output)) {
-      result.status = "FAIL";
-      result.description = `Couldn't find expected output (${step.runBrowserScript.output}) in the script's return value.`;
-      return result;
-    }
+    const outputMatches = matchesExpectedOutput(
+      serialized,
+      step.runBrowserScript.output
+    );
+    result.outputs.outputMatches = outputMatches;
+    specs.push({
+      statement: `$$outputs.outputMatches == true`,
+      severity: "fail",
+    });
+    descriptions.push(
+      outputMatches
+        ? `Found expected output (${step.runBrowserScript.output}) in the script's return value.`
+        : `Couldn't find expected output (${step.runBrowserScript.output}) in the script's return value.`
+    );
   }
 
-  // Check if the return value is saved to a file. Wrap the filesystem work so a
-  // permissions error, bad path, full disk, or a file deleted mid-run returns a
-  // deterministic FAIL instead of throwing out of the runner.
+  // (b) Saved-file variation ≤ maxVariation — APPLICABLE only when `path` is set
+  // AND an existing file is being compared against. File-write / overwrite SIDE
+  // EFFECTS are preserved exactly and run unconditionally whenever `path` is
+  // set; the assertion is gated on there being a prior file (the "file didn't
+  // exist yet → write, NO variation assertion" path emits no variation spec).
+  // When applicable, the computed `fractionalDiff` is EXPOSED as
+  // `outputs.variation` and the spec is `$$outputs.variation <= maxVariation`
+  // at WARNING severity, referenceable downstream. A filesystem error (bad
+  // path, permissions, full disk, file removed mid-run) is an EXECUTION error,
+  // not an assertion: FAIL with NO records.
   if (step.runBrowserScript.path) {
     try {
       const dir = path.dirname(step.runBrowserScript.path);
@@ -119,7 +159,8 @@ async function runBrowserScript({
       log(config, "debug", `Saving script result to file: ${filePath}`);
 
       if (!fs.existsSync(filePath)) {
-        // Doesn't exist, save output to file
+        // Doesn't exist, save output to file. No prior content to compare
+        // against, so there is NO variation assertion in this branch.
         fs.writeFileSync(filePath, serialized);
       } else {
         const existingFile = fs.readFileSync(filePath, "utf8");
@@ -129,30 +170,38 @@ async function runBrowserScript({
         );
         log(config, "debug", `Fractional difference: ${fractionalDiff}`);
 
+        // Expose the computed variation as an output the expression references.
+        result.outputs.variation = fractionalDiff;
+        specs.push({
+          statement: `$$outputs.variation <= ${step.runBrowserScript.maxVariation}`,
+          severity: "warning",
+        });
+
+        // File side effects (write/overwrite) are unchanged from prior behavior.
         if (fractionalDiff > step.runBrowserScript.maxVariation) {
           if (
             step.runBrowserScript.overwrite == "aboveVariation" ||
             step.runBrowserScript.overwrite == "true"
           ) {
             fs.writeFileSync(filePath, serialized);
-            result.description += ` Saved output to file.`;
+            descriptions.push(`Saved output to file.`);
           } else {
-            result.description += ` Didn't overwrite the existing file.`;
+            descriptions.push(`Didn't overwrite the existing file.`);
           }
-          result.status = "WARNING";
-          result.description += ` The difference between the existing output and the new output (${fractionalDiff.toFixed(
-            2
-          )}) is greater than the max accepted variation (${
-            step.runBrowserScript.maxVariation
-          }).`;
-          return result;
-        }
-
-        // Within variation: only "true" forces a rewrite; otherwise the
-        // existing file is left as-is and the step passes without a note.
-        if (step.runBrowserScript.overwrite == "true") {
-          fs.writeFileSync(filePath, serialized);
-          result.description += ` Saved output to file.`;
+          descriptions.push(
+            `The difference between the existing output and the new output (${fractionalDiff.toFixed(
+              2
+            )}) is greater than the max accepted variation (${
+              step.runBrowserScript.maxVariation
+            }).`
+          );
+        } else {
+          // Within variation: only "true" forces a rewrite; otherwise the
+          // existing file is left as-is.
+          if (step.runBrowserScript.overwrite == "true") {
+            fs.writeFileSync(filePath, serialized);
+            descriptions.push(`Saved output to file.`);
+          }
         }
       }
     } catch (error: any) {
@@ -160,6 +209,16 @@ async function runBrowserScript({
       result.description = `Couldn't persist script output at ${step.runBrowserScript.path}: ${error.message}`;
       return result;
     }
+  }
+
+  // Evaluate the applicable specs through the shared engine. Zero applicable
+  // specs (neither `output` nor a compared file) roll up to PASS.
+  const ctx = buildConditionContext({ outputs: result.outputs });
+  const { assertions, status } = await evaluateImplicitAssertions(specs, ctx);
+  result.assertions = assertions;
+  result.status = status;
+  if (descriptions.length > 0) {
+    result.description = `${result.description} ${descriptions.join(" ")}`;
   }
 
   return result;

--- a/src/core/tests/saveScreenshot.ts
+++ b/src/core/tests/saveScreenshot.ts
@@ -297,6 +297,11 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
         // File already exists
         result.status = "SKIPPED";
         result.description = `File already exists: ${filePath}`;
+        // No verification specs were gathered (we short-circuit before capture
+        // and comparison), but keep the `assertions` shape consistent with every
+        // other return path — an empty array rather than undefined. The SKIPPED
+        // status itself is unchanged.
+        result.assertions = [];
         return result;
       } else {
         // Set temp file path

--- a/src/core/tests/saveScreenshot.ts
+++ b/src/core/tests/saveScreenshot.ts
@@ -11,6 +11,11 @@ import path from "node:path";
 import fs from "node:fs";
 import { loadHeavyDep } from "../../runtime/loader.js";
 import { isRecordingActive } from "./ffmpegRecorder.js";
+import {
+  buildConditionContext,
+  evaluateImplicitAssertions,
+} from "../routing.js";
+import type { ImplicitAssertionSpec } from "../routing.js";
 
 // pngjs, sharp, and pixelmatch are all heavy runtime deps. Lazy-load each
 // the first time a screenshot step needs it. Use `typeof import('…')`
@@ -98,6 +103,46 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
     },
   };
   let element: any;
+
+  // ---------------------------------------------------------------------------
+  // Unified assertion model (mirrors runShell.ts / httpRequest.ts / findElement.ts).
+  //
+  // Each implicit VERIFICATION check is a `$$` runtime EXPRESSION evaluated by
+  // the shared engine (`evaluateImplicitAssertions`). We do NOT compute
+  // PASS/FAIL/WARNING inline. Instead we (1) compute the derived input the
+  // expression references and EXPOSE it as an output, (2) push an APPLICABLE
+  // spec onto `specs` IN ORDER, then (3) hand the ordered list to the shared
+  // engine, which performs the in-order evaluation, the FAIL short-circuit
+  // (later applicable checks become SKIPPED), and the
+  // FAIL > WARNING > SKIPPED > PASS roll-up.
+  //
+  // Applicable verification specs, IN ORDER:
+  //   (1) crop element found      `$$outputs.cropElementFound == true`  (fail)    — only when `crop` is set
+  //   (2) element fits viewport   `$$outputs.fitsViewport == true`      (fail)    — only when `crop` is set
+  //   (3) aspect ratios match     `$$outputs.aspectRatioMatch == true`  (fail)    — only when comparing against an existing/URL reference
+  //   (4) variation <= max        `$$outputs.variation <= <max>`        (warning) — only when comparing against an existing/URL reference
+  //
+  // EXECUTION errors (NOT assertions) still return FAIL with NO assertion
+  // records, preserving the prior early returns + messages exactly:
+  //   - can't load sharp/PNG/pixelmatch; invalid step; can't fetch the URL
+  //     reference; path escapes the run folder; the underlying findElement call
+  //     itself errors; can't capture; can't decode PNG; can't crop/extract.
+  // SKIPPED is preserved when the file exists and overwrite is "false".
+  //
+  // ALL existing outputs (`screenshotPath`, `changed`, `referenceUrl`,
+  // `sourceIntegration`, `element`) and every file write/overwrite/rename side
+  // effect (including the URL-reference read-only path) are preserved exactly.
+  // `evaluateApplicable()` is the single helper that runs the engine over the
+  // specs gathered so far and stamps `result.assertions` + `result.status`; it
+  // is called at every terminal point.
+  const specs: ImplicitAssertionSpec[] = [];
+  const evaluateApplicable = async () => {
+    const ctx = buildConditionContext({ outputs: result.outputs });
+    const { assertions, status } = await evaluateImplicitAssertions(specs, ctx);
+    result.assertions = assertions;
+    result.status = status;
+    return result;
+  };
   // Lazy-load heavy deps once per saveScreenshot invocation; ensureRuntime
   // already materialized them ahead of step execution. The ctx threads
   // through so a user-overridden cacheDir resolves from the same location
@@ -286,15 +331,28 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
       step: findStep,
       driver,
     });
-    if (findResult.status === "FAIL") {
-      return findResult;
-    }
+    // (1) Crop element existence is a VERIFICATION ASSERTION. findElement FAILs
+    // when no element matches, so `findResult.status === "FAIL"` (or a missing
+    // rawElement) means the crop target wasn't found: expose
+    // `outputs.cropElementFound = false`, push the spec, and evaluate -> FAIL.
+    // This preserves the prior `Couldn't find element to crop.` FAIL status
+    // (capture never runs). When the element IS found, the spec PASSes and we
+    // continue to capture.
     element = findResult.outputs?.rawElement;
-    if (!element) {
-      result.status = "FAIL";
+    if (findResult.status === "FAIL" || !element) {
+      result.outputs.cropElementFound = false;
+      specs.push({
+        statement: `$$outputs.cropElementFound == true`,
+        severity: "fail",
+      });
       result.description = `Couldn't find element to crop.`;
-      return result;
+      return await evaluateApplicable();
     }
+    result.outputs.cropElementFound = true;
+    specs.push({
+      statement: `$$outputs.cropElementFound == true`,
+      severity: "fail",
+    });
     if (element) result.outputs.element = findResult.outputs.element;
     // Determine if element bounding box + padding is within viewport
     const rect = {
@@ -319,14 +377,21 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
       padding = step.screenshot.crop.padding;
     }
 
-    // Check if element can fit in viewport
-    if (
-      rect.width + padding.right + padding.left > viewport.width ||
-      rect.height + padding.top + padding.bottom > viewport.height
-    ) {
-      result.status = "FAIL";
+    // (2) Element fits the viewport is a VERIFICATION ASSERTION. Compute the
+    // boolean with the existing logic, expose it as `outputs.fitsViewport`, and
+    // push the spec. When it's false we evaluate immediately and return (capture
+    // never runs), preserving the prior `Element can't fit in viewport.` FAIL.
+    const fitsViewport =
+      rect.width + padding.right + padding.left <= viewport.width &&
+      rect.height + padding.top + padding.bottom <= viewport.height;
+    result.outputs.fitsViewport = fitsViewport;
+    specs.push({
+      statement: `$$outputs.fitsViewport == true`,
+      severity: "fail",
+    });
+    if (!fitsViewport) {
       result.description = `Element can't fit in viewport.`;
-      return result;
+      return await evaluateApplicable();
     }
 
     // Scroll element into view at top-left with padding
@@ -481,7 +546,10 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
       if (step.screenshot.sourceIntegration) {
         result.outputs.sourceIntegration = step.screenshot.sourceIntegration;
       }
-      return result;
+      // No comparison was performed (unconditional overwrite), so no comparison
+      // assertion is applicable; evaluate whatever specs were gathered (only the
+      // crop specs, which already PASSed) -> PASS, matching the prior behavior.
+      return await evaluateApplicable();
     }
     let fractionalDiff;
 
@@ -507,9 +575,18 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
         return result;
       }
 
-      // Compare aspect ratio of images
-      if (!aspectRatiosMatch(img1, img2)) {
-        result.status = "FAIL";
+      // (3) Aspect ratios match is a VERIFICATION ASSERTION. Compute the boolean
+      // with the existing helper, expose it as `outputs.aspectRatioMatch`, and
+      // push the spec. On mismatch we evaluate immediately and return (the
+      // variation spec is never pushed — the diff can't be computed across
+      // mismatched ratios), preserving the prior FAIL status exactly.
+      const aspectRatioMatch = aspectRatiosMatch(img1, img2);
+      result.outputs.aspectRatioMatch = aspectRatioMatch;
+      specs.push({
+        statement: `$$outputs.aspectRatioMatch == true`,
+        severity: "fail",
+      });
+      if (!aspectRatioMatch) {
         result.description = `Couldn't compare images. Images have different aspect ratios.`;
         if (
           !isUrlPath &&
@@ -518,7 +595,7 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
         ) {
           fs.unlinkSync(filePath);
         }
-        return result;
+        return await evaluateApplicable();
       }
 
       // Resize images to same size
@@ -579,12 +656,22 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
         fractionalDiff,
       });
 
+      // (4) Pixel-diff variation <= maxVariation is a VERIFICATION ASSERTION at
+      // WARNING severity. Expose the computed fractional diff as
+      // `outputs.variation` and push the spec; the shared engine records WARNING
+      // (not FAIL) when it evaluates false, matching the prior `WARNING` status.
+      // The file-write/rename side effects below are preserved exactly.
+      result.outputs.variation = fractionalDiff;
+      specs.push({
+        statement: `$$outputs.variation <= ${step.screenshot.maxVariation}`,
+        severity: "warning",
+      });
+
       if (fractionalDiff > step.screenshot.maxVariation) {
         if (step.screenshot.overwrite == "aboveVariation" && !isUrlPath) {
           // Replace old file with new file
           fs.renameSync(filePath, existFilePath);
         }
-        result.status = "WARNING";
         result.description += ` The difference between the existing screenshot and new screenshot (${fractionalDiff.toFixed(
           2
         )}) is greater than the max accepted variation (${
@@ -606,7 +693,9 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
             result.outputs.sourceIntegration = step.screenshot.sourceIntegration;
           }
         }
-        return result;
+        // The WARNING-severity variation spec evaluates false here -> WARNING
+        // (no short-circuit), matching the prior `result.status = "WARNING"`.
+        return await evaluateApplicable();
       } else {
         result.description += ` Screenshots are within maximum accepted variation: ${fractionalDiff.toFixed(
           2
@@ -638,6 +727,11 @@ async function saveScreenshot({ config, step, driver }: { config: any; step: any
     }
   }
 
-  // PASS
-  return result;
+  // Evaluate the applicable verification specs gathered above (crop existence /
+  // viewport / aspect-ratio / within-variation as applicable) through the shared
+  // engine and stamp `result.assertions` + `result.status`. A brand-new capture
+  // with no reference to compare pushes no comparison specs; with no crop either
+  // the spec list is empty -> PASS (capture succeeded). Within-variation falls
+  // through here with a PASSing variation spec -> PASS.
+  return await evaluateApplicable();
 }

--- a/src/core/tests/typeKeys.ts
+++ b/src/core/tests/typeKeys.ts
@@ -4,6 +4,11 @@ import {
 } from "./findStrategies.js";
 import { loadHeavyDep } from "../../runtime/loader.js";
 import { isRecordingActive } from "./ffmpegRecorder.js";
+import {
+  buildConditionContext,
+  evaluateImplicitAssertions,
+} from "../routing.js";
+import type { ImplicitAssertionSpec } from "../routing.js";
 
 export { typeKeys };
 
@@ -90,8 +95,25 @@ async function getSpecialKeyMap(
 }
 
 // Type a sequence of keys in the active element.
+//
+// Unified assertion model: when the step targets a specific element (any
+// element criterion present), element EXISTENCE is the single implicit
+// verification — exposed as `outputs.found` and asserted via the trivial
+// `$$outputs.found == true` expression through the shared engine. The focus
+// (`element.click`) + `driver.keys` typing are EXECUTION: a failure there sets
+// FAIL with NO extra assertion record. When NO element criteria are present the
+// step types into the ACTIVE element, so there is no existence check at all —
+// zero applicable specs roll up to PASS with empty `assertions`.
 async function typeKeys({ config, step, driver }: { config: any; step: any; driver: any }) {
-  let result = { status: "PASS", description: "Typed keys." };
+  // `assertions` starts empty: the no-criteria (active-element) path types into
+  // the focused element with no existence check, so zero applicable specs roll
+  // up to PASS with an empty assertions array. The criteria path overwrites it.
+  let result: any = {
+    status: "PASS",
+    description: "Typed keys.",
+    outputs: {},
+    assertions: [],
+  };
 
   // Validate step payload
   const isValidStep = validate({ schemaKey: "step_v3", object: step });
@@ -149,14 +171,27 @@ async function typeKeys({ config, step, driver }: { config: any; step: any; driv
       driver,
     });
 
+    // Compute the existence output and evaluate the implicit assertion through
+    // the shared engine: found→PASS, not-found→FAIL.
+    result.outputs.found = !!foundElement;
+    const specs: ImplicitAssertionSpec[] = [
+      { statement: "$$outputs.found == true", severity: "fail" },
+    ];
+    const { assertions, status } = await evaluateImplicitAssertions(
+      specs,
+      buildConditionContext({ outputs: result.outputs })
+    );
+    result.assertions = assertions;
+    result.status = status;
+
     if (!foundElement) {
-      result.status = "FAIL";
       result.description = error || `Couldn't find element to type into.`;
       return result;
     }
     element = foundElement;
 
-    // Focus on the element before typing
+    // Focus on the element before typing. This is EXECUTION: a failure sets
+    // FAIL with no extra assertion record (the found assertion stays PASS).
     try {
       await element.click();
     } catch (error: any) {

--- a/test/checkLink-assertions.test.js
+++ b/test/checkLink-assertions.test.js
@@ -4,8 +4,11 @@ import { checkLink } from "../dist/core/tests/checkLink.js";
 
 const config = { logLevel: "silent" };
 
-function findAssertion(assertions, prefix) {
-  return (assertions || []).find((a) => a.statement.startsWith(prefix));
+// Unified model: implicit assertions carry a $$ runtime-expression statement
+// (e.g. "$$outputs.statusCode oneOf [200,301,302,307,308]"), so match on a
+// substring of the statement rather than a prose prefix.
+function findAssertion(assertions, token) {
+  return (assertions || []).find((a) => a.statement.includes(token));
 }
 
 let server;
@@ -43,8 +46,10 @@ describe("checkLink articulated assertions (Phase 4a.2a)", function () {
     assert.ok(sc, "expected a statusCode assertion");
     assert.equal(sc.source, "implicit");
     assert.equal(sc.result, "PASS");
-    assert.deepEqual(sc.expected, [200, 301, 302, 307, 308]);
-    assert.equal(sc.actual, 200);
+    // Unified model: a $$ runtime expression over the exposed output.
+    assert.match(sc.statement, /\$\$outputs\.statusCode oneOf/);
+    // checkLink now exposes a computed statusCode output.
+    assert.equal(result.outputs.statusCode, 200);
   });
 
   it("emits a FAIL statusCode assertion and FAIL status for an unaccepted code", async () => {
@@ -61,8 +66,8 @@ describe("checkLink articulated assertions (Phase 4a.2a)", function () {
     const sc = findAssertion(result.assertions, "statusCode");
     assert.ok(sc);
     assert.equal(sc.result, "FAIL");
-    assert.deepEqual(sc.expected, [200]);
-    assert.equal(sc.actual, 404);
+    assert.match(sc.statement, /\$\$outputs\.statusCode oneOf/);
+    assert.equal(result.outputs.statusCode, 404);
   });
 
   it("returns FAIL with no assertions for an unresolvable URL (execution error)", async () => {

--- a/test/findElement.test.js
+++ b/test/findElement.test.js
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { findElement } from "../dist/core/tests/findElement.js";
+
+const config = { logLevel: "silent" };
+
+// Helper: find the implicit assertion whose statement CONTAINS `needle`. Under
+// the unified model `statement` is a runtime `$$` expression, so we match on the
+// distinguishing output reference (here, "found").
+function findAssertion(assertions, needle) {
+  return (assertions || []).find((a) => a.statement.includes(needle));
+}
+
+// Build a mock element exposing the methods setElementOutputs probes plus
+// click(). `clickImpl` lets a test force the click sub-effect to throw.
+function makeElement({ elementId = "el-1", clickImpl } = {}) {
+  return {
+    elementId,
+    getText: async () => "Submit",
+    getHTML: async () => "<button>Submit</button>",
+    getTagName: async () => "button",
+    getValue: async () => "",
+    getLocation: async () => ({ x: 0, y: 0 }),
+    getSize: async () => ({ width: 10, height: 10 }),
+    isClickable: async () => true,
+    isEnabled: async () => true,
+    isSelected: async () => false,
+    isDisplayed: async () => true,
+    isExisting: async () => true,
+    getAttribute: async () => null,
+    getComputedLabel: async () => "Submit",
+    waitForExist: async () => true,
+    click: clickImpl || (async () => {}),
+  };
+}
+
+// Mock driver whose $$ (criteria selector path) returns the given candidates.
+function makeDriver({ candidates = [], $impl } = {}) {
+  return {
+    $$: async () => candidates,
+    $: $impl || (async () => null),
+    pause: async () => {},
+  };
+}
+
+describe("findElement unified assertion model", function () {
+  this.timeout(15000);
+
+  it("found via selector → found==true, assertion PASS, status PASS, element.* populated", async () => {
+    const element = makeElement();
+    const driver = makeDriver({ candidates: [element] });
+    const result = await findElement({
+      config,
+      step: { find: { selector: "button" } },
+      driver,
+    });
+    assert.equal(result.status, "PASS");
+    assert.equal(result.outputs.found, true);
+    const found = findAssertion(result.assertions, "found");
+    assert.ok(found, "expected a found assertion");
+    assert.equal(found.source, "implicit");
+    assert.equal(found.result, "PASS");
+    assert.equal(found.statement, "$$outputs.found == true");
+    // element.* / rawElement preserved
+    assert.equal(result.outputs.element.tag, "button");
+    assert.equal(result.outputs.element.text, "Submit");
+    assert.equal(result.outputs.rawElement, element);
+  });
+
+  it("found via shorthand string → found==true, assertion PASS, element.* populated", async () => {
+    const element = makeElement();
+    // Shorthand exact-match path resolves the text promise (driver.$).
+    const driver = makeDriver({ $impl: async () => element });
+    const result = await findElement({
+      config,
+      step: { find: "Submit" },
+      driver,
+    });
+    assert.equal(result.status, "PASS");
+    assert.equal(result.outputs.found, true);
+    assert.equal(findAssertion(result.assertions, "found").result, "PASS");
+    assert.equal(result.outputs.element.tag, "button");
+    assert.equal(result.outputs.rawElement, element);
+  });
+
+  it("not found (criteria) → found==false, assertion FAIL, status FAIL, no element.*", async () => {
+    // No candidates ever match → criteria path times out quickly.
+    const driver = makeDriver({ candidates: [] });
+    const result = await findElement({
+      config,
+      step: { find: { selector: "button", timeout: 50 } },
+      driver,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.equal(result.outputs.found, false);
+    const found = findAssertion(result.assertions, "found");
+    assert.ok(found);
+    assert.equal(found.result, "FAIL");
+    assert.equal(found.statement, "$$outputs.found == true");
+    assert.equal(result.outputs.element, undefined);
+    assert.equal(result.outputs.rawElement, undefined);
+  });
+
+  it("not found (shorthand) → found==false, assertion FAIL, status FAIL", async () => {
+    const driver = makeDriver({ $impl: async () => null });
+    const result = await findElement({
+      config,
+      step: { find: "Nonexistent" },
+      driver,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.equal(result.outputs.found, false);
+    assert.equal(findAssertion(result.assertions, "found").result, "FAIL");
+  });
+
+  it("found but click sub-effect fails → status FAIL with NO extra assertion record", async () => {
+    const element = makeElement({
+      clickImpl: async () => {
+        throw new Error("not interactable");
+      },
+    });
+    const driver = makeDriver({ candidates: [element] });
+    const result = await findElement({
+      config,
+      step: { find: { selector: "button", click: true } },
+      driver,
+    });
+    // Sub-effect failure is EXECUTION → FAIL.
+    assert.equal(result.status, "FAIL");
+    // The element WAS found, so found==true and the existence assertion PASSed;
+    // the click failure adds NO extra record.
+    assert.equal(result.outputs.found, true);
+    assert.equal(result.assertions.length, 1);
+    const found = findAssertion(result.assertions, "found");
+    assert.equal(found.result, "PASS");
+    assert.ok(/Couldn't click/.test(result.description));
+  });
+});

--- a/test/httpRequest-assertions.test.js
+++ b/test/httpRequest-assertions.test.js
@@ -91,6 +91,52 @@ describe("httpRequest articulated assertions (Phase 4a.2a)", function () {
     assert.equal(result.outputs.response.statusCode, 404);
   });
 
+  it("allowAdditionalFields:false with UNSET response.body -> noUnexpectedFields PASS (no crash)", async () => {
+    // response.body is not provided, so the expected body defaults to {} (no
+    // keys). With no expected fields there are no unexpected fields to flag, so
+    // the noUnexpectedFields check must PASS and never pass undefined into the
+    // object comparison helper.
+    const result = await httpRequest({
+      config,
+      step: {
+        httpRequest: {
+          url: `http://localhost:${serverPort}/200`,
+          method: "get",
+          statusCodes: [200],
+          allowAdditionalFields: false,
+        },
+      },
+    });
+    assert.equal(result.status, "PASS", result.description);
+    const noExtra = findAssertion(result.assertions, "noUnexpectedFields");
+    assert.ok(noExtra, "expected a noUnexpectedFields assertion");
+    assert.equal(noExtra.result, "PASS");
+    assert.match(noExtra.statement, /\$\$outputs\.noUnexpectedFields == true/);
+    assert.equal(result.outputs.noUnexpectedFields, true);
+  });
+
+  it("allowAdditionalFields:false with expected body subset present -> noUnexpectedFields PASS", async () => {
+    // The server returns {status, name, items}. Expecting that exact superset
+    // as the body means no unexpected fields relative to it -> PASS.
+    const result = await httpRequest({
+      config,
+      step: {
+        httpRequest: {
+          url: `http://localhost:${serverPort}/200`,
+          method: "get",
+          statusCodes: [200],
+          allowAdditionalFields: false,
+          response: { body: { status: 200, name: "John", items: [1, 2] } },
+        },
+      },
+    });
+    assert.equal(result.status, "PASS", result.description);
+    const noExtra = findAssertion(result.assertions, "noUnexpectedFields");
+    assert.ok(noExtra, "expected a noUnexpectedFields assertion");
+    assert.equal(noExtra.result, "PASS");
+    assert.equal(result.outputs.noUnexpectedFields, true);
+  });
+
   it("required-fields check: present -> PASS", async () => {
     const result = await httpRequest({
       config,

--- a/test/httpRequest-assertions.test.js
+++ b/test/httpRequest-assertions.test.js
@@ -7,8 +7,12 @@ import { httpRequest } from "../dist/core/tests/httpRequest.js";
 
 const config = { logLevel: "silent" };
 
-function findAssertion(assertions, prefix) {
-  return (assertions || []).find((a) => a.statement.startsWith(prefix));
+// Unified model: implicit assertions carry a $$ runtime-expression statement
+// (e.g. "$$outputs.response.statusCode oneOf [200]",
+// "$$outputs.bodyMatches == true"), so match on a substring of the statement
+// rather than a prose prefix.
+function findAssertion(assertions, token) {
+  return (assertions || []).find((a) => a.statement.includes(token));
 }
 
 let server;
@@ -64,7 +68,7 @@ describe("httpRequest articulated assertions (Phase 4a.2a)", function () {
     assert.ok(sc, "expected a statusCode assertion");
     assert.equal(sc.source, "implicit");
     assert.equal(sc.result, "PASS");
-    assert.equal(sc.actual, 200);
+    assert.match(sc.statement, /\$\$outputs\.response\.statusCode oneOf/);
     // outputs preserved
     assert.equal(result.outputs.response.statusCode, 200);
   });
@@ -83,8 +87,8 @@ describe("httpRequest articulated assertions (Phase 4a.2a)", function () {
     assert.equal(result.status, "FAIL");
     const sc = findAssertion(result.assertions, "statusCode");
     assert.equal(sc.result, "FAIL");
-    assert.deepEqual(sc.expected, [200]);
-    assert.equal(sc.actual, 404);
+    assert.match(sc.statement, /\$\$outputs\.response\.statusCode oneOf/);
+    assert.equal(result.outputs.response.statusCode, 404);
   });
 
   it("required-fields check: present -> PASS", async () => {
@@ -100,9 +104,11 @@ describe("httpRequest articulated assertions (Phase 4a.2a)", function () {
       },
     });
     assert.equal(result.status, "PASS", result.description);
-    const req = findAssertion(result.assertions, "response fields present");
+    const req = findAssertion(result.assertions, "requiredFieldsPresent");
     assert.ok(req, "expected a required-fields assertion");
     assert.equal(req.result, "PASS");
+    assert.match(req.statement, /\$\$outputs\.requiredFieldsPresent == true/);
+    assert.equal(result.outputs.requiredFieldsPresent, true);
   });
 
   it("status PASS but body type mismatch FAILs, with no leaked status", async () => {
@@ -120,9 +126,11 @@ describe("httpRequest articulated assertions (Phase 4a.2a)", function () {
     assert.equal(result.status, "FAIL");
     const sc = findAssertion(result.assertions, "statusCode");
     assert.equal(sc.result, "PASS");
-    const body = findAssertion(result.assertions, "response.body");
-    assert.ok(body, "expected a response.body assertion");
+    const body = findAssertion(result.assertions, "bodyMatches");
+    assert.ok(body, "expected a bodyMatches assertion");
     assert.equal(body.result, "FAIL");
+    assert.match(body.statement, /\$\$outputs\.bodyMatches == true/);
+    assert.equal(result.outputs.bodyMatches, false);
   });
 
   it("short-circuits: a FAIL early leaves later applicable checks SKIPPED", async () => {
@@ -141,7 +149,7 @@ describe("httpRequest articulated assertions (Phase 4a.2a)", function () {
     assert.equal(result.status, "FAIL");
     const sc = findAssertion(result.assertions, "statusCode");
     assert.equal(sc.result, "FAIL");
-    const body = findAssertion(result.assertions, "response.body");
+    const body = findAssertion(result.assertions, "bodyMatches");
     assert.ok(body, "applicable-but-not-reached body assertion must be present");
     assert.equal(body.result, "SKIPPED");
     assert.equal(body.source, "implicit");
@@ -166,9 +174,11 @@ describe("httpRequest articulated assertions (Phase 4a.2a)", function () {
         },
       });
       assert.equal(result.status, "WARNING", result.description);
-      const v = findAssertion(result.assertions, "saved-file variation");
+      const v = findAssertion(result.assertions, "outputs.variation");
       assert.ok(v, "expected a saved-file variation assertion");
       assert.equal(v.result, "WARNING");
+      assert.match(v.statement, /\$\$outputs\.variation <=/);
+      assert.equal(typeof result.outputs.variation, "number");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -224,9 +234,10 @@ describe("httpRequest articulated assertions (Phase 4a.2a)", function () {
       },
     });
     assert.equal(result.status, "PASS", result.description);
-    const body = findAssertion(result.assertions, "response.body");
-    assert.ok(body, "expected a response.body assertion");
+    const body = findAssertion(result.assertions, "bodyMatches");
+    assert.ok(body, "expected a bodyMatches assertion");
     assert.equal(body.result, "PASS");
+    assert.equal(result.outputs.bodyMatches, true);
   });
 
   it("string response.body MATCH + headers MISMATCH -> FAIL (headers now evaluated, not short-circuited)", async () => {
@@ -247,12 +258,13 @@ describe("httpRequest articulated assertions (Phase 4a.2a)", function () {
     // Old behavior: PASS (headers check skipped after the body matched).
     // New behavior: FAIL (the headers check now runs).
     assert.equal(result.status, "FAIL", result.description);
-    const body = findAssertion(result.assertions, "response.body");
-    assert.ok(body, "expected a response.body assertion");
+    const body = findAssertion(result.assertions, "bodyMatches");
+    assert.ok(body, "expected a bodyMatches assertion");
     assert.equal(body.result, "PASS", "the string body itself still matches");
-    const headers = findAssertion(result.assertions, "response.headers");
+    const headers = findAssertion(result.assertions, "headersMatch");
     assert.ok(headers, "headers assertion must be evaluated, not skipped");
     assert.equal(headers.result, "FAIL");
+    assert.equal(result.outputs.headersMatch, false);
   });
 
   it("string response.body MATCH + path set -> file IS written (save no longer short-circuited)", async () => {
@@ -272,7 +284,7 @@ describe("httpRequest articulated assertions (Phase 4a.2a)", function () {
         },
       });
       assert.equal(result.status, "PASS", result.description);
-      const body = findAssertion(result.assertions, "response.body");
+      const body = findAssertion(result.assertions, "bodyMatches");
       assert.equal(body.result, "PASS");
       // The save side effect must run even though the string body already
       // matched (the old early return skipped it entirely).

--- a/test/interaction-assertions.test.js
+++ b/test/interaction-assertions.test.js
@@ -254,4 +254,53 @@ describe("dragAndDrop unified assertion model", function () {
     assert.equal(src.result, "FAIL");
     assert.equal(tgt.result, "SKIPPED");
   });
+
+  it("undefined inner outputs.found is coerced to sourceFound=false → FAIL (input-guard parity)", async () => {
+    // Backward-compat guard for the input-guard concern: findElement's input
+    // guard returns FAIL with outputs:{} (no `found`). dragAndDrop reads
+    // `sourceResult.outputs?.found === true`, so an absent/undefined `found`
+    // must coerce to sourceFound=false and FAIL, matching a failed find.
+    //
+    // The dragAndDrop step schema and the inner find schema are tightly
+    // aligned, so a source malformed enough to trip find's input guard already
+    // trips dragAndDrop's own step_v3 guard first — also FAIL. We therefore
+    // exercise the coercion directly: a driver whose criteria search returns no
+    // candidates makes findElement resolve with found=false (the closest
+    // reachable analogue of a no-`found` result), and the assertion FAILs.
+    const driver = makeDriver({ candidates: [] });
+    const result = await dragAndDropElement({
+      config,
+      step: {
+        dragAndDrop: {
+          source: { selector: "#a", timeout: 50 },
+          target: { selector: "#b", timeout: 50 },
+        },
+      },
+      driver,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.equal(result.outputs.sourceFound, false);
+    const src = findAssertion(result.assertions, "sourceFound");
+    assert.equal(src.result, "FAIL");
+  });
+
+  it("malformed source is rejected by dragAndDrop's own input guard → FAIL", async () => {
+    // A source bad enough to trip the inner find input guard trips
+    // dragAndDrop's top-level step_v3 guard first: FAIL, no findElement call,
+    // no assertion records. This is the outer half of the input-guard chain
+    // that keeps a never-`found` inner result from mattering in practice.
+    const driver = makeDriver({ candidates: [makeElement()] });
+    const result = await dragAndDropElement({
+      config,
+      step: {
+        dragAndDrop: {
+          source: { selector: { nested: "object" } },
+          target: { selector: "#b" },
+        },
+      },
+      driver,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.match(result.description, /Invalid step definition/);
+  });
 });

--- a/test/interaction-assertions.test.js
+++ b/test/interaction-assertions.test.js
@@ -1,5 +1,51 @@
 import assert from "node:assert/strict";
 import { rollUpAssertions } from "../dist/core/utils.js";
+import { clickElement } from "../dist/core/tests/click.js";
+import { typeKeys } from "../dist/core/tests/typeKeys.js";
+import { dragAndDropElement } from "../dist/core/tests/dragAndDrop.js";
+
+const config = { logLevel: "silent" };
+
+// Unified model: implicit assertions carry a $$ runtime-expression statement
+// (e.g. "$$outputs.found == true"), so match on a substring of the statement.
+function findAssertion(assertions, needle) {
+  return (assertions || []).find((a) => a.statement.includes(needle));
+}
+
+// Mock element exposing the methods setElementOutputs probes plus click()/keys.
+function makeElement({ elementId = "el-1", clickImpl } = {}) {
+  return {
+    elementId,
+    getText: async () => "Submit",
+    getHTML: async () => "<button>Submit</button>",
+    getTagName: async () => "button",
+    getValue: async () => "",
+    getLocation: async () => ({ x: 0, y: 0 }),
+    getSize: async () => ({ width: 10, height: 10 }),
+    isClickable: async () => true,
+    isEnabled: async () => true,
+    isSelected: async () => false,
+    isDisplayed: async () => true,
+    isExisting: async () => true,
+    getAttribute: async () => null,
+    getProperty: async () => false,
+    getComputedLabel: async () => "Submit",
+    waitForExist: async () => true,
+    click: clickImpl || (async () => {}),
+    dragAndDrop: async () => {},
+  };
+}
+
+// Mock driver whose $$ (criteria selector path) returns the given candidates.
+function makeDriver({ candidates = [], $impl, keysImpl } = {}) {
+  return {
+    $$: async () => candidates,
+    $: $impl || (async () => null),
+    pause: async () => {},
+    keys: keysImpl || (async () => {}),
+    execute: async () => true,
+  };
+}
 
 // rollUpAssertions: unlike rollUpResults, an empty/falsy assertion set rolls up
 // to PASS (zero applicable assertions + successful execution = PASS). Used by
@@ -29,5 +75,183 @@ describe("rollUpAssertions", function () {
   });
   it("[WARNING] -> WARNING", () => {
     assert.equal(rollUpAssertions([{ result: "WARNING" }]), "WARNING");
+  });
+});
+
+describe("click unified assertion model", function () {
+  this.timeout(15000);
+
+  it("found → found==true, assertion PASS, status PASS (propagated from find)", async () => {
+    const element = makeElement();
+    const driver = makeDriver({ candidates: [element] });
+    const result = await clickElement({
+      config,
+      step: { click: { selector: "button" } },
+      driver,
+    });
+    assert.equal(result.status, "PASS");
+    assert.equal(result.outputs.found, true);
+    const found = findAssertion(result.assertions, "found");
+    assert.ok(found, "expected a found assertion propagated from find");
+    assert.equal(found.source, "implicit");
+    assert.equal(found.result, "PASS");
+    assert.equal(found.statement, "$$outputs.found == true");
+  });
+
+  it("not found → found==false, assertion FAIL, status FAIL", async () => {
+    const driver = makeDriver({ candidates: [] });
+    const result = await clickElement({
+      config,
+      step: { click: { selector: "button", timeout: 50 } },
+      driver,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.equal(result.outputs.found, false);
+    const found = findAssertion(result.assertions, "found");
+    assert.ok(found);
+    assert.equal(found.result, "FAIL");
+    assert.equal(found.statement, "$$outputs.found == true");
+  });
+
+  it("found but click sub-effect fails → status FAIL, found assertion still PASS (execution)", async () => {
+    const element = makeElement({
+      clickImpl: async () => {
+        throw new Error("not interactable");
+      },
+    });
+    const driver = makeDriver({ candidates: [element] });
+    const result = await clickElement({
+      config,
+      step: { click: { selector: "button" } },
+      driver,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.equal(result.outputs.found, true);
+    assert.equal(result.assertions.length, 1);
+    assert.equal(findAssertion(result.assertions, "found").result, "PASS");
+  });
+});
+
+describe("typeKeys unified assertion model", function () {
+  this.timeout(15000);
+
+  it("criteria found → found==true, assertion PASS, status PASS", async () => {
+    const element = makeElement();
+    const driver = makeDriver({ candidates: [element] });
+    const result = await typeKeys({
+      config,
+      step: { type: { keys: ["hello"], selector: "input" } },
+      driver,
+    });
+    assert.equal(result.status, "PASS");
+    assert.equal(result.outputs.found, true);
+    const found = findAssertion(result.assertions, "found");
+    assert.ok(found, "expected a found assertion built from criteria");
+    assert.equal(found.source, "implicit");
+    assert.equal(found.result, "PASS");
+    assert.equal(found.statement, "$$outputs.found == true");
+  });
+
+  it("criteria not found → found==false, assertion FAIL, status FAIL", async () => {
+    const driver = makeDriver({ candidates: [] });
+    const result = await typeKeys({
+      config,
+      step: { type: { keys: ["hello"], selector: "input" } },
+      driver,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.equal(result.outputs.found, false);
+    assert.equal(findAssertion(result.assertions, "found").result, "FAIL");
+  });
+
+  it("no criteria + keys (active element) → PASS with empty assertions", async () => {
+    const driver = makeDriver();
+    const result = await typeKeys({
+      config,
+      step: { type: { keys: ["hello"] } },
+      driver,
+    });
+    assert.equal(result.status, "PASS");
+    assert.deepEqual(result.assertions, []);
+  });
+
+  it("no keys → SKIPPED", async () => {
+    const driver = makeDriver();
+    const result = await typeKeys({
+      config,
+      step: { type: { keys: [] } },
+      driver,
+    });
+    assert.equal(result.status, "SKIPPED");
+  });
+
+  it("criteria found but focus/keys execution error → FAIL, no extra record", async () => {
+    const element = makeElement();
+    const driver = makeDriver({
+      candidates: [element],
+      keysImpl: async () => {
+        throw new Error("send keys failed");
+      },
+    });
+    const result = await typeKeys({
+      config,
+      step: { type: { keys: ["hello"], selector: "input" } },
+      driver,
+    });
+    assert.equal(result.status, "FAIL");
+    // Element WAS found → found==true, existence assertion PASSed; the keys
+    // failure is EXECUTION and adds NO extra record.
+    assert.equal(result.outputs.found, true);
+    assert.equal(result.assertions.length, 1);
+    assert.equal(findAssertion(result.assertions, "found").result, "PASS");
+  });
+});
+
+describe("dragAndDrop unified assertion model", function () {
+  this.timeout(15000);
+
+  it("both found → sourceFound/targetFound==true, two assertions PASS, status PASS", async () => {
+    const element = makeElement();
+    const driver = makeDriver({ candidates: [element] });
+    const result = await dragAndDropElement({
+      config,
+      step: {
+        dragAndDrop: { source: { selector: "#a" }, target: { selector: "#b" } },
+      },
+      driver,
+    });
+    assert.equal(result.status, "PASS");
+    assert.equal(result.outputs.sourceFound, true);
+    assert.equal(result.outputs.targetFound, true);
+    assert.equal(result.assertions.length, 2);
+    const src = findAssertion(result.assertions, "sourceFound");
+    const tgt = findAssertion(result.assertions, "targetFound");
+    assert.ok(src && tgt);
+    assert.equal(src.statement, "$$outputs.sourceFound == true");
+    assert.equal(tgt.statement, "$$outputs.targetFound == true");
+    assert.equal(src.result, "PASS");
+    assert.equal(tgt.result, "PASS");
+  });
+
+  it("source not found → sourceFound==false FAIL, targetFound SKIPPED, status FAIL", async () => {
+    // Source find polls a never-matching selector and times out; give a short
+    // timeout to keep it quick.
+    const driver = makeDriver({ candidates: [] });
+    const result = await dragAndDropElement({
+      config,
+      step: {
+        dragAndDrop: {
+          source: { selector: "#a", timeout: 50 },
+          target: { selector: "#b", timeout: 50 },
+        },
+      },
+      driver,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.equal(result.outputs.sourceFound, false);
+    const src = findAssertion(result.assertions, "sourceFound");
+    const tgt = findAssertion(result.assertions, "targetFound");
+    assert.equal(src.result, "FAIL");
+    assert.equal(tgt.result, "SKIPPED");
   });
 });

--- a/test/runBrowserScript.test.js
+++ b/test/runBrowserScript.test.js
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runBrowserScript } from "../dist/core/tests/runBrowserScript.js";
+
+const config = { logLevel: "silent" };
+
+// Helper: find the implicit assertion whose statement CONTAINS `needle`.
+function findAssertion(assertions, needle) {
+  return (assertions || []).find((a) => a.statement.includes(needle));
+}
+
+// Mock driver whose execute() returns the given value.
+function makeDriver(returnValue) {
+  return { execute: async () => returnValue };
+}
+
+describe("runBrowserScript unified assertion model", function () {
+  this.timeout(15000);
+
+  it("output match → outputMatches==true, assertion PASS, status PASS", async () => {
+    const result = await runBrowserScript({
+      config,
+      driver: makeDriver("hello world"),
+      step: { runBrowserScript: { script: "return 'hello world'", output: "hello" } },
+    });
+    assert.equal(result.status, "PASS");
+    assert.equal(result.outputs.outputMatches, true);
+    const om = findAssertion(result.assertions, "outputMatches");
+    assert.ok(om, "expected an outputMatches assertion");
+    assert.equal(om.source, "implicit");
+    assert.equal(om.result, "PASS");
+    assert.equal(om.statement, "$$outputs.outputMatches == true");
+    assert.equal(result.outputs.result, "hello world");
+  });
+
+  it("output mismatch → outputMatches==false, assertion FAIL, status FAIL", async () => {
+    const result = await runBrowserScript({
+      config,
+      driver: makeDriver("hello world"),
+      step: { runBrowserScript: { script: "return 'hello world'", output: "goodbye" } },
+    });
+    assert.equal(result.status, "FAIL");
+    assert.equal(result.outputs.outputMatches, false);
+    const om = findAssertion(result.assertions, "outputMatches");
+    assert.ok(om);
+    assert.equal(om.result, "FAIL");
+  });
+
+  it("no driver → execution error FAIL with NO assertion records", async () => {
+    const result = await runBrowserScript({
+      config,
+      driver: undefined,
+      step: { runBrowserScript: { script: "return 1", output: "1" } },
+    });
+    assert.equal(result.status, "FAIL");
+    assert.equal(result.assertions, undefined);
+  });
+
+  it("output + path over-variation → variation assertion WARNING, status WARNING", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rbs-test-"));
+    const filePath = path.join(dir, "snapshot.txt");
+    // Seed an existing file very different from the new output so the
+    // fractional difference exceeds maxVariation (0).
+    fs.writeFileSync(filePath, "completely different prior content");
+    try {
+      const result = await runBrowserScript({
+        config,
+        driver: makeDriver("brand new output value"),
+        step: {
+          runBrowserScript: {
+            script: "return 'brand new output value'",
+            output: "brand new",
+            path: filePath,
+            maxVariation: 0,
+            overwrite: "false",
+          },
+        },
+      });
+      // output match PASSes; variation exceeds → WARNING; roll-up WARNING.
+      assert.equal(result.status, "WARNING");
+      assert.ok(typeof result.outputs.variation === "number");
+      assert.ok(result.outputs.variation > 0);
+      const variation = findAssertion(result.assertions, "variation");
+      assert.ok(variation, "expected a variation assertion");
+      assert.equal(variation.result, "WARNING");
+      assert.ok(
+        variation.statement.startsWith("$$outputs.variation <="),
+        "variation statement shape"
+      );
+      // output match still recorded as PASS
+      assert.equal(findAssertion(result.assertions, "outputMatches").result, "PASS");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("neither output nor path → status PASS with empty assertions", async () => {
+    const result = await runBrowserScript({
+      config,
+      driver: makeDriver(42),
+      step: { runBrowserScript: { script: "return 42" } },
+    });
+    assert.equal(result.status, "PASS");
+    assert.ok(Array.isArray(result.assertions));
+    assert.equal(result.assertions.length, 0);
+    assert.equal(result.outputs.result, 42);
+  });
+});

--- a/test/saveScreenshot.test.js
+++ b/test/saveScreenshot.test.js
@@ -276,7 +276,10 @@ describeIfSharp("saveScreenshot unified assertions", function () {
       driver: fakeDriver(buf),
     });
     assert.equal(result.status, "SKIPPED");
-    assert.equal(result.assertions, undefined);
+    // The SKIPPED early-return carries an empty assertions array so the result
+    // shape is consistent with every other return path (no comparison specs
+    // were gathered, but the field is never left undefined).
+    assert.deepEqual(result.assertions, []);
   });
 
   it("overwrite:true with existing reference -> PASS, no comparison assertion, file overwritten", async function () {

--- a/test/saveScreenshot.test.js
+++ b/test/saveScreenshot.test.js
@@ -1,8 +1,49 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
 import {
   clampCropRect,
   aspectRatiosMatch,
+  saveScreenshot,
 } from "../dist/core/tests/saveScreenshot.js";
+
+const require = createRequire(import.meta.url);
+
+// Lazily resolve sharp; the unified-model integration tests are skipped if the
+// heavy dep isn't installed in this environment.
+let sharp;
+try {
+  const mod = require("sharp");
+  sharp = mod && (mod.default ?? mod);
+} catch {
+  sharp = null;
+}
+
+// Build a solid-color PNG buffer of the given dimensions.
+async function makePngBuffer(width, height, { r, g, b } = { r: 255, g: 0, b: 0 }) {
+  return sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r, g, b },
+    },
+  })
+    .png()
+    .toBuffer();
+}
+
+// A fake WebDriver whose saveScreenshot writes a chosen PNG buffer to the
+// target path. No crop -> execute()/pause() are never called.
+function fakeDriver(buffer) {
+  return {
+    async saveScreenshot(filePath) {
+      fs.writeFileSync(filePath, buffer);
+    },
+  };
+}
 
 describe("clampCropRect", function () {
   it("produces identical dimensions when requested rect straddles y=0 vs sits just below", function () {
@@ -109,5 +150,171 @@ describe("aspectRatiosMatch", function () {
       aspectRatiosMatch({ width: 200, height: 100 }, { width: 100, height: 100 }),
       false,
     );
+  });
+});
+
+// Unified assertion model: each implicit verification check is exposed as a
+// computed output and asserted via a `$$` expression evaluated by the shared
+// engine. These tests use a fake driver that writes real PNGs so the
+// comparison/decode paths run for real, and assert that:
+//   - status (PASS/WARNING/FAIL/SKIPPED) is byte-identical to prior behavior,
+//   - the emitted assertions are the expected `{statement, source, result}`,
+//   - the computed outputs the statements reference are present.
+const describeIfSharp = sharp ? describe : describe.skip;
+
+describeIfSharp("saveScreenshot unified assertions", function () {
+  this.timeout(20000);
+  let tmpDir;
+
+  beforeEach(function () {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dd-screenshot-"));
+  });
+  afterEach(function () {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const config = {};
+
+  it("new capture (no reference) -> PASS with no comparison assertions", async function () {
+    const target = path.join(tmpDir, "shot.png");
+    const buf = await makePngBuffer(100, 80);
+    const result = await saveScreenshot({
+      config,
+      step: { stepId: "s1", screenshot: { path: target } },
+      driver: fakeDriver(buf),
+    });
+    assert.equal(result.status, "PASS");
+    // No reference + no crop -> empty applicable spec list.
+    assert.deepEqual(result.assertions, []);
+    assert.equal(result.outputs.screenshotPath, target);
+    assert.equal(result.outputs.changed, true);
+    assert.ok(fs.existsSync(target));
+  });
+
+  it("within-variation (identical reference) -> PASS with a passing variation assertion", async function () {
+    const target = path.join(tmpDir, "shot.png");
+    const buf = await makePngBuffer(100, 80);
+    // Pre-create the reference (identical image).
+    fs.writeFileSync(target, buf);
+    const result = await saveScreenshot({
+      config,
+      step: {
+        stepId: "s2",
+        screenshot: { path: target, maxVariation: 0.05, overwrite: "aboveVariation" },
+      },
+      driver: fakeDriver(buf),
+    });
+    assert.equal(result.status, "PASS");
+    // aspect-ratio (PASS) then variation (PASS).
+    assert.deepEqual(result.assertions, [
+      { statement: "$$outputs.aspectRatioMatch == true", source: "implicit", result: "PASS" },
+      { statement: "$$outputs.variation <= 0.05", source: "implicit", result: "PASS" },
+    ]);
+    assert.equal(result.outputs.aspectRatioMatch, true);
+    assert.equal(typeof result.outputs.variation, "number");
+    assert.ok(result.outputs.variation <= 0.05);
+  });
+
+  it("over-variation -> WARNING with a warning variation assertion", async function () {
+    const target = path.join(tmpDir, "shot.png");
+    // Reference is red; new capture is fully different (blue) -> ~100% diff.
+    const refBuf = await makePngBuffer(100, 80, { r: 255, g: 0, b: 0 });
+    const newBuf = await makePngBuffer(100, 80, { r: 0, g: 0, b: 255 });
+    fs.writeFileSync(target, refBuf);
+    const result = await saveScreenshot({
+      config,
+      step: {
+        stepId: "s3",
+        // aboveVariation = the default comparison mode: compare, and replace the
+        // reference when the diff exceeds maxVariation.
+        screenshot: { path: target, maxVariation: 0.05, overwrite: "aboveVariation" },
+      },
+      driver: fakeDriver(newBuf),
+    });
+    assert.equal(result.status, "WARNING");
+    assert.deepEqual(result.assertions, [
+      { statement: "$$outputs.aspectRatioMatch == true", source: "implicit", result: "PASS" },
+      { statement: "$$outputs.variation <= 0.05", source: "implicit", result: "WARNING" },
+    ]);
+    assert.equal(result.outputs.aspectRatioMatch, true);
+    assert.ok(result.outputs.variation > 0.05);
+  });
+
+  it("aspect-ratio mismatch -> FAIL; variation spec never pushed", async function () {
+    const target = path.join(tmpDir, "shot.png");
+    const refBuf = await makePngBuffer(200, 100); // 2:1
+    const newBuf = await makePngBuffer(100, 100); // 1:1
+    fs.writeFileSync(target, refBuf);
+    const result = await saveScreenshot({
+      config,
+      step: {
+        stepId: "s4",
+        screenshot: { path: target, maxVariation: 0.05, overwrite: "aboveVariation" },
+      },
+      driver: fakeDriver(newBuf),
+    });
+    assert.equal(result.status, "FAIL");
+    assert.deepEqual(result.assertions, [
+      { statement: "$$outputs.aspectRatioMatch == true", source: "implicit", result: "FAIL" },
+    ]);
+    assert.equal(result.outputs.aspectRatioMatch, false);
+    assert.equal(result.outputs.variation, undefined);
+  });
+
+  it("file exists + overwrite:false -> SKIPPED with no assertions", async function () {
+    const target = path.join(tmpDir, "shot.png");
+    const buf = await makePngBuffer(100, 80);
+    fs.writeFileSync(target, buf);
+    const result = await saveScreenshot({
+      config,
+      step: {
+        // overwrite:"false" + existing file short-circuits to SKIPPED BEFORE any
+        // capture/comparison.
+        stepId: "s5",
+        screenshot: { path: target, overwrite: "false" },
+      },
+      driver: fakeDriver(buf),
+    });
+    assert.equal(result.status, "SKIPPED");
+    assert.equal(result.assertions, undefined);
+  });
+
+  it("overwrite:true with existing reference -> PASS, no comparison assertion, file overwritten", async function () {
+    const target = path.join(tmpDir, "shot.png");
+    const refBuf = await makePngBuffer(100, 80, { r: 255, g: 0, b: 0 });
+    const newBuf = await makePngBuffer(100, 80, { r: 0, g: 255, b: 0 });
+    fs.writeFileSync(target, refBuf);
+    const result = await saveScreenshot({
+      config,
+      step: {
+        stepId: "s6",
+        screenshot: { path: target, overwrite: "true" },
+      },
+      driver: fakeDriver(newBuf),
+    });
+    assert.equal(result.status, "PASS");
+    // Unconditional overwrite -> no comparison performed -> empty applicable specs.
+    assert.deepEqual(result.assertions, []);
+    assert.equal(result.outputs.changed, true);
+    assert.equal(result.outputs.screenshotPath, target);
+  });
+
+  it("PNG decode error on a non-PNG reference -> EXECUTION FAIL, no assertions", async function () {
+    const target = path.join(tmpDir, "shot.png");
+    // Existing reference is NOT a valid PNG.
+    fs.writeFileSync(target, "not a png");
+    const buf = await makePngBuffer(100, 80);
+    const result = await saveScreenshot({
+      config,
+      step: {
+        stepId: "s7",
+        screenshot: { path: target, maxVariation: 0.05, overwrite: "aboveVariation" },
+      },
+      driver: fakeDriver(buf),
+    });
+    assert.equal(result.status, "FAIL");
+    assert.match(result.description, /Couldn't decode PNG/);
+    // Execution error -> no assertion records.
+    assert.equal(result.assertions, undefined);
   });
 });


### PR DESCRIPTION
## Summary

Stage 2 of dynamic routing — completes the **unified assertion model** across **every step action**. Builds on the foundation in #355 (which converted `runShell` as the exemplar). Each action now generates its implicit checks as `$$` runtime-expression assertions evaluated by the shared `evaluateImplicitAssertions` engine; structurally-complex checks expose a **computed output** and assert a simple expression over it (no new operators). The computed outputs are also user-referenceable in conditions and custom assertions.

**Non-breaking:** rolled-up step status (PASS/FAIL/WARNING/SKIPPED) is byte-identical to the prior model for every action — verified per-commit (httpRequest via side-by-side old-vs-new execution; screenshot via a per-case status table). The runner step loop (`tests.ts`) is untouched.

## Commits / actions

- **httpRequest, checkLink** (`8eebded1`) — checkLink exposes `outputs.statusCode`; httpRequest exposes `requiredFieldsPresent` / `responseSchemaValid` / `noUnexpectedFields` / `bodyMatches` / `headersMatch` / `variation`. Local `AssertionRecord` types replaced by the shared `ImplicitAssertionRecord`.
- **find, runBrowserScript** (`184b056b`) — find exposes `outputs.found` (`$$outputs.found == true`); sub-effects (moveTo/click/type) stay execution. runBrowserScript exposes `outputMatches` / `variation`.
- **click, type, dragAndDrop** (`d04ea796`) — click propagates find's existence assertion; type builds `found` from criteria (no-criteria → PASS empty, no-keys → SKIPPED); dragAndDrop exposes `sourceFound` / `targetFound`. The interactions are execution.
- **screenshot** (`ce83c275`) — exposes `cropElementFound` / `fitsViewport` / `aspectRatioMatch` / `variation`; operational failures stay execution errors; overwrite:false → SKIPPED; URL-reference read-only path preserved.

## Verification

Each action's existing unit tests + assertion tests pass; backward-compat confirmed against the prior committed versions; driver actions spot-checked via firefox-headless E2E fixtures where runnable; runCode inherits the unified model via runShell.

## Not in this PR (tracked follow-ups)

The Phase-5 prerequisites from the #355 review (array-`if` AND evaluation, runShell SKIPPED-description polish), and a schema-normalization pass (the `$ref`/`retry.delay`/`expected`-`actual` nits **plus the output-schema bloat** behind the raised test timeout). Then: custom user assertions, guard-`if` execution, routing handlers, retry, goToStep, goToTest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)