### PR TITLE
feat(assertions): evaluate author-written custom assertions at runtime

### DIFF
--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -158,6 +158,28 @@ async function evaluateImplicitAssertions(
 }
 
 /**
+ * The CURRENT step as seen by the custom-assertion helper. Only `assertions` is
+ * read here; it is the author condition form (string | string[]). An
+ * array-of-objects (the report shape) is tolerated by the type but ignored at
+ * runtime — it is not author input.
+ */
+interface CustomAssertionStep {
+  assertions?: string | string[] | unknown[];
+}
+
+/**
+ * The action's result the helper folds custom records into (and mutates).
+ * `status` is the rolled-up verdict; `assertions` holds any prior (implicit)
+ * records; `outputs` is the per-action computed-output bag conditions read.
+ */
+interface CustomAssertionActionResult {
+  status: string;
+  assertions?: ImplicitAssertionRecord[];
+  outputs?: any;
+  [key: string]: any;
+}
+
+/**
  * Evaluate the author-written `step.assertions` (the "custom" condition form)
  * AFTER an action has run, folding the results into `actionResult`.
  *
@@ -168,17 +190,17 @@ async function evaluateImplicitAssertions(
  *   - Only the condition form is evaluated: a string or an array of strings
  *     (AND across the array). An array-of-objects (the report shape) is IGNORED
  *     — it is not author input.
- *   - If the action produced no assertable result — i.e. it was deliberately
- *     SKIPPED (e.g. `wait: false`), or it returned FAIL with NO implicit
- *     assertion records (an execution-error early return) — the custom
- *     assertions are emitted as SKIPPED, NOT evaluated, and the original status
- *     is preserved (no re-roll).
- *   - Otherwise, when an existing implicit record already FAILed, the custom
- *     records continue that short-circuit (all SKIPPED).
+ *   - Custom assertions are EVALUATED (and the status re-rolled) ONLY when the
+ *     action's status is PASS or WARNING. For ANY other status (FAIL for any
+ *     reason — execution error, an implicit FAIL record, etc. — or SKIPPED) the
+ *     custom checks are emitted as SKIPPED, NOT evaluated, and the action's
+ *     original status is PRESERVED (no re-roll). This guarantees custom
+ *     assertions can only ADD a failure to a passing/warning step, never
+ *     rescue/upgrade a failing or skipped one.
  *   - Custom assertions are FAIL-only (no WARNING). An unresolvable `$$` fails
  *     closed to FAIL (via `evaluateAssertion`).
- *   - Custom records are appended to `actionResult.assertions` and
- *     `actionResult.status` is re-rolled across ALL records.
+ *   - Custom records are appended to `actionResult.assertions` and, when
+ *     evaluated, `actionResult.status` is re-rolled across ALL records.
  *
  * Cross-step `$$steps.*` in custom assertions is DEFERRED: `steps` is passed as
  * `{}` here (resolution would fail closed to FAIL today).
@@ -188,11 +210,11 @@ async function evaluateImplicitAssertions(
  * @returns The same (mutated) `actionResult`, for convenience.
  */
 async function evaluateCustomAssertions(args: {
-  step: any;
-  actionResult: any;
+  step?: CustomAssertionStep;
+  actionResult?: CustomAssertionActionResult;
   platform?: string;
-}): Promise<any> {
-  const { step, actionResult, platform } = args || ({} as any);
+}): Promise<CustomAssertionActionResult | undefined> {
+  const { step, actionResult, platform } = args;
   if (!step || !actionResult) return actionResult;
 
   // Normalize the author condition form. Only string | string[] is user input;
@@ -216,28 +238,17 @@ async function evaluateCustomAssertions(args: {
     ? actionResult.assertions
     : [];
 
-  // No assertable result: either a deliberately-skipped step (status SKIPPED,
-  // e.g. `wait: false`) or an execution-error early return (the action FAILed
-  // before producing any implicit records). In both cases there is nothing
-  // meaningful to assert on, so the custom checks are SKIPPED (not evaluated)
-  // and the action's original status is PRESERVED (no re-roll that could flip
-  // SKIPPED -> PASS/FAIL or demote FAIL -> SKIPPED).
-  const noAssertableResult =
-    actionResult.status === "SKIPPED" ||
-    (actionResult.status === "FAIL" && existing.length === 0);
-
-  // Continue an implicit short-circuit when an implicit check already FAILed.
-  const implicitFailed = existing.some((a) => a.result === "FAIL");
-
   const specs: ImplicitAssertionSpec[] = statements.map((statement) => ({
     statement,
     severity: "fail",
   }));
 
-  if (noAssertableResult) {
-    // Nothing meaningful to assert on: emit SKIPPED custom records but PRESERVE
-    // the action's original (SKIPPED or FAIL) status — a re-roll over a lone
-    // SKIPPED record would wrongly flip SKIPPED -> PASS / demote FAIL -> SKIPPED.
+  // Custom assertions may only ADD a failure to a passing/warning step. For any
+  // other status (FAIL for any reason — execution error or an existing implicit
+  // FAIL record — or SKIPPED) there is nothing meaningful to assert on: emit
+  // SKIPPED custom records and PRESERVE the original status (no re-roll, which
+  // could otherwise upgrade a FAIL to PASS or flip a SKIPPED).
+  if (actionResult.status !== "PASS" && actionResult.status !== "WARNING") {
     const customRecords: ImplicitAssertionRecord[] = specs.map((spec) => ({
       statement: spec.statement,
       source: "custom",
@@ -255,7 +266,7 @@ async function evaluateCustomAssertions(args: {
   const { assertions: customRecords } = await evaluateImplicitAssertions(
     specs,
     ctx,
-    { source: "custom", startFailed: implicitFailed }
+    { source: "custom" }
   );
 
   actionResult.assertions = [...existing, ...customRecords];
@@ -275,4 +286,6 @@ export type {
   ImplicitAssertionSpec,
   ImplicitAssertionRecord,
   EvaluateAssertionsOptions,
+  CustomAssertionStep,
+  CustomAssertionActionResult,
 };

--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -79,12 +79,29 @@ interface ImplicitAssertionSpec {
 /**
  * One emitted assertion record. `statement` is the runtime expression that was
  * (or would have been) evaluated. Under the unified model `expected`/`actual`
- * are vestigial and omitted here.
+ * are vestigial and omitted here. `source` distinguishes engine-emitted
+ * ("implicit") records from author-written ("custom") `step.assertions`.
  */
 interface ImplicitAssertionRecord {
   statement: string;
-  source: "implicit";
+  source: "implicit" | "custom";
   result: "PASS" | "FAIL" | "WARNING" | "SKIPPED";
+}
+
+/**
+ * Options for the shared evaluator. Defaults reproduce the original
+ * implicit-only behavior so the 8 existing call sites are untouched.
+ */
+interface EvaluateAssertionsOptions {
+  /** Stamped onto every emitted record's `source`. Defaults to "implicit". */
+  source?: "implicit" | "custom";
+  /**
+   * When true, the evaluator starts in the short-circuited state: the FIRST
+   * spec (and every later one) is recorded SKIPPED without evaluation. Used by
+   * custom assertions to CONTINUE an implicit short-circuit — when an implicit
+   * check already FAILed, the custom checks are not meaningful to assert on.
+   */
+  startFailed?: boolean;
 }
 
 /**
@@ -98,22 +115,27 @@ interface ImplicitAssertionRecord {
  *
  * @param specs - Ordered, already-applicable specs.
  * @param context - A `buildConditionContext(...)` output.
+ * @param options - Optional `{ source, startFailed }` (see
+ *   `EvaluateAssertionsOptions`). Defaults reproduce implicit-only behavior.
  * @returns `{ assertions, status }`.
  */
 async function evaluateImplicitAssertions(
   specs: ImplicitAssertionSpec[],
-  context: ConditionContext
+  context: ConditionContext,
+  options: EvaluateAssertionsOptions = {}
 ): Promise<{ assertions: ImplicitAssertionRecord[]; status: string }> {
+  const source = options.source ?? "implicit";
   const records: ImplicitAssertionRecord[] = [];
-  let failed = false;
+  let failed = options.startFailed === true;
 
   for (const spec of specs) {
     if (failed) {
-      // Short-circuit: an earlier assertion FAILed, so this applicable check is
-      // not evaluated — report it as SKIPPED.
+      // Short-circuit: an earlier assertion FAILed (or the chain was started in
+      // the failed state), so this applicable check is not evaluated — report
+      // it as SKIPPED.
       records.push({
         statement: spec.statement,
-        source: "implicit",
+        source,
         result: "SKIPPED",
       });
       continue;
@@ -129,17 +151,128 @@ async function evaluateImplicitAssertions(
       result = "FAIL";
     }
     if (result === "FAIL") failed = true;
-    records.push({ statement: spec.statement, source: "implicit", result });
+    records.push({ statement: spec.statement, source, result });
   }
 
   return { assertions: records, status: rollUpAssertions(records) };
 }
 
-export { buildConditionContext, evaluateImplicitAssertions };
+/**
+ * Evaluate the author-written `step.assertions` (the "custom" condition form)
+ * AFTER an action has run, folding the results into `actionResult`.
+ *
+ * This is the runner-facing helper for custom assertions. It is strictly
+ * additive: a step with no usable `assertions` field is left byte-identical.
+ *
+ * Contract:
+ *   - Only the condition form is evaluated: a string or an array of strings
+ *     (AND across the array). An array-of-objects (the report shape) is IGNORED
+ *     — it is not author input.
+ *   - If the action produced no assertable result — i.e. it was deliberately
+ *     SKIPPED (e.g. `wait: false`), or it returned FAIL with NO implicit
+ *     assertion records (an execution-error early return) — the custom
+ *     assertions are emitted as SKIPPED, NOT evaluated, and the original status
+ *     is preserved (no re-roll).
+ *   - Otherwise, when an existing implicit record already FAILed, the custom
+ *     records continue that short-circuit (all SKIPPED).
+ *   - Custom assertions are FAIL-only (no WARNING). An unresolvable `$$` fails
+ *     closed to FAIL (via `evaluateAssertion`).
+ *   - Custom records are appended to `actionResult.assertions` and
+ *     `actionResult.status` is re-rolled across ALL records.
+ *
+ * Cross-step `$$steps.*` in custom assertions is DEFERRED: `steps` is passed as
+ * `{}` here (resolution would fail closed to FAIL today).
+ *
+ * @param args - `{ step, actionResult, platform }`. `platform` is the mapped
+ *   `context.platform` value (or undefined).
+ * @returns The same (mutated) `actionResult`, for convenience.
+ */
+async function evaluateCustomAssertions(args: {
+  step: any;
+  actionResult: any;
+  platform?: string;
+}): Promise<any> {
+  const { step, actionResult, platform } = args || ({} as any);
+  if (!step || !actionResult) return actionResult;
+
+  // Normalize the author condition form. Only string | string[] is user input;
+  // an array-of-objects is the report shape and is ignored.
+  const raw = step.assertions;
+  let statements: string[] | null = null;
+  if (typeof raw === "string") {
+    statements = [raw];
+  } else if (
+    Array.isArray(raw) &&
+    raw.length > 0 &&
+    raw.every((s) => typeof s === "string")
+  ) {
+    statements = raw as string[];
+  }
+  if (!statements || statements.length === 0) return actionResult;
+
+  const existing: ImplicitAssertionRecord[] = Array.isArray(
+    actionResult.assertions
+  )
+    ? actionResult.assertions
+    : [];
+
+  // No assertable result: either a deliberately-skipped step (status SKIPPED,
+  // e.g. `wait: false`) or an execution-error early return (the action FAILed
+  // before producing any implicit records). In both cases there is nothing
+  // meaningful to assert on, so the custom checks are SKIPPED (not evaluated)
+  // and the action's original status is PRESERVED (no re-roll that could flip
+  // SKIPPED -> PASS/FAIL or demote FAIL -> SKIPPED).
+  const noAssertableResult =
+    actionResult.status === "SKIPPED" ||
+    (actionResult.status === "FAIL" && existing.length === 0);
+
+  // Continue an implicit short-circuit when an implicit check already FAILed.
+  const implicitFailed = existing.some((a) => a.result === "FAIL");
+
+  const specs: ImplicitAssertionSpec[] = statements.map((statement) => ({
+    statement,
+    severity: "fail",
+  }));
+
+  if (noAssertableResult) {
+    // Nothing meaningful to assert on: emit SKIPPED custom records but PRESERVE
+    // the action's original (SKIPPED or FAIL) status — a re-roll over a lone
+    // SKIPPED record would wrongly flip SKIPPED -> PASS / demote FAIL -> SKIPPED.
+    const customRecords: ImplicitAssertionRecord[] = specs.map((spec) => ({
+      statement: spec.statement,
+      source: "custom",
+      result: "SKIPPED",
+    }));
+    actionResult.assertions = [...existing, ...customRecords];
+    return actionResult;
+  }
+
+  const ctx = buildConditionContext({
+    platform,
+    outputs: actionResult.outputs,
+    steps: {},
+  });
+  const { assertions: customRecords } = await evaluateImplicitAssertions(
+    specs,
+    ctx,
+    { source: "custom", startFailed: implicitFailed }
+  );
+
+  actionResult.assertions = [...existing, ...customRecords];
+  actionResult.status = rollUpAssertions(actionResult.assertions);
+  return actionResult;
+}
+
+export {
+  buildConditionContext,
+  evaluateImplicitAssertions,
+  evaluateCustomAssertions,
+};
 export type {
   BuildConditionContextArgs,
   ConditionContext,
   StepContextEntry,
   ImplicitAssertionSpec,
   ImplicitAssertionRecord,
+  EvaluateAssertionsOptions,
 };

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -65,6 +65,7 @@ import { randomUUID } from "node:crypto";
 import { setAppiumHome } from "./appium.js";
 import { contentHash } from "../common/src/detectTests.js";
 import { resolveExpression } from "./expressions.js";
+import { evaluateCustomAssertions } from "./routing.js";
 import {
   getEnvironment,
   getAvailableApps,
@@ -1998,6 +1999,20 @@ async function runStep({
   // Clean up actionResult outputs
   if (actionResult?.outputs?.rawElement) {
     delete actionResult.outputs.rawElement;
+  }
+
+  // Evaluate author-written custom assertions (`step.assertions`). Strictly
+  // additive: with no usable `assertions` field this is a no-op and the
+  // actionResult is byte-identical. Folds custom records into
+  // actionResult.assertions and re-rolls actionResult.status. See
+  // evaluateCustomAssertions for the execution-error -> SKIPPED and
+  // implicit-FAIL short-circuit semantics.
+  if (step.assertions && actionResult) {
+    await evaluateCustomAssertions({
+      step,
+      actionResult,
+      platform: context?.platform,
+    });
   }
 
   // If variables are defined, resolve and set them

--- a/test/core-artifacts/custom-assertions.spec.json
+++ b/test/core-artifacts/custom-assertions.spec.json
@@ -1,0 +1,45 @@
+{
+  "description": "Custom user assertions (step.assertions condition form) are evaluated at runtime against the step's outputs. This spec covers the PASSING permutations (string form, string[] AND form, and a custom check layered on top of a passing implicit check). It must resolve PASS on every OS; FAIL/SKIPPED permutations are covered by focused it(...) tests in core-core.test.js. Node is always present, so node -e is cross-platform.",
+  "tests": [
+    {
+      "steps": [
+        {
+          "description": "String form: a single passing custom assertion on exitCode.",
+          "runShell": "node -e \"process.exit(0)\"",
+          "assertions": "$$outputs.exitCode == 0"
+        },
+        {
+          "description": "String[] form (AND): every custom assertion must pass.",
+          "runShell": {
+            "command": "node -e \"console.log('hello world')\"",
+            "stdio": "hello world"
+          },
+          "assertions": [
+            "$$outputs.exitCode == 0",
+            "$$outputs.stdio.stdout contains \"hello\""
+          ]
+        },
+        {
+          "description": "Custom check layered on a passing implicit check (exitCodes). Both implicit and custom records should be PASS.",
+          "runShell": {
+            "command": "node -e \"process.exit(0)\"",
+            "exitCodes": [
+              0
+            ]
+          },
+          "assertions": "$$outputs.exitCode oneOf [0]"
+        }
+      ]
+    },
+    {
+      "description": "A deliberately-skipped action (wait: false) that ALSO carries custom assertions must stay SKIPPED — custom assertions must not be evaluated or re-roll the status. The failing custom expr must NOT flip the step to PASS or FAIL.",
+      "steps": [
+        {
+          "description": "wait: false skips the action; the custom assertion (deliberately false) must not be evaluated.",
+          "wait": false,
+          "assertions": "$$outputs.x == 1"
+        }
+      ]
+    }
+  ]
+}

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -58,6 +58,73 @@ describe("Run tests successfully", function () {
     }
   });
 
+  it("Custom assertion FAIL fails the step and skips the rest of the test", async () => {
+    // An action that EXECUTES fine (exit 0) but whose custom assertion is false.
+    // The custom-assertion FAIL must fail the step, and the existing step-loop
+    // FAIL handling must then skip the remaining step.
+    const customFailTest = {
+      tests: [
+        {
+          steps: [
+            {
+              runShell: "node -e \"process.exit(0)\"",
+              assertions: "$$outputs.exitCode == 1",
+            },
+            {
+              runShell: "node -e \"process.exit(0)\"",
+            },
+          ],
+        },
+      ],
+    };
+    const tempFilePath = path.resolve("./test/temp-custom-fail-test.json");
+    fs.writeFileSync(tempFilePath, JSON.stringify(customFailTest, null, 2));
+    const config = { input: tempFilePath, logLevel: "debug" };
+    let result;
+    try {
+      result = await runTests(config);
+      assert.equal(result.summary.steps.fail, 1);
+      assert.equal(result.summary.steps.skipped, 1);
+    } finally {
+      fs.unlinkSync(tempFilePath);
+    }
+  });
+
+  it("Custom assertion records are SKIPPED when an implicit check already FAILed", async () => {
+    // Exit code 1 with exitCodes [0] makes the IMPLICIT check FAIL. The custom
+    // assertion must then be SKIPPED (not evaluated), and the step stays FAIL.
+    const implicitFailTest = {
+      tests: [
+        {
+          steps: [
+            {
+              runShell: { command: "node -e \"process.exit(1)\"", exitCodes: [0] },
+              assertions: "$$outputs.exitCode == 1",
+            },
+          ],
+        },
+      ],
+    };
+    const tempFilePath = path.resolve("./test/temp-implicit-fail-test.json");
+    fs.writeFileSync(tempFilePath, JSON.stringify(implicitFailTest, null, 2));
+    const config = { input: tempFilePath, logLevel: "debug" };
+    let result;
+    try {
+      result = await runTests(config);
+      assert.equal(result.summary.steps.fail, 1);
+      const step = result.specs[0].tests[0].contexts[0].steps[0];
+      const custom = (step.assertions || []).filter((a) => a.source === "custom");
+      assert.equal(custom.length, 1);
+      assert.equal(custom[0].result, "SKIPPED");
+      const implicit = (step.assertions || []).filter(
+        (a) => a.source === "implicit"
+      );
+      assert.ok(implicit.some((a) => a.result === "FAIL"));
+    } finally {
+      fs.unlinkSync(tempFilePath);
+    }
+  });
+
   it("Test skips when unsafe and unsafe is disallowed", async () => {
     const unsafeTest = {
       tests: [

--- a/test/custom-assertions.test.js
+++ b/test/custom-assertions.test.js
@@ -149,6 +149,28 @@ describe("routing: evaluateCustomAssertions", function () {
     assert.equal(custom[0].result, "SKIPPED");
   });
 
+  it("execution-error action (FAIL, but all-PASS implicit records) + passing custom -> custom SKIPPED, status STAYS FAIL (no upgrade)", async function () {
+    // An execution failure that occurred AFTER implicit assertions were emitted:
+    // status is FAIL but every existing record is PASS. Custom assertions must
+    // NOT be evaluated and the FAIL must NOT be upgraded to PASS by a re-roll.
+    const actionResult = {
+      status: "FAIL",
+      description: "boom after implicit checks passed",
+      outputs: { exitCode: 0 },
+      assertions: [
+        { statement: "$$outputs.exitCode oneOf [0]", source: "implicit", result: "PASS" },
+      ],
+    };
+    await evaluateCustomAssertions({
+      step: { assertions: "$$outputs.exitCode == 0" }, // would PASS if evaluated
+      actionResult,
+    });
+    assert.equal(actionResult.status, "FAIL");
+    const custom = actionResult.assertions.filter((a) => a.source === "custom");
+    assert.equal(custom.length, 1);
+    assert.equal(custom[0].result, "SKIPPED");
+  });
+
   it("SKIPPED-status action (no records) + custom -> custom SKIPPED, status stays SKIPPED (not flipped)", async function () {
     // A deliberately-skipped step (e.g. `wait: false`) returns status SKIPPED
     // with no assertion records. Custom assertions must NOT be evaluated and

--- a/test/custom-assertions.test.js
+++ b/test/custom-assertions.test.js
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import {
+  buildConditionContext,
+  evaluateImplicitAssertions,
+  evaluateCustomAssertions,
+} from "../dist/core/routing.js";
+
+// Generalization of the shared evaluator: a `source` stamp and a `startFailed`
+// short-circuit so custom assertions can reuse the SAME engine as implicit ones
+// without touching the 8 implicit call sites.
+describe("routing: evaluateImplicitAssertions (generalized)", function () {
+  const ctx = buildConditionContext({
+    outputs: { exitCode: 0, stdioMatched: true },
+  });
+
+  it("defaults: source 'implicit', no short-circuit (unchanged)", async function () {
+    const specs = [{ statement: "$$outputs.exitCode == 0", severity: "fail" }];
+    const { assertions, status } = await evaluateImplicitAssertions(specs, ctx);
+    assert.equal(status, "PASS");
+    assert.equal(assertions[0].source, "implicit");
+    assert.equal(assertions[0].result, "PASS");
+  });
+
+  it("source option stamps the record source", async function () {
+    const specs = [{ statement: "$$outputs.exitCode == 0", severity: "fail" }];
+    const { assertions } = await evaluateImplicitAssertions(specs, ctx, {
+      source: "custom",
+    });
+    assert.equal(assertions[0].source, "custom");
+  });
+
+  it("startFailed=true forces every spec to SKIPPED (no evaluation)", async function () {
+    const specs = [
+      { statement: "$$outputs.exitCode == 0", severity: "fail" },
+      { statement: "$$outputs.stdioMatched == true", severity: "fail" },
+    ];
+    const { assertions, status } = await evaluateImplicitAssertions(specs, ctx, {
+      source: "custom",
+      startFailed: true,
+    });
+    assert.equal(status, "SKIPPED");
+    assert.ok(assertions.every((a) => a.result === "SKIPPED"));
+    assert.ok(assertions.every((a) => a.source === "custom"));
+  });
+});
+
+// The runStep-facing helper: decides whether to evaluate or skip custom
+// assertions, evaluates them, appends to actionResult.assertions, and re-rolls
+// actionResult.status. Tested as a pure unit (no driver / HTTP).
+describe("routing: evaluateCustomAssertions", function () {
+  it("custom PASS on a passing action -> status PASS, source 'custom'", async function () {
+    const actionResult = {
+      status: "PASS",
+      outputs: { exitCode: 0 },
+      assertions: [
+        { statement: "$$outputs.exitCode oneOf [0]", source: "implicit", result: "PASS" },
+      ],
+    };
+    await evaluateCustomAssertions({
+      step: { assertions: "$$outputs.exitCode == 0" },
+      actionResult,
+    });
+    assert.equal(actionResult.status, "PASS");
+    const custom = actionResult.assertions.filter((a) => a.source === "custom");
+    assert.equal(custom.length, 1);
+    assert.equal(custom[0].result, "PASS");
+  });
+
+  it("custom FAIL on a passing action -> status FAIL", async function () {
+    const actionResult = {
+      status: "PASS",
+      outputs: { exitCode: 0 },
+      assertions: [
+        { statement: "$$outputs.exitCode oneOf [0]", source: "implicit", result: "PASS" },
+      ],
+    };
+    await evaluateCustomAssertions({
+      step: { assertions: "$$outputs.exitCode == 1" },
+      actionResult,
+    });
+    assert.equal(actionResult.status, "FAIL");
+    const custom = actionResult.assertions.filter((a) => a.source === "custom");
+    assert.equal(custom[0].result, "FAIL");
+  });
+
+  it("string[] form is AND: all pass -> PASS", async function () {
+    const actionResult = {
+      status: "PASS",
+      outputs: { exitCode: 0, value: 5 },
+      assertions: [{ statement: "x", source: "implicit", result: "PASS" }],
+    };
+    await evaluateCustomAssertions({
+      step: { assertions: ["$$outputs.exitCode == 0", "$$outputs.value == 5"] },
+      actionResult,
+    });
+    assert.equal(actionResult.status, "PASS");
+    const custom = actionResult.assertions.filter((a) => a.source === "custom");
+    assert.equal(custom.length, 2);
+    assert.ok(custom.every((a) => a.result === "PASS"));
+  });
+
+  it("string[] form is AND: one fails -> FAIL, and later short-circuits to SKIPPED", async function () {
+    const actionResult = {
+      status: "PASS",
+      outputs: { exitCode: 0, value: 5 },
+      assertions: [{ statement: "x", source: "implicit", result: "PASS" }],
+    };
+    await evaluateCustomAssertions({
+      step: { assertions: ["$$outputs.exitCode == 1", "$$outputs.value == 5"] },
+      actionResult,
+    });
+    assert.equal(actionResult.status, "FAIL");
+    const custom = actionResult.assertions.filter((a) => a.source === "custom");
+    assert.equal(custom[0].result, "FAIL");
+    assert.equal(custom[1].result, "SKIPPED");
+  });
+
+  it("after an implicit FAIL: custom records are SKIPPED, status stays FAIL", async function () {
+    const actionResult = {
+      status: "FAIL",
+      outputs: { exitCode: 1 },
+      assertions: [
+        { statement: "$$outputs.exitCode oneOf [0]", source: "implicit", result: "FAIL" },
+      ],
+    };
+    await evaluateCustomAssertions({
+      step: { assertions: "$$outputs.exitCode == 1" },
+      actionResult,
+    });
+    assert.equal(actionResult.status, "FAIL");
+    const custom = actionResult.assertions.filter((a) => a.source === "custom");
+    assert.equal(custom.length, 1);
+    assert.equal(custom[0].result, "SKIPPED");
+  });
+
+  it("execution-error action (FAIL, NO implicit records) + custom -> custom SKIPPED, not evaluated", async function () {
+    const actionResult = {
+      status: "FAIL",
+      description: "boom",
+      // no assertions array at all (early return before any implicit eval)
+    };
+    await evaluateCustomAssertions({
+      step: { assertions: "$$outputs.exitCode == 0" },
+      actionResult,
+    });
+    assert.equal(actionResult.status, "FAIL");
+    const custom = actionResult.assertions.filter((a) => a.source === "custom");
+    assert.equal(custom.length, 1);
+    assert.equal(custom[0].result, "SKIPPED");
+  });
+
+  it("SKIPPED-status action (no records) + custom -> custom SKIPPED, status stays SKIPPED (not flipped)", async function () {
+    // A deliberately-skipped step (e.g. `wait: false`) returns status SKIPPED
+    // with no assertion records. Custom assertions must NOT be evaluated and
+    // must NOT re-roll the status. Both a passing and a failing custom expr
+    // stay SKIPPED, and the action stays SKIPPED.
+    const passing = {
+      status: "SKIPPED",
+      description: "Wait skipped.",
+      outputs: { x: 1 },
+    };
+    await evaluateCustomAssertions({
+      step: { assertions: "$$outputs.x == 1" },
+      actionResult: passing,
+    });
+    assert.equal(passing.status, "SKIPPED");
+    let custom = passing.assertions.filter((a) => a.source === "custom");
+    assert.equal(custom.length, 1);
+    assert.equal(custom[0].result, "SKIPPED");
+
+    const failing = {
+      status: "SKIPPED",
+      description: "Wait skipped.",
+      outputs: { x: 1 },
+    };
+    await evaluateCustomAssertions({
+      step: { assertions: "$$outputs.x == 2" },
+      actionResult: failing,
+    });
+    assert.equal(failing.status, "SKIPPED");
+    custom = failing.assertions.filter((a) => a.source === "custom");
+    assert.equal(custom.length, 1);
+    assert.equal(custom[0].result, "SKIPPED");
+  });
+
+  it("unresolvable $$ in a custom expr -> FAIL (fail closed)", async function () {
+    const actionResult = {
+      status: "PASS",
+      outputs: { exitCode: 0 },
+      assertions: [{ statement: "x", source: "implicit", result: "PASS" }],
+    };
+    await evaluateCustomAssertions({
+      step: { assertions: "$$outputs.notThere == 1" },
+      actionResult,
+    });
+    assert.equal(actionResult.status, "FAIL");
+    const custom = actionResult.assertions.filter((a) => a.source === "custom");
+    assert.equal(custom[0].result, "FAIL");
+  });
+
+  it("array-of-objects assertions form is IGNORED (report shape, not user input)", async function () {
+    const actionResult = {
+      status: "PASS",
+      outputs: { exitCode: 0 },
+      assertions: [{ statement: "x", source: "implicit", result: "PASS" }],
+    };
+    await evaluateCustomAssertions({
+      step: { assertions: [{ statement: "$$outputs.exitCode == 1" }] },
+      actionResult,
+    });
+    // unchanged: no custom records added, status still PASS
+    assert.equal(actionResult.status, "PASS");
+    assert.equal(
+      actionResult.assertions.filter((a) => a.source === "custom").length,
+      0
+    );
+  });
+
+  it("no assertions field -> byte-identical (no-op)", async function () {
+    const actionResult = {
+      status: "PASS",
+      outputs: { exitCode: 0 },
+      assertions: [{ statement: "x", source: "implicit", result: "PASS" }],
+    };
+    const before = JSON.stringify(actionResult);
+    await evaluateCustomAssertions({ step: {}, actionResult });
+    assert.equal(JSON.stringify(actionResult), before);
+  });
+});


### PR DESCRIPTION
## Summary

First runtime feature of the dynamic-routing roadmap: the step `assertions` field (validated since the schema foundation) is now **evaluated at runtime**. After an action runs, `runStep` folds any author-written custom assertions into the step's assertion records and re-rolls the step status.

**Strictly additive — first change to the runner step path:** a step with no `assertions` field is byte-identical, and the step loop is otherwise unchanged. The runner change in `tests.ts` is a single guarded call to a pure helper.

## Behavior
- `routing.ts`: `evaluateImplicitAssertions` gains optional `{source, startFailed}` (defaults reproduce the implicit behavior — the 8 action call sites are untouched). New pure helper `evaluateCustomAssertions` normalizes `step.assertions` (`string|string[]`; ignores the report-shape array-of-objects), evaluates each as a `$$` expression (`source:"custom"`, severity `fail`) against `buildConditionContext` over the step's outputs, appends records, and re-rolls via `rollUpAssertions`.
- Custom checks **short-circuit from the implicit ones** (an implicit FAIL leaves custom records SKIPPED), and are themselves SKIPPED with status preserved when the action produced no assertable result — an execution-error FAIL with no records, **or a deliberately-SKIPPED step** (e.g. `wait:false`). Unresolvable `$$` fails closed to FAIL.
- So a step passes only if its implicit **and** custom checks pass; custom assertions can add a failure but can't rescue an implicit/execution failure.

## Tests
Unit (`custom-assertions.test.js`, incl. the SKIPPED-step guard), a PASS/SKIPPED feature fixture, and focused FAIL-permutation tests in `core-core.test.js`. Canary green.

## Deferred
Cross-step `$$steps.*` in custom assertions (`steps:{}` for now — current-step `$$outputs.*` + `$$platform` supported). Namespace note: custom assertions use the `$$outputs.*` conditions namespace (vs `step.variables`' bare `$$name`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)