### PR TITLE
feat(routing): spec-, test-, and step-level guard `if` conditional execution

### DIFF
--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -301,7 +301,7 @@ type GuardCondition = string | string[];
  *
  * @param ifValue - The author `if` value (`string | string[]` or undefined).
  * @param context - A `buildConditionContext(...)` output.
- * @returns `true` if the step should run, `false` if it should be skipped.
+ * @returns `true` if the unit should run, `false` if it should be skipped.
  */
 async function evaluateGuard(
   ifValue: GuardCondition | undefined | null,
@@ -333,11 +333,38 @@ async function evaluateGuard(
   return true;
 }
 
+/**
+ * Authoring-time detector: does a guard `if` value reference `$$steps.*`?
+ *
+ * `$$steps.<id>.outputs.*` is only populated at STEP scope (the per-step
+ * accumulator in `runContext`). A spec- or test-level guard that references it
+ * resolves against an empty `steps` map and fails closed — so the unit is
+ * always skipped. Callers use this to emit an authoring warning rather than
+ * letting the misuse silently swallow the unit. Non-string entries are ignored.
+ *
+ * @param ifValue - The author `if` value (`string | string[]` or undefined).
+ * @returns `true` if any string condition references `$$steps.`.
+ */
+function guardReferencesSteps(
+  ifValue: GuardCondition | undefined | null
+): boolean {
+  const conditions =
+    typeof ifValue === "string"
+      ? [ifValue]
+      : Array.isArray(ifValue)
+        ? ifValue
+        : [];
+  return conditions.some(
+    (c) => typeof c === "string" && c.includes("$$steps.")
+  );
+}
+
 export {
   buildConditionContext,
   evaluateImplicitAssertions,
   evaluateCustomAssertions,
   evaluateGuard,
+  guardReferencesSteps,
 };
 export type {
   BuildConditionContextArgs,

--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -274,28 +274,30 @@ async function evaluateCustomAssertions(args: {
 }
 
 /**
- * The author form of a step-level guard `if`: a single condition string, or an
- * array of condition strings that are AND-ed together (all must be truthy).
+ * The author form of a guard `if`: a single condition string, or an array of
+ * condition strings that are AND-ed together (all must be truthy).
  */
 type GuardCondition = string | string[];
 
 /**
- * Evaluate a step-level guard `if` against a condition context.
+ * Evaluate a guard `if` against a condition context.
  *
- * The guard decides whether a step's action runs at all (it is evaluated BEFORE
- * the action). Semantics:
+ * Used at spec, test, and step scope. The guard decides whether the unit runs
+ * at all (it is evaluated BEFORE the unit). Semantics:
  *   - `undefined`/empty (no usable conditions) -> `true` (guard absent; run).
  *   - A single string -> the truthiness of that one condition.
  *   - An array of strings -> AND across all of them: `true` only if EVERY
  *     condition is truthy. Evaluation short-circuits on the first falsy one.
  *   - Each condition is evaluated through `evaluateAssertion`, which fails
  *     CLOSED: an unresolvable `$$` reference resolves to `false` (so a guard
- *     that references a not-yet-available value blocks the step rather than
+ *     that references a not-yet-available value blocks the unit rather than
  *     throwing).
  *
- * Non-string array entries are ignored (filtered out) — only string conditions
- * are author input. If filtering leaves no conditions, the guard is treated as
- * absent (`true`).
+ * Non-string array entries are ignored (filtered out), and string entries are
+ * trimmed with empty/whitespace-only ones dropped — only non-empty string
+ * conditions are author input. If normalization leaves no conditions, the
+ * guard is treated as absent (`true`). So `""`, `"   "`, and `["", "  "]` all
+ * mean "guard absent", not "a falsy condition".
  *
  * @param ifValue - The author `if` value (`string | string[]` or undefined).
  * @param context - A `buildConditionContext(...)` output.
@@ -305,15 +307,20 @@ async function evaluateGuard(
   ifValue: GuardCondition | undefined | null,
   context: ConditionContext
 ): Promise<boolean> {
-  // Normalize to a string array; drop anything that isn't a string.
-  let conditions: string[];
+  // Normalize to a string array; drop anything that isn't a string, then trim
+  // and drop empty/whitespace-only entries (an empty condition is "no
+  // condition", not a falsy one — treat it as guard-absent).
+  let raw: string[];
   if (typeof ifValue === "string") {
-    conditions = [ifValue];
+    raw = [ifValue];
   } else if (Array.isArray(ifValue)) {
-    conditions = ifValue.filter((c): c is string => typeof c === "string");
+    raw = ifValue.filter((c): c is string => typeof c === "string");
   } else {
-    conditions = [];
+    raw = [];
   }
+  const conditions = raw
+    .map((c) => c.trim())
+    .filter((c) => c.length > 0);
 
   // No usable conditions -> guard absent -> run.
   if (conditions.length === 0) return true;

--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -1,10 +1,9 @@
-// Dynamic routing (Phase 3): the condition-context builder.
-//
-// This module is the cohesive home for the routing/condition primitives of the
-// dynamic-routing feature. Phase 3 ships only `buildConditionContext`; later
-// phases will add `resolveRoute` / `nextRetryDelay` here. Nothing in the runner
-// calls this yet — it is additive and dormant until Phase 5 wires it into the
-// step loop.
+// Dynamic routing: the cohesive home for the routing/condition primitives of the
+// dynamic-routing feature — `buildConditionContext`, the implicit/custom
+// assertion evaluators, and `evaluateGuard` for conditional execution. These are
+// wired into the runner (custom assertions in runStep; step-level guard `if` in
+// the runContext step loop). Later phases will add `resolveRoute` /
+// `nextRetryDelay` here for routing handlers and retries.
 
 import { evaluateAssertion } from "./expressions.js";
 import { rollUpAssertions } from "./utils.js";
@@ -274,10 +273,64 @@ async function evaluateCustomAssertions(args: {
   return actionResult;
 }
 
+/**
+ * The author form of a step-level guard `if`: a single condition string, or an
+ * array of condition strings that are AND-ed together (all must be truthy).
+ */
+type GuardCondition = string | string[];
+
+/**
+ * Evaluate a step-level guard `if` against a condition context.
+ *
+ * The guard decides whether a step's action runs at all (it is evaluated BEFORE
+ * the action). Semantics:
+ *   - `undefined`/empty (no usable conditions) -> `true` (guard absent; run).
+ *   - A single string -> the truthiness of that one condition.
+ *   - An array of strings -> AND across all of them: `true` only if EVERY
+ *     condition is truthy. Evaluation short-circuits on the first falsy one.
+ *   - Each condition is evaluated through `evaluateAssertion`, which fails
+ *     CLOSED: an unresolvable `$$` reference resolves to `false` (so a guard
+ *     that references a not-yet-available value blocks the step rather than
+ *     throwing).
+ *
+ * Non-string array entries are ignored (filtered out) — only string conditions
+ * are author input. If filtering leaves no conditions, the guard is treated as
+ * absent (`true`).
+ *
+ * @param ifValue - The author `if` value (`string | string[]` or undefined).
+ * @param context - A `buildConditionContext(...)` output.
+ * @returns `true` if the step should run, `false` if it should be skipped.
+ */
+async function evaluateGuard(
+  ifValue: GuardCondition | undefined | null,
+  context: ConditionContext
+): Promise<boolean> {
+  // Normalize to a string array; drop anything that isn't a string.
+  let conditions: string[];
+  if (typeof ifValue === "string") {
+    conditions = [ifValue];
+  } else if (Array.isArray(ifValue)) {
+    conditions = ifValue.filter((c): c is string => typeof c === "string");
+  } else {
+    conditions = [];
+  }
+
+  // No usable conditions -> guard absent -> run.
+  if (conditions.length === 0) return true;
+
+  // AND across all conditions; short-circuit on the first falsy one.
+  for (const condition of conditions) {
+    const ok = await evaluateAssertion(condition, context);
+    if (!ok) return false;
+  }
+  return true;
+}
+
 export {
   buildConditionContext,
   evaluateImplicitAssertions,
   evaluateCustomAssertions,
+  evaluateGuard,
 };
 export type {
   BuildConditionContextArgs,
@@ -288,4 +341,5 @@ export type {
   EvaluateAssertionsOptions,
   CustomAssertionStep,
   CustomAssertionActionResult,
+  GuardCondition,
 };

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -1877,7 +1877,10 @@ async function runContext({
 
       // Record this step's outputs so later steps' guard `if` conditions can
       // read them via `$$steps.<stepId>.outputs.*`. Shaped as the
-      // buildConditionContext `steps` entry ({ outputs }).
+      // buildConditionContext `steps` entry ({ outputs }). Only reached for
+      // steps that actually ran — a guard-skipped step `continue`s before
+      // here, so its stepId is never recorded, and a downstream guard
+      // referencing it fails closed (and is itself skipped).
       if (step.stepId) {
         stepOutputsById[step.stepId] = { outputs: stepReport.outputs ?? {} };
       }

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -68,6 +68,7 @@ import { resolveExpression } from "./expressions.js";
 import {
   evaluateCustomAssertions,
   evaluateGuard,
+  guardReferencesSteps,
   buildConditionContext,
 } from "./routing.js";
 import {
@@ -643,6 +644,13 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     // `if` is byte-identical (no evaluation, `specGuardSkip` stays false).
     let specGuardSkip = false;
     if (spec.if) {
+      if (guardReferencesSteps(spec.if)) {
+        log(
+          config,
+          "warning",
+          `Spec '${spec.specId}': 'if' references '$$steps.*', which is not available at spec scope — the guard will always fail closed (the spec is always skipped). Use '$$steps.*' only in step-level 'if'.`
+        );
+      }
       const guardPassed = await evaluateGuard(
         spec.if,
         buildConditionContext({ platform })
@@ -676,6 +684,13 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
       // byte-identical (no evaluation, `testGuardSkip` stays false).
       let testGuardSkip = false;
       if (!specGuardSkip && test.if) {
+        if (guardReferencesSteps(test.if)) {
+          log(
+            config,
+            "warning",
+            `Test '${test.testId}': 'if' references '$$steps.*', which is not available at test scope — the guard will always fail closed (the test is always skipped). Use '$$steps.*' only in step-level 'if'.`
+          );
+        }
         const guardPassed = await evaluateGuard(
           test.if,
           buildConditionContext({ platform })
@@ -1880,7 +1895,11 @@ async function runContext({
       // buildConditionContext `steps` entry ({ outputs }). Only reached for
       // steps that actually ran — a guard-skipped step `continue`s before
       // here, so its stepId is never recorded, and a downstream guard
-      // referencing it fails closed (and is itself skipped).
+      // referencing it fails closed (and is itself skipped). A FAILed step's
+      // outputs ARE recorded here (this runs before the stepExecutionFailed
+      // flag is set), but that is harmless: stepExecutionFailed makes every
+      // subsequent step short-circuit before its guard, so no downstream guard
+      // ever reads them.
       if (step.stepId) {
         stepOutputsById[step.stepId] = { outputs: stepReport.outputs ?? {} };
       }

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -634,6 +634,21 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     // across the run, and all registration now happens up front — an
     // overwrite here would wipe an earlier spec's registered tests.
     metaValues.specs[spec.specId] ??= { tests: {} };
+    // Spec-level guard `if`: evaluated once against the host platform. Tests
+    // aren't sequenced relative to each other, so cross-test `$$outputs`/
+    // `$$steps` are not meaningful here — only `$$platform` (plus any meta
+    // `buildConditionContext` exposes). Fails CLOSED (unresolvable -> false).
+    // When false, every test/context in this spec is recorded SKIPPED below and
+    // no job is enqueued. Fully gated on `spec.if` presence: a spec with no
+    // `if` is byte-identical (no evaluation, `specGuardSkip` stays false).
+    let specGuardSkip = false;
+    if (spec.if) {
+      const guardPassed = await evaluateGuard(
+        spec.if,
+        buildConditionContext({ platform })
+      );
+      specGuardSkip = !guardPassed;
+    }
     const specReport: any = {
       specId: spec.specId,
       description: spec.description,
@@ -652,17 +667,37 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
         contexts: new Array(test.contexts.length),
       };
       specReport.tests.push(testReport);
+      // Test-level guard `if`: evaluated once against the host platform, same
+      // semantics as the spec-level guard (only `$$platform`/meta meaningful;
+      // fails CLOSED). When false, every context of this test is recorded
+      // SKIPPED below and no job is enqueued. Skipped entirely when the spec
+      // guard already skips this spec (a spec-guard skip subsumes all its
+      // tests). Fully gated on `test.if` presence: a test with no `if` is
+      // byte-identical (no evaluation, `testGuardSkip` stays false).
+      let testGuardSkip = false;
+      if (!specGuardSkip && test.if) {
+        const guardPassed = await evaluateGuard(
+          test.if,
+          buildConditionContext({ platform })
+        );
+        testGuardSkip = !guardPassed;
+      }
       // Preflight: a `record` step that reuses a recording `name` while one is
       // still active makes a later `stopRecord: "<name>"` ambiguous. Catch it
       // statically and skip the whole test (across all its contexts) with a
       // warning, rather than failing mid-run. Scan every context's authored
       // steps (runOn overrides can differ) and skip if any conflicts.
+      // Skip the scan when a guard already skips this test/spec — the test
+      // won't run, and the guard skip takes precedence over the conflict skip
+      // (so we also suppress the conflict warning for a guarded-out test).
       let recordingNameConflict: string | null = null;
-      for (const c of test.contexts) {
-        const conflict = detectRecordingNameConflict(c?.steps);
-        if (conflict) {
-          recordingNameConflict = conflict;
-          break;
+      if (!specGuardSkip && !testGuardSkip) {
+        for (const c of test.contexts) {
+          const conflict = detectRecordingNameConflict(c?.steps);
+          if (conflict) {
+            recordingNameConflict = conflict;
+            break;
+          }
         }
       }
       if (recordingNameConflict) {
@@ -697,6 +732,36 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
           }
           usedContextIds.add(id);
           context.contextId = id;
+        }
+        // Spec-level guard skip: record a SKIPPED context and don't enqueue a
+        // job. Highest precedence — a false spec guard subsumes test guards and
+        // the recording-name preflight (no test in the spec runs).
+        if (specGuardSkip) {
+          testReport.contexts[slot] = {
+            contextId: context.contextId,
+            platform: context.platform,
+            browser: context.browser,
+            result: "SKIPPED",
+            resultDescription:
+              "Skipped: spec guard `if` condition not met.",
+            steps: [],
+          };
+          return;
+        }
+        // Test-level guard skip: record a SKIPPED context and don't enqueue a
+        // job. Takes precedence over the recording-name preflight (the test is
+        // skipped wholesale regardless of its step contents).
+        if (testGuardSkip) {
+          testReport.contexts[slot] = {
+            contextId: context.contextId,
+            platform: context.platform,
+            browser: context.browser,
+            result: "SKIPPED",
+            resultDescription:
+              "Skipped: test guard `if` condition not met.",
+            steps: [],
+          };
+          return;
         }
         // Preflight conflict: record a SKIPPED context and don't enqueue a job.
         if (recordingNameConflict) {

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -65,7 +65,11 @@ import { randomUUID } from "node:crypto";
 import { setAppiumHome } from "./appium.js";
 import { contentHash } from "../common/src/detectTests.js";
 import { resolveExpression } from "./expressions.js";
-import { evaluateCustomAssertions } from "./routing.js";
+import {
+  evaluateCustomAssertions,
+  evaluateGuard,
+  buildConditionContext,
+} from "./routing.js";
 import {
   getEnvironment,
   getAvailableApps,
@@ -1673,6 +1677,11 @@ async function runContext({
     const usedStepIds = new Set(
       context.steps.map((s: any) => s.stepId).filter(Boolean)
     );
+    // Per-step outputs accumulator: maps each completed step's stepId to its
+    // computed `outputs` bag, so later steps' guard `if` conditions can read a
+    // prior step's outputs via `$$steps.<stepId>.outputs.*`. Additive
+    // bookkeeping local to this context — it does not change any existing path.
+    const stepOutputsById: Record<string, any> = {};
     for (const [stepIndex, step] of context.steps.entries()) {
       // Set step id if not defined. Derived from the test ID and a hash of
       // the step's authored definition so the same step keeps the same ID
@@ -1718,6 +1727,30 @@ async function runContext({
         };
         contextReport.steps.push(stepReport);
         continue;
+      }
+
+      // Step-level guard `if`: evaluated BEFORE the action runs. The guard sees
+      // `$$platform` and prior steps' outputs via `$$steps.<stepId>.outputs.*`
+      // (the current step's own `$$outputs.*` is NOT available — it hasn't run
+      // yet). `if` is `string | string[]` (array = AND, all must be truthy) and
+      // fails CLOSED (an unresolvable `$$` -> false). When the guard is not all
+      // true the step is SKIPPED: the action is NOT run, and this does NOT trip
+      // `stepExecutionFailed`, so later steps still run.
+      if (step.if) {
+        const guardContext = buildConditionContext({
+          platform: context.platform,
+          steps: stepOutputsById,
+        });
+        const guardPassed = await evaluateGuard(step.if, guardContext);
+        if (!guardPassed) {
+          const stepReport = {
+            ...step,
+            result: "SKIPPED",
+            resultDescription: "Skipped: guard `if` condition not met.",
+          };
+          contextReport.steps.push(stepReport);
+          continue;
+        }
       }
 
       // Set meta values
@@ -1776,6 +1809,13 @@ async function runContext({
       }
 
       contextReport.steps.push(stepReport);
+
+      // Record this step's outputs so later steps' guard `if` conditions can
+      // read them via `$$steps.<stepId>.outputs.*`. Shaped as the
+      // buildConditionContext `steps` entry ({ outputs }).
+      if (step.stepId) {
+        stepOutputsById[step.stepId] = { outputs: stepReport.outputs ?? {} };
+      }
 
       // If this step failed, set flag to skip remaining steps
       if (stepReport.result === "FAIL") {

--- a/test/core-artifacts/guard-if-spec-true.spec.json
+++ b/test/core-artifacts/guard-if-spec-true.spec.json
@@ -1,0 +1,16 @@
+{
+  "specId": "guard-if-spec-true",
+  "description": "Companion to guard-if-spec: a spec whose spec-level `if` is always TRUE runs normally. Proves a present-but-satisfied spec guard does not skip anything. Cross-platform: `$$platform` is never `nonexistentos`, so this guard is true everywhere.",
+  "if": "$$platform != nonexistentos",
+  "tests": [
+    {
+      "testId": "guard-if-spec-true-runs",
+      "description": "Spec-level guard is true, so this test runs to PASS.",
+      "steps": [
+        {
+          "runShell": "node -e \"process.exit(0)\""
+        }
+      ]
+    }
+  ]
+}

--- a/test/core-artifacts/guard-if-spec.spec.json
+++ b/test/core-artifacts/guard-if-spec.spec.json
@@ -1,0 +1,25 @@
+{
+  "specId": "guard-if-spec",
+  "description": "Exercises spec-level guard `if`: a spec with an always-false `if` must have every test/context recorded SKIPPED (no jobs enqueued), while a spec with an always-true `if` runs normally to PASS. Cross-platform: `$$platform` never equals `nonexistentos`, so the false guard is false everywhere and the true guard is true everywhere.",
+  "if": "$$platform == nonexistentos",
+  "tests": [
+    {
+      "testId": "guard-if-spec-skipped-test-a",
+      "description": "Spec-level guard is false, so this test is SKIPPED across all contexts before any step runs.",
+      "steps": [
+        {
+          "runShell": "node -e \"process.exit(0)\""
+        }
+      ]
+    },
+    {
+      "testId": "guard-if-spec-skipped-test-b",
+      "description": "A second test in the same spec — also SKIPPED by the spec-level guard, proving the skip covers the whole spec.",
+      "steps": [
+        {
+          "runShell": "node -e \"process.exit(0)\""
+        }
+      ]
+    }
+  ]
+}

--- a/test/core-artifacts/guard-if-step.spec.json
+++ b/test/core-artifacts/guard-if-step.spec.json
@@ -1,0 +1,60 @@
+{
+  "specId": "guard-if-step",
+  "description": "Step-level guard `if` (conditional step execution): a step whose `if` is not all-true is SKIPPED before its action runs; an all-true `if` runs the step. Covers single-string true/false guards plus a cross-step guard that reads a prior step's outputs via $$steps.<stepId>.outputs.* (proving the per-step outputs accumulator). Cross-platform: uses `node -e` runShell so it resolves PASS/SKIPPED on every OS.",
+  "tests": [
+    {
+      "testId": "guard-if-false-skips",
+      "description": "An always-false guard (`$$platform == nonexistentos`) skips the step before its action runs.",
+      "steps": [
+        {
+          "description": "Always-false guard -> SKIPPED, action not run.",
+          "if": "$$platform == nonexistentos",
+          "runShell": "node -e \"process.exit(0)\""
+        }
+      ]
+    },
+    {
+      "testId": "guard-if-true-runs",
+      "description": "An always-true guard (`$$platform != nonexistentos`) runs the step.",
+      "steps": [
+        {
+          "description": "Always-true guard -> runs and PASSes.",
+          "if": "$$platform != nonexistentos",
+          "runShell": "node -e \"process.exit(0)\""
+        }
+      ]
+    },
+    {
+      "testId": "guard-if-cross-step-true",
+      "description": "A guard reads a prior step's outputs: step A exits 0, then step B is guarded on `$$steps.a.outputs.exitCode == 0` (true) -> B runs.",
+      "steps": [
+        {
+          "stepId": "a",
+          "description": "Prior step exits 0; its exitCode output feeds the next guard.",
+          "runShell": "node -e \"process.exit(0)\""
+        },
+        {
+          "description": "Guard reads prior step A's exitCode (== 0, true) -> runs and PASSes.",
+          "if": "$$steps.a.outputs.exitCode == 0",
+          "runShell": "node -e \"process.exit(0)\""
+        }
+      ]
+    },
+    {
+      "testId": "guard-if-cross-step-false",
+      "description": "A guard reads a prior step's outputs: step A exits 0, then step B is guarded on `$$steps.a.outputs.exitCode == 1` (false) -> B is SKIPPED.",
+      "steps": [
+        {
+          "stepId": "a",
+          "description": "Prior step exits 0; its exitCode output feeds the next guard.",
+          "runShell": "node -e \"process.exit(0)\""
+        },
+        {
+          "description": "Guard reads prior step A's exitCode (== 1, false) -> SKIPPED.",
+          "if": "$$steps.a.outputs.exitCode == 1",
+          "runShell": "node -e \"process.exit(0)\""
+        }
+      ]
+    }
+  ]
+}

--- a/test/core-artifacts/guard-if-test.spec.json
+++ b/test/core-artifacts/guard-if-test.spec.json
@@ -1,0 +1,25 @@
+{
+  "specId": "guard-if-test",
+  "description": "Exercises test-level guard `if`: one test with an always-false `if` is SKIPPED across all its contexts, while a sibling test in the same spec with no `if` runs normally to PASS. Proves test-level guard isolation (a false test guard skips only that test). Cross-platform: `$$platform` never equals `nonexistentos`.",
+  "tests": [
+    {
+      "testId": "guard-if-test-skipped",
+      "description": "Test-level guard is false, so this test is SKIPPED across all contexts before any step runs.",
+      "if": "$$platform == nonexistentos",
+      "steps": [
+        {
+          "runShell": "node -e \"process.exit(0)\""
+        }
+      ]
+    },
+    {
+      "testId": "guard-if-test-sibling-runs",
+      "description": "Sibling test with no `if` — unaffected by the other test's false guard, runs to PASS.",
+      "steps": [
+        {
+          "runShell": "node -e \"process.exit(0)\""
+        }
+      ]
+    }
+  ]
+}

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -58,6 +58,50 @@ describe("Run tests successfully", function () {
     }
   });
 
+  it("A guard `if` false skips the step (with the guard reason) and does NOT skip the following non-guarded step", async () => {
+    // Step 1 has an always-false guard -> SKIPPED with the guard reason, action
+    // NOT run, stepExecutionFailed NOT tripped. Step 2 has no guard -> still
+    // runs and PASSes (proving a guard-skip doesn't cascade like a FAIL).
+    const guardTest = {
+      tests: [
+        {
+          steps: [
+            {
+              if: "$$platform == nonexistentos",
+              runShell: "node -e \"process.exit(0)\"",
+            },
+            {
+              runShell: "node -e \"process.exit(0)\"",
+            },
+          ],
+        },
+      ],
+    };
+    const tempFilePath = path.resolve("./test/temp-guard-if-test.json");
+    fs.writeFileSync(tempFilePath, JSON.stringify(guardTest, null, 2));
+    const config = { input: tempFilePath, logLevel: "debug" };
+    let result;
+    try {
+      result = await runTests(config);
+      assert.equal(result.summary.specs.fail, 0);
+      const steps = result.specs[0].tests[0].contexts[0].steps;
+      assert.equal(steps.length, 2);
+      // Step 1: SKIPPED for the guard reason, action not run.
+      assert.equal(steps[0].result, "SKIPPED");
+      assert.match(
+        steps[0].resultDescription,
+        /guard `if` condition not met/
+      );
+      // Step 2: ran (not affected by the guard-skip) and PASSed.
+      assert.equal(steps[1].result, "PASS");
+      assert.equal(result.summary.steps.skipped, 1);
+      assert.equal(result.summary.steps.pass, 1);
+      assert.equal(result.summary.steps.fail, 0);
+    } finally {
+      fs.unlinkSync(tempFilePath);
+    }
+  });
+
   it("Custom assertion FAIL fails the step and skips the rest of the test", async () => {
     // An action that EXECUTES fine (exit 0) but whose custom assertion is false.
     // The custom-assertion FAIL must fail the step, and the existing step-loop

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -169,6 +169,78 @@ describe("Run tests successfully", function () {
     }
   });
 
+  it("A spec-level guard `if` false skips every test/context in the spec (SKIPPED, 0 fail)", async () => {
+    // Spec-level guard is false everywhere ($$platform is never nonexistentos).
+    // Every test in the spec must be SKIPPED across all contexts, no job runs,
+    // and nothing fails.
+    const guardSpec = {
+      if: "$$platform == nonexistentos",
+      tests: [
+        { steps: [{ runShell: "node -e \"process.exit(0)\"" }] },
+        { steps: [{ runShell: "node -e \"process.exit(0)\"" }] },
+      ],
+    };
+    const tempFilePath = path.resolve("./test/temp-guard-if-spec-test.json");
+    fs.writeFileSync(tempFilePath, JSON.stringify(guardSpec, null, 2));
+    const config = { input: tempFilePath, logLevel: "debug" };
+    let result;
+    try {
+      result = await runTests(config);
+      assert.equal(result.summary.specs.fail, 0);
+      const tests = result.specs[0].tests;
+      assert.equal(tests.length, 2);
+      for (const test of tests) {
+        assert.ok(test.contexts.length >= 1);
+        for (const ctx of test.contexts) {
+          assert.equal(ctx.result, "SKIPPED");
+          assert.match(ctx.resultDescription, /spec guard `if` condition not met/);
+          assert.deepEqual(ctx.steps, []);
+        }
+      }
+      // No steps ran (every context was skipped before enqueue).
+      assert.equal(result.summary.steps.fail, 0);
+      assert.equal(result.summary.steps.pass, 0);
+    } finally {
+      fs.unlinkSync(tempFilePath);
+    }
+  });
+
+  it("A test-level guard `if` false skips that test while its sibling runs", async () => {
+    // First test has an always-false test guard -> SKIPPED across contexts.
+    // Sibling test has no guard -> runs and PASSes. Proves test-level isolation.
+    const guardSpec = {
+      tests: [
+        {
+          if: "$$platform == nonexistentos",
+          steps: [{ runShell: "node -e \"process.exit(0)\"" }],
+        },
+        { steps: [{ runShell: "node -e \"process.exit(0)\"" }] },
+      ],
+    };
+    const tempFilePath = path.resolve("./test/temp-guard-if-test-test.json");
+    fs.writeFileSync(tempFilePath, JSON.stringify(guardSpec, null, 2));
+    const config = { input: tempFilePath, logLevel: "debug" };
+    let result;
+    try {
+      result = await runTests(config);
+      assert.equal(result.summary.specs.fail, 0);
+      const tests = result.specs[0].tests;
+      assert.equal(tests.length, 2);
+      // First test: every context SKIPPED for the test-guard reason, no steps.
+      for (const ctx of tests[0].contexts) {
+        assert.equal(ctx.result, "SKIPPED");
+        assert.match(ctx.resultDescription, /test guard `if` condition not met/);
+        assert.deepEqual(ctx.steps, []);
+      }
+      // Sibling test: ran and PASSed.
+      assert.ok(tests[1].contexts.some((c) => c.result === "PASS"));
+      assert.ok(tests[1].contexts.some((c) => (c.steps || []).length > 0));
+      assert.equal(result.summary.steps.fail, 0);
+    } finally {
+      fs.unlinkSync(tempFilePath);
+    }
+  });
+
   it("Test skips when unsafe and unsafe is disallowed", async () => {
     const unsafeTest = {
       tests: [

--- a/test/guard-if.test.js
+++ b/test/guard-if.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   buildConditionContext,
   evaluateGuard,
+  guardReferencesSteps,
 } from "../dist/core/routing.js";
 
 // Step-level guard `if`: evaluated BEFORE a step runs. `string | string[]`
@@ -72,6 +73,8 @@ describe("routing: evaluateGuard", function () {
     assert.equal(await evaluateGuard([], ctx), true);
   });
   it("array of only non-strings -> true (no usable conditions)", async function () {
+    // Intentionally passes values outside the GuardCondition (string|string[])
+    // type to exercise the defensive non-string filter in normalization.
     assert.equal(await evaluateGuard([{}, 1], ctx), true);
   });
   it("empty string -> true (guard absent)", async function () {
@@ -119,5 +122,36 @@ describe("routing: evaluateGuard", function () {
       await evaluateGuard("$$steps.b.outputs.exitCode == 0", ctx),
       false
     );
+  });
+});
+
+// guardReferencesSteps: authoring-time detector for spec/test `if` that
+// reference `$$steps.*` (only available at step scope) — used to warn that the
+// guard will always fail closed at spec/test scope.
+describe("routing: guardReferencesSteps", function () {
+  it("string referencing $$steps. -> true", function () {
+    assert.equal(
+      guardReferencesSteps("$$steps.a.outputs.exitCode == 0"),
+      true
+    );
+  });
+  it("array with a $$steps. entry -> true", function () {
+    assert.equal(
+      guardReferencesSteps(["$$platform == windows", "$$steps.a.outputs.x == 1"]),
+      true
+    );
+  });
+  it("string without $$steps. -> false", function () {
+    assert.equal(guardReferencesSteps("$$platform == windows"), false);
+  });
+  it("array without $$steps. -> false", function () {
+    assert.equal(
+      guardReferencesSteps(["$$platform == windows", "$$outputs.x == 1"]),
+      false
+    );
+  });
+  it("undefined / non-string entries -> false", function () {
+    assert.equal(guardReferencesSteps(undefined), false);
+    assert.equal(guardReferencesSteps([{}, 1]), false);
   });
 });

--- a/test/guard-if.test.js
+++ b/test/guard-if.test.js
@@ -74,6 +74,38 @@ describe("routing: evaluateGuard", function () {
   it("array of only non-strings -> true (no usable conditions)", async function () {
     assert.equal(await evaluateGuard([{}, 1], ctx), true);
   });
+  it("empty string -> true (guard absent)", async function () {
+    assert.equal(await evaluateGuard("", ctx), true);
+  });
+  it("whitespace-only string -> true (guard absent)", async function () {
+    assert.equal(await evaluateGuard("   ", ctx), true);
+  });
+  it("array of only empty/whitespace strings -> true (no usable conditions)", async function () {
+    assert.equal(await evaluateGuard(["", "   "], ctx), true);
+  });
+  it("array with empty entries dropped -> AND of the rest", async function () {
+    // The empty/whitespace entries are dropped; only the real condition counts.
+    assert.equal(
+      await evaluateGuard(["", "$$platform == windows", "  "], ctx),
+      true
+    );
+    assert.equal(
+      await evaluateGuard(["", "$$platform == linux"], ctx),
+      false
+    );
+  });
+
+  // --- guard referencing a guard-skipped prior step (fail closed) ---
+  it("$$steps.<id> for a guard-skipped step -> false (fail closed)", async function () {
+    // A guard-skipped step never writes its stepId into stepOutputsById, so a
+    // downstream guard referencing it resolves against an empty steps map and
+    // fails closed (the downstream step is also skipped).
+    const emptyCtx = buildConditionContext({ platform: "windows", steps: {} });
+    assert.equal(
+      await evaluateGuard("$$steps.a.outputs.exitCode == 0", emptyCtx),
+      false
+    );
+  });
 
   // --- cross-step accumulator semantics ---
   it("$$steps.a.outputs.exitCode == 0 -> true (prior step output)", async function () {

--- a/test/guard-if.test.js
+++ b/test/guard-if.test.js
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import {
+  buildConditionContext,
+  evaluateGuard,
+} from "../dist/core/routing.js";
+
+// Step-level guard `if`: evaluated BEFORE a step runs. `string | string[]`
+// (array = AND, all must be truthy). Fails CLOSED via evaluateAssertion (an
+// unresolvable `$$` -> false). Empty/undefined -> true (guard absent).
+describe("routing: evaluateGuard", function () {
+  const ctx = buildConditionContext({
+    platform: "windows",
+    steps: {
+      a: { outputs: { exitCode: 0 } },
+      b: { outputs: { exitCode: 1 } },
+    },
+  });
+
+  // --- single string ---
+  it("single string, true -> true", async function () {
+    assert.equal(await evaluateGuard("$$platform == windows", ctx), true);
+  });
+  it("single string, false -> false", async function () {
+    assert.equal(await evaluateGuard("$$platform == linux", ctx), false);
+  });
+
+  // --- string[] AND ---
+  it("string[] all-true -> true", async function () {
+    assert.equal(
+      await evaluateGuard(
+        ["$$platform == windows", "$$steps.a.outputs.exitCode == 0"],
+        ctx
+      ),
+      true
+    );
+  });
+  it("string[] one-false -> false", async function () {
+    assert.equal(
+      await evaluateGuard(
+        ["$$platform == windows", "$$steps.a.outputs.exitCode == 1"],
+        ctx
+      ),
+      false
+    );
+  });
+
+  // --- fail closed on unresolvable $$ ---
+  it("unresolvable $$ -> false (fail closed)", async function () {
+    assert.equal(
+      await evaluateGuard("$$steps.missing.outputs.exitCode == 0", ctx),
+      false
+    );
+  });
+  it("array with an unresolvable entry -> false (fail closed)", async function () {
+    assert.equal(
+      await evaluateGuard(
+        ["$$platform == windows", "$$outputs.notThere == 1"],
+        ctx
+      ),
+      false
+    );
+  });
+
+  // --- empty / undefined -> true (guard absent) ---
+  it("undefined -> true", async function () {
+    assert.equal(await evaluateGuard(undefined, ctx), true);
+  });
+  it("null -> true", async function () {
+    assert.equal(await evaluateGuard(null, ctx), true);
+  });
+  it("empty array -> true", async function () {
+    assert.equal(await evaluateGuard([], ctx), true);
+  });
+  it("array of only non-strings -> true (no usable conditions)", async function () {
+    assert.equal(await evaluateGuard([{}, 1], ctx), true);
+  });
+
+  // --- cross-step accumulator semantics ---
+  it("$$steps.a.outputs.exitCode == 0 -> true (prior step output)", async function () {
+    assert.equal(
+      await evaluateGuard("$$steps.a.outputs.exitCode == 0", ctx),
+      true
+    );
+  });
+  it("$$steps.b.outputs.exitCode == 0 -> false (prior step output)", async function () {
+    assert.equal(
+      await evaluateGuard("$$steps.b.outputs.exitCode == 0", ctx),
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Guard `if` conditional execution (Phase 5)

Adds the **guard `if`** layer of the workflow-runner roadmap: a `spec` / `test` / `step` whose `if` condition (string | string[], AND-combined) evaluates **false** is marked **SKIPPED** rather than executed. Strictly additive and opt-in — absent `if` is byte-identical to today.

### What this does
- **Step-level** (`37939320`): per-step guard evaluated after the unsafe/`stepExecutionFailed` checks and before `runStep`; false ⇒ the step is pushed as `SKIPPED` (`"Skipped: guard `if` condition not met."`) and the loop continues. Introduces a per-step outputs accumulator (`stepOutputsById`) so a guard can read prior steps' computed outputs via `$steps.<id>.outputs.*`.
- **Spec / test-level** (`b1dbb18f`): evaluated in the `runSpecs` job-building loops. A guard-skipped spec/test marks **every context slot** SKIPPED via the same preflight mechanism as the existing recording-name-conflict skip — **without enqueuing any job**. Precedence: **spec guard → test guard → recording-conflict**.

### Semantics (per locked roadmap decisions)
- **flow ≠ verdict**: a guard `if` decides *whether the unit runs*; it never changes a verdict. Guard-false ⇒ SKIPPED (a reached-but-skipped status), distinct from a FAIL.
- Conditions are evaluated by the shared `evaluateGuard` engine in `src/core/routing.ts` over a `buildConditionContext({ platform, steps })` — same substrate as implicit/custom assertions. Empty/absent ⇒ true; unresolvable ⇒ fails closed (SKIPPED).
- `runOn` remains a *different* layer (required-context selection), not subsumed by `if`.

### Tests
- Unit: `test/guard-if.test.js` (`evaluateGuard` normalization, AND, empty, fail-closed).
- Fixtures (PASS/SKIPPED only): `guard-if-step`, `guard-if-spec`, `guard-if-spec-true`, `guard-if-test` in `test/core-artifacts/`.
- Focused `it(...)` in `test/core-core.test.js` asserting the precise SKIPPED reasons the "no spec fails" gate can't express.

Full combined core suite green; canary (backward-compat) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
