### PR TITLE
fix(runner): clear self-kill watchdog when main() completes

### DIFF
--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -571,6 +571,17 @@ async function main() {
 	// .unref() — the timer alone shouldn't keep the event loop alive.
 	selfKill.unref();
 
+	// Track the currently-armed self-kill timer so we can disarm it on every
+	// exit path. The watchdog exists only to bound a *hung* run; once main()
+	// returns there is nothing left to bound, so the timer must be cleared.
+	// If we don't, an in-process caller (e.g. the test suite, which calls
+	// `await main()` directly) leaves an unref'd `process.exit(124)` pending.
+	// It's unref'd so it won't keep the loop alive on its own, but if the
+	// host process is still alive when it fires, it kills the whole process.
+	// The re-arm path below repoints this reference at the replacement timer.
+	let activeSelfKill = selfKill;
+	try {
+
 	let canceledBySignal = false;
 	let childRunning = false;
 	const onPreSpawnSigterm = async () => {
@@ -633,6 +644,9 @@ async function main() {
 			process.exit(124);
 		}, specTimeout * 1000);
 		respec.unref();
+		// Repoint the tracked reference so the finally below clears the
+		// timer that's actually armed, not the original (already-cleared) one.
+		activeSelfKill = respec;
 	}
 
 	const shipper = makeLogShipper(apiBase, runId, token);
@@ -724,6 +738,17 @@ async function main() {
 	}
 	await postFinalize(apiBase, runId, token, finalizeBody);
 	return exitCode;
+
+	} finally {
+		// Disarm the self-kill watchdog on every exit path (normal return or
+		// throw). main() has finished, so the run is no longer "hung" — there's
+		// nothing left for the watchdog to bound. Leaving it armed would let a
+		// pending process.exit(124) fire later inside any still-alive host
+		// process (notably the in-process test runner). Clearing here keeps
+		// production behavior identical: when run as a script the process exits
+		// immediately after main() resolves anyway.
+		clearTimeout(activeSelfKill);
+	}
 }
 
 // Module-import guard so the test file can `import` from this module

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -8,14 +8,8 @@ const artifactPath = path.resolve("./test/core-artifacts");
 const config_base = JSON.parse(fs.readFileSync(`${artifactPath}/config.json`, "utf8"));
 
 describe("Run tests successfully", function () {
-  // 60 minutes for the combined core test suite (runs all specs in one Appium
-  // session). Local runtime is ~9 min; slow CI runners (observed: macOS-latest
-  // node 22) run 2-3x slower with extra browser/Appium startup variance. The
-  // former 30-min cap left almost no margin and fired intermittently, killing
-  // the run mid-suite (surfaces as a timeout abort). 60 min is ~6x local
-  // runtime — comfortable headroom on a 3x-slow runner — and stays well under
-  // the 90-min GitHub job timeout-minutes backstop in .github/workflows/test.yml.
-  this.timeout(3600000);
+  // 30 minutes for the combined core test suite (runs all specs in one Appium session)
+  this.timeout(1800000);
   describe("Core test suite", function () {
     // Run all spec files in a single runTests() call to avoid repeated Appium restarts.
     // This starts Appium once and runs all specs within that session.

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -8,8 +8,14 @@ const artifactPath = path.resolve("./test/core-artifacts");
 const config_base = JSON.parse(fs.readFileSync(`${artifactPath}/config.json`, "utf8"));
 
 describe("Run tests successfully", function () {
-  // 30 minutes for the combined core test suite (runs all specs in one Appium session)
-  this.timeout(1800000);
+  // 60 minutes for the combined core test suite (runs all specs in one Appium
+  // session). Local runtime is ~9 min; slow CI runners (observed: macOS-latest
+  // node 22) run 2-3x slower with extra browser/Appium startup variance. The
+  // former 30-min cap left almost no margin and fired intermittently, killing
+  // the run mid-suite (surfaces as a timeout abort). 60 min is ~6x local
+  // runtime — comfortable headroom on a 3x-slow runner — and stays well under
+  // the 90-min GitHub job timeout-minutes backstop in .github/workflows/test.yml.
+  this.timeout(3600000);
   describe("Core test suite", function () {
     // Run all spec files in a single runTests() call to avoid repeated Appium restarts.
     // This starts Appium once and runs all specs within that session.

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -915,6 +915,64 @@ describe("runner-entrypoint: main()", () => {
     assert.equal(observed.finalize.status, "succeeded");
   });
 
+  it("clears the self-kill watchdog when main() completes (no leaked process.exit(124))", async function () {
+    // Regression: main() armed an unref'd `setTimeout(() => process.exit(124))`
+    // self-kill watchdog but never cleared it on normal completion. When main()
+    // is called in-process (as this suite does), that timer outlived the call
+    // and, on a host process still alive when it fired, killed the whole
+    // process with exit code 124 — surfacing as an intermittent, slow-runner
+    // (macOS) `npm test` abort. The watchdog only needs to bound a *hung* run;
+    // once main() returns there's nothing to bound, so it must be disarmed.
+    //
+    // This case runs on every platform: it drives the 410 (canceled) path,
+    // which arms the initial self-kill and returns without spawning a child —
+    // so it doesn't need the POSIX-only fake-runner shebang the other main()
+    // cases rely on.
+    await setupSpec(410);
+    // Set env directly rather than via envForRun(): the 410 path returns
+    // before provisioning, so it needs no workspace/runner fixture — and
+    // this keeps the case Windows-safe (beforeEach skips tmpDir setup on
+    // Windows, which would make envForRun()'s path.join throw).
+    process.env.DD_API_BASE = api.base;
+    process.env.DD_RUN_ID = "run-main-1";
+    process.env.DD_RUN_TOKEN = "tok-main-1";
+    // A tiny timeout so the leaked timer (if any) would fire almost
+    // immediately after main() resolves — well within the wait below.
+    process.env.DD_TIMEOUT_SECONDS = "0.05"; // 50ms
+
+    const realExit = process.exit;
+    const exitCalls = [];
+    // Stub process.exit so a fired watchdog records its code instead of
+    // tearing down the mocha process.
+    process.exit = (code) => {
+      exitCalls.push(code);
+    };
+    try {
+      const code = await main();
+      assert.equal(code, 0);
+      // Wait well past the 50ms self-kill window. If main() left the timer
+      // armed, process.exit(124) fires during this wait and is recorded.
+      await new Promise((r) => setTimeout(r, 250));
+      assert.deepEqual(
+        exitCalls,
+        [],
+        `self-kill watchdog leaked: process.exit called with ${exitCalls.join(", ")}`
+      );
+    } finally {
+      process.exit = realExit;
+      // afterEach skips its cleanup on Windows, so close the loopback
+      // server and clear env here to avoid leaking either across tests.
+      if (api) {
+        await closeServer(api.server);
+        api = null;
+      }
+      delete process.env.DD_API_BASE;
+      delete process.env.DD_RUN_ID;
+      delete process.env.DD_RUN_TOKEN;
+      delete process.env.DD_TIMEOUT_SECONDS;
+    }
+  });
+
   it("posts failed finalize with workspace_provision_failed for unsupported source", async function () {
     if (isWindows) this.skip();
     await setupSpec({


### PR DESCRIPTION
## Summary

The CI "Test" job's `npm test` step intermittently aborted with **exit code 124** (observed on slow runners, notably macOS). The earlier version of this PR misdiagnosed it as a mocha/job timeout and bumped the combined core suite's `this.timeout` 30→60 min. That was the **wrong fix** and has been reverted here.

## Real root cause (from the failing CI log)

The job died at **~18 min** (not 30, not the GitHub job timeout). The last meaningful log line before failure was:

```
{"level":"warn","msg":"self-kill timeout exceeded","timeoutSeconds":60}
##[error]Process completed with exit code 124.
```

That message comes from an **internal self-kill watchdog** in `bin/runner-entrypoint.js`:

```js
const selfKill = setTimeout(() => {
  localLog('warn', 'self-kill timeout exceeded', { timeoutSeconds });
  process.exit(124);
}, timeoutSeconds * 1000);
selfKill.unref();
```

`main()` is **exported** and the runner-entrypoint test suite calls `await main()` **in-process** (with `DD_TIMEOUT_SECONDS=60` in the test env). Each call armed a 60s `process.exit(124)` timer **inside the mocha process**. `main()` only ever cleared that timer on the re-arm path (when `spec.timeout_seconds` diverged) — **never on normal completion**.

Because the timer is `.unref()`'d it doesn't keep the event loop alive on its own, but it still **fires if the host process is alive when it elapses**. The combined core suite runs ~18 min, so on a slow runner the mocha process was still alive 60s after those in-process `main()` calls → the watchdog fired → `process.exit(124)` killed the entire `npm test` run mid-suite. Fast runners usually exited before 60s elapsed, which is why the failure was **intermittent and macOS-specific**.

## Fix

Disarm the self-kill watchdog on **every** exit path of `main()`. The watchdog exists only to bound a *hung* run; once `main()` returns there's nothing left to bound, so clearing on completion doesn't weaken it.

- Track the currently-armed timer in `activeSelfKill`.
- The re-arm path repoints `activeSelfKill` at the replacement timer.
- A `finally` wrapping the body of `main()` calls `clearTimeout(activeSelfKill)`, so it's cleared whether `main()` returns normally or throws.

Production behavior is unchanged: when run as a script, the process exits immediately after `main()` resolves anyway.

## Regression test

Added a cross-platform test in `test/runner-entrypoint.test.js` that drives the 410 (canceled) path (no child spawn, so it runs on Windows too), stubs `process.exit`, uses a short `DD_TIMEOUT_SECONDS`, and asserts no `process.exit(124)` fires after `main()` resolves past the self-kill window. Verified red→green: without the fix it fails with `self-kill watchdog leaked: process.exit called with 124`; with the fix it passes.

## Also reverted

The earlier 30→60 min `this.timeout` bump in `test/core-core.test.js` (unrelated to the real cause) is restored to its `next` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
