### PR TITLE
feat(hints): surface custom assertions and retry for transient errors

### DIFF
--- a/src/hints/context.ts
+++ b/src/hints/context.ts
@@ -138,6 +138,9 @@ export async function buildHintContext(
     hasRelativeUrls: walkData.hasRelativeUrls,
     hasCurlInRunShell: walkData.hasCurlInRunShell,
     hasNodeOrPythonInRunShell: walkData.hasNodeOrPythonInRunShell,
+    usedCustomAssertions: walkData.usedCustomAssertions,
+    usedRetry: walkData.usedRetry,
+    failedTransientRequest: walkData.failedTransientRequest,
     agentDetections,
     hasPackageJson,
     hasDocDetectiveNpmScript,
@@ -382,6 +385,9 @@ interface WalkData {
   hasRelativeUrls: boolean;
   hasCurlInRunShell: boolean;
   hasNodeOrPythonInRunShell: boolean;
+  usedCustomAssertions: boolean;
+  usedRetry: boolean;
+  failedTransientRequest: boolean;
 }
 
 function emptyWalkData(): WalkData {
@@ -395,8 +401,14 @@ function emptyWalkData(): WalkData {
     hasRelativeUrls: false,
     hasCurlInRunShell: false,
     hasNodeOrPythonInRunShell: false,
+    usedCustomAssertions: false,
+    usedRetry: false,
+    failedTransientRequest: false,
   };
 }
+
+// Test/step routing handler keys.
+const ROUTING_HANDLER_KEYS = ["onPass", "onFail", "onWarning", "onSkip"];
 
 export function walkResults(results: any): WalkData {
   const data = emptyWalkData();
@@ -433,6 +445,48 @@ function inspectStep(step: any, data: WalkData): void {
   if (!step || typeof step !== "object") return;
   for (const key of STEP_ACTION_KEYS) {
     if (step[key] !== undefined) data.usedStepTypes.add(key);
+  }
+
+  // Custom assertions: under the unified model every step report carries an
+  // `assertions` array of records; a `source: "custom"` record means the user
+  // authored a `step.assertions` condition (implicit records have
+  // `source: "implicit"`). Powers `useAssertionsForOutputChecks`.
+  if (Array.isArray(step.assertions)) {
+    if (step.assertions.some((a: any) => a?.source === "custom")) {
+      data.usedCustomAssertions = true;
+    }
+  }
+  // Routing retry: the step report spreads the authored step, so its routing
+  // handlers (onPass/onFail/...) are present. A `retry` entry in any of them
+  // means the user already uses retry. Powers `useRetryForTransientErrors`.
+  for (const handlerKey of ROUTING_HANDLER_KEYS) {
+    const handler = step[handlerKey];
+    if (
+      Array.isArray(handler) &&
+      handler.some((e: any) => e && typeof e === "object" && e.retry != null)
+    ) {
+      data.usedRetry = true;
+    }
+  }
+  // A request step (httpRequest/checkLink) that FAILed with a TRANSIENT
+  // server-side status — a 429 (rate limit) or any 5xx — i.e. the kind of
+  // product-side error that routing retry-with-backoff is meant to ride out.
+  // A 4xx like 404 is NOT transient (retry won't help), so it's excluded.
+  // httpRequest exposes `outputs.response.statusCode`; checkLink exposes
+  // `outputs.statusCode`. Powers `useRetryForTransientErrors`.
+  if (step.result === "FAIL") {
+    let statusCode: unknown;
+    if (step.httpRequest !== undefined) {
+      statusCode = step.outputs?.response?.statusCode;
+    } else if (step.checkLink !== undefined) {
+      statusCode = step.outputs?.statusCode;
+    }
+    if (
+      typeof statusCode === "number" &&
+      (statusCode === 429 || statusCode >= 500)
+    ) {
+      data.failedTransientRequest = true;
+    }
   }
 
   // Find-step detection (selector vs stable identifier).

--- a/src/hints/hints.ts
+++ b/src/hints/hints.ts
@@ -423,7 +423,7 @@ export const HINTS: Hint[] = [
       "Steps like `runShell`, `httpRequest`, and `runCode` pass when they execute — but you can also assert on what they produced. Add an `assertions` expression over `$$outputs.*` to check a specific value:",
       "",
       "```json",
-      "{ \"runShell\": \"node --version\", \"assertions\": \"$$outputs.stdio contains v20\" }",
+      "{ \"runShell\": \"node --version\", \"assertions\": \"$$outputs.stdio.stdout contains v20\" }",
       "```",
       "",
       "A failed assertion fails the step (and the test) — turning \"it ran\" into \"it returned what I expected\". Pass an array of strings to require several.",

--- a/src/hints/hints.ts
+++ b/src/hints/hints.ts
@@ -644,7 +644,7 @@ export const HINTS: Hint[] = [
       "{ \"httpRequest\": \"https://api.example.com/data\", \"onFail\": [{ \"retry\": { \"limit\": 3, \"delay\": 1000, \"backoff\": \"exponential\" } }] }",
       "```",
       "",
-      "Retry never changes the verdict — if the upstream is still erroring after the retries, the step still fails, so a real outage isn't masked.",
+      "The same `onFail` retry works on a `checkLink` step. Retry never changes the verdict — if the upstream is still erroring after the retries, the step still fails, so a real outage isn't masked.",
     ].join("\n"),
     when: (ctx) => ctx.failedTransientRequest && !ctx.usedRetry,
   },

--- a/src/hints/hints.ts
+++ b/src/hints/hints.ts
@@ -414,6 +414,28 @@ export const HINTS: Hint[] = [
   },
 
   // ------------------------------------------------------------------
+  // useAssertionsForOutputChecks (feature discovery)
+  // ------------------------------------------------------------------
+  {
+    id: "useAssertionsForOutputChecks",
+    priority: 40,
+    markdown: [
+      "Steps like `runShell`, `httpRequest`, and `runCode` pass when they execute — but you can also assert on what they produced. Add an `assertions` expression over `$$outputs.*` to check a specific value:",
+      "",
+      "```json",
+      "{ \"runShell\": \"node --version\", \"assertions\": \"$$outputs.stdio contains v20\" }",
+      "```",
+      "",
+      "A failed assertion fails the step (and the test) — turning \"it ran\" into \"it returned what I expected\". Pass an array of strings to require several.",
+    ].join("\n"),
+    when: (ctx) =>
+      !ctx.usedCustomAssertions &&
+      (ctx.usedStepTypes.has("runShell") ||
+        ctx.usedStepTypes.has("httpRequest") ||
+        ctx.usedStepTypes.has("runCode")),
+  },
+
+  // ------------------------------------------------------------------
   // useCheckLinkStep (feature discovery)
   // ------------------------------------------------------------------
   {
@@ -607,6 +629,24 @@ export const HINTS: Hint[] = [
       ctx.failedCount > 0 &&
       !ctx.producedRecordings &&
       ctx.usedBrowserContexts.size > 0,
+  },
+
+  // ------------------------------------------------------------------
+  // useRetryForTransientErrors (current-run problem)
+  // ------------------------------------------------------------------
+  {
+    id: "useRetryForTransientErrors",
+    priority: 20,
+    markdown: [
+      "A request returned a transient server error this run (a 429 rate-limit or a 5xx). `onFail` retry with exponential backoff re-runs the step before failing — the standard way to ride out rate limits and flaky upstreams:",
+      "",
+      "```json",
+      "{ \"httpRequest\": \"https://api.example.com/data\", \"onFail\": [{ \"retry\": { \"limit\": 3, \"delay\": 1000, \"backoff\": \"exponential\" } }] }",
+      "```",
+      "",
+      "Retry never changes the verdict — if the upstream is still erroring after the retries, the step still fails, so a real outage isn't masked.",
+    ].join("\n"),
+    when: (ctx) => ctx.failedTransientRequest && !ctx.usedRetry,
   },
 
   // ------------------------------------------------------------------

--- a/src/hints/types.ts
+++ b/src/hints/types.ts
@@ -170,6 +170,30 @@ export interface HintContext {
    * `results.recordingForcedSerial`. Powers `recordConcurrently`.
    */
   recordingForcedSerial: boolean;
+  /**
+   * True if any step report carried a `source: "custom"` assertion record —
+   * i.e. the user authored a `step.assertions` condition. (Every step also has
+   * `source: "implicit"` records under the unified model, so this specifically
+   * detects user-authored assertions.) Powers `useAssertionsForOutputChecks`.
+   * Sourced from the `walkResults` step pass.
+   */
+  usedCustomAssertions: boolean;
+  /**
+   * True if any step's routing handler (`onPass`/`onFail`/`onWarning`/`onSkip`)
+   * contained a `retry` entry — i.e. the user already uses routing retry.
+   * Powers `useRetryForTransientErrors`. Sourced from the `walkResults` step
+   * pass (the report spreads the authored step, so handlers are present).
+   */
+  usedRetry: boolean;
+  /**
+   * True if any request step (`httpRequest`/`checkLink`) FAILed this run with a
+   * TRANSIENT server-side status — a 429 (rate limit) or any 5xx. A 4xx like
+   * 404 is excluded (not transient — retry won't help). Powers
+   * `useRetryForTransientErrors`. Sourced from the `walkResults` step pass
+   * (`outputs.response.statusCode` for httpRequest, `outputs.statusCode` for
+   * checkLink).
+   */
+  failedTransientRequest: boolean;
 }
 
 export interface Hint {

--- a/test/hints.test.js
+++ b/test/hints.test.js
@@ -629,6 +629,83 @@ describe("hints/context", function () {
       expect(data.usedStepTypes.size).to.equal(0);
       expect(data.usedBrowserContexts.size).to.equal(0);
       expect(data.producedScreenshots).to.equal(false);
+      expect(data.usedCustomAssertions).to.equal(false);
+      expect(data.usedRetry).to.equal(false);
+      expect(data.failedTransientRequest).to.equal(false);
+    });
+
+    it("usedCustomAssertions is true only for a source:'custom' assertion record", function () {
+      // Implicit-only records must NOT count (every step has those).
+      const implicitOnly = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          { runShell: "x", assertions: [{ source: "implicit", result: "PASS" }] },
+        ] }] }] }],
+      });
+      expect(implicitOnly.usedCustomAssertions).to.equal(false);
+      // A custom record counts.
+      const custom = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          { runShell: "x", assertions: [
+            { source: "implicit", result: "PASS" },
+            { source: "custom", result: "PASS" },
+          ] },
+        ] }] }] }],
+      });
+      expect(custom.usedCustomAssertions).to.equal(true);
+    });
+
+    it("usedRetry is true when a routing handler carries a retry entry", function () {
+      const withRetry = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          { find: "Submit", onFail: [{ retry: { limit: 2 } }] },
+        ] }] }] }],
+      });
+      expect(withRetry.usedRetry).to.equal(true);
+      // A non-retry handler (continue/stop/goToStep) does not count.
+      const noRetry = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          { find: "Submit", onFail: [{ continue: true }] },
+        ] }] }] }],
+      });
+      expect(noRetry.usedRetry).to.equal(false);
+    });
+
+    it("failedTransientRequest is true only for a FAILed request with a 429/5xx status", function () {
+      // httpRequest FAILed with a 429 -> transient.
+      const http429 = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          { httpRequest: "x", result: "FAIL", outputs: { response: { statusCode: 429 } } },
+        ] }] }] }],
+      });
+      expect(http429.failedTransientRequest).to.equal(true);
+      // checkLink FAILed with a 503 -> transient.
+      const link503 = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          { checkLink: "x", result: "FAIL", outputs: { statusCode: 503 } },
+        ] }] }] }],
+      });
+      expect(link503.failedTransientRequest).to.equal(true);
+      // A 404 is NOT transient (retry won't help) -> excluded.
+      const http404 = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          { httpRequest: "x", result: "FAIL", outputs: { response: { statusCode: 404 } } },
+        ] }] }] }],
+      });
+      expect(http404.failedTransientRequest).to.equal(false);
+      // A PASSing request (even a 200) does not count.
+      const passed = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          { httpRequest: "x", result: "PASS", outputs: { response: { statusCode: 200 } } },
+        ] }] }] }],
+      });
+      expect(passed.failedTransientRequest).to.equal(false);
+      // A FAILed non-request step (runShell) does not count.
+      const failedShell = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          { runShell: "exit 1", result: "FAIL" },
+        ] }] }] }],
+      });
+      expect(failedShell.failedTransientRequest).to.equal(false);
     });
   });
 
@@ -1330,6 +1407,9 @@ function fakeCtx(partial = {}) {
     hasNodeOrPythonInRunShell: false,
     hasRstFiles: false,
     recordingForcedSerial: false,
+    usedCustomAssertions: false,
+    usedRetry: false,
+    failedTransientRequest: false,
     ...partial,
   };
 }
@@ -1402,12 +1482,12 @@ describe("hints/index pickByPriority + priorityWeight", function () {
 
 describe("hints/hints (registry)", function () {
   it("every hint has stable id, body, predicate, and a numeric priority when set", function () {
-    // 31 active hints. `useFileTypesForRst` is commented out in the
+    // 33 active hints. `useFileTypesForRst` is commented out in the
     // registry but the `RST_EXTENSIONS` constant, the
     // `detectRstFiles` helper, and the `hasRstFiles` context field
     // are kept in place so the hint can be re-enabled without
     // re-plumbing.
-    expect(HINTS.length).to.equal(31);
+    expect(HINTS.length).to.equal(33);
     const ids = new Set();
     // Ids are camelCase, matching the convention used everywhere else
     // in the project (step names like `goTo`, config fields like
@@ -1819,6 +1899,49 @@ describe("hints/hints (registry)", function () {
         })
       )
     ).to.equal(false);
+  });
+
+  it("useAssertionsForOutputChecks: fires for an output step with no custom assertions", function () {
+    const h = findHint("useAssertionsForOutputChecks");
+    expect(h.priority).to.equal(40);
+    // Positive: a runShell step, user isn't asserting on outputs yet.
+    expect(
+      h.when(fakeCtx({ usedStepTypes: new Set(["runShell"]) }))
+    ).to.equal(true);
+    // Also fires for httpRequest / runCode.
+    expect(
+      h.when(fakeCtx({ usedStepTypes: new Set(["httpRequest"]) }))
+    ).to.equal(true);
+    expect(
+      h.when(fakeCtx({ usedStepTypes: new Set(["runCode"]) }))
+    ).to.equal(true);
+    // Negative: already using custom assertions -> skip.
+    expect(
+      h.when(
+        fakeCtx({
+          usedStepTypes: new Set(["runShell"]),
+          usedCustomAssertions: true,
+        })
+      )
+    ).to.equal(false);
+    // Negative: no output-producing step in the run -> skip.
+    expect(
+      h.when(fakeCtx({ usedStepTypes: new Set(["goTo", "find"]) }))
+    ).to.equal(false);
+  });
+
+  it("useRetryForTransientErrors: fires when a request failed transiently and retry isn't used", function () {
+    const h = findHint("useRetryForTransientErrors");
+    expect(h.priority).to.equal(20);
+    // Positive: a request FAILed with a transient status (429/5xx), no retry.
+    expect(h.when(fakeCtx({ failedTransientRequest: true }))).to.equal(true);
+    // Negative: already using retry -> skip.
+    expect(
+      h.when(fakeCtx({ failedTransientRequest: true, usedRetry: true }))
+    ).to.equal(false);
+    // Negative: no transient request failure (e.g. a 404, or a non-request
+    // failure) -> skip.
+    expect(h.when(fakeCtx({ failedTransientRequest: false }))).to.equal(false);
   });
 
   it("useRunBrowserScriptStep: fires on browser + find when runBrowserScript isn't used", function () {

--- a/test/hints.test.js
+++ b/test/hints.test.js
@@ -654,13 +654,16 @@ describe("hints/context", function () {
       expect(custom.usedCustomAssertions).to.equal(true);
     });
 
-    it("usedRetry is true when a routing handler carries a retry entry", function () {
-      const withRetry = walkResults({
-        specs: [{ tests: [{ contexts: [{ steps: [
-          { find: "Submit", onFail: [{ retry: { limit: 2 } }] },
-        ] }] }] }],
-      });
-      expect(withRetry.usedRetry).to.equal(true);
+    it("usedRetry is true when any routing handler carries a retry entry", function () {
+      // Detection iterates all four handler keys, not just onFail.
+      for (const key of ["onPass", "onFail", "onWarning", "onSkip"]) {
+        const data = walkResults({
+          specs: [{ tests: [{ contexts: [{ steps: [
+            { find: "Submit", [key]: [{ retry: { limit: 2 } }] },
+          ] }] }] }],
+        });
+        expect(data.usedRetry, `retry in ${key}`).to.equal(true);
+      }
       // A non-retry handler (continue/stop/goToStep) does not count.
       const noRetry = walkResults({
         specs: [{ tests: [{ contexts: [{ steps: [


### PR DESCRIPTION
## Post-run hints for the routing/assertion features

Adds **two** post-run hints surfacing the new dynamic-routing features, per the strict `src/hints/AGENTS.md` convention (tight signal, opt-in, actionable, "if in doubt don't").

- **`useAssertionsForOutputChecks`** (priority 40) — fires when a run used an output-producing step (`runShell`/`httpRequest`/`runCode`) but never authored a custom `assertions` condition. Nudges asserting on `$$outputs.*`.
- **`useRetryForTransientErrors`** (priority 20) — fires when a request step (`httpRequest`/`checkLink`) FAILed this run with a **transient** server status (a 429 rate-limit or a 5xx) and routing `retry` isn't used. Nudges `onFail:[{retry:{…,backoff:"exponential"}}]` to ride out rate limits / flaky upstreams; notes retry never changes the verdict. A 4xx like 404 is excluded (not transient).

New `walkResults` signals: `usedCustomAssertions`, `usedRetry`, `failedTransientRequest` (429/5xx via `outputs.response.statusCode` / `outputs.statusCode`). Guard `if`/goToStep/goToTest/meta were intentionally left without hints (no clean signal → noise). 155 hints tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)