### PR TITLE
test(runner): exercise concurrentRunners=2 cross-OS by splitting out serial-only recording specs

### DIFF
--- a/test/appium-port-conflict.test.js
+++ b/test/appium-port-conflict.test.js
@@ -10,7 +10,7 @@ const driverSpec = path.join(artifactPath, "wait-with-driver.spec.json");
 
 function makeConfig() {
   const config = JSON.parse(JSON.stringify(config_base));
-  config.runTests.input = driverSpec;
+  config.input = driverSpec;
   return config;
 }
 

--- a/test/artifacts/config.json
+++ b/test/artifacts/config.json
@@ -1,5 +1,6 @@
 {
   "logLevel": "debug",
+  "concurrentRunners": 2,
   "telemetry": {
     "send": false
   }

--- a/test/core-artifacts/config.json
+++ b/test/core-artifacts/config.json
@@ -5,6 +5,7 @@
   "logLevel": "debug",
   "relativePathBase": "file",
   "detectSteps": false,
+  "concurrentRunners": 2,
   "runOn": [
     {
       "platforms": ["mac", "linux"],

--- a/test/core-artifacts/config.json
+++ b/test/core-artifacts/config.json
@@ -1,30 +1,21 @@
 {
-  "envVariables": "",
   "input": ".",
   "output": ".",
   "recursive": true,
   "logLevel": "debug",
   "relativePathBase": "file",
-  "runTests": {
-    "input": "./dev/doc-content.md",
-    "output": ".",
-    "setup": "",
-    "cleanup": "",
-    "recursive": true,
-    "detectSteps": false,
-    "mediaDirectory": ".",
-    "downloadDirectory": ".",
-    "contexts": [
-      {
-        "app": { "name": "firefox", "options": { "headless": true } },
-        "platforms": ["mac", "linux"]
-      },
-      {
-        "app": { "name": "firefox", "options": { "headless": true } },
-        "platforms": ["windows"]
-      }
-    ]
-  },
+  "detectSteps": false,
+  "concurrentRunners": 2,
+  "runOn": [
+    {
+      "platforms": ["mac", "linux"],
+      "browsers": [{ "name": "firefox", "headless": true }]
+    },
+    {
+      "platforms": ["windows"],
+      "browsers": [{ "name": "firefox", "headless": true }]
+    }
+  ],
   "integrations": {
     "openApi": [
       {

--- a/test/core-artifacts/config.json
+++ b/test/core-artifacts/config.json
@@ -5,7 +5,6 @@
   "logLevel": "debug",
   "relativePathBase": "file",
   "detectSteps": false,
-  "concurrentRunners": 2,
   "runOn": [
     {
       "platforms": ["mac", "linux"],

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -15,7 +15,7 @@ describe("Run tests successfully", function () {
     // This starts Appium once and runs all specs within that session.
     it("All core spec files pass", async () => {
       const config_tests = JSON.parse(JSON.stringify(config_base));
-      config_tests.runTests.input = artifactPath;
+      config_tests.input = artifactPath;
       const result = await runTests(config_tests);
       if (result === null) assert.fail("Expected result to be non-null");
       const failedSpecs = result.specs.filter((s) => s.result === "FAIL");

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -37,13 +37,17 @@ describe("Run tests successfully", function () {
     ];
     const onlySerial = SERIAL_ONLY.map((id) => `^${escapeRe(id)}$`);
 
-    // The bulk of the suite, run under concurrentRunners=2 (from config.json) on
-    // every OS. No recording specs here, so the runner must NOT fall back to
-    // forced-serial recording mode — asserted below so a serial-forcing spec
-    // can't silently slip through the filter and mask the concurrency.
+    // The bulk of the suite, run under concurrentRunners=2 on every OS. No
+    // recording specs here, so the runner must NOT fall back to forced-serial
+    // recording mode — asserted below so a serial-forcing spec can't silently
+    // slip through the filter and mask the concurrency. concurrentRunners is set
+    // here (not in config.json) so the shared config_base stays serial for other
+    // consumers like appium-port-conflict.test.js, which probes single-Appium
+    // port behavior and must not start a second Appium server.
     it("Non-recording core specs pass under concurrentRunners=2", async () => {
       const config_tests = JSON.parse(JSON.stringify(config_base));
       config_tests.input = artifactPath;
+      config_tests.concurrentRunners = 2;
       config_tests.specFilter = excludeSerial;
       const result = await runTests(config_tests);
       if (result === null) assert.fail("Expected result to be non-null");

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -11,11 +11,62 @@ describe("Run tests successfully", function () {
   // 30 minutes for the combined core test suite (runs all specs in one Appium session)
   this.timeout(1800000);
   describe("Core test suite", function () {
-    // Run all spec files in a single runTests() call to avoid repeated Appium restarts.
-    // This starts Appium once and runs all specs within that session.
-    it("All core spec files pass", async () => {
+    // Specs that MUST run serially (concurrentRunners=1), split out so the rest
+    // of the suite can be exercised under real concurrency on every OS:
+    //   - recording / recording-permutations / autorecord / "Do all the things!"
+    //     drive ffmpeg/browser recordings, which need exclusive use of the
+    //     display. Left in a concurrent run they either force the whole run
+    //     serial (no Xvfb: Windows/macOS) or clobber each other's driver
+    //     sessions (Linux+Xvfb -> `invalid session id`).
+    //   - cookie-tests starts httpbin in Docker in its first test and depends on
+    //     it in later tests; concurrent test execution races that setup (the
+    //     dependent tests hit localhost:8080 before the container is up).
+    const SERIAL_ONLY = [
+      "recording",
+      "recording-permutations",
+      "autorecord",
+      "Do all the things! - Spec",
+      "cookie-tests",
+    ];
+    const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // specFilter is include-only (regex on specId). For the concurrent pass,
+    // exclude the serial set with a single anchored negative-lookahead; for the
+    // serial pass, include exactly that set.
+    const excludeSerial = [
+      `^(?!(?:${SERIAL_ONLY.map(escapeRe).join("|")})$).*$`,
+    ];
+    const onlySerial = SERIAL_ONLY.map((id) => `^${escapeRe(id)}$`);
+
+    // The bulk of the suite, run under concurrentRunners=2 (from config.json) on
+    // every OS. No recording specs here, so the runner must NOT fall back to
+    // forced-serial recording mode — asserted below so a serial-forcing spec
+    // can't silently slip through the filter and mask the concurrency.
+    it("Non-recording core specs pass under concurrentRunners=2", async () => {
       const config_tests = JSON.parse(JSON.stringify(config_base));
       config_tests.input = artifactPath;
+      config_tests.specFilter = excludeSerial;
+      const result = await runTests(config_tests);
+      if (result === null) assert.fail("Expected result to be non-null");
+      assert.notEqual(
+        result.recordingForcedSerial,
+        true,
+        "Concurrent pass was forced serial — a recording spec leaked past the filter; add it to SERIAL_ONLY."
+      );
+      const failedSpecs = result.specs.filter((s) => s.result === "FAIL");
+      assert.equal(
+        result.summary.specs.fail,
+        0,
+        `${failedSpecs.length} spec(s) failed: ${failedSpecs.map((s) => s.specId).join(", ")}`
+      );
+    });
+
+    // Recording + setup-ordered specs, run serially. (concurrentRunners=1 here
+    // is also what no-Xvfb platforms fall back to for recording anyway.)
+    it("Recording and setup-ordered core specs pass serially", async () => {
+      const config_tests = JSON.parse(JSON.stringify(config_base));
+      config_tests.input = artifactPath;
+      config_tests.concurrentRunners = 1;
+      config_tests.specFilter = onlySerial;
       const result = await runTests(config_tests);
       if (result === null) assert.fail("Expected result to be non-null");
       const failedSpecs = result.specs.filter((s) => s.result === "FAIL");


### PR DESCRIPTION
## What

Exercises the concurrent runner path (`concurrentRunners: 2`) — including #377's phase-barrier ordering and the routed-spec sequencer merged into `next` — across **all operating systems**, by splitting the serial-required specs out of the core suite so the bulk can run genuinely concurrent everywhere.

Also migrates `test/core-artifacts/config.json` off the deprecated v2→v3 compatibility shim to native config_v3 (it was a config_v2 file; adding the v3-only `concurrentRunners` field made it match neither schema).

## The problem the split solves

A single combined `runTests()` over the core fixtures can't be run concurrently cross-platform:

- **Recording specs** (`recording`, `recording-permutations`, `autorecord`, `Do all the things! - Spec`) drive ffmpeg/browser recordings that need **exclusive use of the display**. In a concurrent run they either:
  - force the *whole* run serial where there's no Xvfb (Windows/macOS) — silently defeating the concurrency, or
  - clobber each other's driver sessions under Xvfb (Linux) → `WebDriverError: invalid session id`.
- **`cookie-tests`** starts httpbin in Docker in its first test and depends on it in later tests; concurrent test execution **races that setup** (dependent tests hit `localhost:8080` before the container is up).

(All four surfaced as real failures on the Linux matrix jobs in an earlier revision.)

## The split

`core-core.test.js` now runs two `runTests()` passes, partitioned by `specFilter`:

1. **Non-recording core specs @ `concurrentRunners: 2`** — on every OS. No recording specs here, so the runner can't fall back to forced-serial mode; asserted via `result.recordingForcedSerial !== true` so a serial-forcing spec can't silently slip past the filter and mask the concurrency.
2. **Recording + setup-ordered specs @ `concurrentRunners: 1`** — serial.

Both passes assert **zero spec failures** (PASS/SKIPPED only).

## Verification

- **Local (Windows):** concurrent pass genuinely parallel — per-context `[testId/contextId]` log prefixes present (456), `executing serially` count 0 — and green; serial pass green. **52 passing / 2 pending.**
- **CI:** this PR's matrix is the cross-OS proof — the concurrent pass now runs in parallel on Linux, macOS, and Windows.

## Notes

- The merged routing/ordering code is not implicated by any of the above — its own tests pass, including `core-ordering.test.js` at `concurrentRunners: 4`.
- `test/artifacts/config.json` (checkLink / CLI suites, HTTP-only) also runs at `concurrentRunners: 2`.
- Test-only change; no production behavior or public contract altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)