### PR TITLE
feat(runner): support long-running background processes for runShell/runCode

### DIFF
--- a/adrs/01002-background-processes.md
+++ b/adrs/01002-background-processes.md
@@ -1,0 +1,107 @@
+---
+status: accepted
+date: 2026-06-22
+decision-makers: doc-detective maintainers
+---
+
+# Long-running background processes for runShell/runCode
+
+## Context and Problem Statement
+
+`runShell` and `runCode` are blocking: each spawns a command, waits for it to exit, then asserts on
+the exit code / stdio / saved output. There is no way to start a **long-lived** process — a Docker
+container, a dev server, a database — keep it running while many tests execute against it, and tear
+it down at cleanup.
+
+Authors work around this today with external scripts or `beforeAny`/`afterAll` shell steps that
+background a process with `&` and `disown`, but the runner then has no handle on it: nothing waits
+for it to become ready (so the first test races startup), nothing tears it down (so it orphans), and
+on Ctrl-C the process leaks. How do we let a test run own a long-lived process end-to-end —
+start → ready-gate → reuse → guaranteed teardown — without a breaking change to the step model?
+
+## Decision Drivers
+
+* Generic: any long-running process, not Docker-specific.
+* Readiness must be explicit — "the port is bound" / "the log says ready" / "HTTP 200" / a delay —
+  so tests don't race a half-started process.
+* Teardown must be guaranteed: explicit (a step) **and** automatic (run end, and on Ctrl-C/SIGTERM).
+* No breaking changes to existing `runShell`/`runCode` behavior; blocking mode stays byte-identical.
+* Fit the existing run lifecycle (`beforeAny`/`afterAll`, the Appium-style run-owned resource that is
+  started once and torn down once).
+
+## Considered Options
+
+* **A. `background` flag + `readyWhen` gate + run-level registry + `stopProcess` step** (chosen).
+* **B. A dedicated `service`/`daemon` step type** separate from `runShell`/`runCode`.
+* **C. Config-level `services` block** declaring long-lived processes outside the step stream.
+
+## Decision Outcome
+
+Chosen option: **A**, because it reuses the two step types authors already know, places start/stop in
+the step stream (so `beforeAny` start / `afterAll` stop reads naturally), and models the process as a
+run-owned resource exactly like Appium. B duplicates all of `runShell`/`runCode`'s command/option
+surface in a third step type. C moves process lifecycle out of the visible test flow and couples it
+to config, which is harder to reason about per-spec and doesn't compose with routing.
+
+Mechanism:
+
+1. **`background: true`** on `runShell`/`runCode` (`src/core/tests/runShell.ts`,
+   `runCode.ts`): spawn non-blocking via `spawnBackgroundCommand` and return as soon as the process
+   is ready. In background mode the exit-code / stdio / saved-output assertions don't apply, and
+   `timeout` is reinterpreted as the **readiness deadline**. A `name` (required by schema when
+   `background: true`) keys the process in the registry; a duplicate name FAILs rather than
+   double-spawning.
+2. **`readyWhen`** gate with exactly one of four probes (`src/core/utils.ts`): `port` (TCP connect),
+   `httpGet` (status code), `log` (regex over buffered output), `delayMs` (fixed wait). Readiness is
+   raced against process exit, so a process that dies during startup FAILs fast instead of waiting
+   the whole deadline.
+3. **Run-level process registry** owned by `runSpecs` (`src/core/tests.ts`): a `Map` threaded
+   through `runContext`/`runRoutedSpec` → `runStep` → the step handlers, so a process started in one
+   spec/test survives for the whole run (e.g. start in `beforeAny`, use across `main`, stop in
+   `afterAll`).
+4. **`stopProcess` step** (`src/core/tests/stopProcess.ts`, new `stopProcess_v3` schema): tree-kills
+   a process by `name` and deregisters it; accepts a string shorthand or `{ name, ignoreMissing }`.
+   `ignoreMissing: true` makes stopping an already-gone process a PASS.
+5. **Guaranteed teardown** (`src/core/tests.ts`): the existing Appium-teardown `finally` also sweeps
+   any still-registered process (run-end auto-cleanup), and new `SIGINT`/`SIGTERM` handlers tear
+   down background processes, Appium, and Xvfb on interrupt — the handlers are removed in the same
+   `finally` so repeated programmatic `runSpecs` calls don't accumulate listeners. (This also fixes
+   the pre-existing Appium-leak-on-Ctrl-C.)
+6. **`runCode` temp-script lifetime**: a backgrounded script is still being read by the interpreter
+   after `runShell` returns, so its temp file deletion is deferred to teardown instead of the
+   immediate `finally` used in blocking mode.
+
+## Consequences
+
+* **Good** — a single run can stand up shared infrastructure once, run many tests against it, and
+  tear it down deterministically, with an explicit readiness contract instead of `sleep` guesses.
+* **Good** — teardown is guaranteed on success, failure, run-end, and interrupt; the interrupt path
+  also closes the prior Appium leak.
+* **Trade-off** — a process that forks a daemon and then exits (some Docker images, some databases)
+  trips the "exited before ready" path and FAILs; documented in the `readyWhen` schema with the
+  guidance to use `port`/`httpGet`/`delayMs` for those rather than relying on the parent staying
+  alive.
+* **Trade-off** — `readyWhen.log` with `stream: "any"` matches against stdout-then-stderr
+  concatenation, not a true temporal interleave; documented in the schema (target a single stream
+  when ordering across streams matters).
+* **Neutral / out of scope** — cross-runner *shared* processes under `concurrentRunners` are not
+  modeled: the registry is run-owned and start/stop are single-owner. Per-runner instances and
+  start-or-attach semantics are deferred; the run-owned placement is forward-compatible with them.
+* **Neutral** — `readyWhen` on a non-background step is ignored rather than rejected (kept permissive
+  to avoid over-constraining; documented as ignored).
+
+## Confirmation
+
+* Unit (`test/background-process.test.js`): `spawnBackgroundCommand` returns immediately and buffers
+  output; each probe (`port`/`httpGet`/`log`/`delayMs`) resolves and times out correctly; readiness
+  fails fast on early exit; `stopProcess` kills + deregisters + honors `ignoreMissing`; the real
+  `runShell`/`runCode` background branches (readiness, outputs, name collision, timeout-deregister,
+  deferred temp cleanup).
+* Schema (`src/common/test/validate.test.js`): positive + negative cases for `background`/`name`/
+  every `readyWhen` probe and both `stopProcess` forms (two-probe, unknown probe, missing name,
+  out-of-range port, whitespace name).
+* End-to-end: `test/background-runner.test.js` drives `runTests()` for explicit-stop and run-end
+  auto-sweep; `test/core-artifacts/background-processes.spec.json` exercises every permutation
+  through the canonical `test/core-core.test.js` fixture gate (all probes, `stopProcess`
+  string/object, `ignoreMissing`, auto-sweep, `runShell` and `runCode` background) and must resolve
+  PASS/SKIPPED across the CI matrix (macOS / Linux / Windows × node 22/24).

--- a/src/common/src/schemas/dereferenceSchemas.cjs
+++ b/src/common/src/schemas/dereferenceSchemas.cjs
@@ -51,6 +51,7 @@ async function dereferenceSchemas() {
     "spec_v3.schema.json",
     "step_v3.schema.json",
     "stopRecord_v3.schema.json",
+    "stopProcess_v3.schema.json",
     "test_v3.schema.json",
     "type_v3.schema.json",
     "wait_v3.schema.json",

--- a/src/common/src/schemas/src_schemas/runCode_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/runCode_v3.schema.json
@@ -103,7 +103,8 @@
             "type": "string",
             "description": "Unique identifier for a background process within the run. Required when `background` is `true`. Reference it from a `stopProcess` step to stop the process.",
             "minLength": 1,
-            "pattern": "\\S"
+            "pattern": "\\S",
+            "transform": ["trim"]
           },
           "readyWhen": {
             "type": "object",

--- a/src/common/src/schemas/src_schemas/runCode_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/runCode_v3.schema.json
@@ -91,9 +91,119 @@
           },
           "timeout": {
             "type": "integer",
-            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
+            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails. When `background` is `true`, this is instead the max time to wait for `readyWhen` to be satisfied before the step fails.",
             "default": 60000
+          },
+          "background": {
+            "type": "boolean",
+            "description": "If `true`, start the code as a long-running background process and return immediately instead of waiting for it to exit. Requires `name`. When `true`, `exitCodes`, `stdio`, and output saving (`path`, `directory`, `maxVariation`, `overwrite`) are ignored, and `timeout` is the max time to wait for `readyWhen`. The process is owned by the run and is stopped by a `stopProcess` step or automatically when the run finishes.",
+            "default": false
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique identifier for a background process within the run. Required when `background` is `true`. Reference it from a `stopProcess` step to stop the process.",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "readyWhen": {
+            "type": "object",
+            "description": "Gate that blocks the step until the background process is ready. Only applies when `background` is `true`. Specify exactly one probe.",
+            "additionalProperties": false,
+            "oneOf": [
+              { "required": ["port"] },
+              { "required": ["log"] },
+              { "required": ["httpGet"] },
+              { "required": ["delayMs"] }
+            ],
+            "properties": {
+              "port": {
+                "type": "object",
+                "description": "Wait until a TCP port accepts connections.",
+                "additionalProperties": false,
+                "required": ["port"],
+                "properties": {
+                  "port": {
+                    "type": "integer",
+                    "description": "TCP port to probe.",
+                    "minimum": 1,
+                    "maximum": 65535
+                  },
+                  "host": {
+                    "type": "string",
+                    "description": "Host to probe.",
+                    "default": "127.0.0.1"
+                  },
+                  "pollIntervalMs": {
+                    "type": "integer",
+                    "description": "Milliseconds between connection attempts.",
+                    "minimum": 50,
+                    "default": 500
+                  }
+                }
+              },
+              "log": {
+                "type": "object",
+                "description": "Wait until the process's output matches a regular expression.",
+                "additionalProperties": false,
+                "required": ["pattern"],
+                "properties": {
+                  "pattern": {
+                    "type": "string",
+                    "description": "Regular expression source (no surrounding slashes) tested against the process output.",
+                    "minLength": 1
+                  },
+                  "stream": {
+                    "type": "string",
+                    "description": "Which stream to match against.",
+                    "enum": ["stdout", "stderr", "any"],
+                    "default": "any"
+                  }
+                }
+              },
+              "httpGet": {
+                "type": "object",
+                "description": "Wait until an HTTP GET request returns an expected status code.",
+                "additionalProperties": false,
+                "required": ["url"],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "description": "URL to request."
+                  },
+                  "statusCodes": {
+                    "type": "array",
+                    "description": "Status codes that indicate readiness.",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "default": [200]
+                  },
+                  "pollIntervalMs": {
+                    "type": "integer",
+                    "description": "Milliseconds between requests.",
+                    "minimum": 50,
+                    "default": 500
+                  }
+                }
+              },
+              "delayMs": {
+                "type": "integer",
+                "description": "Fixed delay in milliseconds before considering the process ready.",
+                "minimum": 0
+              }
+            }
           }
+        },
+        "if": {
+          "properties": {
+            "background": {
+              "const": true
+            }
+          },
+          "required": ["background"]
+        },
+        "then": {
+          "required": ["name"]
         },
         "title": "Run code (detailed)"
       }
@@ -132,6 +242,18 @@
       "directory": "output",
       "maxVariation": 0.1,
       "overwrite": "aboveVariation"
+    },
+    {
+      "language": "javascript",
+      "code": "require('http').createServer((req, res) => res.end('ok')).listen(8088);",
+      "background": true,
+      "name": "api",
+      "readyWhen": {
+        "port": {
+          "port": 8088
+        }
+      },
+      "timeout": 15000
     }
   ]
 }

--- a/src/common/src/schemas/src_schemas/runCode_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/runCode_v3.schema.json
@@ -107,7 +107,7 @@
           },
           "readyWhen": {
             "type": "object",
-            "description": "Gate that blocks the step until the background process is ready. Only applies when `background` is `true`. Specify exactly one probe.",
+            "description": "Gate that blocks the step until the background process is ready. Only applies when `background` is `true` (otherwise it is ignored). Specify exactly one probe. Note: a process that forks a daemon and then exits (common for some Docker images and databases) is treated as having exited before becoming ready and the step fails — use a `port`, `httpGet`, or `delayMs` probe for those rather than relying on the foreground process staying alive.",
             "additionalProperties": false,
             "oneOf": [
               { "required": ["port"] },
@@ -154,7 +154,7 @@
                   },
                   "stream": {
                     "type": "string",
-                    "description": "Which stream to match against.",
+                    "description": "Which stream to match against. With `any`, buffered stdout and stderr are concatenated (all stdout, then all stderr), not interleaved in emission order — a pattern that depends on the time-ordering of output across both streams may not match; target a single stream for that.",
                     "enum": ["stdout", "stderr", "any"],
                     "default": "any"
                   }

--- a/src/common/src/schemas/src_schemas/runShell_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/runShell_v3.schema.json
@@ -105,7 +105,8 @@
             "type": "string",
             "description": "Unique identifier for a background process within the run. Required when `background` is `true`. Reference it from a `stopProcess` step to stop the process.",
             "minLength": 1,
-            "pattern": "\\S"
+            "pattern": "\\S",
+            "transform": ["trim"]
           },
           "readyWhen": {
             "type": "object",

--- a/src/common/src/schemas/src_schemas/runShell_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/runShell_v3.schema.json
@@ -93,9 +93,119 @@
           },
           "timeout": {
             "type": "integer",
-            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
+            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails. When `background` is `true`, this is instead the max time to wait for `readyWhen` to be satisfied before the step fails.",
             "default": 60000
+          },
+          "background": {
+            "type": "boolean",
+            "description": "If `true`, start the command as a long-running background process and return immediately instead of waiting for it to exit. Requires `name`. When `true`, `exitCodes`, `stdio`, and output saving (`path`, `directory`, `maxVariation`, `overwrite`) are ignored, and `timeout` is the max time to wait for `readyWhen`. The process is owned by the run and is stopped by a `stopProcess` step or automatically when the run finishes.",
+            "default": false
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique identifier for a background process within the run. Required when `background` is `true`. Reference it from a `stopProcess` step to stop the process.",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "readyWhen": {
+            "type": "object",
+            "description": "Gate that blocks the step until the background process is ready. Only applies when `background` is `true`. Specify exactly one probe.",
+            "additionalProperties": false,
+            "oneOf": [
+              { "required": ["port"] },
+              { "required": ["log"] },
+              { "required": ["httpGet"] },
+              { "required": ["delayMs"] }
+            ],
+            "properties": {
+              "port": {
+                "type": "object",
+                "description": "Wait until a TCP port accepts connections.",
+                "additionalProperties": false,
+                "required": ["port"],
+                "properties": {
+                  "port": {
+                    "type": "integer",
+                    "description": "TCP port to probe.",
+                    "minimum": 1,
+                    "maximum": 65535
+                  },
+                  "host": {
+                    "type": "string",
+                    "description": "Host to probe.",
+                    "default": "127.0.0.1"
+                  },
+                  "pollIntervalMs": {
+                    "type": "integer",
+                    "description": "Milliseconds between connection attempts.",
+                    "minimum": 50,
+                    "default": 500
+                  }
+                }
+              },
+              "log": {
+                "type": "object",
+                "description": "Wait until the process's output matches a regular expression.",
+                "additionalProperties": false,
+                "required": ["pattern"],
+                "properties": {
+                  "pattern": {
+                    "type": "string",
+                    "description": "Regular expression source (no surrounding slashes) tested against the process output.",
+                    "minLength": 1
+                  },
+                  "stream": {
+                    "type": "string",
+                    "description": "Which stream to match against.",
+                    "enum": ["stdout", "stderr", "any"],
+                    "default": "any"
+                  }
+                }
+              },
+              "httpGet": {
+                "type": "object",
+                "description": "Wait until an HTTP GET request returns an expected status code.",
+                "additionalProperties": false,
+                "required": ["url"],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "description": "URL to request."
+                  },
+                  "statusCodes": {
+                    "type": "array",
+                    "description": "Status codes that indicate readiness.",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "default": [200]
+                  },
+                  "pollIntervalMs": {
+                    "type": "integer",
+                    "description": "Milliseconds between requests.",
+                    "minimum": 50,
+                    "default": 500
+                  }
+                }
+              },
+              "delayMs": {
+                "type": "integer",
+                "description": "Fixed delay in milliseconds before considering the process ready.",
+                "minimum": 0
+              }
+            }
           }
+        },
+        "if": {
+          "properties": {
+            "background": {
+              "const": true
+            }
+          },
+          "required": ["background"]
+        },
+        "then": {
+          "required": ["name"]
         },
         "title": "Run shell command (detailed)"
       }
@@ -150,6 +260,20 @@
       "directory": "output",
       "maxVariation": 0.1,
       "overwrite": "aboveVariation"
+    },
+    {
+      "command": "docker run -p 8080:80 nginx",
+      "background": true,
+      "name": "web",
+      "readyWhen": {
+        "httpGet": {
+          "url": "http://localhost:8080",
+          "statusCodes": [
+            200
+          ]
+        }
+      },
+      "timeout": 30000
     }
   ]
 }

--- a/src/common/src/schemas/src_schemas/runShell_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/runShell_v3.schema.json
@@ -109,7 +109,7 @@
           },
           "readyWhen": {
             "type": "object",
-            "description": "Gate that blocks the step until the background process is ready. Only applies when `background` is `true`. Specify exactly one probe.",
+            "description": "Gate that blocks the step until the background process is ready. Only applies when `background` is `true` (otherwise it is ignored). Specify exactly one probe. Note: a process that forks a daemon and then exits (common for some Docker images and databases) is treated as having exited before becoming ready and the step fails — use a `port`, `httpGet`, or `delayMs` probe for those rather than relying on the foreground process staying alive.",
             "additionalProperties": false,
             "oneOf": [
               { "required": ["port"] },
@@ -156,7 +156,7 @@
                   },
                   "stream": {
                     "type": "string",
-                    "description": "Which stream to match against.",
+                    "description": "Which stream to match against. With `any`, buffered stdout and stderr are concatenated (all stdout, then all stderr), not interleaved in emission order — a pattern that depends on the time-ordering of output across both streams may not match; target a single stream for that.",
                     "enum": ["stdout", "stderr", "any"],
                     "default": "any"
                   }

--- a/src/common/src/schemas/src_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/step_v3.schema.json
@@ -439,6 +439,23 @@
           "$ref": "#/components/schemas/common"
         },
         {
+          "type": "object",
+          "required": ["stopProcess"],
+          "properties": {
+            "stopProcess": {
+              "$ref": "stopProcess_v3.schema.json#"
+            }
+          },
+          "title": "stopProcess"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/common"
+        },
+        {
           "title": "loadVariables",
           "type": "object",
           "required": ["loadVariables"],
@@ -554,6 +571,29 @@
     },
     {
       "stopRecord": true
+    },
+    {
+      "runShell": {
+        "command": "docker run -p 8080:80 nginx",
+        "background": true,
+        "name": "web",
+        "readyWhen": {
+          "httpGet": {
+            "url": "http://localhost:8080",
+            "statusCodes": [200]
+          }
+        },
+        "timeout": 30000
+      }
+    },
+    {
+      "stopProcess": "web"
+    },
+    {
+      "stopProcess": {
+        "name": "web",
+        "ignoreMissing": true
+      }
     },
     {
       "screenshot": true

--- a/src/common/src/schemas/src_schemas/stopProcess_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/stopProcess_v3.schema.json
@@ -34,7 +34,8 @@
             "type": "string",
             "description": "Name of the background process to stop.",
             "minLength": 1,
-            "pattern": "\\S"
+            "pattern": "\\S",
+            "transform": ["trim"]
           },
           "ignoreMissing": {
             "type": "boolean",

--- a/src/common/src/schemas/src_schemas/stopProcess_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/stopProcess_v3.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "stopProcess",
+  "description": "Stop and deregister a background process started by a `runShell` or `runCode` step with `background: true`.",
+  "anyOf": [
+    {
+      "$ref": "#/components/schemas/string"
+    },
+    {
+      "$ref": "#/components/schemas/object"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "string": {
+        "title": "Stop process (by name)",
+        "description": "Name of the background process to stop.",
+        "type": "string",
+        "minLength": 1,
+        "pattern": "\\S",
+        "transform": [
+          "trim"
+        ]
+      },
+      "object": {
+        "title": "Stop process (detailed)",
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the background process to stop.",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "ignoreMissing": {
+            "type": "boolean",
+            "description": "If `true`, the step passes even when no process with `name` is registered (for example, it was already stopped or never started).",
+            "default": false
+          }
+        }
+      }
+    }
+  },
+  "examples": [
+    "web",
+    {
+      "name": "web",
+      "ignoreMissing": true
+    }
+  ]
+}

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -2344,4 +2344,212 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.valid).to.be.false;
       });
     });
+
+    describe("background processes (runShell/runCode) and stopProcess", function () {
+      it("should validate a background runShell with a port probe", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "docker run -p 5432:5432 postgres",
+              background: true,
+              name: "db",
+              readyWhen: { port: { port: 5432 } },
+            },
+          },
+        });
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+      });
+
+      it("should validate a background runShell with a log probe", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: true,
+              name: "srv",
+              readyWhen: { log: { pattern: "ready to accept", stream: "stdout" } },
+            },
+          },
+        });
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+      });
+
+      it("should validate a background runShell with an httpGet probe", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: true,
+              name: "web",
+              readyWhen: {
+                httpGet: { url: "http://localhost:8080", statusCodes: [200, 204] },
+              },
+              timeout: 30000,
+            },
+          },
+        });
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+      });
+
+      it("should validate a background runShell with a delayMs probe", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: true,
+              name: "srv",
+              readyWhen: { delayMs: 2000 },
+            },
+          },
+        });
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+      });
+
+      it("should validate a background runCode with a port probe", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runCode: {
+              language: "javascript",
+              code: "require('http').createServer((q,r)=>r.end('ok')).listen(8088)",
+              background: true,
+              name: "api",
+              readyWhen: { port: { port: 8088 } },
+            },
+          },
+        });
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+      });
+
+      it("should validate a stopProcess step in string form", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: { stopProcess: "db" },
+        });
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+      });
+
+      it("should validate a stopProcess step in object form with ignoreMissing", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: { stopProcess: { name: "db", ignoreMissing: true } },
+        });
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+      });
+
+      it("should reject a readyWhen with two probes", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: true,
+              name: "srv",
+              readyWhen: { port: { port: 5432 }, delayMs: 1000 },
+            },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+
+      it("should reject a readyWhen with an unknown probe key", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: true,
+              name: "srv",
+              readyWhen: { tcp: { port: 5432 } },
+            },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+
+      it("should reject a background runShell without a name", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: true,
+              readyWhen: { delayMs: 1000 },
+            },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+
+      it("should reject a background runCode without a name", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runCode: {
+              language: "bash",
+              code: "sleep 100",
+              background: true,
+              readyWhen: { delayMs: 1000 },
+            },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+
+      it("should reject a readyWhen port that is out of range", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: true,
+              name: "srv",
+              readyWhen: { port: { port: 70000 } },
+            },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+
+      it("should reject a stopProcess object missing name", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: { stopProcess: { ignoreMissing: true } },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+
+      it("should reject a background process with a whitespace-only name", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: true,
+              name: "   ",
+              readyWhen: { delayMs: 1000 },
+            },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+    });
   });

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -1,4 +1,5 @@
 import kill from "tree-kill";
+import fs from "node:fs";
 // webdriverio is loaded lazily via loadHeavyDep at the driverStart() call
 // site so the shim's CLI startup doesn't pay its ~50MB load cost when the
 // user is only running e.g. install-agents or install status. The type
@@ -63,6 +64,7 @@ import { loadCookie } from "./tests/loadCookie.js";
 import { httpRequest } from "./tests/httpRequest.js";
 import { clickElement } from "./tests/click.js";
 import { runCode } from "./tests/runCode.js";
+import { stopProcess } from "./tests/stopProcess.js";
 import { runBrowserScript } from "./tests/runBrowserScript.js";
 import { dragAndDropElement } from "./tests/dragAndDrop.js";
 import path from "node:path";
@@ -986,6 +988,61 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     }
   }
 
+  // Registry of long-running background processes started by `background`
+  // runShell/runCode steps. Owned by this run (not per-context) so processes
+  // survive across specs/tests and are torn down once — by a stopProcess step
+  // or the run-end sweep in the `finally` below.
+  const processRegistry = new Map<string, any>();
+
+  // Kill every still-registered background process (and its child tree) and
+  // remove any deferred temp scripts. Idempotent: stopProcess already removes
+  // the entries it handles.
+  const killAllRegistered = () => {
+    for (const [name, entry] of processRegistry) {
+      try {
+        if (entry?.bg?.pid) kill(entry.bg.pid);
+      } catch {
+        // best-effort
+      }
+      if (entry?.tempPath) {
+        try {
+          fs.unlinkSync(entry.tempPath);
+        } catch {
+          // best-effort
+        }
+      }
+      processRegistry.delete(name);
+    }
+  };
+
+  // Tear down background processes, Appium servers, and Xvfb on Ctrl-C /
+  // termination, then exit. Registered here and removed in the `finally` so
+  // repeated programmatic runSpecs calls don't accumulate listeners. Without
+  // this, an interrupt mid-run leaked Appium and any background process.
+  let signalHandled = false;
+  const onSignal = (signal: NodeJS.Signals) => {
+    if (signalHandled) return;
+    signalHandled = true;
+    killAllRegistered();
+    for (const server of appiumServers) {
+      try {
+        kill(server.process.pid);
+      } catch {
+        // best-effort
+      }
+    }
+    for (const xvfb of xvfbProcesses) {
+      try {
+        xvfb.kill();
+      } catch {
+        // best-effort
+      }
+    }
+    process.exit(signal === "SIGINT" ? 130 : 143);
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+
   // Everything that uses the Appium servers runs inside this try so the
   // shutdown in `finally` always reaches them — otherwise a throw in
   // warmUpContexts (e.g. getAvailableApps failing during the re-detect) would
@@ -1033,6 +1090,7 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
           metaValues,
           installAttempts,
           warmUpResults,
+          processRegistry,
           logPrefix:
             limit > 1 ? `[${job.test.testId}/${job.context.contextId}]` : "",
         });
@@ -1126,6 +1184,7 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
           metaValues,
           installAttempts,
           warmUpResults,
+          processRegistry,
           platform,
           markAutoRecord,
           limit,
@@ -1156,6 +1215,9 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
       report.summary.specs[specReport.result.toLowerCase()]++;
     }
   } finally {
+    // Run-end teardown: kill any background processes the run didn't explicitly
+    // stop (via stopProcess) so they don't leak.
+    killAllRegistered();
     // Close every Appium server we started.
     for (const server of appiumServers) {
       log(config, "debug", `Closing Appium server on port ${server.port}`);
@@ -1173,6 +1235,8 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
         // Process may already be terminated
       }
     }
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
   }
 
   // Upload changed files back to source integrations (best-effort)
@@ -1249,6 +1313,7 @@ async function runRoutedSpec({
   metaValues,
   installAttempts,
   warmUpResults,
+  processRegistry,
   platform,
   markAutoRecord,
   limit,
@@ -1267,6 +1332,7 @@ async function runRoutedSpec({
   metaValues: any;
   installAttempts: Map<string, "installed" | "failed" | "notInstallable">;
   warmUpResults: Map<string, "ok" | "failed">;
+  processRegistry?: Map<string, any>;
   platform: string | undefined;
   markAutoRecord: () => void;
   limit: number;
@@ -1451,6 +1517,7 @@ async function runRoutedSpec({
           metaValues,
           installAttempts,
           warmUpResults,
+          processRegistry,
           logPrefix:
             limit > 1 ? `[${job.test.testId}/${job.context.contextId}]` : "",
         });
@@ -2212,6 +2279,7 @@ async function runContext({
   metaValues,
   installAttempts,
   warmUpResults,
+  processRegistry,
   logPrefix = "",
 }: {
   config: any;
@@ -2226,6 +2294,7 @@ async function runContext({
   metaValues: any;
   installAttempts: Map<string, "installed" | "failed" | "notInstallable">;
   warmUpResults: Map<string, "ok" | "failed">;
+  processRegistry?: Map<string, any>;
   logPrefix?: string;
 }): Promise<any> {
   const platform = runnerDetails.environment.platform;
@@ -2734,6 +2803,7 @@ async function runContext({
           options: {
             openApiDefinitions: context.openApi || [],
           },
+          processRegistry: processRegistry,
         });
         clog(
           "debug",
@@ -2987,6 +3057,7 @@ async function runStep({
   driver,
   metaValues = {},
   options = {},
+  processRegistry,
 }: {
   config?: any;
   context?: any;
@@ -2994,6 +3065,7 @@ async function runStep({
   driver: any;
   metaValues?: any;
   options?: any;
+  processRegistry?: Map<string, any>;
 }): Promise<any> {
   let actionResult: any;
   // Load values from environment variables
@@ -3057,7 +3129,7 @@ async function runStep({
       driver.state.recordings.push(handle);
     }
   } else if (typeof step.runCode !== "undefined") {
-    actionResult = await runCode({ config: config, step: step });
+    actionResult = await runCode({ config: config, step: step, processRegistry });
   } else if (typeof step.runBrowserScript !== "undefined") {
     actionResult = await runBrowserScript({
       config: config,
@@ -3065,7 +3137,9 @@ async function runStep({
       driver: driver,
     });
   } else if (typeof step.runShell !== "undefined") {
-    actionResult = await runShell({ config: config, step: step });
+    actionResult = await runShell({ config: config, step: step, processRegistry });
+  } else if (typeof step.stopProcess !== "undefined") {
+    actionResult = await stopProcess({ config: config, step: step, processRegistry });
   } else if (typeof step.screenshot !== "undefined") {
     actionResult = await saveScreenshot({
       config: config,

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -994,51 +994,61 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   // or the run-end sweep in the `finally` below.
   const processRegistry = new Map<string, any>();
 
-  // Kill every still-registered background process (and its child tree) and
-  // remove any deferred temp scripts. Idempotent: stopProcess already removes
-  // the entries it handles.
-  const killAllRegistered = () => {
-    for (const [name, entry] of processRegistry) {
+  // Tree-kill a pid and resolve when the kill has actually completed (callback
+  // form), so callers can await termination before exiting/returning.
+  const killTree = (pid?: number) =>
+    new Promise<void>((resolve) => {
+      if (!pid) return resolve();
       try {
-        if (entry?.bg?.pid) kill(entry.bg.pid);
+        kill(pid, "SIGTERM", () => resolve());
       } catch {
-        // best-effort
+        resolve();
       }
-      if (entry?.tempPath) {
-        try {
-          fs.unlinkSync(entry.tempPath);
-        } catch {
-          // best-effort
+    });
+
+  // Kill every still-registered background process (and its child tree) and
+  // remove any deferred temp scripts. Awaits the kills so the process tree is
+  // actually gone before the run returns. Idempotent: stopProcess already
+  // removes the entries it handles.
+  const killAllRegistered = async () => {
+    const entries = [...processRegistry.entries()];
+    processRegistry.clear();
+    await Promise.all(
+      entries.map(async ([, entry]) => {
+        await killTree(entry?.bg?.pid);
+        if (entry?.tempPath) {
+          try {
+            fs.unlinkSync(entry.tempPath);
+          } catch {
+            // best-effort
+          }
         }
-      }
-      processRegistry.delete(name);
-    }
+      })
+    );
   };
 
   // Tear down background processes, Appium servers, and Xvfb on Ctrl-C /
   // termination, then exit. Registered here and removed in the `finally` so
   // repeated programmatic runSpecs calls don't accumulate listeners. Without
-  // this, an interrupt mid-run leaked Appium and any background process.
+  // this, an interrupt mid-run leaked Appium and any background process. The
+  // handler awaits the tree-kills before exiting so children don't outlive it.
   let signalHandled = false;
   const onSignal = (signal: NodeJS.Signals) => {
     if (signalHandled) return;
     signalHandled = true;
-    killAllRegistered();
-    for (const server of appiumServers) {
-      try {
-        kill(server.process.pid);
-      } catch {
-        // best-effort
+    (async () => {
+      await killAllRegistered();
+      await Promise.all(
+        appiumServers.map((server) => killTree(server.process?.pid))
+      );
+      for (const xvfb of xvfbProcesses) {
+        try {
+          xvfb.kill();
+        } catch {
+          // best-effort
+        }
       }
-    }
-    for (const xvfb of xvfbProcesses) {
-      try {
-        xvfb.kill();
-      } catch {
-        // best-effort
-      }
-    }
-    process.exit(signal === "SIGINT" ? 130 : 143);
+    })().finally(() => process.exit(signal === "SIGINT" ? 130 : 143));
   };
   process.on("SIGINT", onSignal);
   process.on("SIGTERM", onSignal);
@@ -1216,8 +1226,9 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     }
   } finally {
     // Run-end teardown: kill any background processes the run didn't explicitly
-    // stop (via stopProcess) so they don't leak.
-    killAllRegistered();
+    // stop (via stopProcess) so they don't leak. Awaited so the trees are gone
+    // before runSpecs returns.
+    await killAllRegistered();
     // Close every Appium server we started.
     for (const server of appiumServers) {
       log(config, "debug", `Closing Appium server on port ${server.port}`);

--- a/src/core/tests/runCode.ts
+++ b/src/core/tests/runCode.ts
@@ -36,8 +36,19 @@ function createTempScript(code: string, language: string) {
   return tmpFile;
 }
 
-// Run gather, compile, and run code.
-async function runCode({ config, step }: { config: any; step: any }) {
+// Run gather, compile, and run code. When `step.runCode.background` is true, the
+// script is started as a long-running process via runShell and the temp script
+// is kept on disk (deletion deferred to teardown) so the interpreter can keep
+// reading it.
+async function runCode({
+  config,
+  step,
+  processRegistry,
+}: {
+  config: any;
+  step: any;
+  processRegistry?: Map<string, any>;
+}) {
   const result: any = {
     status: "PASS",
     description: "Executed code.",
@@ -74,6 +85,11 @@ async function runCode({ config, step }: { config: any; step: any }) {
     return result;
   }
   log(config, "debug", `Created temporary script at: ${scriptPath}`);
+
+  // When the script is started in the background it is still being read by the
+  // interpreter after runShell returns, so its temp file must outlive this
+  // call. Teardown (stopProcess / run-end sweep) deletes it instead.
+  let deferTempCleanup = false;
 
   try {
     if (!step.runCode.command) {
@@ -133,10 +149,20 @@ async function runCode({ config, step }: { config: any; step: any }) {
         ? path.join(step.runCode.directory, step.runCode.path)
         : step.runCode.path;
     }
+    // Forward background settings so runShell starts and registers the process.
+    if (step.runCode.background) {
+      runShellOptions.background = true;
+      runShellOptions.name = step.runCode.name;
+      runShellOptions.readyWhen = step.runCode.readyWhen;
+    }
     const shellStep: any = { runShell: runShellOptions };
 
     // Execute script using runShell
-    const shellResult = await runShell({ config: config, step: shellStep });
+    const shellResult = await runShell({
+      config: config,
+      step: shellStep,
+      processRegistry,
+    });
 
     // Copy results, including the articulated assertion records so runCode
     // reports the same implicit assertions runShell produces.
@@ -145,16 +171,26 @@ async function runCode({ config, step }: { config: any; step: any }) {
     result.outputs = {...result.outputs, ...shellResult.outputs};
     if (typeof shellResult.assertions !== "undefined")
       result.assertions = shellResult.assertions;
+
+    // On a successful background start, keep the temp script and hand its path
+    // to the registry entry so teardown removes it after the process is killed.
+    if (step.runCode.background && shellResult.status === "PASS") {
+      deferTempCleanup = true;
+      const entry = processRegistry?.get(step.runCode.name);
+      if (entry) entry.tempPath = scriptPath;
+    }
   } catch (error: any) {
     result.status = "FAIL";
     result.description = error.message;
   } finally {
-    // Clean up temporary script file
-    try {
-      fs.unlinkSync(scriptPath!);
-      log(config, "debug", `Removed temporary script: ${scriptPath}`);
-    } catch (error: any) {
-      log(config, "warn", `Failed to remove temporary script: ${scriptPath}`);
+    // Clean up temporary script file unless a background process still needs it.
+    if (!deferTempCleanup) {
+      try {
+        fs.unlinkSync(scriptPath!);
+        log(config, "debug", `Removed temporary script: ${scriptPath}`);
+      } catch (error: any) {
+        log(config, "warn", `Failed to remove temporary script: ${scriptPath}`);
+      }
     }
   }
 

--- a/src/core/tests/runCode.ts
+++ b/src/core/tests/runCode.ts
@@ -189,7 +189,7 @@ async function runCode({
         fs.unlinkSync(scriptPath!);
         log(config, "debug", `Removed temporary script: ${scriptPath}`);
       } catch (error: any) {
-        log(config, "warn", `Failed to remove temporary script: ${scriptPath}`);
+        log(config, "warning", `Failed to remove temporary script: ${scriptPath}`);
       }
     }
   }

--- a/src/core/tests/runShell.ts
+++ b/src/core/tests/runShell.ts
@@ -76,7 +76,15 @@ async function runShell({
       result.description = "Background processes require a `name`.";
       return result;
     }
-    if (processRegistry && processRegistry.has(name)) {
+    if (!processRegistry) {
+      // Without a registry there is no way to stop or sweep the process, so it
+      // would leak. Fail fast rather than spawn an untrackable process.
+      result.status = "FAIL";
+      result.description =
+        "Background processes aren't supported in this run mode (no process registry available).";
+      return result;
+    }
+    if (processRegistry.has(name)) {
       result.status = "FAIL";
       result.description = `A background process named "${name}" is already running.`;
       return result;
@@ -95,7 +103,7 @@ async function runShell({
     // Register before awaiting readiness so the run-end sweep can kill the
     // process even if it never becomes ready.
     const entry: any = { name, bg };
-    if (processRegistry) processRegistry.set(name, entry);
+    processRegistry.set(name, entry);
 
     try {
       await waitForReady(bg, step.runShell.readyWhen, {
@@ -103,13 +111,12 @@ async function runShell({
       });
     } catch (error: any) {
       // Readiness failed (timeout or the process exited) — kill and deregister
-      // so a half-started process doesn't leak.
-      try {
-        if (bg.pid) kill(bg.pid);
-      } catch {
-        // best-effort cleanup; the readiness error is what matters
+      // so a half-started process doesn't leak. Await the tree-kill (callback
+      // form) so the process tree is actually gone before the step returns.
+      if (bg.pid) {
+        await new Promise<void>((resolve) => kill(bg.pid!, "SIGTERM", () => resolve()));
       }
-      if (processRegistry) processRegistry.delete(name);
+      processRegistry.delete(name);
       result.status = "FAIL";
       result.description = `Background process "${name}" failed to become ready: ${error.message}`;
       return result;

--- a/src/core/tests/runShell.ts
+++ b/src/core/tests/runShell.ts
@@ -1,6 +1,8 @@
 import { validate } from "../../common/src/validate.js";
 import {
   spawnCommand,
+  spawnBackgroundCommand,
+  waitForReady,
   log,
   calculateFractionalDifference,
 } from "../utils.js";
@@ -9,13 +11,25 @@ import {
   evaluateImplicitAssertions,
 } from "../routing.js";
 import type { ImplicitAssertionSpec } from "../routing.js";
+import kill from "tree-kill";
 import fs from "node:fs";
 import path from "node:path";
 
 export { runShell };
 
-// Run a shell command.
-async function runShell({ config, step }: { config: any; step: any }) {
+// Run a shell command. When `step.runShell.background` is true, the command is
+// started as a long-running process registered in `processRegistry` and the step
+// returns as soon as `readyWhen` is satisfied; the process is torn down later by
+// a stopProcess step or the run-end sweep.
+async function runShell({
+  config,
+  step,
+  processRegistry,
+}: {
+  config: any;
+  step: any;
+  processRegistry?: Map<string, any>;
+}) {
   // Promisify and execute command
   const result: any = {
     status: "PASS",
@@ -52,6 +66,64 @@ async function runShell({ config, step }: { config: any; step: any }) {
     overwrite: step.runShell.overwrite || "aboveVariation",
     timeout: step.runShell.timeout || 60000,
   };
+
+  // Background mode: start the process, register it, wait until ready, and
+  // return immediately. `exitCodes`, `stdio`, and output saving don't apply.
+  if (step.runShell.background) {
+    const name = step.runShell.name;
+    if (!name) {
+      result.status = "FAIL";
+      result.description = "Background processes require a `name`.";
+      return result;
+    }
+    if (processRegistry && processRegistry.has(name)) {
+      result.status = "FAIL";
+      result.description = `A background process named "${name}" is already running.`;
+      return result;
+    }
+
+    const bgOptions: any = {};
+    if (step.runShell.workingDirectory)
+      bgOptions.cwd = step.runShell.workingDirectory;
+
+    const bg = spawnBackgroundCommand(
+      step.runShell.command,
+      step.runShell.args,
+      bgOptions
+    );
+
+    // Register before awaiting readiness so the run-end sweep can kill the
+    // process even if it never becomes ready.
+    const entry: any = { name, bg };
+    if (processRegistry) processRegistry.set(name, entry);
+
+    try {
+      await waitForReady(bg, step.runShell.readyWhen, {
+        timeoutMs: step.runShell.timeout,
+      });
+    } catch (error: any) {
+      // Readiness failed (timeout or the process exited) — kill and deregister
+      // so a half-started process doesn't leak.
+      try {
+        if (bg.pid) kill(bg.pid);
+      } catch {
+        // best-effort cleanup; the readiness error is what matters
+      }
+      if (processRegistry) processRegistry.delete(name);
+      result.status = "FAIL";
+      result.description = `Background process "${name}" failed to become ready: ${error.message}`;
+      return result;
+    }
+
+    result.status = "PASS";
+    result.description = `Started background process "${name}".`;
+    result.outputs = {
+      pid: String(bg.pid ?? ""),
+      name,
+      ready: "true",
+    };
+    return result;
+  }
 
   // Execute command
   const timeout = step.runShell.timeout;

--- a/src/core/tests/stopProcess.ts
+++ b/src/core/tests/stopProcess.ts
@@ -1,0 +1,76 @@
+import { validate } from "../../common/src/validate.js";
+import { log } from "../utils.js";
+import kill from "tree-kill";
+import fs from "node:fs";
+
+export { stopProcess };
+
+// Stop and deregister a background process started by a runShell/runCode step
+// with `background: true`.
+async function stopProcess({
+  config,
+  step,
+  processRegistry,
+}: {
+  config: any;
+  step: any;
+  processRegistry?: Map<string, any>;
+}) {
+  const result: any = {
+    status: "PASS",
+    description: "Stopped process.",
+    outputs: {},
+  };
+
+  // Validate step object
+  const isValidStep = validate({ schemaKey: "step_v3", object: step });
+  if (!isValidStep.valid) {
+    result.status = "FAIL";
+    result.description = `Invalid step definition: ${isValidStep.errors}`;
+    return result;
+  }
+  step = isValidStep.object;
+
+  // Normalize string shorthand to object form
+  let spec = step.stopProcess;
+  if (typeof spec === "string") spec = { name: spec };
+  const name = spec.name;
+  const ignoreMissing = spec.ignoreMissing || false;
+
+  const entry = processRegistry?.get(name);
+  if (!entry) {
+    if (ignoreMissing) {
+      result.status = "PASS";
+      result.description = `No background process named "${name}" is running; nothing to stop.`;
+      return result;
+    }
+    result.status = "FAIL";
+    result.description = `No background process named "${name}" is running.`;
+    return result;
+  }
+
+  // Remove from the registry first so the run-end sweep doesn't double-kill.
+  processRegistry!.delete(name);
+
+  // Tree-kill the process (the spawned shell plus its children).
+  if (entry.bg?.pid) {
+    await new Promise<void>((resolve) =>
+      kill(entry.bg.pid, "SIGTERM", () => resolve())
+    );
+  }
+
+  // Remove any deferred temp script (runCode background) now that it's dead.
+  if (entry.tempPath) {
+    try {
+      fs.unlinkSync(entry.tempPath);
+    } catch {
+      // best-effort; the file may already be gone
+    }
+  }
+
+  log(config, "debug", `Stopped background process "${name}".`);
+  result.status = "PASS";
+  result.description = `Stopped background process "${name}".`;
+  result.outputs = { name, stopped: "true" };
+  return result;
+}

--- a/src/core/tests/stopProcess.ts
+++ b/src/core/tests/stopProcess.ts
@@ -50,7 +50,7 @@ async function stopProcess({
   }
 
   // Remove from the registry first so the run-end sweep doesn't double-kill.
-  processRegistry!.delete(name);
+  processRegistry?.delete(name);
 
   // Tree-kill the process (the spawned shell plus its children).
   if (entry.bg?.pid) {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -362,9 +362,12 @@ async function waitForHttp(
 ): Promise<void> {
   while (true) {
     try {
+      // Cap the per-request timeout to the time left so a single hung request
+      // can't block past the overall readiness deadline (e.g. timeout: 600).
+      const remaining = deadline - Date.now();
       const resp = await axios.get(url, {
         validateStatus: () => true,
-        timeout: 5000,
+        timeout: Math.max(1, Math.min(5000, remaining)),
       });
       if (statusCodes.includes(resp.status)) return;
     } catch {
@@ -453,6 +456,13 @@ async function waitForReady(
   const earlyExit = bg.exited.then((code) => {
     throw new Error(`Process exited before becoming ready (exit code ${code}).`);
   });
+
+  // The race loser settles later (the probe keeps polling to its own deadline;
+  // earlyExit rejects when the process is eventually killed at teardown).
+  // Attach no-op catches so that late rejection is always considered handled and
+  // never surfaces as an unhandledRejection during normal stopProcess teardown.
+  probe.catch(() => {});
+  earlyExit.catch(() => {});
 
   await Promise.race([probe, earlyExit]);
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -5,7 +5,7 @@ import crypto from "node:crypto";
 import dns from "node:dns/promises";
 import net from "node:net";
 import axios from "axios";
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 
 export {
   outputResults,
@@ -17,6 +17,11 @@ export {
   runArchivesArtifacts,
   replaceEnvs,
   spawnCommand,
+  spawnBackgroundCommand,
+  waitForReady,
+  waitForPort,
+  waitForHttp,
+  waitForLog,
   inContainer,
   cleanTemp,
   calculateFractionalDifference,
@@ -39,6 +44,8 @@ export {
   rollUpAssertions,
   createAppiumPool,
 };
+
+export type { BackgroundProcess };
 
 // A fixed set of Appium server ports shared by concurrent runners. `acquire()`
 // hands out a free port, waiting if every port is checked out; `release()`
@@ -225,6 +232,225 @@ async function findFreePort(): Promise<number> {
       server.close(() => resolve(port));
     });
   });
+}
+
+// A handle to a long-running process started by a `background: true`
+// runShell/runCode step. Output is buffered (ring-capped) so readiness probes
+// and debugging can inspect it without waiting for the process to exit.
+interface BackgroundProcess {
+  child: ChildProcess;
+  pid: number | undefined;
+  getStdout(): string;
+  getStderr(): string;
+  getCombined(): string;
+  // Subscribe to new output chunks. Returns an unsubscribe function.
+  onChunk(cb: (chunk: string, stream: "stdout" | "stderr") => void): () => void;
+  // Resolves with the exit code when the process closes, or null if it never
+  // started (spawn error).
+  exited: Promise<number | null>;
+}
+
+// Cap each buffered stream so a process that logs for the whole suite can't
+// grow memory without bound. The tail is what readiness probes care about.
+const BACKGROUND_BUFFER_LIMIT = 256 * 1024;
+
+function backgroundSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Non-blocking sibling of spawnCommand: starts a process and returns a handle
+// immediately instead of awaiting `close`. Mirrors spawnCommand's spawn options
+// (shell:true, windowsHide on win32, cwd) so existing command strings behave the
+// same. With shell:true, child.pid is the shell's pid; tree-kill (used at
+// teardown) handles the child tree.
+function spawnBackgroundCommand(
+  cmd: string,
+  args: string[] = [],
+  options: any = {}
+): BackgroundProcess {
+  const spawnOptions: any = { shell: true };
+  if (process.platform === "win32") spawnOptions.windowsHide = true;
+  if (options.cwd) spawnOptions.cwd = options.cwd;
+
+  const child = spawn(cmd, args, spawnOptions);
+
+  let stdout = "";
+  let stderr = "";
+  const subscribers = new Set<
+    (chunk: string, stream: "stdout" | "stderr") => void
+  >();
+
+  function append(stream: "stdout" | "stderr", text: string) {
+    if (stream === "stdout") {
+      stdout = (stdout + text).slice(-BACKGROUND_BUFFER_LIMIT);
+    } else {
+      stderr = (stderr + text).slice(-BACKGROUND_BUFFER_LIMIT);
+    }
+    for (const cb of subscribers) cb(text, stream);
+  }
+
+  if (child.stdout)
+    child.stdout.on("data", (d: any) => append("stdout", d.toString()));
+  if (child.stderr)
+    child.stderr.on("data", (d: any) => append("stderr", d.toString()));
+
+  // Registering an `error` listener here also prevents an immediate spawn
+  // failure (e.g. a bad command) from crashing the process as an unhandled
+  // 'error' event; the failure surfaces via `exited` resolving with null.
+  const exited = new Promise<number | null>((resolve) => {
+    child.once("close", (code) => resolve(code));
+    child.once("error", () => resolve(null));
+  });
+
+  return {
+    child,
+    pid: child.pid,
+    getStdout: () => stdout,
+    getStderr: () => stderr,
+    getCombined: () => stdout + stderr,
+    onChunk(cb) {
+      subscribers.add(cb);
+      return () => subscribers.delete(cb);
+    },
+    exited,
+  };
+}
+
+// Attempt a single TCP connection. Resolves true on connect, false on any error
+// or per-attempt timeout. Never rejects.
+function tryConnect(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host, port });
+    let settled = false;
+    const finish = (result: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(result);
+    };
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+    socket.setTimeout(2000, () => finish(false));
+  });
+}
+
+// Poll a TCP port until it accepts a connection or the deadline passes.
+async function waitForPort(
+  host: string,
+  port: number,
+  { pollIntervalMs = 500, deadline }: { pollIntervalMs?: number; deadline: number }
+): Promise<void> {
+  while (true) {
+    if (await tryConnect(host, port)) return;
+    if (Date.now() + pollIntervalMs >= deadline) {
+      throw new Error(`Port ${host}:${port} did not open in time.`);
+    }
+    await backgroundSleep(pollIntervalMs);
+  }
+}
+
+// Poll an HTTP endpoint until it returns one of the expected status codes or the
+// deadline passes. Connection errors are swallowed and retried.
+async function waitForHttp(
+  url: string,
+  statusCodes: number[],
+  { pollIntervalMs = 500, deadline }: { pollIntervalMs?: number; deadline: number }
+): Promise<void> {
+  while (true) {
+    try {
+      const resp = await axios.get(url, {
+        validateStatus: () => true,
+        timeout: 5000,
+      });
+      if (statusCodes.includes(resp.status)) return;
+    } catch {
+      // Server not up yet (or transient) — retry until the deadline.
+    }
+    if (Date.now() + pollIntervalMs >= deadline) {
+      throw new Error(
+        `HTTP GET ${url} did not return ${JSON.stringify(statusCodes)} in time.`
+      );
+    }
+    await backgroundSleep(pollIntervalMs);
+  }
+}
+
+// Resolve when the process output matches `pattern` on the selected stream, or
+// reject when the deadline passes. Already-buffered output is checked first so a
+// match emitted before subscription isn't missed.
+function waitForLog(
+  bg: BackgroundProcess,
+  pattern: string,
+  stream: "stdout" | "stderr" | "any",
+  { deadline }: { deadline: number }
+): Promise<void> {
+  const regex = new RegExp(pattern);
+  const bufferFor = () =>
+    stream === "stdout"
+      ? bg.getStdout()
+      : stream === "stderr"
+      ? bg.getStderr()
+      : bg.getCombined();
+
+  return new Promise((resolve, reject) => {
+    if (regex.test(bufferFor())) return resolve();
+    let unsubscribe = () => {};
+    const timer = setTimeout(() => {
+      unsubscribe();
+      reject(new Error(`Log pattern /${pattern}/ not seen in time.`));
+    }, Math.max(0, deadline - Date.now()));
+    unsubscribe = bg.onChunk((_chunk, s) => {
+      if (stream !== "any" && s !== stream) return;
+      if (regex.test(bufferFor())) {
+        clearTimeout(timer);
+        unsubscribe();
+        resolve();
+      }
+    });
+  });
+}
+
+// Block until the background process satisfies its readiness probe, fails fast
+// if the process exits first, or rejects when `timeoutMs` elapses. Probe shape
+// defaults are applied here too (defense-in-depth — AJV may not fill defaults
+// nested under anyOf branches).
+async function waitForReady(
+  bg: BackgroundProcess,
+  readyWhen: any,
+  { timeoutMs }: { timeoutMs: number }
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  let probe: Promise<void>;
+  if (readyWhen?.port) {
+    probe = waitForPort(
+      readyWhen.port.host || "127.0.0.1",
+      readyWhen.port.port,
+      { pollIntervalMs: readyWhen.port.pollIntervalMs || 500, deadline }
+    );
+  } else if (readyWhen?.httpGet) {
+    probe = waitForHttp(
+      readyWhen.httpGet.url,
+      readyWhen.httpGet.statusCodes || [200],
+      { pollIntervalMs: readyWhen.httpGet.pollIntervalMs || 500, deadline }
+    );
+  } else if (readyWhen?.log) {
+    probe = waitForLog(bg, readyWhen.log.pattern, readyWhen.log.stream || "any", {
+      deadline,
+    });
+  } else if (readyWhen && typeof readyWhen.delayMs === "number") {
+    probe = backgroundSleep(Math.min(readyWhen.delayMs, timeoutMs));
+  } else {
+    // No readyWhen: consider ready as soon as the process is spawned.
+    probe = Promise.resolve();
+  }
+
+  // Fail fast if the process dies before becoming ready.
+  const earlyExit = bg.exited.then((code) => {
+    throw new Error(`Process exited before becoming ready (exit code ${code}).`);
+  });
+
+  await Promise.race([probe, earlyExit]);
 }
 
 function compileFilter(patterns?: string[] | unknown): RegExp[] {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -342,10 +342,14 @@ async function waitForPort(
 ): Promise<void> {
   while (true) {
     if (await tryConnect(host, port)) return;
-    if (Date.now() + pollIntervalMs >= deadline) {
+    // Only give up once the clock has actually run out, and bound the wait to
+    // the time remaining so a final probe still happens near the deadline. A
+    // fixed `Date.now() + pollIntervalMs >= deadline` check would throw with
+    // time still on the clock on a slow host, skipping a winnable attempt.
+    if (Date.now() >= deadline) {
       throw new Error(`Port ${host}:${port} did not open in time.`);
     }
-    await backgroundSleep(pollIntervalMs);
+    await backgroundSleep(Math.min(pollIntervalMs, deadline - Date.now()));
   }
 }
 
@@ -366,12 +370,12 @@ async function waitForHttp(
     } catch {
       // Server not up yet (or transient) — retry until the deadline.
     }
-    if (Date.now() + pollIntervalMs >= deadline) {
+    if (Date.now() >= deadline) {
       throw new Error(
         `HTTP GET ${url} did not return ${JSON.stringify(statusCodes)} in time.`
       );
     }
-    await backgroundSleep(pollIntervalMs);
+    await backgroundSleep(Math.min(pollIntervalMs, deadline - Date.now()));
   }
 }
 

--- a/test/background-process.test.js
+++ b/test/background-process.test.js
@@ -1,0 +1,417 @@
+import assert from "node:assert/strict";
+import net from "node:net";
+import http from "node:http";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import {
+  spawnBackgroundCommand,
+  waitForPort,
+  waitForHttp,
+  waitForLog,
+  waitForReady,
+  findFreePort,
+} from "../dist/core/utils.js";
+import { stopProcess } from "../dist/core/tests/stopProcess.js";
+import { runShell } from "../dist/core/tests/runShell.js";
+import { runCode } from "../dist/core/tests/runCode.js";
+
+const require = createRequire(import.meta.url);
+const treeKill = require("tree-kill");
+
+// Kill the whole process tree (shell + child) so a shell:true background
+// process doesn't leak; child.kill() alone leaves the grandchild alive.
+function killTree(pid) {
+  return new Promise((resolve) => treeKill(pid, "SIGKILL", () => resolve()));
+}
+
+// Build a minimal fake BackgroundProcess for probe-logic tests that don't need
+// a real child process.
+function fakeBg({ exited = new Promise(() => {}) } = {}) {
+  let stdout = "";
+  let stderr = "";
+  const subs = new Set();
+  return {
+    exited,
+    getStdout: () => stdout,
+    getStderr: () => stderr,
+    getCombined: () => stdout + stderr,
+    onChunk(cb) {
+      subs.add(cb);
+      return () => subs.delete(cb);
+    },
+    // test helper to push output
+    _emit(text, stream = "stdout") {
+      if (stream === "stdout") stdout += text;
+      else stderr += text;
+      for (const cb of subs) cb(text, stream);
+    },
+  };
+}
+
+describe("spawnBackgroundCommand", function () {
+  this.timeout(15000);
+
+  it("returns immediately and buffers stdout from a long-running process", async function () {
+    const tmp = path.join(os.tmpdir(), `dd-bg-test-${process.pid}.js`);
+    fs.writeFileSync(
+      tmp,
+      `console.log("STARTED"); setInterval(() => {}, 100000);`
+    );
+    const bg = spawnBackgroundCommand(`"${process.execPath}" "${tmp}"`);
+    try {
+      assert.equal(typeof bg.pid, "number");
+      // Wait until the buffered output shows the startup line.
+      const start = Date.now();
+      while (!bg.getStdout().includes("STARTED") && Date.now() - start < 5000) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      assert.ok(bg.getStdout().includes("STARTED"), "expected buffered stdout");
+      assert.ok(bg.getCombined().includes("STARTED"));
+    } finally {
+      await killTree(bg.pid);
+      await bg.exited;
+      fs.rmSync(tmp, { force: true });
+    }
+  });
+
+  it("resolves `exited` with null when the command can't be spawned", async function () {
+    const bg = spawnBackgroundCommand(
+      "this-command-definitely-does-not-exist-xyz",
+      [],
+      {}
+    );
+    const code = await bg.exited;
+    // Either the shell reports a non-zero exit code, or spawn errors (null).
+    assert.ok(code === null || typeof code === "number");
+  });
+});
+
+describe("waitForPort", function () {
+  this.timeout(10000);
+
+  it("resolves once a port is accepting connections", async function () {
+    const port = await findFreePort();
+    const server = net.createServer();
+    await new Promise((r) => server.listen(port, "127.0.0.1", r));
+    try {
+      await waitForPort("127.0.0.1", port, {
+        pollIntervalMs: 50,
+        deadline: Date.now() + 5000,
+      });
+    } finally {
+      await new Promise((r) => server.close(r));
+    }
+  });
+
+  it("rejects when nothing is listening before the deadline", async function () {
+    const port = await findFreePort();
+    await assert.rejects(
+      waitForPort("127.0.0.1", port, {
+        pollIntervalMs: 50,
+        deadline: Date.now() + 300,
+      }),
+      /did not open in time/
+    );
+  });
+});
+
+describe("waitForHttp", function () {
+  this.timeout(10000);
+
+  it("resolves when the endpoint returns an expected status", async function () {
+    const port = await findFreePort();
+    const server = http.createServer((req, res) => {
+      res.statusCode = 200;
+      res.end("ok");
+    });
+    await new Promise((r) => server.listen(port, "127.0.0.1", r));
+    try {
+      await waitForHttp(`http://127.0.0.1:${port}/`, [200], {
+        pollIntervalMs: 50,
+        deadline: Date.now() + 5000,
+      });
+    } finally {
+      await new Promise((r) => server.close(r));
+    }
+  });
+
+  it("rejects when the status never matches before the deadline", async function () {
+    const port = await findFreePort();
+    const server = http.createServer((req, res) => {
+      res.statusCode = 503;
+      res.end("nope");
+    });
+    await new Promise((r) => server.listen(port, "127.0.0.1", r));
+    try {
+      await assert.rejects(
+        waitForHttp(`http://127.0.0.1:${port}/`, [200], {
+          pollIntervalMs: 50,
+          deadline: Date.now() + 400,
+        }),
+        /did not return/
+      );
+    } finally {
+      await new Promise((r) => server.close(r));
+    }
+  });
+});
+
+describe("waitForLog", function () {
+  this.timeout(10000);
+
+  it("resolves when already-buffered output matches", async function () {
+    const bg = fakeBg();
+    bg._emit("server ready to accept connections\n");
+    await waitForLog(bg, "ready to accept", "any", {
+      deadline: Date.now() + 1000,
+    });
+  });
+
+  it("resolves when a later chunk matches on the chosen stream", async function () {
+    const bg = fakeBg();
+    const p = waitForLog(bg, "listening", "stderr", {
+      deadline: Date.now() + 2000,
+    });
+    bg._emit("noise on stdout\n", "stdout");
+    bg._emit("now listening on 8080\n", "stderr");
+    await p;
+  });
+
+  it("rejects when the pattern is never seen before the deadline", async function () {
+    const bg = fakeBg();
+    await assert.rejects(
+      waitForLog(bg, "never-appears", "any", { deadline: Date.now() + 200 }),
+      /not seen in time/
+    );
+  });
+});
+
+describe("waitForReady", function () {
+  this.timeout(10000);
+
+  it("resolves after a delayMs probe", async function () {
+    const bg = fakeBg();
+    const start = Date.now();
+    await waitForReady(bg, { delayMs: 100 }, { timeoutMs: 5000 });
+    assert.ok(Date.now() - start >= 90);
+  });
+
+  it("resolves immediately when no readyWhen is given", async function () {
+    const bg = fakeBg();
+    await waitForReady(bg, undefined, { timeoutMs: 5000 });
+  });
+
+  it("resolves via a port probe", async function () {
+    const port = await findFreePort();
+    const server = net.createServer();
+    await new Promise((r) => server.listen(port, "127.0.0.1", r));
+    const bg = fakeBg();
+    try {
+      await waitForReady(
+        bg,
+        { port: { port, host: "127.0.0.1", pollIntervalMs: 50 } },
+        { timeoutMs: 5000 }
+      );
+    } finally {
+      await new Promise((r) => server.close(r));
+    }
+  });
+
+  it("fails fast when the process exits before becoming ready", async function () {
+    const port = await findFreePort(); // nothing listening here
+    const bg = fakeBg({ exited: Promise.resolve(1) });
+    await assert.rejects(
+      waitForReady(
+        bg,
+        { port: { port, host: "127.0.0.1", pollIntervalMs: 50 } },
+        { timeoutMs: 5000 }
+      ),
+      /exited before becoming ready/
+    );
+  });
+});
+
+describe("stopProcess", function () {
+  this.timeout(15000);
+
+  function spawnLongLived() {
+    const tmp = path.join(
+      os.tmpdir(),
+      `dd-stop-test-${process.pid}-${Math.floor(performance.now())}.js`
+    );
+    fs.writeFileSync(tmp, `setInterval(() => {}, 100000);`);
+    const bg = spawnBackgroundCommand(`"${process.execPath}" "${tmp}"`);
+    return { bg, tmp };
+  }
+
+  it("stops a registered process and removes it from the registry", async function () {
+    const { bg, tmp } = spawnLongLived();
+    const registry = new Map([["srv", { name: "srv", bg }]]);
+    const result = await stopProcess({
+      config: {},
+      step: { stopProcess: "srv" },
+      processRegistry: registry,
+    });
+    assert.equal(result.status, "PASS");
+    assert.equal(registry.has("srv"), false);
+    await bg.exited; // process actually terminated
+    fs.rmSync(tmp, { force: true });
+  });
+
+  it("removes a deferred temp script when stopping a runCode-style process", async function () {
+    const { bg, tmp } = spawnLongLived();
+    const registry = new Map([["api", { name: "api", bg, tempPath: tmp }]]);
+    const result = await stopProcess({
+      config: {},
+      step: { stopProcess: { name: "api" } },
+      processRegistry: registry,
+    });
+    assert.equal(result.status, "PASS");
+    await bg.exited;
+    assert.equal(fs.existsSync(tmp), false, "temp script should be deleted");
+  });
+
+  it("passes for a missing process when ignoreMissing is true", async function () {
+    const registry = new Map();
+    const result = await stopProcess({
+      config: {},
+      step: { stopProcess: { name: "nope", ignoreMissing: true } },
+      processRegistry: registry,
+    });
+    assert.equal(result.status, "PASS");
+  });
+
+  it("fails for a missing process when ignoreMissing is false", async function () {
+    const registry = new Map();
+    const result = await stopProcess({
+      config: {},
+      step: { stopProcess: "nope" },
+      processRegistry: registry,
+    });
+    assert.equal(result.status, "FAIL");
+  });
+});
+
+describe("runShell/runCode background (integration)", function () {
+  this.timeout(20000);
+
+  it("runShell starts a background server, becomes ready, and is stoppable", async function () {
+    const port = await findFreePort();
+    const tmp = path.join(os.tmpdir(), `dd-srv-${process.pid}.js`);
+    fs.writeFileSync(
+      tmp,
+      `require('http').createServer((q,r)=>r.end('ok')).listen(+process.argv[2]);`
+    );
+    const registry = new Map();
+    try {
+      const result = await runShell({
+        config: {},
+        step: {
+          runShell: {
+            command: `"${process.execPath}" "${tmp}" ${port}`,
+            background: true,
+            name: "web",
+            readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+            timeout: 10000,
+          },
+        },
+        processRegistry: registry,
+      });
+      assert.equal(result.status, "PASS");
+      assert.equal(result.outputs.name, "web");
+      assert.equal(result.outputs.ready, "true");
+      assert.ok(registry.has("web"));
+      // Port is actually accepting connections.
+      await waitForPort("127.0.0.1", port, {
+        pollIntervalMs: 100,
+        deadline: Date.now() + 2000,
+      });
+    } finally {
+      await stopProcess({
+        config: {},
+        step: { stopProcess: { name: "web", ignoreMissing: true } },
+        processRegistry: registry,
+      });
+      fs.rmSync(tmp, { force: true });
+    }
+  });
+
+  it("runShell fails on a name collision", async function () {
+    const registry = new Map([["web", { name: "web", bg: { pid: undefined } }]]);
+    const result = await runShell({
+      config: {},
+      step: {
+        runShell: {
+          command: "echo hi",
+          background: true,
+          name: "web",
+          readyWhen: { delayMs: 10 },
+        },
+      },
+      processRegistry: registry,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.match(result.description, /already running/);
+  });
+
+  it("runShell fails and deregisters when readiness times out", async function () {
+    const port = await findFreePort(); // nothing will ever listen here
+    const tmp = path.join(os.tmpdir(), `dd-noready-${process.pid}.js`);
+    fs.writeFileSync(tmp, `setInterval(() => {}, 100000);`);
+    const registry = new Map();
+    const result = await runShell({
+      config: {},
+      step: {
+        runShell: {
+          command: `"${process.execPath}" "${tmp}"`,
+          background: true,
+          name: "stuck",
+          readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+          timeout: 600,
+        },
+      },
+      processRegistry: registry,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.match(result.description, /failed to become ready/);
+    assert.equal(registry.has("stuck"), false);
+    fs.rmSync(tmp, { force: true });
+  });
+
+  it("runCode starts a background server and defers temp-script cleanup", async function () {
+    const port = await findFreePort();
+    const registry = new Map();
+    try {
+      const result = await runCode({
+        config: {},
+        step: {
+          runCode: {
+            language: "javascript",
+            code: `require('http').createServer((q,r)=>r.end('ok')).listen(${port});`,
+            background: true,
+            name: "api",
+            readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+            timeout: 10000,
+          },
+        },
+        processRegistry: registry,
+      });
+      assert.equal(result.status, "PASS");
+      assert.ok(registry.has("api"));
+      const entry = registry.get("api");
+      assert.ok(entry.tempPath, "temp script path should be retained on the entry");
+      assert.equal(fs.existsSync(entry.tempPath), true, "temp script kept while running");
+    } finally {
+      const entry = registry.get("api");
+      const tempPath = entry?.tempPath;
+      await stopProcess({
+        config: {},
+        step: { stopProcess: { name: "api", ignoreMissing: true } },
+        processRegistry: registry,
+      });
+      if (tempPath) assert.equal(fs.existsSync(tempPath), false, "temp script removed on stop");
+    }
+  });
+});

--- a/test/background-runner.test.js
+++ b/test/background-runner.test.js
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { runTests } from "../dist/core/index.js";
+import { findFreePort } from "../dist/core/utils.js";
+
+// Poll-bind a port until it is free (the OS may take a moment to release it
+// after the background process is killed).
+async function assertPortFree(port, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const free = await new Promise((resolve) => {
+      const s = net.createServer();
+      s.once("error", () => resolve(false));
+      s.listen(port, "127.0.0.1", () => s.close(() => resolve(true)));
+    });
+    if (free) return;
+    if (Date.now() > deadline) throw new Error(`Port ${port} still in use`);
+    await new Promise((r) => setTimeout(r, 150));
+  }
+}
+
+function serverCode(port) {
+  return `require('http').createServer((q,r)=>r.end('ok')).listen(${port});`;
+}
+
+describe("Background processes via runTests", function () {
+  this.timeout(60000);
+
+  it("starts a background process and stops it with stopProcess", async function () {
+    const port = await findFreePort();
+    const spec = {
+      tests: [
+        {
+          steps: [
+            {
+              runCode: {
+                language: "javascript",
+                code: serverCode(port),
+                background: true,
+                name: "srv",
+                readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+                timeout: 15000,
+              },
+            },
+            { stopProcess: "srv" },
+          ],
+        },
+      ],
+    };
+    const tempFilePath = path.resolve("./test/temp-bg-stop.json");
+    fs.writeFileSync(tempFilePath, JSON.stringify(spec, null, 2));
+    try {
+      const result = await runTests({ input: tempFilePath, logLevel: "silent" });
+      assert.equal(result.summary.steps.fail, 0, "no steps should fail");
+      assert.equal(result.summary.steps.pass, 2, "both steps should pass");
+      await assertPortFree(port);
+    } finally {
+      fs.rmSync(tempFilePath, { force: true });
+    }
+  });
+
+  it("auto-tears-down a background process left running at run end", async function () {
+    const port = await findFreePort();
+    const spec = {
+      tests: [
+        {
+          steps: [
+            {
+              runCode: {
+                language: "javascript",
+                code: serverCode(port),
+                background: true,
+                name: "leaked",
+                readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+                timeout: 15000,
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const tempFilePath = path.resolve("./test/temp-bg-autosweep.json");
+    fs.writeFileSync(tempFilePath, JSON.stringify(spec, null, 2));
+    try {
+      const result = await runTests({ input: tempFilePath, logLevel: "silent" });
+      assert.equal(result.summary.steps.fail, 0, "the start step should pass");
+      // No stopProcess step — the run-end sweep must have killed it.
+      await assertPortFree(port);
+    } finally {
+      fs.rmSync(tempFilePath, { force: true });
+    }
+  });
+});

--- a/test/background-runner.test.js
+++ b/test/background-runner.test.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
+import os from "node:os";
 import assert from "node:assert/strict";
 import { runTests } from "../dist/core/index.js";
 import { findFreePort } from "../dist/core/utils.js";
@@ -49,7 +50,7 @@ describe("Background processes via runTests", function () {
         },
       ],
     };
-    const tempFilePath = path.resolve("./test/temp-bg-stop.json");
+    const tempFilePath = path.join(os.tmpdir(), `dd-temp-bg-stop-${process.pid}.json`);
     fs.writeFileSync(tempFilePath, JSON.stringify(spec, null, 2));
     try {
       const result = await runTests({ input: tempFilePath, logLevel: "silent" });
@@ -81,7 +82,7 @@ describe("Background processes via runTests", function () {
         },
       ],
     };
-    const tempFilePath = path.resolve("./test/temp-bg-autosweep.json");
+    const tempFilePath = path.join(os.tmpdir(), `dd-temp-bg-autosweep-${process.pid}.json`);
     fs.writeFileSync(tempFilePath, JSON.stringify(spec, null, 2));
     try {
       const result = await runTests({ input: tempFilePath, logLevel: "silent" });

--- a/test/core-artifacts/background-processes.spec.json
+++ b/test/core-artifacts/background-processes.spec.json
@@ -1,0 +1,163 @@
+{
+  "specId": "background-processes",
+  "description": "Exercises long-running background processes end-to-end: `background: true` on runCode/runShell with each readyWhen probe (port, log, httpGet, delayMs), stopProcess in string and object form, the ignoreMissing path, and the run-end auto-sweep (a process left running with no stopProcess). All steps are non-driver (Node only), so they run and PASS on every platform; each test uses a distinct port and process name to stay safe under concurrentRunners.",
+  "tests": [
+    {
+      "testId": "bg-runcode-port",
+      "description": "runCode background server, port readiness probe, stopped via stopProcess string form.",
+      "steps": [
+        {
+          "runCode": {
+            "language": "javascript",
+            "code": "require('http').createServer((q,r)=>r.end('ok')).listen(8201,'127.0.0.1');",
+            "background": true,
+            "name": "bg-port",
+            "readyWhen": {
+              "port": {
+                "port": 8201,
+                "host": "127.0.0.1"
+              }
+            },
+            "timeout": 15000
+          }
+        },
+        {
+          "stopProcess": "bg-port"
+        }
+      ]
+    },
+    {
+      "testId": "bg-runcode-log",
+      "description": "runCode background process, log-pattern readiness probe, stopped via stopProcess object form.",
+      "steps": [
+        {
+          "runCode": {
+            "language": "javascript",
+            "code": "console.log('DD_BG_READY'); setInterval(() => {}, 1000000);",
+            "background": true,
+            "name": "bg-log",
+            "readyWhen": {
+              "log": {
+                "pattern": "DD_BG_READY",
+                "stream": "stdout"
+              }
+            },
+            "timeout": 15000
+          }
+        },
+        {
+          "stopProcess": {
+            "name": "bg-log"
+          }
+        }
+      ]
+    },
+    {
+      "testId": "bg-runcode-httpget",
+      "description": "runCode background server, httpGet readiness probe, stopped via stopProcess.",
+      "steps": [
+        {
+          "runCode": {
+            "language": "javascript",
+            "code": "require('http').createServer((q,r)=>r.end('ok')).listen(8202,'127.0.0.1');",
+            "background": true,
+            "name": "bg-http",
+            "readyWhen": {
+              "httpGet": {
+                "url": "http://127.0.0.1:8202",
+                "statusCodes": [
+                  200
+                ]
+              }
+            },
+            "timeout": 15000
+          }
+        },
+        {
+          "stopProcess": "bg-http"
+        }
+      ]
+    },
+    {
+      "testId": "bg-runcode-delay",
+      "description": "runCode background process, fixed-delay readiness probe, stopped via stopProcess.",
+      "steps": [
+        {
+          "runCode": {
+            "language": "javascript",
+            "code": "setInterval(() => {}, 1000000);",
+            "background": true,
+            "name": "bg-delay",
+            "readyWhen": {
+              "delayMs": 300
+            },
+            "timeout": 15000
+          }
+        },
+        {
+          "stopProcess": "bg-delay"
+        }
+      ]
+    },
+    {
+      "testId": "bg-runshell-port",
+      "description": "runShell background server (node bg-server.js), port readiness probe, stopped via stopProcess.",
+      "steps": [
+        {
+          "runShell": {
+            "command": "node",
+            "args": [
+              "test/core-artifacts/bg-server.js",
+              "8203"
+            ],
+            "background": true,
+            "name": "bg-shell",
+            "readyWhen": {
+              "port": {
+                "port": 8203,
+                "host": "127.0.0.1"
+              }
+            },
+            "timeout": 15000
+          }
+        },
+        {
+          "stopProcess": "bg-shell"
+        }
+      ]
+    },
+    {
+      "testId": "bg-autosweep",
+      "description": "Background process started with no stopProcess — the run-end sweep must tear it down. The start step PASSES; cleanup is implicit.",
+      "steps": [
+        {
+          "runCode": {
+            "language": "javascript",
+            "code": "require('http').createServer((q,r)=>r.end('ok')).listen(8204,'127.0.0.1');",
+            "background": true,
+            "name": "bg-autosweep",
+            "readyWhen": {
+              "port": {
+                "port": 8204,
+                "host": "127.0.0.1"
+              }
+            },
+            "timeout": 15000
+          }
+        }
+      ]
+    },
+    {
+      "testId": "bg-stopprocess-ignoremissing",
+      "description": "stopProcess with ignoreMissing on a name that was never started PASSES instead of failing.",
+      "steps": [
+        {
+          "stopProcess": {
+            "name": "bg-never-started",
+            "ignoreMissing": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/core-artifacts/bg-server.js
+++ b/test/core-artifacts/bg-server.js
@@ -1,0 +1,8 @@
+// Long-running HTTP server used by background-process fixtures
+// (test/core-artifacts/background-processes.spec.json) to exercise a
+// `runShell` step with `background: true`. Cross-platform (Node only).
+// ESM, because the repo's package.json sets "type": "module".
+// Usage: node bg-server.js <port>
+import http from "node:http";
+const port = Number(process.argv[2] || 0);
+http.createServer((req, res) => res.end("ok")).listen(port, "127.0.0.1");


### PR DESCRIPTION
## What & why

`runShell` and `runCode` are currently blocking — they spawn a process, wait for it to exit, then assert on the result. There's no way to start a long-lived process (a docker container, dev server, or database) during setup, keep it running while many tests execute, and tear it down at cleanup.

This adds a **`background: true`** mode plus a **`stopProcess`** step so authors can do exactly that. It's generic — any long-running process, not docker-specific.

## How it works

```jsonc
// setup (e.g. in a beforeAny spec)
{ "runShell": {
    "command": "docker run -p 8080:80 nginx",
    "background": true,
    "name": "web",
    "readyWhen": { "httpGet": { "url": "http://localhost:8080", "statusCodes": [200] } },
    "timeout": 30000
} }
// ...many tests run against it...
// cleanup
{ "stopProcess": "web" }
```

- **`background: true`** spawns non-blocking and returns as soon as `readyWhen` is satisfied. `name` is required (enforced by schema `if/then`). In background mode, `timeout` is the readiness deadline and the exit-code/stdio/output assertions don't apply.
- **`readyWhen`** supports four probes (exactly one): `port` (TCP), `log` (regex on output), `httpGet` (status), `delayMs`.
- **`stopProcess`** (`"name"` or `{ name, ignoreMissing }`) tree-kills the process by name.
- A **run-level process registry** owned by `runSpecs` holds processes so they survive across specs/tests. The existing Appium-teardown `finally` also **auto-sweeps** any background process the run didn't explicitly stop, and new **SIGINT/SIGTERM** handlers tear down background processes, Appium, and Xvfb on Ctrl-C (these leaked before).
- `runCode` defers temp-script deletion to teardown for background scripts (otherwise the interpreter would be reading a deleted file).

## Reviewer notes

- **Generated schema artifacts are intentionally not committed.** `output_schemas/*`, `schemas.json`, and `src/common/src/types/generated/*` are regenerated by `npm run build`, which CI runs before tests. next's committed copies are already regenerated-on-build, so committing them here would add tens of thousands of lines of unrelated churn. The source of truth in this PR is `src_schemas/*` + `dereferenceSchemas.cjs`.
- **Concurrency:** background processes are owned by the single run-level registry; `concurrentRunners` behavior is unchanged. Per-runner/shared-process semantics under concurrency are out of scope here.

## Tests

- Schema positives/negatives in `validate.test.js` (all four probes, both `stopProcess` forms, missing-name, two-probe, out-of-range, whitespace-name).
- `test/background-process.test.js` — unit coverage of `spawnBackgroundCommand`, each readiness probe + timeout paths, `stopProcess`, and the real `runShell`/`runCode` background branches (readiness, outputs, name collision, timeout-deregister, deferred temp cleanup).
- `test/background-runner.test.js` — end-to-end via `runTests`: explicit `stopProcess` and the run-end auto-sweep (asserts the port is freed afterward).
- Verified locally: full `npm run build` (733 common tests), the new suites, and `utils`/`exports`/`dryRun` regression runs all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)