### PR TITLE
refactor(runner): make runShell/runCode `background` an object with name + readyWhen

### DIFF
--- a/adrs/01002-background-processes.md
+++ b/adrs/01002-background-processes.md
@@ -45,13 +45,16 @@ to config, which is harder to reason about per-spec and doesn't compose with rou
 
 Mechanism:
 
-1. **`background: true`** on `runShell`/`runCode` (`src/core/tests/runShell.ts`,
-   `runCode.ts`): spawn non-blocking via `spawnBackgroundCommand` and return as soon as the process
-   is ready. In background mode the exit-code / stdio / saved-output assertions don't apply, and
-   `timeout` is reinterpreted as the **readiness deadline**. A `name` (required by schema when
-   `background: true`) keys the process in the registry; a duplicate name FAILs rather than
-   double-spawning.
-2. **`readyWhen`** gate with exactly one of four probes (`src/core/utils.ts`): `port` (TCP connect),
+1. **`background` object** on `runShell`/`runCode` (`src/core/tests/runShell.ts`,
+   `runCode.ts`): a `background: { name, readyWhen? }` object whose *presence* signals background
+   mode (there is no `background: false` — omit it for a normal blocking run). Spawn non-blocking via
+   `spawnBackgroundCommand` and return as soon as the process is ready. In background mode the
+   exit-code / stdio / saved-output assertions don't apply, and step-level `timeout` is reinterpreted
+   as the **readiness deadline**. `name` is required inside `background` and keys the process in the
+   registry; a duplicate name FAILs rather than double-spawning. (An earlier iteration used a boolean
+   `background: true` with sibling `name`/`readyWhen`; collapsing the three into one cohesive object
+   keeps the related fields together and makes "is this backgrounded?" a single presence check.)
+2. **`readyWhen`** (inside `background`, optional) gate with exactly one of four probes (`src/core/utils.ts`): `port` (TCP connect),
    `httpGet` (status code), `log` (regex over buffered output), `delayMs` (fixed wait). Readiness is
    raced against process exit, so a process that dies during startup FAILs fast instead of waiting
    the whole deadline.

--- a/src/common/src/schemas/src_schemas/runCode_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/runCode_v3.schema.json
@@ -91,120 +91,112 @@
           },
           "timeout": {
             "type": "integer",
-            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails. When `background` is `true`, this is instead the max time to wait for `readyWhen` to be satisfied before the step fails.",
+            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails. When `background` is set, this is instead the max time to wait for `background.readyWhen` to be satisfied before the step fails.",
             "default": 60000
           },
           "background": {
-            "type": "boolean",
-            "description": "If `true`, start the code as a long-running background process and return immediately instead of waiting for it to exit. Requires `name`. When `true`, `exitCodes`, `stdio`, and output saving (`path`, `directory`, `maxVariation`, `overwrite`) are ignored, and `timeout` is the max time to wait for `readyWhen`. The process is owned by the run and is stopped by a `stopProcess` step or automatically when the run finishes.",
-            "default": false
-          },
-          "name": {
-            "type": "string",
-            "description": "Unique identifier for a background process within the run. Required when `background` is `true`. Reference it from a `stopProcess` step to stop the process.",
-            "minLength": 1,
-            "pattern": "\\S",
-            "transform": ["trim"]
-          },
-          "readyWhen": {
             "type": "object",
-            "description": "Gate that blocks the step until the background process is ready. Only applies when `background` is `true` (otherwise it is ignored). Specify exactly one probe. Note: a process that forks a daemon and then exits (common for some Docker images and databases) is treated as having exited before becoming ready and the step fails — use a `port`, `httpGet`, or `delayMs` probe for those rather than relying on the foreground process staying alive.",
+            "description": "Start the code as a long-running background process and return as soon as it is ready, instead of waiting for it to exit. When set, `exitCodes`, `stdio`, and output saving (`path`, `directory`, `maxVariation`, `overwrite`) are ignored, and `timeout` is the max time to wait for `readyWhen`. The process is owned by the run and is stopped by a `stopProcess` step or automatically when the run finishes.",
             "additionalProperties": false,
-            "oneOf": [
-              { "required": ["port"] },
-              { "required": ["log"] },
-              { "required": ["httpGet"] },
-              { "required": ["delayMs"] }
-            ],
+            "required": ["name"],
             "properties": {
-              "port": {
+              "name": {
+                "type": "string",
+                "description": "Unique identifier for this background process within the run. Reference it from a `stopProcess` step to stop it.",
+                "minLength": 1,
+                "pattern": "\\S",
+                "transform": ["trim"]
+              },
+              "readyWhen": {
                 "type": "object",
-                "description": "Wait until a TCP port accepts connections.",
+                "description": "Gate that blocks the step until the background process is ready. Specify exactly one probe. Omit to consider the process ready as soon as it is spawned. Note: a process that forks a daemon and then exits (common for some Docker images and databases) is treated as having exited before becoming ready and the step fails — use a `port`, `httpGet`, or `delayMs` probe for those rather than relying on the foreground process staying alive.",
                 "additionalProperties": false,
-                "required": ["port"],
+                "oneOf": [
+                  { "required": ["port"] },
+                  { "required": ["log"] },
+                  { "required": ["httpGet"] },
+                  { "required": ["delayMs"] }
+                ],
                 "properties": {
                   "port": {
-                    "type": "integer",
-                    "description": "TCP port to probe.",
-                    "minimum": 1,
-                    "maximum": 65535
+                    "type": "object",
+                    "description": "Wait until a TCP port accepts connections.",
+                    "additionalProperties": false,
+                    "required": ["port"],
+                    "properties": {
+                      "port": {
+                        "type": "integer",
+                        "description": "TCP port to probe.",
+                        "minimum": 1,
+                        "maximum": 65535
+                      },
+                      "host": {
+                        "type": "string",
+                        "description": "Host to probe.",
+                        "default": "127.0.0.1"
+                      },
+                      "pollIntervalMs": {
+                        "type": "integer",
+                        "description": "Milliseconds between connection attempts.",
+                        "minimum": 50,
+                        "default": 500
+                      }
+                    }
                   },
-                  "host": {
-                    "type": "string",
-                    "description": "Host to probe.",
-                    "default": "127.0.0.1"
+                  "log": {
+                    "type": "object",
+                    "description": "Wait until the process's output matches a regular expression.",
+                    "additionalProperties": false,
+                    "required": ["pattern"],
+                    "properties": {
+                      "pattern": {
+                        "type": "string",
+                        "description": "Regular expression source (no surrounding slashes) tested against the process output.",
+                        "minLength": 1
+                      },
+                      "stream": {
+                        "type": "string",
+                        "description": "Which stream to match against. With `any`, buffered stdout and stderr are concatenated (all stdout, then all stderr), not interleaved in emission order — a pattern that depends on the time-ordering of output across both streams may not match; target a single stream for that.",
+                        "enum": ["stdout", "stderr", "any"],
+                        "default": "any"
+                      }
+                    }
                   },
-                  "pollIntervalMs": {
+                  "httpGet": {
+                    "type": "object",
+                    "description": "Wait until an HTTP GET request returns an expected status code.",
+                    "additionalProperties": false,
+                    "required": ["url"],
+                    "properties": {
+                      "url": {
+                        "type": "string",
+                        "description": "URL to request."
+                      },
+                      "statusCodes": {
+                        "type": "array",
+                        "description": "Status codes that indicate readiness.",
+                        "items": {
+                          "type": "integer"
+                        },
+                        "default": [200]
+                      },
+                      "pollIntervalMs": {
+                        "type": "integer",
+                        "description": "Milliseconds between requests.",
+                        "minimum": 50,
+                        "default": 500
+                      }
+                    }
+                  },
+                  "delayMs": {
                     "type": "integer",
-                    "description": "Milliseconds between connection attempts.",
-                    "minimum": 50,
-                    "default": 500
+                    "description": "Fixed delay in milliseconds before considering the process ready.",
+                    "minimum": 0
                   }
                 }
-              },
-              "log": {
-                "type": "object",
-                "description": "Wait until the process's output matches a regular expression.",
-                "additionalProperties": false,
-                "required": ["pattern"],
-                "properties": {
-                  "pattern": {
-                    "type": "string",
-                    "description": "Regular expression source (no surrounding slashes) tested against the process output.",
-                    "minLength": 1
-                  },
-                  "stream": {
-                    "type": "string",
-                    "description": "Which stream to match against. With `any`, buffered stdout and stderr are concatenated (all stdout, then all stderr), not interleaved in emission order — a pattern that depends on the time-ordering of output across both streams may not match; target a single stream for that.",
-                    "enum": ["stdout", "stderr", "any"],
-                    "default": "any"
-                  }
-                }
-              },
-              "httpGet": {
-                "type": "object",
-                "description": "Wait until an HTTP GET request returns an expected status code.",
-                "additionalProperties": false,
-                "required": ["url"],
-                "properties": {
-                  "url": {
-                    "type": "string",
-                    "description": "URL to request."
-                  },
-                  "statusCodes": {
-                    "type": "array",
-                    "description": "Status codes that indicate readiness.",
-                    "items": {
-                      "type": "integer"
-                    },
-                    "default": [200]
-                  },
-                  "pollIntervalMs": {
-                    "type": "integer",
-                    "description": "Milliseconds between requests.",
-                    "minimum": 50,
-                    "default": 500
-                  }
-                }
-              },
-              "delayMs": {
-                "type": "integer",
-                "description": "Fixed delay in milliseconds before considering the process ready.",
-                "minimum": 0
               }
             }
           }
-        },
-        "if": {
-          "properties": {
-            "background": {
-              "const": true
-            }
-          },
-          "required": ["background"]
-        },
-        "then": {
-          "required": ["name"]
         },
         "title": "Run code (detailed)"
       }
@@ -247,11 +239,12 @@
     {
       "language": "javascript",
       "code": "require('http').createServer((req, res) => res.end('ok')).listen(8088);",
-      "background": true,
-      "name": "api",
-      "readyWhen": {
-        "port": {
-          "port": 8088
+      "background": {
+        "name": "api",
+        "readyWhen": {
+          "port": {
+            "port": 8088
+          }
         }
       },
       "timeout": 15000

--- a/src/common/src/schemas/src_schemas/runShell_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/runShell_v3.schema.json
@@ -93,120 +93,112 @@
           },
           "timeout": {
             "type": "integer",
-            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails. When `background` is `true`, this is instead the max time to wait for `readyWhen` to be satisfied before the step fails.",
+            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails. When `background` is set, this is instead the max time to wait for `background.readyWhen` to be satisfied before the step fails.",
             "default": 60000
           },
           "background": {
-            "type": "boolean",
-            "description": "If `true`, start the command as a long-running background process and return immediately instead of waiting for it to exit. Requires `name`. When `true`, `exitCodes`, `stdio`, and output saving (`path`, `directory`, `maxVariation`, `overwrite`) are ignored, and `timeout` is the max time to wait for `readyWhen`. The process is owned by the run and is stopped by a `stopProcess` step or automatically when the run finishes.",
-            "default": false
-          },
-          "name": {
-            "type": "string",
-            "description": "Unique identifier for a background process within the run. Required when `background` is `true`. Reference it from a `stopProcess` step to stop the process.",
-            "minLength": 1,
-            "pattern": "\\S",
-            "transform": ["trim"]
-          },
-          "readyWhen": {
             "type": "object",
-            "description": "Gate that blocks the step until the background process is ready. Only applies when `background` is `true` (otherwise it is ignored). Specify exactly one probe. Note: a process that forks a daemon and then exits (common for some Docker images and databases) is treated as having exited before becoming ready and the step fails — use a `port`, `httpGet`, or `delayMs` probe for those rather than relying on the foreground process staying alive.",
+            "description": "Start the command as a long-running background process and return as soon as it is ready, instead of waiting for it to exit. When set, `exitCodes`, `stdio`, and output saving (`path`, `directory`, `maxVariation`, `overwrite`) are ignored, and `timeout` is the max time to wait for `readyWhen`. The process is owned by the run and is stopped by a `stopProcess` step or automatically when the run finishes.",
             "additionalProperties": false,
-            "oneOf": [
-              { "required": ["port"] },
-              { "required": ["log"] },
-              { "required": ["httpGet"] },
-              { "required": ["delayMs"] }
-            ],
+            "required": ["name"],
             "properties": {
-              "port": {
+              "name": {
+                "type": "string",
+                "description": "Unique identifier for this background process within the run. Reference it from a `stopProcess` step to stop it.",
+                "minLength": 1,
+                "pattern": "\\S",
+                "transform": ["trim"]
+              },
+              "readyWhen": {
                 "type": "object",
-                "description": "Wait until a TCP port accepts connections.",
+                "description": "Gate that blocks the step until the background process is ready. Specify exactly one probe. Omit to consider the process ready as soon as it is spawned. Note: a process that forks a daemon and then exits (common for some Docker images and databases) is treated as having exited before becoming ready and the step fails — use a `port`, `httpGet`, or `delayMs` probe for those rather than relying on the foreground process staying alive.",
                 "additionalProperties": false,
-                "required": ["port"],
+                "oneOf": [
+                  { "required": ["port"] },
+                  { "required": ["log"] },
+                  { "required": ["httpGet"] },
+                  { "required": ["delayMs"] }
+                ],
                 "properties": {
                   "port": {
-                    "type": "integer",
-                    "description": "TCP port to probe.",
-                    "minimum": 1,
-                    "maximum": 65535
+                    "type": "object",
+                    "description": "Wait until a TCP port accepts connections.",
+                    "additionalProperties": false,
+                    "required": ["port"],
+                    "properties": {
+                      "port": {
+                        "type": "integer",
+                        "description": "TCP port to probe.",
+                        "minimum": 1,
+                        "maximum": 65535
+                      },
+                      "host": {
+                        "type": "string",
+                        "description": "Host to probe.",
+                        "default": "127.0.0.1"
+                      },
+                      "pollIntervalMs": {
+                        "type": "integer",
+                        "description": "Milliseconds between connection attempts.",
+                        "minimum": 50,
+                        "default": 500
+                      }
+                    }
                   },
-                  "host": {
-                    "type": "string",
-                    "description": "Host to probe.",
-                    "default": "127.0.0.1"
+                  "log": {
+                    "type": "object",
+                    "description": "Wait until the process's output matches a regular expression.",
+                    "additionalProperties": false,
+                    "required": ["pattern"],
+                    "properties": {
+                      "pattern": {
+                        "type": "string",
+                        "description": "Regular expression source (no surrounding slashes) tested against the process output.",
+                        "minLength": 1
+                      },
+                      "stream": {
+                        "type": "string",
+                        "description": "Which stream to match against. With `any`, buffered stdout and stderr are concatenated (all stdout, then all stderr), not interleaved in emission order — a pattern that depends on the time-ordering of output across both streams may not match; target a single stream for that.",
+                        "enum": ["stdout", "stderr", "any"],
+                        "default": "any"
+                      }
+                    }
                   },
-                  "pollIntervalMs": {
+                  "httpGet": {
+                    "type": "object",
+                    "description": "Wait until an HTTP GET request returns an expected status code.",
+                    "additionalProperties": false,
+                    "required": ["url"],
+                    "properties": {
+                      "url": {
+                        "type": "string",
+                        "description": "URL to request."
+                      },
+                      "statusCodes": {
+                        "type": "array",
+                        "description": "Status codes that indicate readiness.",
+                        "items": {
+                          "type": "integer"
+                        },
+                        "default": [200]
+                      },
+                      "pollIntervalMs": {
+                        "type": "integer",
+                        "description": "Milliseconds between requests.",
+                        "minimum": 50,
+                        "default": 500
+                      }
+                    }
+                  },
+                  "delayMs": {
                     "type": "integer",
-                    "description": "Milliseconds between connection attempts.",
-                    "minimum": 50,
-                    "default": 500
+                    "description": "Fixed delay in milliseconds before considering the process ready.",
+                    "minimum": 0
                   }
                 }
-              },
-              "log": {
-                "type": "object",
-                "description": "Wait until the process's output matches a regular expression.",
-                "additionalProperties": false,
-                "required": ["pattern"],
-                "properties": {
-                  "pattern": {
-                    "type": "string",
-                    "description": "Regular expression source (no surrounding slashes) tested against the process output.",
-                    "minLength": 1
-                  },
-                  "stream": {
-                    "type": "string",
-                    "description": "Which stream to match against. With `any`, buffered stdout and stderr are concatenated (all stdout, then all stderr), not interleaved in emission order — a pattern that depends on the time-ordering of output across both streams may not match; target a single stream for that.",
-                    "enum": ["stdout", "stderr", "any"],
-                    "default": "any"
-                  }
-                }
-              },
-              "httpGet": {
-                "type": "object",
-                "description": "Wait until an HTTP GET request returns an expected status code.",
-                "additionalProperties": false,
-                "required": ["url"],
-                "properties": {
-                  "url": {
-                    "type": "string",
-                    "description": "URL to request."
-                  },
-                  "statusCodes": {
-                    "type": "array",
-                    "description": "Status codes that indicate readiness.",
-                    "items": {
-                      "type": "integer"
-                    },
-                    "default": [200]
-                  },
-                  "pollIntervalMs": {
-                    "type": "integer",
-                    "description": "Milliseconds between requests.",
-                    "minimum": 50,
-                    "default": 500
-                  }
-                }
-              },
-              "delayMs": {
-                "type": "integer",
-                "description": "Fixed delay in milliseconds before considering the process ready.",
-                "minimum": 0
               }
             }
           }
-        },
-        "if": {
-          "properties": {
-            "background": {
-              "const": true
-            }
-          },
-          "required": ["background"]
-        },
-        "then": {
-          "required": ["name"]
         },
         "title": "Run shell command (detailed)"
       }
@@ -264,14 +256,15 @@
     },
     {
       "command": "docker run -p 8080:80 nginx",
-      "background": true,
-      "name": "web",
-      "readyWhen": {
-        "httpGet": {
-          "url": "http://localhost:8080",
-          "statusCodes": [
-            200
-          ]
+      "background": {
+        "name": "web",
+        "readyWhen": {
+          "httpGet": {
+            "url": "http://localhost:8080",
+            "statusCodes": [
+              200
+            ]
+          }
         }
       },
       "timeout": 30000

--- a/src/common/src/schemas/src_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/step_v3.schema.json
@@ -575,12 +575,13 @@
     {
       "runShell": {
         "command": "docker run -p 8080:80 nginx",
-        "background": true,
-        "name": "web",
-        "readyWhen": {
-          "httpGet": {
-            "url": "http://localhost:8080",
-            "statusCodes": [200]
+        "background": {
+          "name": "web",
+          "readyWhen": {
+            "httpGet": {
+              "url": "http://localhost:8080",
+              "statusCodes": [200]
+            }
           }
         },
         "timeout": 30000

--- a/src/common/src/schemas/src_schemas/stopProcess_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/stopProcess_v3.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "stopProcess",
-  "description": "Stop and deregister a background process started by a `runShell` or `runCode` step with `background: true`.",
+  "description": "Stop and deregister a background process started by a `runShell` or `runCode` step with a `background` object.",
   "anyOf": [
     {
       "$ref": "#/components/schemas/string"

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -2352,9 +2352,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
           object: {
             runShell: {
               command: "docker run -p 5432:5432 postgres",
-              background: true,
-              name: "db",
-              readyWhen: { port: { port: 5432 } },
+              background: { name: "db", readyWhen: { port: { port: 5432 } } },
             },
           },
         });
@@ -2368,9 +2366,10 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
           object: {
             runShell: {
               command: "my-server",
-              background: true,
-              name: "srv",
-              readyWhen: { log: { pattern: "ready to accept", stream: "stdout" } },
+              background: {
+                name: "srv",
+                readyWhen: { log: { pattern: "ready to accept", stream: "stdout" } },
+              },
             },
           },
         });
@@ -2384,10 +2383,11 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
           object: {
             runShell: {
               command: "my-server",
-              background: true,
-              name: "web",
-              readyWhen: {
-                httpGet: { url: "http://localhost:8080", statusCodes: [200, 204] },
+              background: {
+                name: "web",
+                readyWhen: {
+                  httpGet: { url: "http://localhost:8080", statusCodes: [200, 204] },
+                },
               },
               timeout: 30000,
             },
@@ -2403,9 +2403,21 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
           object: {
             runShell: {
               command: "my-server",
-              background: true,
-              name: "srv",
-              readyWhen: { delayMs: 2000 },
+              background: { name: "srv", readyWhen: { delayMs: 2000 } },
+            },
+          },
+        });
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+      });
+
+      it("should validate a background with no readyWhen (ready on spawn)", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: { name: "srv" },
             },
           },
         });
@@ -2420,9 +2432,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
             runCode: {
               language: "javascript",
               code: "require('http').createServer((q,r)=>r.end('ok')).listen(8088)",
-              background: true,
-              name: "api",
-              readyWhen: { port: { port: 8088 } },
+              background: { name: "api", readyWhen: { port: { port: 8088 } } },
             },
           },
         });
@@ -2448,15 +2458,41 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.equal("");
       });
 
+      it("should reject a background that is not an object (e.g. true)", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: { command: "my-server", background: true },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+
+      it("should reject an unknown key inside background", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: { name: "srv", bogus: true },
+            },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+
       it("should reject a readyWhen with two probes", function () {
         const result = validate({
           schemaKey: "step_v3",
           object: {
             runShell: {
               command: "my-server",
-              background: true,
-              name: "srv",
-              readyWhen: { port: { port: 5432 }, delayMs: 1000 },
+              background: {
+                name: "srv",
+                readyWhen: { port: { port: 5432 }, delayMs: 1000 },
+              },
             },
           },
         });
@@ -2470,9 +2506,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
           object: {
             runShell: {
               command: "my-server",
-              background: true,
-              name: "srv",
-              readyWhen: { tcp: { port: 5432 } },
+              background: { name: "srv", readyWhen: { tcp: { port: 5432 } } },
             },
           },
         });
@@ -2486,8 +2520,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
           object: {
             runShell: {
               command: "my-server",
-              background: true,
-              readyWhen: { delayMs: 1000 },
+              background: { readyWhen: { delayMs: 1000 } },
             },
           },
         });
@@ -2502,8 +2535,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
             runCode: {
               language: "bash",
               code: "sleep 100",
-              background: true,
-              readyWhen: { delayMs: 1000 },
+              background: { readyWhen: { delayMs: 1000 } },
             },
           },
         });
@@ -2517,9 +2549,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
           object: {
             runShell: {
               command: "my-server",
-              background: true,
-              name: "srv",
-              readyWhen: { port: { port: 70000 } },
+              background: { name: "srv", readyWhen: { port: { port: 70000 } } },
             },
           },
         });
@@ -2542,9 +2572,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
           object: {
             runShell: {
               command: "my-server",
-              background: true,
-              name: "   ",
-              readyWhen: { delayMs: 1000 },
+              background: { name: "   ", readyWhen: { delayMs: 1000 } },
             },
           },
         });

--- a/src/core/tests/runCode.ts
+++ b/src/core/tests/runCode.ts
@@ -36,8 +36,9 @@ function createTempScript(code: string, language: string) {
   return tmpFile;
 }
 
-// Run gather, compile, and run code. When `step.runCode.background` is true, the
-// script is started as a long-running process via runShell and the temp script
+// Run gather, compile, and run code. When `step.runCode.background` is set (an
+// object with a `name` and optional `readyWhen`), the script is started as a
+// long-running process via runShell and the temp script
 // is kept on disk (deletion deferred to teardown) so the interpreter can keep
 // reading it.
 async function runCode({

--- a/src/core/tests/runCode.ts
+++ b/src/core/tests/runCode.ts
@@ -149,11 +149,10 @@ async function runCode({
         ? path.join(step.runCode.directory, step.runCode.path)
         : step.runCode.path;
     }
-    // Forward background settings so runShell starts and registers the process.
+    // Forward the background object (name + readyWhen) so runShell starts and
+    // registers the process.
     if (step.runCode.background) {
-      runShellOptions.background = true;
-      runShellOptions.name = step.runCode.name;
-      runShellOptions.readyWhen = step.runCode.readyWhen;
+      runShellOptions.background = step.runCode.background;
     }
     const shellStep: any = { runShell: runShellOptions };
 
@@ -176,7 +175,7 @@ async function runCode({
     // to the registry entry so teardown removes it after the process is killed.
     if (step.runCode.background && shellResult.status === "PASS") {
       deferTempCleanup = true;
-      const entry = processRegistry?.get(step.runCode.name);
+      const entry = processRegistry?.get(step.runCode.background.name);
       if (entry) entry.tempPath = scriptPath;
     }
   } catch (error: any) {

--- a/src/core/tests/runShell.ts
+++ b/src/core/tests/runShell.ts
@@ -69,8 +69,11 @@ async function runShell({
 
   // Background mode: start the process, register it, wait until ready, and
   // return immediately. `exitCodes`, `stdio`, and output saving don't apply.
+  // `background` is an object holding `name` and (optional) `readyWhen`; its
+  // presence signals background mode.
   if (step.runShell.background) {
-    const name = step.runShell.name;
+    const background = step.runShell.background;
+    const name = background.name;
     if (!name) {
       result.status = "FAIL";
       result.description = "Background processes require a `name`.";
@@ -106,7 +109,7 @@ async function runShell({
     processRegistry.set(name, entry);
 
     try {
-      await waitForReady(bg, step.runShell.readyWhen, {
+      await waitForReady(bg, background.readyWhen, {
         timeoutMs: step.runShell.timeout,
       });
     } catch (error: any) {

--- a/src/core/tests/runShell.ts
+++ b/src/core/tests/runShell.ts
@@ -17,10 +17,11 @@ import path from "node:path";
 
 export { runShell };
 
-// Run a shell command. When `step.runShell.background` is true, the command is
-// started as a long-running process registered in `processRegistry` and the step
-// returns as soon as `readyWhen` is satisfied; the process is torn down later by
-// a stopProcess step or the run-end sweep.
+// Run a shell command. When `step.runShell.background` is set (an object with a
+// `name` and optional `readyWhen`), the command is started as a long-running
+// process registered in `processRegistry` and the step returns as soon as
+// `readyWhen` is satisfied; the process is torn down later by a stopProcess step
+// or the run-end sweep.
 async function runShell({
   config,
   step,

--- a/src/core/tests/runShell.ts
+++ b/src/core/tests/runShell.ts
@@ -75,6 +75,9 @@ async function runShell({
   if (step.runShell.background) {
     const background = step.runShell.background;
     const name = background.name;
+    // The schema requires `name` when `background` is an object, so a
+    // schema-validated step always has it. This guard is defence-in-depth for
+    // programmatic callers that construct steps without validating.
     if (!name) {
       result.status = "FAIL";
       result.description = "Background processes require a `name`.";

--- a/src/core/tests/stopProcess.ts
+++ b/src/core/tests/stopProcess.ts
@@ -6,7 +6,7 @@ import fs from "node:fs";
 export { stopProcess };
 
 // Stop and deregister a background process started by a runShell/runCode step
-// with `background: true`.
+// with a `background` object.
 async function stopProcess({
   config,
   step,

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -234,7 +234,7 @@ async function findFreePort(): Promise<number> {
   });
 }
 
-// A handle to a long-running process started by a `background: true`
+// A handle to a long-running process started by a `background`
 // runShell/runCode step. Output is buffered (ring-capped) so readiness probes
 // and debugging can inspect it without waiting for the process to exit.
 interface BackgroundProcess {

--- a/test/background-process.test.js
+++ b/test/background-process.test.js
@@ -311,9 +311,10 @@ describe("runShell/runCode background (integration)", function () {
         step: {
           runShell: {
             command: `"${process.execPath}" "${tmp}" ${port}`,
-            background: true,
-            name: "web",
-            readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+            background: {
+              name: "web",
+              readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+            },
             timeout: 10000,
           },
         },
@@ -345,9 +346,7 @@ describe("runShell/runCode background (integration)", function () {
       step: {
         runShell: {
           command: "echo hi",
-          background: true,
-          name: "web",
-          readyWhen: { delayMs: 10 },
+          background: { name: "web", readyWhen: { delayMs: 10 } },
         },
       },
       processRegistry: registry,
@@ -366,9 +365,10 @@ describe("runShell/runCode background (integration)", function () {
       step: {
         runShell: {
           command: `"${process.execPath}" "${tmp}"`,
-          background: true,
-          name: "stuck",
-          readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+          background: {
+            name: "stuck",
+            readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+          },
           timeout: 600,
         },
       },
@@ -390,9 +390,10 @@ describe("runShell/runCode background (integration)", function () {
           runCode: {
             language: "javascript",
             code: `require('http').createServer((q,r)=>r.end('ok')).listen(${port});`,
-            background: true,
-            name: "api",
-            readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+            background: {
+              name: "api",
+              readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+            },
             timeout: 10000,
           },
         },

--- a/test/background-runner.test.js
+++ b/test/background-runner.test.js
@@ -39,9 +39,10 @@ describe("Background processes via runTests", function () {
               runCode: {
                 language: "javascript",
                 code: serverCode(port),
-                background: true,
-                name: "srv",
-                readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+                background: {
+                  name: "srv",
+                  readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+                },
                 timeout: 15000,
               },
             },
@@ -72,9 +73,10 @@ describe("Background processes via runTests", function () {
               runCode: {
                 language: "javascript",
                 code: serverCode(port),
-                background: true,
-                name: "leaked",
-                readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+                background: {
+                  name: "leaked",
+                  readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+                },
                 timeout: 15000,
               },
             },

--- a/test/core-artifacts/background-processes.spec.json
+++ b/test/core-artifacts/background-processes.spec.json
@@ -104,6 +104,25 @@
       ]
     },
     {
+      "testId": "bg-runcode-noprobe",
+      "description": "Background process with no readyWhen — ready as soon as it is spawned; stopped via stopProcess.",
+      "steps": [
+        {
+          "runCode": {
+            "language": "javascript",
+            "code": "setInterval(() => {}, 1000000);",
+            "background": {
+              "name": "bg-noprobe"
+            },
+            "timeout": 15000
+          }
+        },
+        {
+          "stopProcess": "bg-noprobe"
+        }
+      ]
+    },
+    {
       "testId": "bg-runshell-port",
       "description": "runShell background server (node bg-server.js), port readiness probe, stopped via stopProcess.",
       "steps": [

--- a/test/core-artifacts/background-processes.spec.json
+++ b/test/core-artifacts/background-processes.spec.json
@@ -1,6 +1,6 @@
 {
   "specId": "background-processes",
-  "description": "Exercises long-running background processes end-to-end: `background: true` on runCode/runShell with each readyWhen probe (port, log, httpGet, delayMs), stopProcess in string and object form, the ignoreMissing path, and the run-end auto-sweep (a process left running with no stopProcess). All steps are non-driver (Node only), so they run and PASS on every platform; each test uses a distinct port and process name to stay safe under concurrentRunners.",
+  "description": "Exercises long-running background processes end-to-end: a `background` object ({ name, readyWhen }) on runCode/runShell with each readyWhen probe (port, log, httpGet, delayMs), stopProcess in string and object form, the ignoreMissing path, and the run-end auto-sweep (a process left running with no stopProcess). All steps are non-driver (Node only), so they run and PASS on every platform; each test uses a distinct port and process name to stay safe under concurrentRunners.",
   "tests": [
     {
       "testId": "bg-runcode-port",
@@ -10,12 +10,13 @@
           "runCode": {
             "language": "javascript",
             "code": "require('http').createServer((q,r)=>r.end('ok')).listen(8201,'127.0.0.1');",
-            "background": true,
-            "name": "bg-port",
-            "readyWhen": {
-              "port": {
-                "port": 8201,
-                "host": "127.0.0.1"
+            "background": {
+              "name": "bg-port",
+              "readyWhen": {
+                "port": {
+                  "port": 8201,
+                  "host": "127.0.0.1"
+                }
               }
             },
             "timeout": 15000
@@ -34,12 +35,13 @@
           "runCode": {
             "language": "javascript",
             "code": "console.log('DD_BG_READY'); setInterval(() => {}, 1000000);",
-            "background": true,
-            "name": "bg-log",
-            "readyWhen": {
-              "log": {
-                "pattern": "DD_BG_READY",
-                "stream": "stdout"
+            "background": {
+              "name": "bg-log",
+              "readyWhen": {
+                "log": {
+                  "pattern": "DD_BG_READY",
+                  "stream": "stdout"
+                }
               }
             },
             "timeout": 15000
@@ -60,14 +62,15 @@
           "runCode": {
             "language": "javascript",
             "code": "require('http').createServer((q,r)=>r.end('ok')).listen(8202,'127.0.0.1');",
-            "background": true,
-            "name": "bg-http",
-            "readyWhen": {
-              "httpGet": {
-                "url": "http://127.0.0.1:8202",
-                "statusCodes": [
-                  200
-                ]
+            "background": {
+              "name": "bg-http",
+              "readyWhen": {
+                "httpGet": {
+                  "url": "http://127.0.0.1:8202",
+                  "statusCodes": [
+                    200
+                  ]
+                }
               }
             },
             "timeout": 15000
@@ -86,10 +89,11 @@
           "runCode": {
             "language": "javascript",
             "code": "setInterval(() => {}, 1000000);",
-            "background": true,
-            "name": "bg-delay",
-            "readyWhen": {
-              "delayMs": 300
+            "background": {
+              "name": "bg-delay",
+              "readyWhen": {
+                "delayMs": 300
+              }
             },
             "timeout": 15000
           }
@@ -110,12 +114,13 @@
               "test/core-artifacts/bg-server.js",
               "8203"
             ],
-            "background": true,
-            "name": "bg-shell",
-            "readyWhen": {
-              "port": {
-                "port": 8203,
-                "host": "127.0.0.1"
+            "background": {
+              "name": "bg-shell",
+              "readyWhen": {
+                "port": {
+                  "port": 8203,
+                  "host": "127.0.0.1"
+                }
               }
             },
             "timeout": 15000
@@ -134,12 +139,13 @@
           "runCode": {
             "language": "javascript",
             "code": "require('http').createServer((q,r)=>r.end('ok')).listen(8204,'127.0.0.1');",
-            "background": true,
-            "name": "bg-autosweep",
-            "readyWhen": {
-              "port": {
-                "port": 8204,
-                "host": "127.0.0.1"
+            "background": {
+              "name": "bg-autosweep",
+              "readyWhen": {
+                "port": {
+                  "port": 8204,
+                  "host": "127.0.0.1"
+                }
               }
             },
             "timeout": 15000

--- a/test/core-artifacts/background-processes.spec.json
+++ b/test/core-artifacts/background-processes.spec.json
@@ -1,6 +1,6 @@
 {
   "specId": "background-processes",
-  "description": "Exercises long-running background processes end-to-end: a `background` object ({ name, readyWhen }) on runCode/runShell with each readyWhen probe (port, log, httpGet, delayMs), stopProcess in string and object form, the ignoreMissing path, and the run-end auto-sweep (a process left running with no stopProcess). All steps are non-driver (Node only), so they run and PASS on every platform; each test uses a distinct port and process name to stay safe under concurrentRunners.",
+  "description": "Exercises long-running background processes end-to-end: a `background` object ({ name, readyWhen }) on runCode/runShell with each readyWhen probe (port, log, httpGet, delayMs) plus the no-readyWhen form (ready as soon as spawned), stopProcess in string and object form, the ignoreMissing path, and the run-end auto-sweep (a process left running with no stopProcess). All steps are non-driver (Node only), so they run and PASS on every platform; each test uses a distinct port and process name to stay safe under concurrentRunners.",
   "tests": [
     {
       "testId": "bg-runcode-port",

--- a/test/core-artifacts/bg-server.js
+++ b/test/core-artifacts/bg-server.js
@@ -1,6 +1,6 @@
 // Long-running HTTP server used by background-process fixtures
 // (test/core-artifacts/background-processes.spec.json) to exercise a
-// `runShell` step with `background: true`. Cross-platform (Node only).
+// `runShell` step with a `background` object. Cross-platform (Node only).
 // ESM, because the repo's package.json sets "type": "module".
 // Usage: node bg-server.js <port>
 import http from "node:http";


### PR DESCRIPTION
Follow-up to #381 (merged + released as `4.15.0-next.15`). Reshapes the background-process API so `background` is a single object holding `name` and `readyWhen`, instead of a boolean flag with sibling fields.

```jsonc
// before (4.15.0-next.15)
{ "runShell": { "command": "…", "background": true, "name": "web", "readyWhen": { "httpGet": { … } } } }
// after (this PR)
{ "runShell": { "command": "…", "background": { "name": "web", "readyWhen": { "httpGet": { … } } } } }
```

### What & why
The three loosely-coupled siblings (`background`, `name`, `readyWhen`) collapse into one cohesive object whose *presence* signals background mode. There is no `background: false` — omit it for a normal blocking run. `name` is required inside `background`; `readyWhen` stays optional; step-level `timeout` is still the readiness deadline when `background` is set.

### ⚠️ Breaking change to the `next` prerelease
The boolean shape shipped in `4.15.0-next.15` on the **`next`** channel only (never on `latest`/stable). This PR changes that shape, so it's a breaking change to the prerelease API. Landing it as a fast-follow before `next` promotes to `main` means the boolean shape never reaches stable. Titled `refactor` (not `feat!`) per maintainer preference — squash/label as you see fit if you want semantic-release to record a major bump.

### Changes
- **Schema** (`runShell_v3`, `runCode_v3`): the `background`(boolean)/`name`/`readyWhen` siblings and the `if/then` collapse into one `background` object (`required: ["name"]`, optional `readyWhen`, `additionalProperties: false`). Updated `step_v3` + per-schema examples and the `stopProcess_v3` description.
- **Runtime**: `runShell` reads `name`/`readyWhen` from the object; `runCode` forwards the whole object and looks up the registry entry via `background.name`. The registry, `stopProcess`, dispatcher, and teardown are unchanged (still keyed by the name string).
- **Tests/fixtures/ADR** updated to the object shape, with new negatives (a non-object `background` like `true`, and unknown keys inside `background`, both rejected) and a positive for `background` with no `readyWhen`.
- Generated schema artifacts are not committed (CI regenerates via `npm run build`), consistent with #381.

### Verification
Local: `npm run build` (736 common tests), the background unit/integration suites (23 tests), and the `test/core-artifacts/background-processes.spec.json` fixture (7 tests / 12 steps) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)