### PR TITLE
refactor(runner): rename background readyWhen to waitUntil and flatten its conditions

### DIFF
--- a/adrs/01002-background-processes.md
+++ b/adrs/01002-background-processes.md
@@ -114,3 +114,36 @@ Mechanism:
   conditions, `stopProcess` string/object, `ignoreMissing`, auto-sweep, `runShell` and `runCode`
   background) and must resolve
   PASS/SKIPPED across the CI matrix (macOS / Linux / Windows × node 22/24).
+
+## Pros and Cons of the Options
+
+### A. `background` object + `waitUntil` gate + run-level registry + `stopProcess` step
+
+* Good, because it reuses the two step types authors already know (`runShell`/`runCode`) — no new
+  command/option surface to learn or maintain.
+* Good, because start/stop live in the visible step stream, so `beforeAny` start / `afterAll` stop
+  reads naturally and composes with routing.
+* Good, because the process is a run-owned resource modeled exactly like Appium (started once, torn
+  down once), reusing the existing teardown/finally machinery.
+* Good, because `waitUntil` mirrors goTo's terminology and runShell's flat field conventions, so the
+  readiness contract is familiar.
+* Bad, because the lifecycle spans multiple steps/specs (start here, stop there), so a missing
+  `stopProcess` relies on the run-end sweep rather than being structurally impossible.
+* Bad, because PID-based teardown can't guarantee cleanup on a hard kill (SIGKILL/power loss).
+
+### B. A dedicated `service`/`daemon` step type
+
+* Good, because the lifecycle could be self-contained in one declaration.
+* Bad, because it duplicates all of `runShell`/`runCode`'s command/args/cwd/env surface in a third
+  step type, doubling the schema and runtime maintenance.
+* Bad, because authors must learn a separate step just to background a command they already know how
+  to run.
+
+### C. Config-level `services` block
+
+* Good, because run-wide services are declared in one place.
+* Bad, because it moves process lifecycle out of the visible test flow and couples it to config,
+  which is harder to reason about per-spec and doesn't compose with routing or `beforeAny`/`afterAll`
+  ordering.
+* Bad, because it can't express a service scoped to a single spec without additional config
+  machinery.

--- a/adrs/01002-background-processes.md
+++ b/adrs/01002-background-processes.md
@@ -31,7 +31,7 @@ start → ready-gate → reuse → guaranteed teardown — without a breaking ch
 
 ## Considered Options
 
-* **A. `background` flag + `readyWhen` gate + run-level registry + `stopProcess` step** (chosen).
+* **A. `background` object + `waitUntil` gate + run-level registry + `stopProcess` step** (chosen).
 * **B. A dedicated `service`/`daemon` step type** separate from `runShell`/`runCode`.
 * **C. Config-level `services` block** declaring long-lived processes outside the step stream.
 
@@ -46,7 +46,7 @@ to config, which is harder to reason about per-spec and doesn't compose with rou
 Mechanism:
 
 1. **`background` object** on `runShell`/`runCode` (`src/core/tests/runShell.ts`,
-   `runCode.ts`): a `background: { name, readyWhen? }` object whose *presence* signals background
+   `runCode.ts`): a `background: { name, waitUntil? }` object whose *presence* signals background
    mode (there is no `background: false` — omit it for a normal blocking run). Spawn non-blocking via
    `spawnBackgroundCommand` and return as soon as the process is ready. In background mode the
    exit-code / stdio / saved-output assertions don't apply, and step-level `timeout` is reinterpreted
@@ -54,10 +54,13 @@ Mechanism:
    registry; a duplicate name FAILs rather than double-spawning. (An earlier iteration used a boolean
    `background: true` with sibling `name`/`readyWhen`; collapsing the three into one cohesive object
    keeps the related fields together and makes "is this backgrounded?" a single presence check.)
-2. **`readyWhen`** (inside `background`, optional) gate with exactly one of four probes (`src/core/utils.ts`): `port` (TCP connect),
-   `httpGet` (status code), `log` (regex over buffered output), `delayMs` (fixed wait). Readiness is
-   raced against process exit, so a process that dies during startup FAILs fast instead of waiting
-   the whole deadline.
+2. **`waitUntil`** (inside `background`, optional) gate with AND-combinable conditions
+   (`src/core/utils.ts`), borrowing goTo's `waitUntil` terminology: `port` (TCP connect, an integer),
+   `stdio` (substring-or-`/regex/` over combined stdout+stderr, mirroring runShell's `stdio` field),
+   `httpGet` (a URL string, ready on any 2xx), and `delayMs` (a fixed minimum wait). Any combination
+   may be given; every condition present must pass. The fields are flat (no `host`/`pollIntervalMs`/
+   `statusCodes`/`stream` knobs) to match runShell's other fields. Readiness is raced against process
+   exit, so a process that dies during startup FAILs fast instead of waiting the whole deadline.
 3. **Run-level process registry** owned by `runSpecs` (`src/core/tests.ts`): a `Map` threaded
    through `runContext`/`runRoutedSpec` → `runStep` → the step handlers, so a process started in one
    spec/test survives for the whole run (e.g. start in `beforeAny`, use across `main`, stop in
@@ -81,30 +84,33 @@ Mechanism:
 * **Good** — teardown is guaranteed on success, failure, run-end, and interrupt; the interrupt path
   also closes the prior Appium leak.
 * **Trade-off** — a process that forks a daemon and then exits (some Docker images, some databases)
-  trips the "exited before ready" path and FAILs; documented in the `readyWhen` schema with the
+  trips the "exited before ready" path and FAILs; documented in the `waitUntil` schema with the
   guidance to use `port`/`httpGet`/`delayMs` for those rather than relying on the parent staying
   alive.
-* **Trade-off** — `readyWhen.log` with `stream: "any"` matches against stdout-then-stderr
-  concatenation, not a true temporal interleave; documented in the schema (target a single stream
-  when ordering across streams matters).
+* **Trade-off** — `waitUntil.stdio` searches both streams as a single combined buffer (stdout then
+  stderr), not a true temporal interleave; a match that depends on the cross-stream ordering of
+  output may not behave as expected. Matches runShell's existing `stdio` semantics.
 * **Neutral / out of scope** — cross-runner *shared* processes under `concurrentRunners` are not
   modeled: the registry is run-owned and start/stop are single-owner. Per-runner instances and
   start-or-attach semantics are deferred; the run-owned placement is forward-compatible with them.
-* **Neutral** — `readyWhen` on a non-background step is ignored rather than rejected (kept permissive
-  to avoid over-constraining; documented as ignored).
+* **Neutral** — `waitUntil` lives inside the `background` object, so it can't be set on a
+  non-background step; an empty or omitted `waitUntil` means "ready as soon as spawned."
 
 ## Confirmation
 
 * Unit (`test/background-process.test.js`): `spawnBackgroundCommand` returns immediately and buffers
-  output; each probe (`port`/`httpGet`/`log`/`delayMs`) resolves and times out correctly; readiness
+  output; each condition (`port`/`httpGet`/`stdio`/`delayMs`) resolves and times out correctly,
+  and combined conditions all gate together; readiness
   fails fast on early exit; `stopProcess` kills + deregisters + honors `ignoreMissing`; the real
   `runShell`/`runCode` background branches (readiness, outputs, name collision, timeout-deregister,
   deferred temp cleanup).
 * Schema (`src/common/test/validate.test.js`): positive + negative cases for `background`/`name`/
-  every `readyWhen` probe and both `stopProcess` forms (two-probe, unknown probe, missing name,
+  every `waitUntil` condition (and combined conditions) and both `stopProcess` forms (non-object
+  `background`, unknown key in `background`/`waitUntil`, old object-shaped port, missing name,
   out-of-range port, whitespace name).
 * End-to-end: `test/background-runner.test.js` drives `runTests()` for explicit-stop and run-end
   auto-sweep; `test/core-artifacts/background-processes.spec.json` exercises every permutation
-  through the canonical `test/core-core.test.js` fixture gate (all probes, `stopProcess`
-  string/object, `ignoreMissing`, auto-sweep, `runShell` and `runCode` background) and must resolve
+  through the canonical `test/core-core.test.js` fixture gate (all `waitUntil` conditions, combined
+  conditions, `stopProcess` string/object, `ignoreMissing`, auto-sweep, `runShell` and `runCode`
+  background) and must resolve
   PASS/SKIPPED across the CI matrix (macOS / Linux / Windows × node 22/24).

--- a/src/common/src/schemas/src_schemas/runCode_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/runCode_v3.schema.json
@@ -91,12 +91,12 @@
           },
           "timeout": {
             "type": "integer",
-            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails. When `background` is set, this is instead the max time to wait for `background.readyWhen` to be satisfied before the step fails.",
+            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails. When `background` is set, this is instead the max time to wait for `background.waitUntil` to be satisfied before the step fails.",
             "default": 60000
           },
           "background": {
             "type": "object",
-            "description": "Start the code as a long-running background process and return as soon as it is ready, instead of waiting for it to exit. When set, `exitCodes`, `stdio`, and output saving (`path`, `directory`, `maxVariation`, `overwrite`) are ignored, and `timeout` is the max time to wait for `readyWhen`. The process is owned by the run and is stopped by a `stopProcess` step or automatically when the run finishes.",
+            "description": "Start the code as a long-running background process and return as soon as it is ready, instead of waiting for it to exit. When set, `exitCodes`, `stdio`, and output saving (`path`, `directory`, `maxVariation`, `overwrite`) are ignored, and `timeout` is the max time to wait for `waitUntil`. The process is owned by the run and is stopped by a `stopProcess` step or automatically when the run finishes.",
             "additionalProperties": false,
             "required": ["name"],
             "properties": {
@@ -107,90 +107,28 @@
                 "pattern": "\\S",
                 "transform": ["trim"]
               },
-              "readyWhen": {
+              "waitUntil": {
                 "type": "object",
-                "description": "Gate that blocks the step until the background process is ready. Specify exactly one probe. Omit to consider the process ready as soon as it is spawned. Note: a process that forks a daemon and then exits (common for some Docker images and databases) is treated as having exited before becoming ready and the step fails — use a `port`, `httpGet`, or `delayMs` probe for those rather than relying on the foreground process staying alive.",
+                "description": "Conditions that must all be met before the process is considered ready and the step proceeds. Omit to consider the process ready as soon as it is spawned. Specify any combination; every condition given must pass before `timeout` elapses. Note: a process that forks a daemon and then exits (common for some Docker images and databases) is treated as having exited before becoming ready and the step fails — use `port`, `httpGet`, or `delayMs` for those rather than a condition that depends on the foreground process staying alive.",
                 "additionalProperties": false,
-                "oneOf": [
-                  { "required": ["port"] },
-                  { "required": ["log"] },
-                  { "required": ["httpGet"] },
-                  { "required": ["delayMs"] }
-                ],
                 "properties": {
                   "port": {
-                    "type": "object",
-                    "description": "Wait until a TCP port accepts connections.",
-                    "additionalProperties": false,
-                    "required": ["port"],
-                    "properties": {
-                      "port": {
-                        "type": "integer",
-                        "description": "TCP port to probe.",
-                        "minimum": 1,
-                        "maximum": 65535
-                      },
-                      "host": {
-                        "type": "string",
-                        "description": "Host to probe.",
-                        "default": "127.0.0.1"
-                      },
-                      "pollIntervalMs": {
-                        "type": "integer",
-                        "description": "Milliseconds between connection attempts.",
-                        "minimum": 50,
-                        "default": 500
-                      }
-                    }
+                    "type": "integer",
+                    "description": "Wait until this TCP port accepts connections on localhost.",
+                    "minimum": 1,
+                    "maximum": 65535
                   },
-                  "log": {
-                    "type": "object",
-                    "description": "Wait until the process's output matches a regular expression.",
-                    "additionalProperties": false,
-                    "required": ["pattern"],
-                    "properties": {
-                      "pattern": {
-                        "type": "string",
-                        "description": "Regular expression source (no surrounding slashes) tested against the process output.",
-                        "minLength": 1
-                      },
-                      "stream": {
-                        "type": "string",
-                        "description": "Which stream to match against. With `any`, buffered stdout and stderr are concatenated (all stdout, then all stderr), not interleaved in emission order — a pattern that depends on the time-ordering of output across both streams may not match; target a single stream for that.",
-                        "enum": ["stdout", "stderr", "any"],
-                        "default": "any"
-                      }
-                    }
+                  "stdio": {
+                    "type": "string",
+                    "description": "Wait until the process's output contains this content. Searches both stdout and stderr. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/ready on \\d+/`."
                   },
                   "httpGet": {
-                    "type": "object",
-                    "description": "Wait until an HTTP GET request returns an expected status code.",
-                    "additionalProperties": false,
-                    "required": ["url"],
-                    "properties": {
-                      "url": {
-                        "type": "string",
-                        "description": "URL to request."
-                      },
-                      "statusCodes": {
-                        "type": "array",
-                        "description": "Status codes that indicate readiness.",
-                        "items": {
-                          "type": "integer"
-                        },
-                        "default": [200]
-                      },
-                      "pollIntervalMs": {
-                        "type": "integer",
-                        "description": "Milliseconds between requests.",
-                        "minimum": 50,
-                        "default": 500
-                      }
-                    }
+                    "type": "string",
+                    "description": "Wait until an HTTP GET request to this URL returns a 2xx status."
                   },
                   "delayMs": {
                     "type": "integer",
-                    "description": "Fixed delay in milliseconds before considering the process ready.",
+                    "description": "Wait at least this many milliseconds.",
                     "minimum": 0
                   }
                 }
@@ -241,10 +179,8 @@
       "code": "require('http').createServer((req, res) => res.end('ok')).listen(8088);",
       "background": {
         "name": "api",
-        "readyWhen": {
-          "port": {
-            "port": 8088
-          }
+        "waitUntil": {
+          "port": 8088
         }
       },
       "timeout": 15000

--- a/src/common/src/schemas/src_schemas/runCode_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/runCode_v3.schema.json
@@ -111,6 +111,7 @@
                 "type": "object",
                 "description": "Conditions that must all be met before the process is considered ready and the step proceeds. Omit to consider the process ready as soon as it is spawned. Specify any combination; every condition given must pass before `timeout` elapses. Note: a process that forks a daemon and then exits (common for some Docker images and databases) is treated as having exited before becoming ready and the step fails — use `port`, `httpGet`, or `delayMs` for those rather than a condition that depends on the foreground process staying alive.",
                 "additionalProperties": false,
+                "minProperties": 1,
                 "properties": {
                   "port": {
                     "type": "integer",
@@ -120,7 +121,8 @@
                   },
                   "stdio": {
                     "type": "string",
-                    "description": "Wait until the process's output contains this content. Searches both stdout and stderr. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/ready on \\d+/`."
+                    "description": "Wait until the process's output contains this content. Searches both stdout and stderr. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/ready on \\d+/`.",
+                    "minLength": 1
                   },
                   "httpGet": {
                     "type": "string",

--- a/src/common/src/schemas/src_schemas/runShell_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/runShell_v3.schema.json
@@ -113,6 +113,7 @@
                 "type": "object",
                 "description": "Conditions that must all be met before the process is considered ready and the step proceeds. Omit to consider the process ready as soon as it is spawned. Specify any combination; every condition given must pass before `timeout` elapses. Note: a process that forks a daemon and then exits (common for some Docker images and databases) is treated as having exited before becoming ready and the step fails — use `port`, `httpGet`, or `delayMs` for those rather than a condition that depends on the foreground process staying alive.",
                 "additionalProperties": false,
+                "minProperties": 1,
                 "properties": {
                   "port": {
                     "type": "integer",
@@ -122,7 +123,8 @@
                   },
                   "stdio": {
                     "type": "string",
-                    "description": "Wait until the process's output contains this content. Searches both stdout and stderr. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/ready on \\d+/`."
+                    "description": "Wait until the process's output contains this content. Searches both stdout and stderr. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/ready on \\d+/`.",
+                    "minLength": 1
                   },
                   "httpGet": {
                     "type": "string",

--- a/src/common/src/schemas/src_schemas/runShell_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/runShell_v3.schema.json
@@ -93,12 +93,12 @@
           },
           "timeout": {
             "type": "integer",
-            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails. When `background` is set, this is instead the max time to wait for `background.readyWhen` to be satisfied before the step fails.",
+            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails. When `background` is set, this is instead the max time to wait for `background.waitUntil` to be satisfied before the step fails.",
             "default": 60000
           },
           "background": {
             "type": "object",
-            "description": "Start the command as a long-running background process and return as soon as it is ready, instead of waiting for it to exit. When set, `exitCodes`, `stdio`, and output saving (`path`, `directory`, `maxVariation`, `overwrite`) are ignored, and `timeout` is the max time to wait for `readyWhen`. The process is owned by the run and is stopped by a `stopProcess` step or automatically when the run finishes.",
+            "description": "Start the command as a long-running background process and return as soon as it is ready, instead of waiting for it to exit. When set, `exitCodes`, `stdio`, and output saving (`path`, `directory`, `maxVariation`, `overwrite`) are ignored, and `timeout` is the max time to wait for `waitUntil`. The process is owned by the run and is stopped by a `stopProcess` step or automatically when the run finishes.",
             "additionalProperties": false,
             "required": ["name"],
             "properties": {
@@ -109,90 +109,28 @@
                 "pattern": "\\S",
                 "transform": ["trim"]
               },
-              "readyWhen": {
+              "waitUntil": {
                 "type": "object",
-                "description": "Gate that blocks the step until the background process is ready. Specify exactly one probe. Omit to consider the process ready as soon as it is spawned. Note: a process that forks a daemon and then exits (common for some Docker images and databases) is treated as having exited before becoming ready and the step fails — use a `port`, `httpGet`, or `delayMs` probe for those rather than relying on the foreground process staying alive.",
+                "description": "Conditions that must all be met before the process is considered ready and the step proceeds. Omit to consider the process ready as soon as it is spawned. Specify any combination; every condition given must pass before `timeout` elapses. Note: a process that forks a daemon and then exits (common for some Docker images and databases) is treated as having exited before becoming ready and the step fails — use `port`, `httpGet`, or `delayMs` for those rather than a condition that depends on the foreground process staying alive.",
                 "additionalProperties": false,
-                "oneOf": [
-                  { "required": ["port"] },
-                  { "required": ["log"] },
-                  { "required": ["httpGet"] },
-                  { "required": ["delayMs"] }
-                ],
                 "properties": {
                   "port": {
-                    "type": "object",
-                    "description": "Wait until a TCP port accepts connections.",
-                    "additionalProperties": false,
-                    "required": ["port"],
-                    "properties": {
-                      "port": {
-                        "type": "integer",
-                        "description": "TCP port to probe.",
-                        "minimum": 1,
-                        "maximum": 65535
-                      },
-                      "host": {
-                        "type": "string",
-                        "description": "Host to probe.",
-                        "default": "127.0.0.1"
-                      },
-                      "pollIntervalMs": {
-                        "type": "integer",
-                        "description": "Milliseconds between connection attempts.",
-                        "minimum": 50,
-                        "default": 500
-                      }
-                    }
+                    "type": "integer",
+                    "description": "Wait until this TCP port accepts connections on localhost.",
+                    "minimum": 1,
+                    "maximum": 65535
                   },
-                  "log": {
-                    "type": "object",
-                    "description": "Wait until the process's output matches a regular expression.",
-                    "additionalProperties": false,
-                    "required": ["pattern"],
-                    "properties": {
-                      "pattern": {
-                        "type": "string",
-                        "description": "Regular expression source (no surrounding slashes) tested against the process output.",
-                        "minLength": 1
-                      },
-                      "stream": {
-                        "type": "string",
-                        "description": "Which stream to match against. With `any`, buffered stdout and stderr are concatenated (all stdout, then all stderr), not interleaved in emission order — a pattern that depends on the time-ordering of output across both streams may not match; target a single stream for that.",
-                        "enum": ["stdout", "stderr", "any"],
-                        "default": "any"
-                      }
-                    }
+                  "stdio": {
+                    "type": "string",
+                    "description": "Wait until the process's output contains this content. Searches both stdout and stderr. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/ready on \\d+/`."
                   },
                   "httpGet": {
-                    "type": "object",
-                    "description": "Wait until an HTTP GET request returns an expected status code.",
-                    "additionalProperties": false,
-                    "required": ["url"],
-                    "properties": {
-                      "url": {
-                        "type": "string",
-                        "description": "URL to request."
-                      },
-                      "statusCodes": {
-                        "type": "array",
-                        "description": "Status codes that indicate readiness.",
-                        "items": {
-                          "type": "integer"
-                        },
-                        "default": [200]
-                      },
-                      "pollIntervalMs": {
-                        "type": "integer",
-                        "description": "Milliseconds between requests.",
-                        "minimum": 50,
-                        "default": 500
-                      }
-                    }
+                    "type": "string",
+                    "description": "Wait until an HTTP GET request to this URL returns a 2xx status."
                   },
                   "delayMs": {
                     "type": "integer",
-                    "description": "Fixed delay in milliseconds before considering the process ready.",
+                    "description": "Wait at least this many milliseconds.",
                     "minimum": 0
                   }
                 }
@@ -258,16 +196,22 @@
       "command": "docker run -p 8080:80 nginx",
       "background": {
         "name": "web",
-        "readyWhen": {
-          "httpGet": {
-            "url": "http://localhost:8080",
-            "statusCodes": [
-              200
-            ]
-          }
+        "waitUntil": {
+          "httpGet": "http://localhost:8080"
         }
       },
       "timeout": 30000
+    },
+    {
+      "command": "docker run -p 5432:5432 -e POSTGRES_PASSWORD=test postgres:16",
+      "background": {
+        "name": "db",
+        "waitUntil": {
+          "port": 5432,
+          "stdio": "/database system is ready to accept connections/"
+        }
+      },
+      "timeout": 60000
     }
   ]
 }

--- a/src/common/src/schemas/src_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/step_v3.schema.json
@@ -577,11 +577,8 @@
         "command": "docker run -p 8080:80 nginx",
         "background": {
           "name": "web",
-          "readyWhen": {
-            "httpGet": {
-              "url": "http://localhost:8080",
-              "statusCodes": [200]
-            }
+          "waitUntil": {
+            "httpGet": "http://localhost:8080"
           }
         },
         "timeout": 30000

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -2517,6 +2517,34 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.be.a("string");
       });
 
+      it("should reject an empty waitUntil object (no conditions)", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: { name: "srv", waitUntil: {} },
+            },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+
+      it("should reject an empty-string stdio condition", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: { name: "srv", waitUntil: { stdio: "" } },
+            },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+
       it("should reject the old object-shaped port condition", function () {
         const result = validate({
           schemaKey: "step_v3",

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -2346,13 +2346,13 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
     });
 
     describe("background processes (runShell/runCode) and stopProcess", function () {
-      it("should validate a background runShell with a port probe", function () {
+      it("should validate a background runShell with a port condition", function () {
         const result = validate({
           schemaKey: "step_v3",
           object: {
             runShell: {
               command: "docker run -p 5432:5432 postgres",
-              background: { name: "db", readyWhen: { port: { port: 5432 } } },
+              background: { name: "db", waitUntil: { port: 5432 } },
             },
           },
         });
@@ -2360,7 +2360,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.equal("");
       });
 
-      it("should validate a background runShell with a log probe", function () {
+      it("should validate a background runShell with a stdio condition", function () {
         const result = validate({
           schemaKey: "step_v3",
           object: {
@@ -2368,7 +2368,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
               command: "my-server",
               background: {
                 name: "srv",
-                readyWhen: { log: { pattern: "ready to accept", stream: "stdout" } },
+                waitUntil: { stdio: "/ready to accept/" },
               },
             },
           },
@@ -2377,7 +2377,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.equal("");
       });
 
-      it("should validate a background runShell with an httpGet probe", function () {
+      it("should validate a background runShell with an httpGet condition", function () {
         const result = validate({
           schemaKey: "step_v3",
           object: {
@@ -2385,9 +2385,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
               command: "my-server",
               background: {
                 name: "web",
-                readyWhen: {
-                  httpGet: { url: "http://localhost:8080", statusCodes: [200, 204] },
-                },
+                waitUntil: { httpGet: "http://localhost:8080" },
               },
               timeout: 30000,
             },
@@ -2397,13 +2395,13 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.equal("");
       });
 
-      it("should validate a background runShell with a delayMs probe", function () {
+      it("should validate a background runShell with a delayMs condition", function () {
         const result = validate({
           schemaKey: "step_v3",
           object: {
             runShell: {
               command: "my-server",
-              background: { name: "srv", readyWhen: { delayMs: 2000 } },
+              background: { name: "srv", waitUntil: { delayMs: 2000 } },
             },
           },
         });
@@ -2411,7 +2409,29 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.equal("");
       });
 
-      it("should validate a background with no readyWhen (ready on spawn)", function () {
+      it("should validate multiple waitUntil conditions combined", function () {
+        const result = validate({
+          schemaKey: "step_v3",
+          object: {
+            runShell: {
+              command: "my-server",
+              background: {
+                name: "srv",
+                waitUntil: {
+                  port: 5432,
+                  stdio: "/ready/",
+                  httpGet: "http://localhost:8080/health",
+                  delayMs: 1000,
+                },
+              },
+            },
+          },
+        });
+        expect(result.valid).to.be.true;
+        expect(result.errors).to.equal("");
+      });
+
+      it("should validate a background with no waitUntil (ready on spawn)", function () {
         const result = validate({
           schemaKey: "step_v3",
           object: {
@@ -2425,14 +2445,14 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.equal("");
       });
 
-      it("should validate a background runCode with a port probe", function () {
+      it("should validate a background runCode with a port condition", function () {
         const result = validate({
           schemaKey: "step_v3",
           object: {
             runCode: {
               language: "javascript",
               code: "require('http').createServer((q,r)=>r.end('ok')).listen(8088)",
-              background: { name: "api", readyWhen: { port: { port: 8088 } } },
+              background: { name: "api", waitUntil: { port: 8088 } },
             },
           },
         });
@@ -2483,16 +2503,13 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.be.a("string");
       });
 
-      it("should reject a readyWhen with two probes", function () {
+      it("should reject an unknown key inside waitUntil", function () {
         const result = validate({
           schemaKey: "step_v3",
           object: {
             runShell: {
               command: "my-server",
-              background: {
-                name: "srv",
-                readyWhen: { port: { port: 5432 }, delayMs: 1000 },
-              },
+              background: { name: "srv", waitUntil: { tcp: 5432 } },
             },
           },
         });
@@ -2500,13 +2517,13 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.be.a("string");
       });
 
-      it("should reject a readyWhen with an unknown probe key", function () {
+      it("should reject the old object-shaped port condition", function () {
         const result = validate({
           schemaKey: "step_v3",
           object: {
             runShell: {
               command: "my-server",
-              background: { name: "srv", readyWhen: { tcp: { port: 5432 } } },
+              background: { name: "srv", waitUntil: { port: { port: 5432 } } },
             },
           },
         });
@@ -2520,7 +2537,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
           object: {
             runShell: {
               command: "my-server",
-              background: { readyWhen: { delayMs: 1000 } },
+              background: { waitUntil: { delayMs: 1000 } },
             },
           },
         });
@@ -2535,7 +2552,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
             runCode: {
               language: "bash",
               code: "sleep 100",
-              background: { readyWhen: { delayMs: 1000 } },
+              background: { waitUntil: { delayMs: 1000 } },
             },
           },
         });
@@ -2543,13 +2560,13 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.be.a("string");
       });
 
-      it("should reject a readyWhen port that is out of range", function () {
+      it("should reject a waitUntil port that is out of range", function () {
         const result = validate({
           schemaKey: "step_v3",
           object: {
             runShell: {
               command: "my-server",
-              background: { name: "srv", readyWhen: { port: { port: 70000 } } },
+              background: { name: "srv", waitUntil: { port: 70000 } },
             },
           },
         });
@@ -2572,7 +2589,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
           object: {
             runShell: {
               command: "my-server",
-              background: { name: "   ", readyWhen: { delayMs: 1000 } },
+              background: { name: "   ", waitUntil: { delayMs: 1000 } },
             },
           },
         });

--- a/src/core/tests/runCode.ts
+++ b/src/core/tests/runCode.ts
@@ -37,7 +37,7 @@ function createTempScript(code: string, language: string) {
 }
 
 // Run gather, compile, and run code. When `step.runCode.background` is set (an
-// object with a `name` and optional `readyWhen`), the script is started as a
+// object with a `name` and optional `waitUntil`), the script is started as a
 // long-running process via runShell and the temp script
 // is kept on disk (deletion deferred to teardown) so the interpreter can keep
 // reading it.
@@ -150,7 +150,7 @@ async function runCode({
         ? path.join(step.runCode.directory, step.runCode.path)
         : step.runCode.path;
     }
-    // Forward the background object (name + readyWhen) so runShell starts and
+    // Forward the background object (name + waitUntil) so runShell starts and
     // registers the process.
     if (step.runCode.background) {
       runShellOptions.background = step.runCode.background;

--- a/src/core/tests/runShell.ts
+++ b/src/core/tests/runShell.ts
@@ -18,9 +18,9 @@ import path from "node:path";
 export { runShell };
 
 // Run a shell command. When `step.runShell.background` is set (an object with a
-// `name` and optional `readyWhen`), the command is started as a long-running
+// `name` and optional `waitUntil`), the command is started as a long-running
 // process registered in `processRegistry` and the step returns as soon as
-// `readyWhen` is satisfied; the process is torn down later by a stopProcess step
+// `waitUntil` is satisfied; the process is torn down later by a stopProcess step
 // or the run-end sweep.
 async function runShell({
   config,
@@ -70,7 +70,7 @@ async function runShell({
 
   // Background mode: start the process, register it, wait until ready, and
   // return immediately. `exitCodes`, `stdio`, and output saving don't apply.
-  // `background` is an object holding `name` and (optional) `readyWhen`; its
+  // `background` is an object holding `name` and (optional) `waitUntil`; its
   // presence signals background mode.
   if (step.runShell.background) {
     const background = step.runShell.background;
@@ -113,7 +113,7 @@ async function runShell({
     processRegistry.set(name, entry);
 
     try {
-      await waitForReady(bg, background.readyWhen, {
+      await waitForReady(bg, background.waitUntil, {
         timeoutMs: step.runShell.timeout,
       });
     } catch (error: any) {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -384,29 +384,45 @@ async function waitForHttp(
 }
 
 // Resolve when the process output matches `expected`, or reject when the
-// deadline passes. Mirrors runShell's `stdio` matching: a substring match, or a
-// regular expression when `expected` is wrapped in forward slashes (`/.../`),
-// tested against both stdout and stderr. Already-buffered output is checked
-// first so a match emitted before subscription isn't missed.
+// deadline passes. Mirrors runShell's `stdio` matching exactly: a substring
+// match, or a regular expression when `expected` is wrapped in forward slashes
+// (`/.../`), tested against stdout OR stderr (each stream separately, not a
+// concatenation — so a match can't span the stdout/stderr boundary).
+// Already-buffered output is checked first so a match emitted before
+// subscription isn't missed.
 function waitForStdio(
   bg: BackgroundProcess,
   expected: string,
   { deadline }: { deadline: number }
 ): Promise<void> {
-  const isRegex = expected.startsWith("/") && expected.endsWith("/");
-  const regex = isRegex ? new RegExp(expected.slice(1, -1)) : null;
-  const matches = (text: string) =>
+  let regex: RegExp | null = null;
+  if (expected.startsWith("/") && expected.endsWith("/")) {
+    try {
+      regex = new RegExp(expected.slice(1, -1));
+    } catch (error: any) {
+      // Surface a Doc Detective-shaped error instead of the engine's raw
+      // SyntaxError; runShell's stdio matching wraps regex compilation similarly.
+      return Promise.reject(
+        new Error(
+          `waitUntil.stdio: invalid regular expression ${expected}: ${error.message}`
+        )
+      );
+    }
+  }
+  const matchesText = (text: string) =>
     regex ? regex.test(text) : text.includes(expected);
+  // stdout OR stderr, checked separately (like runShell's stdio).
+  const matched = () => matchesText(bg.getStdout()) || matchesText(bg.getStderr());
 
   return new Promise((resolve, reject) => {
-    if (matches(bg.getCombined())) return resolve();
+    if (matched()) return resolve();
     let unsubscribe = () => {};
     const timer = setTimeout(() => {
       unsubscribe();
       reject(new Error(`Expected output (${expected}) not seen in time.`));
     }, Math.max(0, deadline - Date.now()));
     unsubscribe = bg.onChunk(() => {
-      if (matches(bg.getCombined())) {
+      if (matched()) {
         clearTimeout(timer);
         unsubscribe();
         resolve();

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -21,7 +21,7 @@ export {
   waitForReady,
   waitForPort,
   waitForHttp,
-  waitForLog,
+  waitForStdio,
   inContainer,
   cleanTemp,
   calculateFractionalDifference,
@@ -334,12 +334,16 @@ function tryConnect(host: string, port: number): Promise<boolean> {
   });
 }
 
-// Poll a TCP port until it accepts a connection or the deadline passes.
+// How long to wait between poll attempts for the port / HTTP conditions.
+const READY_POLL_INTERVAL_MS = 500;
+
+// Poll a TCP port (on localhost) until it accepts a connection or the deadline
+// passes.
 async function waitForPort(
-  host: string,
   port: number,
-  { pollIntervalMs = 500, deadline }: { pollIntervalMs?: number; deadline: number }
+  { deadline }: { deadline: number }
 ): Promise<void> {
+  const host = "127.0.0.1";
   while (true) {
     if (await tryConnect(host, port)) return;
     // Only give up once the clock has actually run out, and bound the wait to
@@ -347,18 +351,17 @@ async function waitForPort(
     // fixed `Date.now() + pollIntervalMs >= deadline` check would throw with
     // time still on the clock on a slow host, skipping a winnable attempt.
     if (Date.now() >= deadline) {
-      throw new Error(`Port ${host}:${port} did not open in time.`);
+      throw new Error(`Port ${port} did not open in time.`);
     }
-    await backgroundSleep(Math.min(pollIntervalMs, deadline - Date.now()));
+    await backgroundSleep(Math.min(READY_POLL_INTERVAL_MS, deadline - Date.now()));
   }
 }
 
-// Poll an HTTP endpoint until it returns one of the expected status codes or the
-// deadline passes. Connection errors are swallowed and retried.
+// Poll an HTTP endpoint until a GET returns a 2xx status or the deadline passes.
+// Connection errors are swallowed and retried.
 async function waitForHttp(
   url: string,
-  statusCodes: number[],
-  { pollIntervalMs = 500, deadline }: { pollIntervalMs?: number; deadline: number }
+  { deadline }: { deadline: number }
 ): Promise<void> {
   while (true) {
     try {
@@ -369,46 +372,41 @@ async function waitForHttp(
         validateStatus: () => true,
         timeout: Math.max(1, Math.min(5000, remaining)),
       });
-      if (statusCodes.includes(resp.status)) return;
+      if (resp.status >= 200 && resp.status < 300) return;
     } catch {
       // Server not up yet (or transient) — retry until the deadline.
     }
     if (Date.now() >= deadline) {
-      throw new Error(
-        `HTTP GET ${url} did not return ${JSON.stringify(statusCodes)} in time.`
-      );
+      throw new Error(`HTTP GET ${url} did not return a 2xx status in time.`);
     }
-    await backgroundSleep(Math.min(pollIntervalMs, deadline - Date.now()));
+    await backgroundSleep(Math.min(READY_POLL_INTERVAL_MS, deadline - Date.now()));
   }
 }
 
-// Resolve when the process output matches `pattern` on the selected stream, or
-// reject when the deadline passes. Already-buffered output is checked first so a
-// match emitted before subscription isn't missed.
-function waitForLog(
+// Resolve when the process output matches `expected`, or reject when the
+// deadline passes. Mirrors runShell's `stdio` matching: a substring match, or a
+// regular expression when `expected` is wrapped in forward slashes (`/.../`),
+// tested against both stdout and stderr. Already-buffered output is checked
+// first so a match emitted before subscription isn't missed.
+function waitForStdio(
   bg: BackgroundProcess,
-  pattern: string,
-  stream: "stdout" | "stderr" | "any",
+  expected: string,
   { deadline }: { deadline: number }
 ): Promise<void> {
-  const regex = new RegExp(pattern);
-  const bufferFor = () =>
-    stream === "stdout"
-      ? bg.getStdout()
-      : stream === "stderr"
-      ? bg.getStderr()
-      : bg.getCombined();
+  const isRegex = expected.startsWith("/") && expected.endsWith("/");
+  const regex = isRegex ? new RegExp(expected.slice(1, -1)) : null;
+  const matches = (text: string) =>
+    regex ? regex.test(text) : text.includes(expected);
 
   return new Promise((resolve, reject) => {
-    if (regex.test(bufferFor())) return resolve();
+    if (matches(bg.getCombined())) return resolve();
     let unsubscribe = () => {};
     const timer = setTimeout(() => {
       unsubscribe();
-      reject(new Error(`Log pattern /${pattern}/ not seen in time.`));
+      reject(new Error(`Expected output (${expected}) not seen in time.`));
     }, Math.max(0, deadline - Date.now()));
-    unsubscribe = bg.onChunk((_chunk, s) => {
-      if (stream !== "any" && s !== stream) return;
-      if (regex.test(bufferFor())) {
+    unsubscribe = bg.onChunk(() => {
+      if (matches(bg.getCombined())) {
         clearTimeout(timer);
         unsubscribe();
         resolve();
@@ -417,54 +415,48 @@ function waitForLog(
   });
 }
 
-// Block until the background process satisfies its readiness probe, fails fast
-// if the process exits first, or rejects when `timeoutMs` elapses. Probe shape
-// defaults are applied here too (defense-in-depth — AJV may not fill defaults
-// nested under anyOf branches).
+// Block until every condition in `waitUntil` is met, fail fast if the process
+// exits first, or reject when `timeoutMs` elapses. Conditions are AND-combined
+// (like goTo's `waitUntil`): all the ones present must pass. An absent or empty
+// `waitUntil` means the process is ready as soon as it is spawned.
 async function waitForReady(
   bg: BackgroundProcess,
-  readyWhen: any,
+  waitUntil: any,
   { timeoutMs }: { timeoutMs: number }
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
 
-  let probe: Promise<void>;
-  if (readyWhen?.port) {
-    probe = waitForPort(
-      readyWhen.port.host || "127.0.0.1",
-      readyWhen.port.port,
-      { pollIntervalMs: readyWhen.port.pollIntervalMs || 500, deadline }
-    );
-  } else if (readyWhen?.httpGet) {
-    probe = waitForHttp(
-      readyWhen.httpGet.url,
-      readyWhen.httpGet.statusCodes || [200],
-      { pollIntervalMs: readyWhen.httpGet.pollIntervalMs || 500, deadline }
-    );
-  } else if (readyWhen?.log) {
-    probe = waitForLog(bg, readyWhen.log.pattern, readyWhen.log.stream || "any", {
-      deadline,
-    });
-  } else if (readyWhen && typeof readyWhen.delayMs === "number") {
-    probe = backgroundSleep(Math.min(readyWhen.delayMs, timeoutMs));
-  } else {
-    // No readyWhen: consider ready as soon as the process is spawned.
-    probe = Promise.resolve();
+  const probes: Promise<void>[] = [];
+  if (waitUntil && typeof waitUntil.port === "number") {
+    probes.push(waitForPort(waitUntil.port, { deadline }));
   }
+  if (waitUntil && typeof waitUntil.httpGet === "string") {
+    probes.push(waitForHttp(waitUntil.httpGet, { deadline }));
+  }
+  if (waitUntil && typeof waitUntil.stdio === "string") {
+    probes.push(waitForStdio(bg, waitUntil.stdio, { deadline }));
+  }
+  if (waitUntil && typeof waitUntil.delayMs === "number") {
+    probes.push(backgroundSleep(Math.min(waitUntil.delayMs, timeoutMs)));
+  }
+
+  // All conditions must pass; an empty set resolves immediately.
+  const ready = Promise.all(probes).then(() => undefined);
 
   // Fail fast if the process dies before becoming ready.
   const earlyExit = bg.exited.then((code) => {
     throw new Error(`Process exited before becoming ready (exit code ${code}).`);
   });
 
-  // The race loser settles later (the probe keeps polling to its own deadline;
+  // The race loser settles later (a probe keeps polling to its own deadline;
   // earlyExit rejects when the process is eventually killed at teardown).
-  // Attach no-op catches so that late rejection is always considered handled and
+  // Attach no-op catches so a late rejection is always considered handled and
   // never surfaces as an unhandledRejection during normal stopProcess teardown.
-  probe.catch(() => {});
+  ready.catch(() => {});
   earlyExit.catch(() => {});
+  for (const p of probes) p.catch(() => {});
 
-  await Promise.race([probe, earlyExit]);
+  await Promise.race([ready, earlyExit]);
 }
 
 function compileFilter(patterns?: string[] | unknown): RegExp[] {

--- a/test/background-process.test.js
+++ b/test/background-process.test.js
@@ -180,6 +180,14 @@ describe("waitForStdio", function () {
       /not seen in time/
     );
   });
+
+  it("rejects a malformed /regex/ with a friendly error", async function () {
+    const bg = fakeBg();
+    await assert.rejects(
+      waitForStdio(bg, "/[unclosed/", { deadline: Date.now() + 1000 }),
+      /invalid regular expression/
+    );
+  });
 });
 
 describe("waitForReady", function () {

--- a/test/background-process.test.js
+++ b/test/background-process.test.js
@@ -9,7 +9,7 @@ import {
   spawnBackgroundCommand,
   waitForPort,
   waitForHttp,
-  waitForLog,
+  waitForStdio,
   waitForReady,
   findFreePort,
 } from "../dist/core/utils.js";
@@ -96,10 +96,7 @@ describe("waitForPort", function () {
     const server = net.createServer();
     await new Promise((r) => server.listen(port, "127.0.0.1", r));
     try {
-      await waitForPort("127.0.0.1", port, {
-        pollIntervalMs: 50,
-        deadline: Date.now() + 5000,
-      });
+      await waitForPort(port, { deadline: Date.now() + 5000 });
     } finally {
       await new Promise((r) => server.close(r));
     }
@@ -108,10 +105,7 @@ describe("waitForPort", function () {
   it("rejects when nothing is listening before the deadline", async function () {
     const port = await findFreePort();
     await assert.rejects(
-      waitForPort("127.0.0.1", port, {
-        pollIntervalMs: 50,
-        deadline: Date.now() + 300,
-      }),
+      waitForPort(port, { deadline: Date.now() + 300 }),
       /did not open in time/
     );
   });
@@ -120,16 +114,15 @@ describe("waitForPort", function () {
 describe("waitForHttp", function () {
   this.timeout(10000);
 
-  it("resolves when the endpoint returns an expected status", async function () {
+  it("resolves when the endpoint returns a 2xx status", async function () {
     const port = await findFreePort();
     const server = http.createServer((req, res) => {
-      res.statusCode = 200;
-      res.end("ok");
+      res.statusCode = 204;
+      res.end();
     });
     await new Promise((r) => server.listen(port, "127.0.0.1", r));
     try {
-      await waitForHttp(`http://127.0.0.1:${port}/`, [200], {
-        pollIntervalMs: 50,
+      await waitForHttp(`http://127.0.0.1:${port}/`, {
         deadline: Date.now() + 5000,
       });
     } finally {
@@ -137,7 +130,7 @@ describe("waitForHttp", function () {
     }
   });
 
-  it("rejects when the status never matches before the deadline", async function () {
+  it("rejects when the status is never 2xx before the deadline", async function () {
     const port = await findFreePort();
     const server = http.createServer((req, res) => {
       res.statusCode = 503;
@@ -146,11 +139,10 @@ describe("waitForHttp", function () {
     await new Promise((r) => server.listen(port, "127.0.0.1", r));
     try {
       await assert.rejects(
-        waitForHttp(`http://127.0.0.1:${port}/`, [200], {
-          pollIntervalMs: 50,
+        waitForHttp(`http://127.0.0.1:${port}/`, {
           deadline: Date.now() + 400,
         }),
-        /did not return/
+        /did not return a 2xx status/
       );
     } finally {
       await new Promise((r) => server.close(r));
@@ -158,31 +150,33 @@ describe("waitForHttp", function () {
   });
 });
 
-describe("waitForLog", function () {
+describe("waitForStdio", function () {
   this.timeout(10000);
 
-  it("resolves when already-buffered output matches", async function () {
+  it("resolves when already-buffered output contains the substring", async function () {
     const bg = fakeBg();
     bg._emit("server ready to accept connections\n");
-    await waitForLog(bg, "ready to accept", "any", {
-      deadline: Date.now() + 1000,
-    });
+    await waitForStdio(bg, "ready to accept", { deadline: Date.now() + 1000 });
   });
 
-  it("resolves when a later chunk matches on the chosen stream", async function () {
+  it("resolves on a later chunk and searches both streams", async function () {
     const bg = fakeBg();
-    const p = waitForLog(bg, "listening", "stderr", {
-      deadline: Date.now() + 2000,
-    });
+    const p = waitForStdio(bg, "listening", { deadline: Date.now() + 2000 });
     bg._emit("noise on stdout\n", "stdout");
-    bg._emit("now listening on 8080\n", "stderr");
+    bg._emit("now listening on 8080\n", "stderr"); // matched even though on stderr
     await p;
   });
 
-  it("rejects when the pattern is never seen before the deadline", async function () {
+  it("supports /regex/ matching", async function () {
+    const bg = fakeBg();
+    bg._emit("started on port 8080\n");
+    await waitForStdio(bg, "/on port \\d+/", { deadline: Date.now() + 1000 });
+  });
+
+  it("rejects when the content is never seen before the deadline", async function () {
     const bg = fakeBg();
     await assert.rejects(
-      waitForLog(bg, "never-appears", "any", { deadline: Date.now() + 200 }),
+      waitForStdio(bg, "never-appears", { deadline: Date.now() + 200 }),
       /not seen in time/
     );
   });
@@ -191,28 +185,61 @@ describe("waitForLog", function () {
 describe("waitForReady", function () {
   this.timeout(10000);
 
-  it("resolves after a delayMs probe", async function () {
+  it("resolves after a delayMs condition", async function () {
     const bg = fakeBg();
     const start = Date.now();
     await waitForReady(bg, { delayMs: 100 }, { timeoutMs: 5000 });
     assert.ok(Date.now() - start >= 90);
   });
 
-  it("resolves immediately when no readyWhen is given", async function () {
+  it("resolves immediately when no waitUntil is given", async function () {
     const bg = fakeBg();
     await waitForReady(bg, undefined, { timeoutMs: 5000 });
   });
 
-  it("resolves via a port probe", async function () {
+  it("resolves via a port condition", async function () {
     const port = await findFreePort();
     const server = net.createServer();
     await new Promise((r) => server.listen(port, "127.0.0.1", r));
     const bg = fakeBg();
     try {
+      await waitForReady(bg, { port }, { timeoutMs: 5000 });
+    } finally {
+      await new Promise((r) => server.close(r));
+    }
+  });
+
+  it("requires ALL combined conditions to pass", async function () {
+    const port = await findFreePort();
+    const server = net.createServer();
+    await new Promise((r) => server.listen(port, "127.0.0.1", r));
+    const bg = fakeBg();
+    bg._emit("up and listening\n");
+    try {
+      // port is open AND stdio already matched AND a short delay → all pass
       await waitForReady(
         bg,
-        { port: { port, host: "127.0.0.1", pollIntervalMs: 50 } },
+        { port, stdio: "listening", delayMs: 50 },
         { timeoutMs: 5000 }
+      );
+    } finally {
+      await new Promise((r) => server.close(r));
+    }
+  });
+
+  it("fails when one combined condition can't be met", async function () {
+    const port = await findFreePort();
+    const server = net.createServer();
+    await new Promise((r) => server.listen(port, "127.0.0.1", r));
+    const bg = fakeBg(); // port opens, but the stdio match never arrives
+    try {
+      await assert.rejects(
+        waitForReady(
+          bg,
+          { port, stdio: "never-shows-up" },
+          { timeoutMs: 500 }
+        ),
+        /not seen in time/
       );
     } finally {
       await new Promise((r) => server.close(r));
@@ -223,11 +250,7 @@ describe("waitForReady", function () {
     const port = await findFreePort(); // nothing listening here
     const bg = fakeBg({ exited: Promise.resolve(1) });
     await assert.rejects(
-      waitForReady(
-        bg,
-        { port: { port, host: "127.0.0.1", pollIntervalMs: 50 } },
-        { timeoutMs: 5000 }
-      ),
+      waitForReady(bg, { port }, { timeoutMs: 5000 }),
       /exited before becoming ready/
     );
   });
@@ -313,7 +336,7 @@ describe("runShell/runCode background (integration)", function () {
             command: `"${process.execPath}" "${tmp}" ${port}`,
             background: {
               name: "web",
-              readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+              waitUntil: { port },
             },
             timeout: 10000,
           },
@@ -325,10 +348,7 @@ describe("runShell/runCode background (integration)", function () {
       assert.equal(result.outputs.ready, "true");
       assert.ok(registry.has("web"));
       // Port is actually accepting connections.
-      await waitForPort("127.0.0.1", port, {
-        pollIntervalMs: 100,
-        deadline: Date.now() + 2000,
-      });
+      await waitForPort(port, { deadline: Date.now() + 2000 });
     } finally {
       await stopProcess({
         config: {},
@@ -346,7 +366,7 @@ describe("runShell/runCode background (integration)", function () {
       step: {
         runShell: {
           command: "echo hi",
-          background: { name: "web", readyWhen: { delayMs: 10 } },
+          background: { name: "web", waitUntil: { delayMs: 10 } },
         },
       },
       processRegistry: registry,
@@ -367,7 +387,7 @@ describe("runShell/runCode background (integration)", function () {
           command: `"${process.execPath}" "${tmp}"`,
           background: {
             name: "stuck",
-            readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+            waitUntil: { port },
           },
           timeout: 600,
         },
@@ -392,7 +412,7 @@ describe("runShell/runCode background (integration)", function () {
             code: `require('http').createServer((q,r)=>r.end('ok')).listen(${port});`,
             background: {
               name: "api",
-              readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+              waitUntil: { port },
             },
             timeout: 10000,
           },

--- a/test/background-runner.test.js
+++ b/test/background-runner.test.js
@@ -41,7 +41,7 @@ describe("Background processes via runTests", function () {
                 code: serverCode(port),
                 background: {
                   name: "srv",
-                  readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+                  waitUntil: { port },
                 },
                 timeout: 15000,
               },
@@ -75,7 +75,7 @@ describe("Background processes via runTests", function () {
                 code: serverCode(port),
                 background: {
                   name: "leaked",
-                  readyWhen: { port: { port, host: "127.0.0.1", pollIntervalMs: 100 } },
+                  waitUntil: { port },
                 },
                 timeout: 15000,
               },

--- a/test/core-artifacts/background-processes.spec.json
+++ b/test/core-artifacts/background-processes.spec.json
@@ -1,10 +1,10 @@
 {
   "specId": "background-processes",
-  "description": "Exercises long-running background processes end-to-end: a `background` object ({ name, readyWhen }) on runCode/runShell with each readyWhen probe (port, log, httpGet, delayMs) plus the no-readyWhen form (ready as soon as spawned), stopProcess in string and object form, the ignoreMissing path, and the run-end auto-sweep (a process left running with no stopProcess). All steps are non-driver (Node only), so they run and PASS on every platform; each test uses a distinct port and process name to stay safe under concurrentRunners.",
+  "description": "Exercises long-running background processes end-to-end: a `background` object ({ name, waitUntil }) on runCode/runShell with each waitUntil condition (port, stdio, httpGet, delayMs), multiple conditions combined, the no-waitUntil form (ready as soon as spawned), stopProcess in string and object form, the ignoreMissing path, and the run-end auto-sweep (a process left running with no stopProcess). All steps are non-driver (Node only), so they run and PASS on every platform; each test uses a distinct port and process name to stay safe under concurrentRunners.",
   "tests": [
     {
       "testId": "bg-runcode-port",
-      "description": "runCode background server, port readiness probe, stopped via stopProcess string form.",
+      "description": "runCode background server, port condition, stopped via stopProcess string form.",
       "steps": [
         {
           "runCode": {
@@ -12,11 +12,8 @@
             "code": "require('http').createServer((q,r)=>r.end('ok')).listen(8201,'127.0.0.1');",
             "background": {
               "name": "bg-port",
-              "readyWhen": {
-                "port": {
-                  "port": 8201,
-                  "host": "127.0.0.1"
-                }
+              "waitUntil": {
+                "port": 8201
               }
             },
             "timeout": 15000
@@ -28,20 +25,17 @@
       ]
     },
     {
-      "testId": "bg-runcode-log",
-      "description": "runCode background process, log-pattern readiness probe, stopped via stopProcess object form.",
+      "testId": "bg-runcode-stdio",
+      "description": "runCode background process, stdio condition (matches stdout or stderr), stopped via stopProcess object form.",
       "steps": [
         {
           "runCode": {
             "language": "javascript",
             "code": "console.log('DD_BG_READY'); setInterval(() => {}, 1000000);",
             "background": {
-              "name": "bg-log",
-              "readyWhen": {
-                "log": {
-                  "pattern": "DD_BG_READY",
-                  "stream": "stdout"
-                }
+              "name": "bg-stdio",
+              "waitUntil": {
+                "stdio": "DD_BG_READY"
               }
             },
             "timeout": 15000
@@ -49,14 +43,14 @@
         },
         {
           "stopProcess": {
-            "name": "bg-log"
+            "name": "bg-stdio"
           }
         }
       ]
     },
     {
       "testId": "bg-runcode-httpget",
-      "description": "runCode background server, httpGet readiness probe, stopped via stopProcess.",
+      "description": "runCode background server, httpGet condition, stopped via stopProcess.",
       "steps": [
         {
           "runCode": {
@@ -64,13 +58,8 @@
             "code": "require('http').createServer((q,r)=>r.end('ok')).listen(8202,'127.0.0.1');",
             "background": {
               "name": "bg-http",
-              "readyWhen": {
-                "httpGet": {
-                  "url": "http://127.0.0.1:8202",
-                  "statusCodes": [
-                    200
-                  ]
-                }
+              "waitUntil": {
+                "httpGet": "http://127.0.0.1:8202"
               }
             },
             "timeout": 15000
@@ -83,7 +72,7 @@
     },
     {
       "testId": "bg-runcode-delay",
-      "description": "runCode background process, fixed-delay readiness probe, stopped via stopProcess.",
+      "description": "runCode background process, fixed-delay condition, stopped via stopProcess.",
       "steps": [
         {
           "runCode": {
@@ -91,7 +80,7 @@
             "code": "setInterval(() => {}, 1000000);",
             "background": {
               "name": "bg-delay",
-              "readyWhen": {
+              "waitUntil": {
                 "delayMs": 300
               }
             },
@@ -104,8 +93,32 @@
       ]
     },
     {
+      "testId": "bg-runcode-combined",
+      "description": "runCode background server with multiple waitUntil conditions combined (port AND stdio AND delayMs) — all must pass.",
+      "steps": [
+        {
+          "runCode": {
+            "language": "javascript",
+            "code": "require('http').createServer((q,r)=>r.end('ok')).listen(8205,'127.0.0.1'); console.log('DD_COMBINED_READY');",
+            "background": {
+              "name": "bg-combined",
+              "waitUntil": {
+                "port": 8205,
+                "stdio": "/DD_COMBINED_READY/",
+                "delayMs": 100
+              }
+            },
+            "timeout": 15000
+          }
+        },
+        {
+          "stopProcess": "bg-combined"
+        }
+      ]
+    },
+    {
       "testId": "bg-runcode-noprobe",
-      "description": "Background process with no readyWhen — ready as soon as it is spawned; stopped via stopProcess.",
+      "description": "Background process with no waitUntil — ready as soon as it is spawned; stopped via stopProcess.",
       "steps": [
         {
           "runCode": {
@@ -124,7 +137,7 @@
     },
     {
       "testId": "bg-runshell-port",
-      "description": "runShell background server (node bg-server.js), port readiness probe, stopped via stopProcess.",
+      "description": "runShell background server (node bg-server.js), port condition, stopped via stopProcess.",
       "steps": [
         {
           "runShell": {
@@ -135,11 +148,8 @@
             ],
             "background": {
               "name": "bg-shell",
-              "readyWhen": {
-                "port": {
-                  "port": 8203,
-                  "host": "127.0.0.1"
-                }
+              "waitUntil": {
+                "port": 8203
               }
             },
             "timeout": 15000
@@ -160,11 +170,8 @@
             "code": "require('http').createServer((q,r)=>r.end('ok')).listen(8204,'127.0.0.1');",
             "background": {
               "name": "bg-autosweep",
-              "readyWhen": {
-                "port": {
-                  "port": 8204,
-                  "host": "127.0.0.1"
-                }
+              "waitUntil": {
+                "port": 8204
               }
             },
             "timeout": 15000


### PR DESCRIPTION
Follow-up to #381/#383. Borrows `goTo`'s `waitUntil` terminology and simplifies the background-process readiness fields to match runShell's other fields.

```jsonc
// before (on next)
"background": { "name": "db", "readyWhen": { "port": { "port": 5432, "host": "127.0.0.1", "pollIntervalMs": 500 } } }
// after (this PR)
"background": { "name": "db", "waitUntil": { "port": 5432 } }
```

### What changed
- **`readyWhen` → `waitUntil`**, and conditions are now **AND-combinable** (like `goTo`'s `waitUntil`) rather than "exactly one probe". Specify any of `port` / `stdio` / `httpGet` / `delayMs` together; every one given must pass before `timeout`.
- **Flattened, runShell-style fields:** `port` is an integer; `httpGet` is a URL string (ready on any **2xx**); `delayMs` is an integer; and the output match is renamed **`log` → `stdio`** — a substring-or-`/regex/` string searched across **both** stdout and stderr, exactly like runShell's existing `stdio` field. Dropped `host` / `pollIntervalMs` / `statusCodes` / `stream`.

```jsonc
"waitUntil": {
  "port": 5432,
  "stdio": "/ready to accept/",
  "httpGet": "http://localhost:8080/health",
  "delayMs": 1000
}
```

- **Runtime** (`src/core/utils.ts`): `waitForPort(port,…)` / `waitForHttp(url,…)` simplified; `waitForLog` → `waitForStdio` (combined-stream substring/regex); `waitForReady` now awaits **all** specified conditions (`Promise.all`) raced against early process exit. `runShell`/`runCode` read `background.waitUntil`.
- Schema / unit+integration tests / fixtures / ADR all updated. Added a positive for combined conditions and a negative for the old object-shaped `port`.

### ⚠️ Breaking change to the `next` prerelease only
`background` is still prerelease-only (`next` channel; never on `latest`). Titled `refactor` per the established framing on #383 — squash/label for a major bump if you'd rather semantic-release record it.

### Verification
Local: `npm run build` (738 common tests), the background unit/integration suites (26 tests, incl. combined-conditions + stdio-regex), and the `background-processes.spec.json` fixture (9 tests through the real runner) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured background process readiness configuration: renamed `readyWhen` to `waitUntil` with simplified condition syntax using direct fields (`port`, `stdio`, `httpGet`, `delayMs`).
  * Added support for combining multiple readiness conditions simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->