### PR TITLE
refactor(runner): simplify stopProcess to a string name that never fails on a missing process

### DIFF
--- a/adrs/01002-background-processes.md
+++ b/adrs/01002-background-processes.md
@@ -65,9 +65,10 @@ Mechanism:
    through `runContext`/`runRoutedSpec` → `runStep` → the step handlers, so a process started in one
    spec/test survives for the whole run (e.g. start in `beforeAny`, use across `main`, stop in
    `afterAll`).
-4. **`stopProcess` step** (`src/core/tests/stopProcess.ts`, new `stopProcess_v3` schema): tree-kills
-   a process by `name` and deregisters it; accepts a string shorthand or `{ name, ignoreMissing }`.
-   `ignoreMissing: true` makes stopping an already-gone process a PASS.
+4. **`stopProcess` step** (`src/core/tests/stopProcess.ts`, new `stopProcess_v3` schema): the value is
+   the process `name` (a string); the step tree-kills the process and deregisters it. Stopping a
+   process that isn't running (already stopped, or never started) is a no-op that still PASSes — there
+   is no failure mode for a missing process and no object form / `ignoreMissing` flag to configure.
 5. **Guaranteed teardown** (`src/core/tests.ts`): the existing Appium-teardown `finally` also sweeps
    any still-registered process (run-end auto-cleanup), and new `SIGINT`/`SIGTERM` handlers tear
    down background processes, Appium, and Xvfb on interrupt — the handlers are removed in the same
@@ -101,17 +102,17 @@ Mechanism:
 * Unit (`test/background-process.test.js`): `spawnBackgroundCommand` returns immediately and buffers
   output; each condition (`port`/`httpGet`/`stdio`/`delayMs`) resolves and times out correctly,
   and combined conditions all gate together; readiness
-  fails fast on early exit; `stopProcess` kills + deregisters + honors `ignoreMissing`; the real
+  fails fast on early exit; `stopProcess` kills + deregisters and no-ops (PASS) on a missing process; the real
   `runShell`/`runCode` background branches (readiness, outputs, name collision, timeout-deregister,
   deferred temp cleanup).
 * Schema (`src/common/test/validate.test.js`): positive + negative cases for `background`/`name`/
-  every `waitUntil` condition (and combined conditions) and both `stopProcess` forms (non-object
-  `background`, unknown key in `background`/`waitUntil`, old object-shaped port, missing name,
-  out-of-range port, whitespace name).
+  every `waitUntil` condition (and combined conditions) and the string-only `stopProcess` (non-object
+  `background`, unknown key in `background`/`waitUntil`, old object-shaped port, object-form
+  `stopProcess`, missing name, out-of-range port, whitespace name).
 * End-to-end: `test/background-runner.test.js` drives `runTests()` for explicit-stop and run-end
   auto-sweep; `test/core-artifacts/background-processes.spec.json` exercises every permutation
   through the canonical `test/core-core.test.js` fixture gate (all `waitUntil` conditions, combined
-  conditions, `stopProcess` string/object, `ignoreMissing`, auto-sweep, `runShell` and `runCode`
+  conditions, `stopProcess` by name, the missing-process no-op, auto-sweep, `runShell` and `runCode`
   background) and must resolve
   PASS/SKIPPED across the CI matrix (macOS / Linux / Windows × node 22/24).
 

--- a/src/common/src/schemas/src_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/step_v3.schema.json
@@ -588,12 +588,6 @@
       "stopProcess": "web"
     },
     {
-      "stopProcess": {
-        "name": "web",
-        "ignoreMissing": true
-      }
-    },
-    {
       "screenshot": true
     },
     {

--- a/src/common/src/schemas/src_schemas/stopProcess_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/stopProcess_v3.schema.json
@@ -1,56 +1,14 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "stopProcess",
-  "description": "Stop and deregister a background process started by a `runShell` or `runCode` step with a `background` object.",
-  "anyOf": [
-    {
-      "$ref": "#/components/schemas/string"
-    },
-    {
-      "$ref": "#/components/schemas/object"
-    }
+  "description": "Stop and deregister a background process started by a `runShell` or `runCode` step (with a `background` object). The value is the process `name`. Stopping a process that isn't running — already stopped, or never started — is a no-op that still passes.",
+  "type": "string",
+  "minLength": 1,
+  "pattern": "\\S",
+  "transform": [
+    "trim"
   ],
-  "components": {
-    "schemas": {
-      "string": {
-        "title": "Stop process (by name)",
-        "description": "Name of the background process to stop.",
-        "type": "string",
-        "minLength": 1,
-        "pattern": "\\S",
-        "transform": [
-          "trim"
-        ]
-      },
-      "object": {
-        "title": "Stop process (detailed)",
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Name of the background process to stop.",
-            "minLength": 1,
-            "pattern": "\\S",
-            "transform": ["trim"]
-          },
-          "ignoreMissing": {
-            "type": "boolean",
-            "description": "If `true`, the step passes even when no process with `name` is registered (for example, it was already stopped or never started).",
-            "default": false
-          }
-        }
-      }
-    }
-  },
   "examples": [
-    "web",
-    {
-      "name": "web",
-      "ignoreMissing": true
-    }
+    "web"
   ]
 }

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -2460,7 +2460,7 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.equal("");
       });
 
-      it("should validate a stopProcess step in string form", function () {
+      it("should validate a stopProcess step (string name)", function () {
         const result = validate({
           schemaKey: "step_v3",
           object: { stopProcess: "db" },
@@ -2469,13 +2469,13 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.equal("");
       });
 
-      it("should validate a stopProcess step in object form with ignoreMissing", function () {
+      it("should reject a stopProcess in object form (string-only)", function () {
         const result = validate({
           schemaKey: "step_v3",
           object: { stopProcess: { name: "db", ignoreMissing: true } },
         });
-        expect(result.valid).to.be.true;
-        expect(result.errors).to.equal("");
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
       });
 
       it("should reject a background that is not an object (e.g. true)", function () {
@@ -2602,10 +2602,10 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.be.a("string");
       });
 
-      it("should reject a stopProcess object missing name", function () {
+      it("should reject a whitespace-only stopProcess name", function () {
         const result = validate({
           schemaKey: "step_v3",
-          object: { stopProcess: { ignoreMissing: true } },
+          object: { stopProcess: "   " },
         });
         expect(result.valid).to.be.false;
         expect(result.errors).to.be.a("string");

--- a/src/core/tests/stopProcess.ts
+++ b/src/core/tests/stopProcess.ts
@@ -6,7 +6,9 @@ import fs from "node:fs";
 export { stopProcess };
 
 // Stop and deregister a background process started by a runShell/runCode step
-// with a `background` object.
+// with a `background` object. The step value is the process `name` (a string).
+// Stopping a process that isn't running (already stopped, or never started) is a
+// no-op that still PASSes.
 async function stopProcess({
   config,
   step,
@@ -31,21 +33,15 @@ async function stopProcess({
   }
   step = isValidStep.object;
 
-  // Normalize string shorthand to object form
-  let spec = step.stopProcess;
-  if (typeof spec === "string") spec = { name: spec };
-  const name = spec.name;
-  const ignoreMissing = spec.ignoreMissing || false;
+  // The step value is the process name.
+  const name = step.stopProcess;
 
   const entry = processRegistry?.get(name);
   if (!entry) {
-    if (ignoreMissing) {
-      result.status = "PASS";
-      result.description = `No background process named "${name}" is running; nothing to stop.`;
-      return result;
-    }
-    result.status = "FAIL";
-    result.description = `No background process named "${name}" is running.`;
+    // Missing process is never a failure — stopping something that isn't
+    // running is a no-op.
+    result.status = "PASS";
+    result.description = `No background process named "${name}" is running; nothing to stop.`;
     return result;
   }
 

--- a/src/core/tests/stopProcess.ts
+++ b/src/core/tests/stopProcess.ts
@@ -33,8 +33,19 @@ async function stopProcess({
   }
   step = isValidStep.object;
 
-  // The step value is the process name.
+  // The step value is the process name. Guard the type defensively: a
+  // multi-action step can satisfy step_v3 via a different `anyOf` branch (or a
+  // programmatic caller can bypass schema transforms), leaving `stopProcess` a
+  // non-string. Fail loudly on that rather than using an object/number as a Map
+  // key and silently reporting a "missing process" no-op.
   const name = step.stopProcess;
+  if (typeof name !== "string" || name.trim().length === 0) {
+    result.status = "FAIL";
+    result.description = `Invalid stopProcess value: expected a process name string, got ${JSON.stringify(
+      name
+    )}.`;
+    return result;
+  }
 
   const entry = processRegistry?.get(name);
   if (!entry) {

--- a/test/background-process.test.js
+++ b/test/background-process.test.js
@@ -296,7 +296,7 @@ describe("stopProcess", function () {
     const registry = new Map([["api", { name: "api", bg, tempPath: tmp }]]);
     const result = await stopProcess({
       config: {},
-      step: { stopProcess: { name: "api" } },
+      step: { stopProcess: "api" },
       processRegistry: registry,
     });
     assert.equal(result.status, "PASS");
@@ -304,24 +304,14 @@ describe("stopProcess", function () {
     assert.equal(fs.existsSync(tmp), false, "temp script should be deleted");
   });
 
-  it("passes for a missing process when ignoreMissing is true", async function () {
-    const registry = new Map();
-    const result = await stopProcess({
-      config: {},
-      step: { stopProcess: { name: "nope", ignoreMissing: true } },
-      processRegistry: registry,
-    });
-    assert.equal(result.status, "PASS");
-  });
-
-  it("fails for a missing process when ignoreMissing is false", async function () {
+  it("passes (no-op) for a missing process", async function () {
     const registry = new Map();
     const result = await stopProcess({
       config: {},
       step: { stopProcess: "nope" },
       processRegistry: registry,
     });
-    assert.equal(result.status, "FAIL");
+    assert.equal(result.status, "PASS");
   });
 });
 
@@ -360,7 +350,7 @@ describe("runShell/runCode background (integration)", function () {
     } finally {
       await stopProcess({
         config: {},
-        step: { stopProcess: { name: "web", ignoreMissing: true } },
+        step: { stopProcess: "web" },
         processRegistry: registry,
       });
       fs.rmSync(tmp, { force: true });
@@ -437,7 +427,7 @@ describe("runShell/runCode background (integration)", function () {
       const tempPath = entry?.tempPath;
       await stopProcess({
         config: {},
-        step: { stopProcess: { name: "api", ignoreMissing: true } },
+        step: { stopProcess: "api" },
         processRegistry: registry,
       });
       if (tempPath) assert.equal(fs.existsSync(tempPath), false, "temp script removed on stop");

--- a/test/background-process.test.js
+++ b/test/background-process.test.js
@@ -313,6 +313,19 @@ describe("stopProcess", function () {
     });
     assert.equal(result.status, "PASS");
   });
+
+  it("fails for a non-string stopProcess value (defensive)", async function () {
+    const registry = new Map();
+    const result = await stopProcess({
+      config: {},
+      // A multi-action step validates via the goTo anyOf branch, so the step
+      // passes step_v3 while stopProcess remains a non-string object.
+      step: { stopProcess: { name: "nope" }, goTo: "https://example.com" },
+      processRegistry: registry,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.match(result.description, /Invalid stopProcess value/);
+  });
 });
 
 describe("runShell/runCode background (integration)", function () {

--- a/test/core-artifacts/background-processes.spec.json
+++ b/test/core-artifacts/background-processes.spec.json
@@ -4,7 +4,7 @@
   "tests": [
     {
       "testId": "bg-runcode-port",
-      "description": "runCode background server, port condition, stopped via stopProcess string form.",
+      "description": "runCode background server, port condition, stopped via stopProcess.",
       "steps": [
         {
           "runCode": {

--- a/test/core-artifacts/background-processes.spec.json
+++ b/test/core-artifacts/background-processes.spec.json
@@ -1,6 +1,6 @@
 {
   "specId": "background-processes",
-  "description": "Exercises long-running background processes end-to-end: a `background` object ({ name, waitUntil }) on runCode/runShell with each waitUntil condition (port, stdio, httpGet, delayMs), multiple conditions combined, the no-waitUntil form (ready as soon as spawned), stopProcess in string and object form, the ignoreMissing path, and the run-end auto-sweep (a process left running with no stopProcess). All steps are non-driver (Node only), so they run and PASS on every platform; each test uses a distinct port and process name to stay safe under concurrentRunners.",
+  "description": "Exercises long-running background processes end-to-end: a `background` object ({ name, waitUntil }) on runCode/runShell with each waitUntil condition (port, stdio, httpGet, delayMs), multiple conditions combined, the no-waitUntil form (ready as soon as spawned), stopProcess (by name), the missing-process no-op, and the run-end auto-sweep (a process left running with no stopProcess). All steps are non-driver (Node only), so they run and PASS on every platform; each test uses a distinct port and process name to stay safe under concurrentRunners.",
   "tests": [
     {
       "testId": "bg-runcode-port",
@@ -26,7 +26,7 @@
     },
     {
       "testId": "bg-runcode-stdio",
-      "description": "runCode background process, stdio condition (matches stdout or stderr), stopped via stopProcess object form.",
+      "description": "runCode background process, stdio condition (matches stdout or stderr), stopped via stopProcess.",
       "steps": [
         {
           "runCode": {
@@ -42,9 +42,7 @@
           }
         },
         {
-          "stopProcess": {
-            "name": "bg-stdio"
-          }
+          "stopProcess": "bg-stdio"
         }
       ]
     },
@@ -180,14 +178,11 @@
       ]
     },
     {
-      "testId": "bg-stopprocess-ignoremissing",
-      "description": "stopProcess with ignoreMissing on a name that was never started PASSES instead of failing.",
+      "testId": "bg-stopprocess-missing",
+      "description": "stopProcess on a name that was never started is a no-op that PASSES.",
       "steps": [
         {
-          "stopProcess": {
-            "name": "bg-never-started",
-            "ignoreMissing": true
-          }
+          "stopProcess": "bg-never-started"
         }
       ]
     }


### PR DESCRIPTION
Follow-up to #381/#383/#384. Simplifies the `stopProcess` step per maintainer request: drop the object form and the `ignoreMissing` flag, and never fail when the named process isn't running.

```jsonc
// before
{ "stopProcess": "web" }
{ "stopProcess": { "name": "web", "ignoreMissing": true } }   // removed
// after — string only
{ "stopProcess": "web" }
```

### What changed
- **Schema** (`stopProcess_v3`): now a plain **string** (the process `name`) — `minLength: 1`, `\S`, trimmed. Removed the object form and `ignoreMissing`. Dropped the object-form example from `step_v3`.
- **Behavior**: stopping a process that isn't running (already stopped, or never started) is a **no-op that PASSes** — there's no longer any failure mode for a missing process, so `ignoreMissing` is unnecessary.
- **Runtime** (`stopProcess.ts`): reads `step.stopProcess` directly as the name; the missing-process branch now returns PASS instead of FAIL.
- Tests / fixtures / ADR updated: schema now **rejects** the object form, and the "missing process" case asserts PASS.

### ⚠️ Breaking change to the `next` prerelease only
`background`/`stopProcess` are prerelease-only on `next` (never on `latest`). `refactor` framing, consistent with #383/#384.

### Verification
Local: `npm run build` (738 common tests), the background unit/integration suites (26 tests), and the `background-processes.spec.json` fixture (9 tests through the real runner) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the `stopProcess` step to accept a process name string only.
  * Stopping a missing or non-running process now consistently passes.

* **Documentation**
  * Updated background process architecture decision record.

* **Tests**
  * Updated test coverage for the simplified `stopProcess` contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->