### PR TITLE
fix(hints): drop stale record-video concurrency warning

### DIFF
--- a/src/hints/hints.ts
+++ b/src/hints/hints.ts
@@ -312,7 +312,7 @@ export const HINTS: Hint[] = [
       '{ "concurrentRunners": true }',
       "```",
       "",
-      "Or pass `--concurrent-runners 4` on the CLI. `true` uses your CPU core count (capped at 4). Keep it at `1` if your tests share variables across contexts or record video.",
+      "Or pass `--concurrent-runners 4` on the CLI. `true` uses your CPU core count (capped at 4). Keep it at `1` if your tests share variables across contexts. Recordings are safe to run concurrently: the `browser` engine records each context's own window, and Doc Detective auto-serializes `ffmpeg` recordings with other browser tests for you.",
     ].join("\n"),
     when: (ctx) =>
       ctx.totalContexts >= 5 &&

--- a/test/hints.test.js
+++ b/test/hints.test.js
@@ -2070,10 +2070,17 @@ describe("hints/hints (registry)", function () {
     expect(
       h.when(fakeCtx({ totalContexts: 5, config: { concurrentRunners: 1 } }))
     ).to.equal(true);
-    // Recording runs should stay sequential — wrong advice for them.
+    // This run had no recordings, so the hint doesn't second-guess a run
+    // that already records (the recordConcurrently hint covers that case).
     expect(
       h.when(fakeCtx({ totalContexts: 5, producedRecordings: true }))
     ).to.equal(false);
+    // The body must not tell users to pin concurrentRunners to 1 for
+    // recording: the browser engine is concurrency-safe and ffmpeg
+    // recordings are auto-serialized by the scheduler (#343/#380).
+    expect(h.markdown).to.not.match(/record video/i);
+    // The still-valid shared-variables guidance stays.
+    expect(h.markdown).to.match(/share variables/i);
   });
 
   it("recordConcurrently: fires only when the run serialized recordings", function () {


### PR DESCRIPTION
## Problem

The `setConcurrentRunners` post-run hint (`src/hints/hints.ts`) told users:

> Keep it at `1` if your tests share variables across contexts **or record video**.

The "or record video" half is stale. Two later changes made recording concurrency-safe:

- **#343** split the record engines — the `browser` engine records each context's own window, so it's safe under concurrency.
- **#380** added a resource-aware scheduler that **auto-serializes** `ffmpeg` recordings with other browser tests, on every platform.

So users no longer need to pin `concurrentRunners` to `1` just because they record. The docs were already reconciled in **#344** (`docs/fern/pages/docs/actions/record.mdx`); this hint was the last stale copy of the old framing.

## What changed

- Reworded the hint body to keep the still-valid shared-variables guidance and replace the stale recording warning with the reconciled framing: the `browser` engine is concurrency-safe and `ffmpeg` recordings are auto-serialized by the scheduler. Wording mirrors `record.mdx` on `main`.
- The predicate is unchanged (it already skips when `producedRecordings` is true, and the separate `recordConcurrently` hint covers serialized-recording runs).

## Test (red → green)

Extended the existing `setConcurrentRunners` registry test in `test/hints.test.js` with focused assertions:

```js
expect(h.markdown).to.not.match(/record video/i);
expect(h.markdown).to.match(/share variables/i);
```

- **Red**: failed on the old body (`expected '…' not to match /record video/i`).
- **Green**: full hints suite passes — `155 passing, 1 pending`.

Also refreshed the now-misleading inline comment on the `producedRecordings: true` assertion (the predicate still skips that case, but not because "recording runs should stay sequential").

## ADR assessment

**No new ADR.** Per `CLAUDE.md`, ADRs document *decisions*, not mechanical/text fixes. This change only aligns user-facing hint text with the already-decided behavior from #343 and #380 (the scheduler decision is recorded in `adrs/01001-resource-aware-concurrency-scheduler.md`). No behavior, contract, or trade-off changes here.

## Docs impact

User-facing docs are already correct — **covered by #344** (`record.mdx`). This PR brings the in-product hint into line with them; no further docs work required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the concurrent runners hint to better explain safe usage with multiple browser contexts.
  * Clarified how `true` is interpreted for concurrent runners, including the CPU core limit.
  * Improved hint behavior so recording-related guidance is shown only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->