### PR TITLE
fix(common): sync generated schema descriptions with source

### DIFF
--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -28587,7 +28587,7 @@
       "title": "Telemetry options"
     },
     "hints": {
-      "description": "Options for the post-run hints feature. After a test run, Doc Detective may print one short, contextual hint with code samples and links to encourage further engagement (for example, suggesting a CI workflow when none is detected). Hints are shown only on a TTY and only at the default `info` log level.",
+      "description": "Options for the post-run hints feature. After a test run, Doc Detective may print one short, contextual hint with code samples and links to encourage further engagement (for example, suggesting a CI workflow when none is detected). Doc Detective displays hints only in an interactive terminal (TTY) and only at the default `info` log level.",
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/src/common/src/types/generated/config_v3.ts
+++ b/src/common/src/types/generated/config_v3.ts
@@ -461,7 +461,7 @@ export interface TelemetryOptions {
   userId?: string;
 }
 /**
- * Options for the post-run hints feature. After a test run, Doc Detective may print one short, contextual hint with code samples and links to encourage further engagement (for example, suggesting a CI workflow when none is detected). Hints are shown only on a TTY and only at the default `info` log level.
+ * Options for the post-run hints feature. After a test run, Doc Detective may print one short, contextual hint with code samples and links to encourage further engagement (for example, suggesting a CI workflow when none is detected). Doc Detective displays hints only in an interactive terminal (TTY) and only at the default `info` log level.
  */
 export interface HintsOptions {
   /**

--- a/src/common/src/types/generated/resolvedTests_v3.ts
+++ b/src/common/src/types/generated/resolvedTests_v3.ts
@@ -502,7 +502,7 @@ export interface TelemetryOptions {
   userId?: string;
 }
 /**
- * Options for the post-run hints feature. After a test run, Doc Detective may print one short, contextual hint with code samples and links to encourage further engagement (for example, suggesting a CI workflow when none is detected). Hints are shown only on a TTY and only at the default `info` log level.
+ * Options for the post-run hints feature. After a test run, Doc Detective may print one short, contextual hint with code samples and links to encourage further engagement (for example, suggesting a CI workflow when none is detected). Doc Detective displays hints only in an interactive terminal (TTY) and only at the default `info` log level.
  */
 export interface HintsOptions {
   /**


### PR DESCRIPTION
## What

Brings four generated schema artifacts back in sync with their source-of-truth description text.

The `hints` property description was corrected to active voice in the source schema (`src/common/src/schemas/src_schemas/config_v3.schema.json`, landed via #304) from the passive *"Hints are shown only on a TTY and only at the default `info` log level."* to *"Doc Detective displays hints only in an interactive terminal (TTY) and only at the default `info` log level."* The generated output bundles still carried the old passive wording.

## Stale files corrected

- `src/common/src/schemas/output_schemas/config_v3.schema.json`
- `src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json`
- `src/common/src/types/generated/config_v3.ts`
- `src/common/src/types/generated/resolvedTests_v3.ts`

`schemas.json` already carried the correct wording, and the docs reference page (`docs/fern/pages/reference/schemas/config.md`) was already correct — no change needed there.

## Scope check

I grepped the whole tree for known stale strings. The only stale string was the `hints` wording above. The other candidate — the `autoScreenshot` "in addition to any explicit" wording flagged in #335 — is **not** stale: every remaining occurrence of "in addition to any explicit" belongs to `autoRecord` ("in addition to any explicit `record` steps"), which matches the source exactly. So this PR touches only the hints text.

## How the diff was kept minimal

Running the official `npm run build:common` regenerates correctly, **but** rewrites ~80 generated files with LF line endings (the repo's generated artifacts are committed with CRLF), producing pure line-ending churn. Per the project's prior approach in #335, I discarded that churn and instead applied **surgical string replacements** to the four files so only the intended one-line description change appears. I verified the official build produces the identical corrected text, so the surgical edits are faithful to the generator.

Resulting diff: 4 files, 1 line each (`4 insertions(+), 4 deletions(-)`), no whitespace/line-ending/reordering noise.

## Verification

- Re-grepped the tracked tree: no `"Hints are shown only on a TTY"` remains.
- Confirmed the corrected wording is present in all four files.
- `npm run build:common` passes (768 common tests green) and its regenerated text matches these edits.

## ADR / docs-impact

- **ADR: none.** Mechanical regen/sync of generated artifacts — no behavior or public-contract change.
- **Docs-impact: none.** The user-facing docs reference page already carries the corrected wording.

## Commit type

`fix(common)` — this corrects text shipped inside the published `doc-detective-common` schema artifacts (the output schemas and generated types are part of the distributed package), so it warrants a patch release rather than a no-op `chore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)