### PR TITLE
test(common): cover inline-step Heretto screenshot integration

### DIFF
--- a/src/common/test/detectTests.test.js
+++ b/src/common/test/detectTests.test.js
@@ -1161,7 +1161,8 @@ function readFixture(filename) {
 
       it("should normalize an array-shaped inline step screenshot before attaching Heretto integration", async function () {
         // An array screenshot is not a valid object shape; the helper resets it
-        // to {} before attaching sourceIntegration (Array.isArray branch).
+        // to {} before attaching sourceIntegration (Array.isArray branch). The
+        // reset drops any path, so the attached filePath resolves to "".
         const content =
           '<!-- test {"steps": [{"goTo": {"url": "https://example.com"}}]} -->\n' +
           '<!-- step {"screenshot": ["shot.png"]} -->';

--- a/src/common/test/detectTests.test.js
+++ b/src/common/test/detectTests.test.js
@@ -1131,6 +1131,83 @@ function readFixture(filename) {
         expect(result[0].steps).to.have.lengthOf(1);
       });
 
+      it("should attach Heretto sourceIntegration to an inline step screenshot (object screenshot)", async function () {
+        // Inline `step` statement carrying an object-shaped screenshot. With a
+        // matching _herettoPathMapping the step-case attaches sourceIntegration
+        // and the resulting step is valid v3, so it survives alongside the
+        // seeded goTo step.
+        const content =
+          '<!-- test {"steps": [{"goTo": {"url": "https://example.com"}}]} -->\n' +
+          '<!-- step {"screenshot": {"path": "shot.png"}} -->';
+        const result = await parseContent({
+          config: {
+            detectSteps: true,
+            _herettoPathMapping: { "docs/": "my-integration" },
+          },
+          content,
+          filePath: "docs/test.md",
+          fileType: markdownFileType,
+        });
+        expect(result).to.have.lengthOf(1);
+        expect(result[0].steps).to.have.lengthOf(2);
+        const screenshotStep = result[0].steps[1];
+        expect(screenshotStep.screenshot.sourceIntegration).to.deep.equal({
+          type: "heretto",
+          integrationName: "my-integration",
+          filePath: "shot.png",
+          contentPath: "docs/test.md",
+        });
+      });
+
+      it("should normalize an array-shaped inline step screenshot before attaching Heretto integration", async function () {
+        // An array screenshot is not a valid object shape; the helper resets it
+        // to {} before attaching sourceIntegration (Array.isArray branch).
+        const content =
+          '<!-- test {"steps": [{"goTo": {"url": "https://example.com"}}]} -->\n' +
+          '<!-- step {"screenshot": ["shot.png"]} -->';
+        const result = await parseContent({
+          config: {
+            detectSteps: true,
+            _herettoPathMapping: { "docs/": "my-integration" },
+          },
+          content,
+          filePath: "docs/test.md",
+          fileType: markdownFileType,
+        });
+        expect(result).to.have.lengthOf(1);
+        expect(result[0].steps).to.have.lengthOf(2);
+        const screenshotStep = result[0].steps[1];
+        expect(screenshotStep.screenshot.sourceIntegration).to.deep.equal({
+          type: "heretto",
+          integrationName: "my-integration",
+          filePath: "",
+          contentPath: "docs/test.md",
+        });
+      });
+
+      it("should skip Heretto integration for an inline step screenshot when file not in mapping", async function () {
+        // Step-case screenshot with _herettoPathMapping set but no matching
+        // entry: findHerettoIntegration returns nothing, so no sourceIntegration
+        // is attached.
+        const content =
+          '<!-- test {"steps": [{"goTo": {"url": "https://example.com"}}]} -->\n' +
+          '<!-- step {"screenshot": {"path": "shot.png"}} -->';
+        const result = await parseContent({
+          config: {
+            detectSteps: true,
+            _herettoPathMapping: { "other/": "my-integration" },
+          },
+          content,
+          filePath: "docs/test.md",
+          fileType: markdownFileType,
+        });
+        expect(result).to.have.lengthOf(1);
+        expect(result[0].steps).to.have.lengthOf(2);
+        expect(result[0].steps[1].screenshot).to.not.have.property(
+          "sourceIntegration"
+        );
+      });
+
       it("should handle fileType with no inlineStatements", async function () {
         const result = await parseContent({
           config: {},


### PR DESCRIPTION
## What changed

Adds three unit tests to `src/common/test/detectTests.test.js` that exercise the inline-`step` Heretto screenshot path through the real parser.

## Why

`src/common`'s coverage ratchet (`npm run test:coverage:ratchet`) enforces a 100% baseline in `coverage-thresholds.json`, but actual coverage on `main` had drifted to **99.67%** lines/statements and **99.53%** branches, so the ratchet was failing.

The gap was in [`detectTests.ts`](src/common/src/detectTests.ts):

- **Lines 707–711** — the inline `step`-statement case that attaches a Heretto `sourceIntegration` to screenshot steps. Only the `markup`/`detectedStep` Heretto path had test coverage.
- **Line 799** — the `Array.isArray` normalization branch in `attachHerettoScreenshotSourceIntegration`. Existing tests only passed string/boolean screenshots, which short-circuit before that check.

## The fix

Three tests covering each meaningfully distinct shape of an inline-`step` screenshot under a configured `_herettoPathMapping`:

1. **Object screenshot** → `sourceIntegration` attached (covers 707–711, the mapping branch, and `Array.isArray`-false).
2. **Array screenshot** → normalized to `{}` first (covers `Array.isArray`-true at 799).
3. **Non-matching `_herettoPathMapping`** → no integration attached (the guard's negative path).

Coverage is now a genuine **100%** on all four metrics and the ratchet passes (776 passing).

## Reviewer notes

- Test-only change — no behavior change, so no ADR / feature fixture / docs impact.
- The previous markup-path Heretto tests gave a false sense of coverage while the inline-`step` path and the array-normalization branch stayed untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)