### PR TITLE
feat(runner): write "Last Verified On" dates back into source docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.27.0-last-verified-on.1](https://github.com/doc-detective/doc-detective/compare/v4.26.2...v4.27.0-last-verified-on.1) (2026-07-10)
+
+
+### Features
+
+* **runner:** write "Last Verified On" dates back into source docs ([bb98c53](https://github.com/doc-detective/doc-detective/commit/bb98c53132151ae8db4f5c5ff09f410c04168519))
+
 ## [4.26.2](https://github.com/doc-detective/doc-detective/compare/v4.26.1...v4.26.2) (2026-07-10)
 
 

--- a/adrs/01046-last-verified-on-marker-writeback.md
+++ b/adrs/01046-last-verified-on-marker-writeback.md
@@ -1,0 +1,121 @@
+---
+status: accepted
+date: 2026-06-29
+decision-makers: doc-detective maintainers
+---
+
+# "Last Verified On" — marker-driven write-back to source docs
+
+## Context and Problem Statement
+
+End-user documentation often wants a freshness/trust signal — "this page was verified working on
+2026-06-26" — that stays current automatically. Doc Detective already *proves* a procedure works by
+running it; the missing piece is writing that verification date **back into the source file** so a
+docs site can render a badge, and surfacing the change for review in CI.
+
+How should Doc Detective decide *what* date to write, *where* to write it, and *how* a user opts in —
+without surprising file mutations, brittle anchoring, or a pile of new configuration?
+
+## Decision Drivers
+
+* The date must land **in the source file** (not just a run artifact), idempotently across re-runs.
+* The signal must be **honest**: a date should mean "verified passing", and must not silently advance
+  when the docs break.
+* Anchoring a date to the right test/spec must survive edits and file reordering.
+* Minimize new surface area: no new config knobs or schema changes if avoidable.
+* CI should be able to turn the change into a pull request with no new plumbing.
+* No breaking changes to public schemas or the report shape.
+
+## Considered Options
+
+* **A. Marker-driven, author-placed, no config** (chosen) — the author writes a static `verified`
+  marker carrying an `id` they choose; Doc Detective resolves the id and writes the date.
+* **B. Config-driven injection** — a `verification` config object (placement/granularity/template)
+  tells Doc Detective where to inject stamps.
+* **C. Sidecar manifest** — write verification data to `.doc-detective/verified.json`; never touch
+  source files.
+
+## Decision Outcome
+
+Chosen option: **A**, because it makes anchoring, idempotency, granularity, and placement the
+author's explicit choice instead of something Doc Detective must infer — which dissolves the hardest
+problems of an injection model (B) and still satisfies the "write directly to the file" requirement
+that C fails.
+
+Behavior decided:
+
+1. **No config, no CLI flag, no configurable marker.** The feature is always on and acts only where a
+   `verified` marker exists in content, and nowhere else. There is no `verification` config object and
+   no schema change.
+2. **Author owns the `id`; Doc Detective owns the `date`.** The marker's `id` references a **test id or
+   a spec id**. After a run, the id is resolved to that unit's roll-up result.
+3. **Write the date only on PASS.** On FAIL/WARNING/SKIPPED the existing date is left untouched, so the
+   badge "ages". Because a date is only ever written on PASS, the date alone is the trust signal — no
+   `status` field is recorded.
+4. **Two marker forms.** An inline comment (per format: markdown/MDX `{/* */}`, `<!-- -->`, and
+   `[comment]: #`; AsciiDoc `// ( )`; HTML/DITA comments) and a page-level YAML front-matter object
+   `doc-detective.verified` with sibling `id` (author-set) and `date` (Doc Detective-written) keys.
+5. **Optional `badge`.** An inline marker with the `badge` attribute additionally maintains a
+   **shields.io static badge image** (`![Last verified …](https://img.shields.io/badge/…)`) on the line
+   after the marker, so it renders without theme work. Doc Detective only writes the URL — shields.io
+   renders it client-side, so there is no network call. Without `badge`, the marker is data-only.
+6. **Unknown id → warn and skip.** A marker whose id matches no test/spec logs a warning and is left
+   untouched, catching typos and deleted tests without failing the run.
+7. **CI uses the existing GitHub Action.** `create_pr_on_change` already turns any post-run file change
+   into a pull request, so date writes flow into a PR with zero Action changes.
+
+### Consequences
+
+* Good: idempotent in-source writes; honest aging; author-explicit anchoring (no content-hash guessing,
+  no orphans); zero new config/schema surface; zero new CI code.
+* Good: implementation is contained in `src/core` (`applyVerifiedMarkers` + pure helpers in
+  `src/core/utils.ts`, wired into `runTests`), so the schemas and the report shape are untouched.
+* Coverage: the writer scans the **union** of the report's content paths and the full detected input
+  set, so a marker in a prose-only page that produces no spec — referencing a test/spec defined in
+  another file — is still updated. The detected input set is side-channelled from `qualifyFiles`
+  (`config._qualifiedFiles`) through `resolvedTests._qualifiedFiles` into the writer, reusing the exact
+  file discovery the run already performed (no re-enumeration, no duplicated globbing).
+  * **Exception — pre-resolved (`DOC_DETECTIVE_API`) runs:** when `runTests` is given caller-supplied
+    `resolvedTests`, `_qualifiedFiles` is never populated, so the candidate set falls back to the
+    report's content paths alone. Markers on the tested pages are still updated; prose-only pages that
+    reference a test defined elsewhere are not, and a `debug` line notes this.
+* Trade-off: `verified` markers must round-trip in the exact comment form they were authored in; the
+  writer never rewrites an MDX `{/* */}` marker as `<!-- -->` (which would break the MDX build).
+
+### Confirmation
+
+* Pure helpers (`verifiedDate`, `shieldsBadge`, `parseVerifiedMarkers`, `applyVerifiedToContent`,
+  `resolveVerifiedId`) are unit-tested in `test/verified-markers.test.js`, including the shields.io
+  dash-doubling, MDX form preservation, idempotency, and aging.
+* End-to-end write-back is covered in `test/verified-writeback.test.js`: a deterministic matrix
+  (markdown/MDX/AsciiDoc/HTML/DITA, data-only and badge, front matter, spec-id and test-id targets,
+  PASS/FAIL/SKIPPED, unknown-id warning, byte-idempotency) driven by a synthetic report, plus two real
+  `runTests` runs — one mutating a temp markdown file with an inline `wait` test, one proving the
+  full-input-set scan updates a prose-only page whose marker references a test defined in another file.
+* These fixtures are intentionally **not** committed `test/core-artifacts/*.spec.json` files: the
+  feature mutates source files, so a committed fixture would be rewritten with the current date on every
+  run and permanently dirty the working tree. The temp-file integration tests are the correct
+  adaptation of the feature-fixture requirement for a file-mutating feature.
+
+## Pros and Cons of the Options
+
+### A. Marker-driven, author-placed, no config
+
+* Good, because anchoring is the author's literal `id` — stable, no orphans, no content-hash inference.
+* Good, because idempotency is "find marker by id, overwrite its date in place" — position-independent.
+* Good, because granularity and placement are free: reference a test or spec id, put the marker anywhere.
+* Good, because it needs no config object, no schema change, and no Action change.
+* Bad, because the author must know/copy a valid id, and a typo'd id only warns rather than failing.
+
+### B. Config-driven injection
+
+* Good, because users get badges without authoring per-location markers.
+* Bad, because Doc Detective must infer a safe insertion point (avoiding code fences/lists/tables) and
+  guess which test owns each stamp, reintroducing orphan and idempotency hazards.
+* Bad, because it adds a `verification` config object and per-format placement machinery.
+
+### C. Sidecar manifest
+
+* Good, because it never risks a bad source-file diff and idempotency is trivial.
+* Bad, because it fails the core requirement to write **directly into the source file**, and requires
+  every docs theme to read a separate JSON file to render anything.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective",
-  "version": "4.26.2",
+  "version": "4.27.0-last-verified-on.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective",
-      "version": "4.26.2",
+      "version": "4.27.0-last-verified-on.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [
@@ -25503,7 +25503,7 @@
     },
     "src/common": {
       "name": "doc-detective-common",
-      "version": "4.26.2",
+      "version": "4.27.0-last-verified-on.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective",
-  "version": "4.26.2",
+  "version": "4.27.0-last-verified-on.1",
   "description": "Treat doc content as testable assertions to validate doc accuracy and product UX.",
   "workspaces": [
     "src/common"

--- a/src/common/package-lock.json
+++ b/src/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "4.26.2",
+  "version": "4.27.0-last-verified-on.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "4.26.2",
+      "version": "4.27.0-last-verified-on.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/src/common/package.json
+++ b/src/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "4.26.2",
+  "version": "4.27.0-last-verified-on.1",
   "description": "Shared components for Doc Detective projects.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/core/detectTests.ts
+++ b/src/core/detectTests.ts
@@ -244,6 +244,7 @@ async function qualifyFiles({ config }: { config: any }) {
 
   if (sequence.length === 0) {
     log(config, "warning", "No input sources specified.");
+    config._qualifiedFiles = [];
     return [];
   }
 
@@ -403,6 +404,10 @@ async function qualifyFiles({ config }: { config: any }) {
       }
     }
   }
+  // Side-channel the full qualified file set (same pattern as `_phaseByFile`)
+  // so the "Last Verified On" write-back can scan prose-only files that carry a
+  // `verified` marker but contribute no spec to the report.
+  config._qualifiedFiles = files;
   return files;
 }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,7 +1,7 @@
 import { setConfig } from "./config.js";
 import { detectTests } from "./detectTests.js";
 import { resolveTests } from "./resolveTests.js";
-import { log, cleanTemp } from "./utils.js";
+import { log, cleanTemp, applyVerifiedMarkers } from "./utils.js";
 import { runSpecs, runViaApi, getRunner } from "./tests.js";
 import { telemetryNotice, sendTelemetry } from "./telem.js";
 import { readFile, resolvePaths } from "./files.js";
@@ -33,6 +33,10 @@ async function detectAndResolveTests({ config }: any) {
     return null;
   }
   const resolvedTests = await resolveTests({ config, detectedTests });
+  // Carry the full qualified input set forward so the verified-marker
+  // write-back can reach prose-only files that produced no spec (see
+  // qualifyFiles' `config._qualifiedFiles`).
+  if (resolvedTests) (resolvedTests as any)._qualifiedFiles = config._qualifiedFiles || [];
   return resolvedTests;
 }
 
@@ -233,6 +237,27 @@ async function runTests(config: any, options: any = {}) {
 
   // Clean up
   cleanTemp();
+
+  // "Last Verified On" write-back: update any `verified` markers in the source
+  // docs with today's date where the referenced test/spec passed. No-op when
+  // no markers exist; never throws (warns and continues on per-file errors).
+  try {
+    // resolvedTests is always set here (runTests returns early otherwise), so the
+    // only fallback needed is for the pre-resolved (DOC_DETECTIVE_API) path, which
+    // never populates _qualifiedFiles — there, the write-back is limited to the
+    // report's content paths and can't reach prose-only pages.
+    const qualifiedFiles = resolvedTests._qualifiedFiles || [];
+    if (options.resolvedTests && qualifiedFiles.length === 0) {
+      log(
+        config,
+        "debug",
+        "Verified write-back: pre-resolved run has no qualified-file list; only report content paths are scanned (prose-only pages skipped)."
+      );
+    }
+    applyVerifiedMarkers({ config, results, files: qualifiedFiles });
+  } catch (err: any) {
+    log(config, "warning", `verified write-back failed: ${err?.message ?? err}`);
+  }
 
   // Send telemetry
   sendTelemetry(config, "runTests", results);

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -15,6 +15,7 @@ import {
   assertConptyAllocatable,
   ensurePtyBackendOnDisk,
 } from "./ptyWatchdog.js";
+import YAML from "yaml";
 
 export {
   outputResults,
@@ -56,6 +57,12 @@ export {
   rollUpAssertions,
   createAppiumPool,
   evaluateContextRequirements,
+  verifiedDate,
+  shieldsBadge,
+  parseVerifiedMarkers,
+  applyVerifiedToContent,
+  resolveVerifiedId,
+  applyVerifiedMarkers,
 };
 
 export type { BackgroundProcess };
@@ -1387,6 +1394,430 @@ function replaceEnvs(stringOrObject: any): any {
     });
   }
   return stringOrObject;
+}
+
+// ===========================================================================
+// "Last Verified On" — marker-driven write-back.
+//
+// Authors place a static `verified` marker carrying an `id` (a test or spec id)
+// they choose; after a run we resolve that id to its roll-up result and, only
+// when it PASSED, write today's date back into the marker. On non-pass the date
+// is left untouched so the badge silently "ages". There is no config: the
+// feature acts wherever a marker exists, and nowhere else. See
+// adrs/01046-last-verified-on-marker-writeback.md.
+// ===========================================================================
+
+// Map a file extension to the doc format whose comment syntax we use. `.mdx`
+// shares the markdown grammar (and uses the JSX-comment variant).
+const VERIFIED_FORMAT_BY_EXT: Record<string, string> = {
+  md: "markdown",
+  markdown: "markdown",
+  mdx: "markdown",
+  adoc: "asciidoc",
+  asciidoc: "asciidoc",
+  asc: "asciidoc",
+  html: "html",
+  htm: "html",
+  dita: "dita",
+  ditamap: "dita",
+  // `.xml` is intentionally omitted: it's a generic extension (POMs, SVGs, feeds,
+  // Spring configs), and treating every .xml as DITA would put unrelated files on
+  // the write-back scan path. DITA authored as `.xml` is uncommon; use `.dita`.
+};
+
+// Per-format marker patterns. Three capture groups: (open)(attrs)(close) so a
+// rewrite preserves the exact comment delimiters that matched — critical for
+// MDX, where an HTML comment would break the build. Markdown/MDX offers all
+// three variants the existing `test`/`step` statements do.
+const VERIFIED_MARKER_PATTERNS: Record<string, string[]> = {
+  markdown: [
+    "(<!--\\s*verified\\s+)([\\s\\S]*?)(\\s*-->)",
+    "(\\{/\\*\\s*verified\\s+)([\\s\\S]*?)(\\s*\\*/\\})",
+    "(\\[comment\\]:\\s*#\\s*\\(verified\\s+)([^)]*?)(\\))",
+  ],
+  asciidoc: ["(//\\s*\\(verified\\s+)([^)]*?)(\\))"],
+  html: ["(<!--\\s*verified\\s+)([\\s\\S]*?)(\\s*-->)"],
+  dita: [
+    "(<!--\\s*verified\\s+)([\\s\\S]*?)(\\s*-->)",
+    "(<\\?doc-detective\\s+verified\\s+)([\\s\\S]*?)(\\s*\\?>)",
+  ],
+};
+
+// Body of an existing DD-managed shields.io image, per format — used to detect
+// and replace the badge line on re-runs instead of duplicating it.
+const VERIFIED_IMG_BODY: Record<string, string> = {
+  markdown: "!\\[[^\\]]*\\]\\([^)]*img\\.shields\\.io/badge[^)]*\\)",
+  html: "<img[^>]*img\\.shields\\.io/badge[^>]*>",
+  asciidoc: "image:\\S*img\\.shields\\.io/badge\\S*\\[[^\\]]*\\]",
+  dita: "<image[^>]*img\\.shields\\.io/badge[\\s\\S]*?</image>",
+};
+
+interface VerifiedMarker {
+  id: string;
+  badge: boolean;
+  date?: string;
+  open: string;
+  attrs: string;
+  close: string;
+  start: number;
+  end: number;
+}
+
+// Filesystem-/badge-friendly calendar date, `YYYY-MM-DD` in UTC (deterministic
+// across runners/timezones), e.g. `2026-06-26`.
+function verifiedDate(d: Date = new Date()): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+// Escape one shields.io URL path segment: `_`→`__`, `-`→`--`, ` `→`_`. The
+// dash-doubling is the easy-to-get-wrong bit (a literal `-` is otherwise the
+// label/message/color separator), so `2026-06-26` → `2026--06--26`.
+function shieldsEscape(segment: string): string {
+  return segment.replace(/_/g, "__").replace(/-/g, "--").replace(/ /g, "_");
+}
+
+// Build a shields.io static badge, wrapped in the format's native image syntax.
+// DD only writes the URL; shields.io renders it client-side (no network call).
+function shieldsBadge(
+  format: string,
+  date: string,
+  { label = "Last verified", color = "brightgreen" }: { label?: string; color?: string } = {}
+): string {
+  const url = `https://img.shields.io/badge/${shieldsEscape(label)}-${shieldsEscape(
+    date
+  )}-${shieldsEscape(color)}`;
+  const alt = `${label} ${date}`;
+  switch (format) {
+    case "asciidoc":
+      return `image:${url}[${alt}]`;
+    case "html":
+      return `<img src="${url}" alt="${alt}">`;
+    case "dita":
+      return `<image href="${url}"><alt>${alt}</alt></image>`;
+    default:
+      return `![${alt}](${url})`;
+  }
+}
+
+// Parse a marker's attribute string (`id=… badge date=…`) into fields. Bare
+// `badge` is a boolean flag; everything else is `key=value`.
+function parseVerifiedAttrs(attrs: string): { id?: string; date?: string; badge: boolean } {
+  const out: { id?: string; date?: string; badge: boolean } = { badge: false };
+  for (const token of attrs.trim().split(/\s+/)) {
+    if (!token) continue;
+    if (token === "badge") {
+      out.badge = true;
+      continue;
+    }
+    const eq = token.indexOf("=");
+    if (eq === -1) continue;
+    const key = token.slice(0, eq);
+    const value = token.slice(eq + 1).replace(/^["']|["']$/g, "");
+    if (key === "id") out.id = value;
+    else if (key === "date") out.date = value;
+    else if (key === "badge") out.badge = value !== "false";
+  }
+  return out;
+}
+
+// Find all inline `verified` markers in `content` for the given format.
+function parseVerifiedMarkers(content: string, format: string): VerifiedMarker[] {
+  const patterns = VERIFIED_MARKER_PATTERNS[format] || VERIFIED_MARKER_PATTERNS.markdown;
+  const markers: VerifiedMarker[] = [];
+  for (const pattern of patterns) {
+    const regex = new RegExp(pattern, "g");
+    for (const m of content.matchAll(regex)) {
+      const parsed = parseVerifiedAttrs(m[2]);
+      if (!parsed.id) continue;
+      markers.push({
+        id: parsed.id,
+        badge: parsed.badge,
+        date: parsed.date,
+        open: m[1],
+        attrs: m[2],
+        close: m[3],
+        start: m.index!,
+        end: m.index! + m[0].length,
+      });
+    }
+  }
+  markers.sort((a, b) => a.start - b.start);
+  return markers;
+}
+
+// Set or replace the `date=` attribute, preserving attribute order and the
+// `badge` flag. Any quotes on an existing value are intentionally normalized away
+// (`date="…"` → `date=…`): the value is an unquoted comment attribute, not YAML,
+// and parseVerifiedAttrs strips quotes on read, so this is a one-time no-op that
+// stays idempotent thereafter.
+function setVerifiedAttrDate(attrs: string, date: string): string {
+  if (/\bdate=\S+/.test(attrs)) return attrs.replace(/\bdate=\S+/, `date=${date}`);
+  return `${attrs.replace(/\s+$/, "")} date=${date}`;
+}
+
+// Idempotent, form-preserving in-place update of every inline marker whose id
+// has a date in `dates` (a Map<id, date>). Markers absent from the map are left
+// untouched (they age). Processed right-to-left so earlier indices stay valid.
+function applyVerifiedToContent(
+  content: string,
+  format: string,
+  dates: Map<string, string>
+): string {
+  // Match the file's existing newline style so a CRLF-authored doc doesn't get
+  // an LF badge line spliced in (which would break byte-idempotency on Windows).
+  const eol = content.includes("\r\n") ? "\r\n" : "\n";
+  const markers = parseVerifiedMarkers(content, format);
+  for (const marker of [...markers].sort((a, b) => b.start - a.start)) {
+    const date = dates.get(marker.id);
+    if (!date) continue;
+    // Badge image lives on the line after the marker (indices ≥ marker.end), so
+    // edit it before rewriting the marker to keep marker.start/end valid.
+    if (marker.badge) {
+      const img = shieldsBadge(format, date);
+      const body = VERIFIED_IMG_BODY[format] || VERIFIED_IMG_BODY.markdown;
+      const imgLineRe = new RegExp(`^([ \\t]*\\r?\\n[ \\t]*)(?:${body})`);
+      const tail = content.slice(marker.end);
+      const mm = tail.match(imgLineRe);
+      if (mm) {
+        content =
+          content.slice(0, marker.end) + mm[1] + img + content.slice(marker.end + mm[0].length);
+      } else {
+        // Indent the new badge line to match the marker's own line, so a marker
+        // inside an indented construct (e.g. a nested list item) doesn't get a
+        // column-0 badge that breaks out of it. Re-runs preserve this via mm[1].
+        const lineStart = content.lastIndexOf("\n", marker.start - 1) + 1;
+        const indent = (content.slice(lineStart, marker.start).match(/^[ \t]*/) || [""])[0];
+        content = content.slice(0, marker.end) + eol + indent + img + content.slice(marker.end);
+      }
+    }
+    const newAttrs = setVerifiedAttrDate(marker.attrs, date);
+    content =
+      content.slice(0, marker.start) +
+      marker.open +
+      newAttrs +
+      marker.close +
+      content.slice(marker.end);
+  }
+  return content;
+}
+
+// Read the `doc-detective.verified.id` from a file's leading YAML front matter,
+// or null if there is none.
+function frontMatterVerifiedId(content: string): string | null {
+  const fm = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fm) return null;
+  try {
+    const doc = YAML.parseDocument(fm[1]);
+    const id = doc.getIn(["doc-detective", "verified", "id"]);
+    return id != null ? String(id) : null;
+  } catch {
+    return null;
+  }
+}
+
+// Fallback for non-block-style (e.g. flow) front matter: re-serialize the block
+// via the YAML parser so the date is still written (honoring the marker
+// contract), accepting that a flow collection may be reformatted. The date is a
+// double-quoted string so YAML 1.1 readers (e.g. js-yaml) don't coerce it to a
+// timestamp.
+function upsertFrontMatterViaYaml(
+  content: string,
+  fm: RegExpMatchArray,
+  eol: string,
+  date: string
+): string {
+  // Only reached after frontMatterVerifiedId() already parsed the id from this
+  // same block, so the parse succeeds and the id path exists; any unexpected
+  // throw is caught by applyVerifiedMarkers' per-file guard.
+  const doc: any = YAML.parseDocument(fm[1]);
+  const node = doc.createNode(date);
+  node.type = "QUOTE_DOUBLE";
+  doc.setIn(["doc-detective", "verified", "date"], node);
+  const newBlock = doc.toString().replace(/\r?\n$/, "").replace(/\r?\n/g, eol);
+  return (
+    content.slice(0, fm.index!) +
+    `---${eol}` +
+    newBlock +
+    `${eol}---` +
+    content.slice(fm.index! + fm[0].length)
+  );
+}
+
+// Set `doc-detective.verified.date` in the leading front matter. The id is read
+// with the YAML parser (robust). For the common block-style shape the write is a
+// *surgical text edit* of only the `date:` line — never a re-stringify of the
+// whole document, which would reflow unrelated fields (e.g. an inline
+// `tags: [a, b]` gains inner padding). Flow-style / unusual shapes fall back to
+// upsertFrontMatterViaYaml so the date is still written. The value is quoted so
+// downstream YAML 1.1 parsers don't coerce it to a Date.
+function upsertFrontMatterVerified(content: string, dates: Map<string, string>): string {
+  const fm = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fm) return content;
+  const id = frontMatterVerifiedId(content);
+  if (id == null) return content;
+  const date = dates.get(id);
+  if (!date) return content;
+
+  // Preserve the front matter's newline style (see applyVerifiedToContent).
+  const eol = fm[0].includes("\r\n") ? "\r\n" : "\n";
+  const lines = fm[1].split(/\r?\n/);
+
+  // Locate the `doc-detective:` mapping first, then the `verified:` key nested
+  // within it — so an unrelated top-level `verified:` elsewhere in the front
+  // matter can't be matched by mistake.
+  let ddIndex = -1;
+  let ddIndent = "";
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^([ \t]*)(?:"doc-detective"|'doc-detective'|doc-detective):[ \t]*(?:#.*)?$/);
+    if (m) {
+      ddIndex = i;
+      ddIndent = m[1];
+      break;
+    }
+  }
+  if (ddIndex === -1) return upsertFrontMatterViaYaml(content, fm, eol, date); // flow style
+
+  // Find the block-style `verified:` key among doc-detective's children and the
+  // extent of its own child lines (those indented deeper than the key).
+  let vIndex = -1;
+  let vIndent = "";
+  for (let i = ddIndex + 1; i < lines.length; i++) {
+    const indentMatch = lines[i].match(/^([ \t]*)\S/);
+    if (!indentMatch) continue; // blank line within the block
+    if (indentMatch[1].length <= ddIndent.length) break; // dedent ends doc-detective
+    const m = lines[i].match(/^([ \t]*)verified:[ \t]*(?:#.*)?$/);
+    if (m) {
+      vIndex = i;
+      vIndent = m[1];
+      break;
+    }
+  }
+  if (vIndex === -1) return upsertFrontMatterViaYaml(content, fm, eol, date); // unusual shape
+
+  let childIndent: string | null = null;
+  let idIndex = -1;
+  let dateIndex = -1;
+  let lastChildIndex = vIndex;
+  for (let i = vIndex + 1; i < lines.length; i++) {
+    const indentMatch = lines[i].match(/^([ \t]*)\S/);
+    if (!indentMatch) continue; // blank line within the block
+    if (indentMatch[1].length <= vIndent.length) break; // dedent ends the block
+    if (childIndent === null) childIndent = indentMatch[1];
+    lastChildIndex = i;
+    // Only direct children of `verified:` count — a deeper `verified.meta.date`
+    // must not be mistaken for `verified.date`.
+    if (indentMatch[1] === childIndent) {
+      if (/^\s*id:/.test(lines[i])) idIndex = i;
+      if (/^\s*date:/.test(lines[i])) dateIndex = i;
+    }
+  }
+  if (childIndent === null) childIndent = `${vIndent}  `;
+
+  if (dateIndex !== -1) {
+    // Replace only the value, preserving any trailing inline comment (` # …`).
+    lines[dateIndex] = lines[dateIndex].replace(
+      /^(\s*date:\s*)("[^"]*"|'[^']*'|[^\s#]*)/,
+      `$1"${date}"`
+    );
+  } else {
+    const insertAfter = idIndex !== -1 ? idIndex : lastChildIndex;
+    lines.splice(insertAfter + 1, 0, `${childIndent}date: "${date}"`);
+  }
+
+  return (
+    content.slice(0, fm.index!) +
+    `---${eol}` +
+    lines.join(eol) +
+    `${eol}---` +
+    content.slice(fm.index! + fm[0].length)
+  );
+}
+
+// Resolve a marker id against a run report: a matching specId or testId returns
+// that unit's roll-up result; otherwise null.
+function resolveVerifiedId(results: any, id: string): string | null {
+  if (!results || !Array.isArray(results.specs)) return null;
+  for (const spec of results.specs) {
+    if (spec?.specId === id) return spec.result ?? null;
+    for (const test of spec?.tests || []) {
+      if (test?.testId === id) return test.result ?? null;
+    }
+  }
+  return null;
+}
+
+// Post-run write-back: for every candidate source file, find its `verified`
+// markers (inline + front matter), resolve each id against the report, and write
+// today's date where the unit PASSED. Unknown ids warn and are skipped; non-pass
+// ids are left to age. Per-file failures warn and continue. Never throws.
+//
+// The candidate set is the union of the report's content paths and the full
+// detected input set (`files`), so a prose-only page that carries a marker but
+// contributes no spec is still updated.
+function applyVerifiedMarkers({
+  config,
+  results,
+  files: detectedFiles = [],
+}: {
+  config: any;
+  results: any;
+  files?: string[];
+}): void {
+  if (!results || !Array.isArray(results.specs)) return;
+
+  const files = new Set<string>();
+  for (const file of detectedFiles) {
+    if (file) files.add(file);
+  }
+  for (const spec of results.specs) {
+    if (spec?.contentPath) files.add(spec.contentPath);
+    for (const test of spec?.tests || []) {
+      if (test?.contentPath) files.add(test.contentPath);
+    }
+  }
+
+  const today = verifiedDate();
+  for (const file of files) {
+    try {
+      if (!fs.existsSync(file)) continue;
+      const ext = (file.split(".").pop() || "").toLowerCase();
+      const format = VERIFIED_FORMAT_BY_EXT[ext];
+      if (!format) continue;
+
+      const original = fs.readFileSync(file, "utf8");
+      // Cheap fast-path: both the inline keyword and the front-matter key are the
+      // literal "verified", so a file without it has no markers to update — skip
+      // the regex scans and YAML parse entirely (the common case on large sets).
+      if (!original.includes("verified")) continue;
+      const inline = parseVerifiedMarkers(original, format);
+      const fmId = frontMatterVerifiedId(original);
+      const ids = new Set(inline.map((m) => m.id));
+      if (fmId) ids.add(fmId);
+      if (ids.size === 0) continue;
+
+      const dates = new Map<string, string>();
+      for (const id of ids) {
+        // Resolve through resolveVerifiedId so the bulk path gives specId
+        // precedence over testId, consistent with the single-lookup helper.
+        const result = resolveVerifiedId(results, id);
+        if (result === null) {
+          log(config, "warning", `verified marker references unknown id '${id}' in ${file}; skipping.`);
+          continue;
+        }
+        if (result === "PASS") dates.set(id, today);
+        // Non-pass: leave the existing date to age.
+      }
+
+      let content = applyVerifiedToContent(original, format, dates);
+      content = upsertFrontMatterVerified(content, dates);
+      if (content !== original) fs.writeFileSync(file, content);
+    } catch (error: any) {
+      log(config, "warning", `Failed to update verified markers in ${file}: ${error?.message ?? error}`);
+    }
+  }
 }
 
 // Filesystem-safe instant token, matching the `doc-detective debug` dump's

--- a/test/verified-markers.test.js
+++ b/test/verified-markers.test.js
@@ -1,0 +1,181 @@
+import {
+  verifiedDate,
+  shieldsBadge,
+  parseVerifiedMarkers,
+  applyVerifiedToContent,
+  resolveVerifiedId,
+} from "../dist/core/utils.js";
+
+before(async function () {
+  const { expect } = await import("chai");
+  global.expect = expect;
+});
+
+describe("Last Verified On — pure helpers", function () {
+  describe("verifiedDate()", function () {
+    it("formats a Date as zero-padded YYYY-MM-DD (UTC)", function () {
+      expect(verifiedDate(new Date("2026-06-26T12:34:56Z"))).to.equal("2026-06-26");
+      expect(verifiedDate(new Date("2026-01-05T00:00:00Z"))).to.equal("2026-01-05");
+    });
+  });
+
+  describe("shieldsBadge()", function () {
+    it("markdown image with shields.io dash-doubling", function () {
+      expect(shieldsBadge("markdown", "2026-06-26")).to.equal(
+        "![Last verified 2026-06-26](https://img.shields.io/badge/Last_verified-2026--06--26-brightgreen)"
+      );
+    });
+    it("asciidoc image macro", function () {
+      expect(shieldsBadge("asciidoc", "2026-06-26")).to.equal(
+        "image:https://img.shields.io/badge/Last_verified-2026--06--26-brightgreen[Last verified 2026-06-26]"
+      );
+    });
+    it("html img tag", function () {
+      expect(shieldsBadge("html", "2026-06-26")).to.equal(
+        '<img src="https://img.shields.io/badge/Last_verified-2026--06--26-brightgreen" alt="Last verified 2026-06-26">'
+      );
+    });
+    it("dita image element", function () {
+      expect(shieldsBadge("dita", "2026-06-26")).to.equal(
+        '<image href="https://img.shields.io/badge/Last_verified-2026--06--26-brightgreen"><alt>Last verified 2026-06-26</alt></image>'
+      );
+    });
+  });
+
+  describe("parseVerifiedMarkers()", function () {
+    it("captures HTML-comment data-only markers in markdown", function () {
+      const markers = parseVerifiedMarkers(
+        "# Title\n<!-- verified id=spec.md~abc date=2026-06-01 -->\n",
+        "markdown"
+      );
+      expect(markers).to.have.length(1);
+      expect(markers[0]).to.include({ id: "spec.md~abc", badge: false, date: "2026-06-01" });
+    });
+    it("captures JSX-comment (MDX) and badge flag", function () {
+      const markers = parseVerifiedMarkers("{/* verified id=x badge */}", "markdown");
+      expect(markers).to.have.length(1);
+      expect(markers[0]).to.include({ id: "x", badge: true });
+      expect(markers[0].date).to.be.undefined;
+    });
+    it("captures link-label comment form", function () {
+      const markers = parseVerifiedMarkers("[comment]: # (verified id=y date=2026-01-02)", "markdown");
+      expect(markers[0]).to.include({ id: "y", date: "2026-01-02" });
+    });
+    it("captures asciidoc form", function () {
+      const markers = parseVerifiedMarkers("// (verified id=z)", "asciidoc");
+      expect(markers[0]).to.include({ id: "z", badge: false });
+    });
+    it("ignores markers without an id", function () {
+      expect(parseVerifiedMarkers("<!-- verified badge -->", "markdown")).to.have.length(0);
+    });
+  });
+
+  describe("applyVerifiedToContent() — data-only", function () {
+    const dates = new Map([["a", "2026-06-26"]]);
+    it("inserts a date when absent", function () {
+      expect(applyVerifiedToContent("<!-- verified id=a -->", "markdown", dates)).to.equal(
+        "<!-- verified id=a date=2026-06-26 -->"
+      );
+    });
+    it("updates an existing date in place", function () {
+      expect(
+        applyVerifiedToContent("<!-- verified id=a date=2026-01-01 -->", "markdown", dates)
+      ).to.equal("<!-- verified id=a date=2026-06-26 -->");
+    });
+    it("is idempotent", function () {
+      const once = applyVerifiedToContent("<!-- verified id=a -->", "markdown", dates);
+      expect(applyVerifiedToContent(once, "markdown", dates)).to.equal(once);
+    });
+    it("leaves markers whose id is not in the date map untouched (ages)", function () {
+      const input = "<!-- verified id=b date=2025-01-01 -->";
+      expect(applyVerifiedToContent(input, "markdown", dates)).to.equal(input);
+    });
+    it("preserves the MDX JSX comment form (never emits <!-- -->)", function () {
+      const out = applyVerifiedToContent("{/* verified id=a date=2026-01-01 */}", "markdown", dates);
+      expect(out).to.equal("{/* verified id=a date=2026-06-26 */}");
+      expect(out).to.not.contain("<!--");
+    });
+  });
+
+  describe("applyVerifiedToContent() — badge", function () {
+    const dates = new Map([["a", "2026-06-26"]]);
+    it("inserts the shields.io image line on first run and updates the date", function () {
+      const out = applyVerifiedToContent("<!-- verified id=a badge -->\n", "markdown", dates);
+      expect(out).to.contain("<!-- verified id=a badge date=2026-06-26 -->");
+      expect(out).to.contain(
+        "![Last verified 2026-06-26](https://img.shields.io/badge/Last_verified-2026--06--26-brightgreen)"
+      );
+    });
+    it("is idempotent across re-runs (no duplicate image, no drift)", function () {
+      const once = applyVerifiedToContent("<!-- verified id=a badge -->\n", "markdown", dates);
+      const twice = applyVerifiedToContent(once, "markdown", dates);
+      expect(twice).to.equal(once);
+    });
+    it("replaces a stale badge image in place", function () {
+      const stale =
+        "<!-- verified id=a badge date=2025-01-01 -->\n" +
+        "![Last verified 2025-01-01](https://img.shields.io/badge/Last_verified-2025--01--01-brightgreen)\n";
+      const out = applyVerifiedToContent(stale, "markdown", dates);
+      expect(out).to.contain("Last_verified-2026--06--26-brightgreen");
+      expect(out).to.not.contain("2025--01--01");
+    });
+  });
+
+  describe("resolveVerifiedId()", function () {
+    const results = {
+      specs: [
+        { specId: "s1", result: "PASS", tests: [{ testId: "t1", result: "PASS" }, { testId: "t2", result: "FAIL" }] },
+      ],
+    };
+    it("resolves a spec id", function () {
+      expect(resolveVerifiedId(results, "s1")).to.equal("PASS");
+    });
+    it("resolves a test id", function () {
+      expect(resolveVerifiedId(results, "t2")).to.equal("FAIL");
+    });
+    it("returns null for an unknown id", function () {
+      expect(resolveVerifiedId(results, "nope")).to.equal(null);
+    });
+    it("returns null for null / non-array-specs inputs", function () {
+      expect(resolveVerifiedId(null, "x")).to.equal(null);
+      expect(resolveVerifiedId({}, "x")).to.equal(null);
+      expect(resolveVerifiedId({ specs: [{ specId: "s", tests: [] }] }, "x")).to.equal(null);
+    });
+    it("gives specId precedence over a same-named testId", function () {
+      const r = { specs: [{ specId: "dup", result: "PASS", tests: [{ testId: "dup", result: "FAIL" }] }] };
+      expect(resolveVerifiedId(r, "dup")).to.equal("PASS");
+    });
+  });
+
+  describe("branch & edge coverage", function () {
+    it("shieldsBadge honors a custom label and color", function () {
+      expect(shieldsBadge("markdown", "2026-06-26", { label: "Verified", color: "green" })).to.equal(
+        "![Verified 2026-06-26](https://img.shields.io/badge/Verified-2026--06--26-green)"
+      );
+    });
+    it("shieldsBadge escapes a color containing a hyphen", function () {
+      expect(shieldsBadge("markdown", "2026-06-26", { color: "ff0000-x" })).to.contain("-ff0000--x)");
+    });
+    it("parseVerifiedMarkers falls back to markdown patterns for an unknown format", function () {
+      const m = parseVerifiedMarkers("<!-- verified id=a -->", "totally-unknown");
+      expect(m).to.have.length(1);
+      expect(m[0].id).to.equal("a");
+    });
+    it("parseVerifiedAttrs handles badge=false, quoted values, and bare non-attr tokens", function () {
+      const m = parseVerifiedMarkers('<!-- verified extra id="a" badge=false -->', "markdown");
+      expect(m[0]).to.include({ id: "a", badge: false });
+    });
+    it("applyVerifiedToContent badge uses the markdown image body for an unknown format", function () {
+      const out = applyVerifiedToContent(
+        "<!-- verified id=a badge -->\n",
+        "unknown",
+        new Map([["a", "2026-06-26"]])
+      );
+      expect(out).to.contain("![Last verified 2026-06-26](https://img.shields.io/badge/");
+    });
+    it("applyVerifiedToContent is a no-op when no marker id is in the date map", function () {
+      const input = "<!-- verified id=other date=2025-01-01 -->";
+      expect(applyVerifiedToContent(input, "markdown", new Map([["a", "2026-06-26"]]))).to.equal(input);
+    });
+  });
+});

--- a/test/verified-writeback.test.js
+++ b/test/verified-writeback.test.js
@@ -1,0 +1,339 @@
+import { applyVerifiedMarkers, verifiedDate } from "../dist/core/utils.js";
+import { runTests } from "../dist/core/index.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+before(async function () {
+  const { expect } = await import("chai");
+  global.expect = expect;
+});
+
+// Recomputed before each test (see beforeEach) rather than captured once at
+// module load, so a suite that spans a UTC midnight boundary can't drift from
+// the date the writer actually stamps.
+let TODAY;
+let tmpDir;
+
+function write(name, content) {
+  const p = path.join(tmpDir, name);
+  fs.writeFileSync(p, content);
+  return p;
+}
+function read(p) {
+  return fs.readFileSync(p, "utf8");
+}
+// Synthetic report: one spec + one passing/failing test, both pointing at `file`.
+function report(file, { specId = "spec~1", testId = "test~1", result = "PASS" } = {}) {
+  return {
+    specs: [
+      {
+        specId,
+        contentPath: file,
+        result,
+        tests: [{ testId, contentPath: file, result }],
+      },
+    ],
+  };
+}
+const silent = { logLevel: "silent" };
+
+describe("Last Verified On — write-back integration", function () {
+  beforeEach(function () {
+    TODAY = verifiedDate();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dd-verified-"));
+  });
+  afterEach(function () {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("PASS writes the date, per format", function () {
+    it("markdown data-only (HTML comment)", function () {
+      const f = write("a.md", "# Doc\n\n<!-- verified id=test~1 -->\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.contain(`<!-- verified id=test~1 date=${TODAY} -->`);
+    });
+    it("mdx preserves the JSX comment form (never emits <!-- -->)", function () {
+      const f = write("a.mdx", "# Doc\n\n{/* verified id=test~1 */}\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      const out = read(f);
+      expect(out).to.contain(`{/* verified id=test~1 date=${TODAY} */}`);
+      expect(out).to.not.contain("<!--");
+    });
+    it("asciidoc line comment", function () {
+      const f = write("a.adoc", "= Doc\n\n// (verified id=test~1)\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.contain(`// (verified id=test~1 date=${TODAY})`);
+    });
+    it("html comment", function () {
+      const f = write("a.html", "<h1>Doc</h1>\n<!-- verified id=test~1 -->\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.contain(`<!-- verified id=test~1 date=${TODAY} -->`);
+    });
+    it("dita comment", function () {
+      const f = write("a.dita", "<topic><title>Doc</title></topic>\n<!-- verified id=test~1 -->\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.contain(`<!-- verified id=test~1 date=${TODAY} -->`);
+    });
+  });
+
+  describe("granularity — id may target a spec or a test", function () {
+    it("resolves a spec id", function () {
+      const f = write("a.md", "<!-- verified id=spec~1 -->\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.contain(`<!-- verified id=spec~1 date=${TODAY} -->`);
+    });
+  });
+
+  describe("badge", function () {
+    it("inserts the shields.io image on PASS and is byte-idempotent", function () {
+      const f = write("a.md", "# Doc\n\n<!-- verified id=test~1 badge -->\n\nMore.\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      const once = read(f);
+      expect(once).to.contain(`<!-- verified id=test~1 badge date=${TODAY} -->`);
+      expect(once).to.contain(
+        `![Last verified ${TODAY}](https://img.shields.io/badge/Last_verified-${TODAY.replace(/-/g, "--")}-brightgreen)`
+      );
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.equal(once); // no duplicate image, no drift
+    });
+    it("asciidoc badge inserts the image macro and is byte-idempotent", function () {
+      const f = write("a.adoc", "= Doc\n\n// (verified id=test~1 badge)\n\nMore.\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      const once = read(f);
+      expect(once).to.contain(
+        `image:https://img.shields.io/badge/Last_verified-${TODAY.replace(/-/g, "--")}-brightgreen[Last verified ${TODAY}]`
+      );
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.equal(once);
+    });
+    it("indents an inserted badge to match the marker's line and stays idempotent", function () {
+      const f = write("a.md", "- item\n  <!-- verified id=test~1 badge -->\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      const once = read(f);
+      // badge image is indented two spaces to match the marker line
+      expect(once).to.match(/\n {2}!\[Last verified \d{4}-\d{2}-\d{2}\]\(https:\/\/img\.shields\.io/);
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.equal(once);
+    });
+    it("dita badge inserts the image element and is byte-idempotent", function () {
+      const f = write(
+        "a.dita",
+        "<topic><title>Doc</title></topic>\n<!-- verified id=test~1 badge -->\n\nMore.\n"
+      );
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      const once = read(f);
+      expect(once).to.contain(
+        `<image href="https://img.shields.io/badge/Last_verified-${TODAY.replace(/-/g, "--")}-brightgreen">`
+      );
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.equal(once);
+    });
+  });
+
+  describe("multiple markers in one file", function () {
+    it("stamps only the passing marker; the failing one ages", function () {
+      const f = write(
+        "a.md",
+        "<!-- verified id=pass~1 -->\n\ntext\n\n<!-- verified id=fail~1 date=2025-01-01 -->\n"
+      );
+      const results = {
+        specs: [
+          {
+            specId: "s",
+            contentPath: f,
+            result: "FAIL",
+            tests: [
+              { testId: "pass~1", contentPath: f, result: "PASS" },
+              { testId: "fail~1", contentPath: f, result: "FAIL" },
+            ],
+          },
+        ],
+      };
+      applyVerifiedMarkers({ config: silent, results });
+      const out = read(f);
+      expect(out).to.contain(`<!-- verified id=pass~1 date=${TODAY} -->`);
+      expect(out).to.contain("<!-- verified id=fail~1 date=2025-01-01 -->"); // unchanged
+    });
+  });
+
+  describe("front matter (doc-detective.verified)", function () {
+    it("writes the date into the front-matter object on PASS", function () {
+      const f = write(
+        "a.md",
+        "---\ntitle: Doc\ndoc-detective:\n  verified:\n    id: test~1\n---\n\n# Doc\n"
+      );
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      const once = read(f);
+      expect(once).to.match(/date:\s*['"]?2\d{3}-\d{2}-\d{2}['"]?/);
+      expect(once).to.contain(TODAY);
+      // body untouched
+      expect(once).to.contain("# Doc");
+      // re-run is byte-identical (date replaced in place, not appended)
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.equal(once);
+    });
+    it("preserves sibling front-matter fields (inline array stays inline)", function () {
+      const f = write(
+        "a.md",
+        "---\ntitle: My Guide\ntags: [api, rest]\ndoc-detective:\n  verified:\n    id: test~1\n---\n\n# Doc\n"
+      );
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      const out = read(f);
+      expect(out).to.contain("tags: [api, rest]"); // not reflowed to block style
+      expect(out).to.contain("title: My Guide");
+      expect(out).to.contain(TODAY);
+    });
+    it("updates verified.date, not a deeper nested meta.date", function () {
+      const f = write(
+        "a.md",
+        "---\ndoc-detective:\n  verified:\n    id: test~1\n    meta:\n      date: 1999-01-01\n---\n\n# Doc\n"
+      );
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      const out = read(f);
+      expect(out).to.contain("date: 1999-01-01"); // nested meta.date untouched
+      expect(out).to.match(/verified:\r?\n {4}id: test~1\r?\n {4}date: "\d{4}-\d{2}-\d{2}"/);
+    });
+    it("preserves a trailing inline comment on the date line", function () {
+      const f = write(
+        "a.md",
+        "---\ndoc-detective:\n  verified:\n    id: test~1\n    date: 2025-01-01 # last check\n---\n\n# Doc\n"
+      );
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.match(/date: "\d{4}-\d{2}-\d{2}" # last check/);
+    });
+    it("uses the surgical path when the doc-detective: key has a trailing comment", function () {
+      const f = write(
+        "a.md",
+        "---\ntags: [api, rest]\ndoc-detective: # dd config\n  verified:\n    id: test~1\n---\n\n# Doc\n"
+      );
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      const out = read(f);
+      expect(out).to.contain("tags: [api, rest]"); // not reflowed → surgical path taken
+      expect(out).to.contain("doc-detective: # dd config"); // key comment preserved
+      expect(out).to.contain(TODAY);
+    });
+  });
+
+  describe("gating", function () {
+    it("FAIL leaves the prior date untouched (ages)", function () {
+      const f = write("a.md", "<!-- verified id=test~1 date=2025-01-01 -->\n");
+      applyVerifiedMarkers({ config: silent, results: report(f, { result: "FAIL" }) });
+      expect(read(f)).to.contain("date=2025-01-01");
+      expect(read(f)).to.not.contain(TODAY);
+    });
+    it("SKIPPED does not write", function () {
+      const f = write("a.md", "<!-- verified id=test~1 -->\n");
+      applyVerifiedMarkers({ config: silent, results: report(f, { result: "SKIPPED" }) });
+      expect(read(f)).to.equal("<!-- verified id=test~1 -->\n");
+    });
+    it("unknown id warns and leaves the file untouched", function () {
+      const f = write("a.md", "<!-- verified id=does-not-exist -->\n");
+      const original = read(f);
+      const logs = [];
+      const realLog = console.log;
+      console.log = (...a) => logs.push(a.join(" "));
+      try {
+        applyVerifiedMarkers({ config: { logLevel: "warning" }, results: report(f) });
+      } finally {
+        console.log = realLog;
+      }
+      expect(read(f)).to.equal(original);
+      expect(logs.join("\n")).to.match(/unknown id 'does-not-exist'/);
+    });
+  });
+
+  describe("skip paths", function () {
+    it("no-ops when results has no specs array", function () {
+      applyVerifiedMarkers({ config: silent, results: {} });
+      applyVerifiedMarkers({ config: silent, results: null });
+    });
+    it("skips a non-existent content path without throwing", function () {
+      const missing = path.join(tmpDir, "nope.md");
+      applyVerifiedMarkers({ config: silent, results: report(missing) });
+      expect(fs.existsSync(missing)).to.equal(false);
+    });
+    it("skips a non-doc extension", function () {
+      const f = write("a.txt", "<!-- verified id=test~1 -->\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.equal("<!-- verified id=test~1 -->\n");
+    });
+    it("fast-paths a doc with no `verified` marker", function () {
+      const f = write("a.md", "# Just docs\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.equal("# Just docs\n");
+    });
+    it("leaves a top-level (non doc-detective) verified key untouched", function () {
+      const f = write("a.md", "---\ntitle: Doc\nverified: true\n---\n\n# Doc\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      expect(read(f)).to.contain("verified: true");
+      expect(read(f)).to.not.match(/date:/);
+    });
+    it("writes the date for flow-style doc-detective front matter (YAML fallback)", function () {
+      const f = write("a.md", "---\ndoc-detective: {verified: {id: test~1}}\n---\n\n# Doc\n");
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      const out = read(f);
+      // Flow-style can't be edited surgically, so the YAML fallback writes the
+      // (quoted) date; the value lands and is read as a string, not a Date.
+      expect(out).to.contain(TODAY);
+      expect(out).to.match(/date:\s*["']\d{4}-\d{2}-\d{2}["']/);
+    });
+  });
+
+  describe("end-to-end via runTests", function () {
+    it("updates a data-only marker after a passing inline wait test", async function () {
+      this.timeout(120000);
+      const f = write(
+        "page.md",
+        [
+          "# Page",
+          "",
+          '<!-- test {"testId": "wait-demo"} -->',
+          '<!-- step {"wait": 10} -->',
+          "<!-- test end -->",
+          "",
+          "<!-- verified id=wait-demo -->",
+          "",
+        ].join("\n")
+      );
+      await runTests({ input: f, logLevel: "silent" });
+      // Assert the date shape, not a pre-captured value: the runner computes the
+      // date itself, so an exact-TODAY compare could flake across a UTC rollover.
+      expect(read(f)).to.match(/<!-- verified id=wait-demo date=\d{4}-\d{2}-\d{2} -->/);
+    });
+
+    it("updates a prose-only file whose marker references a test defined elsewhere", async function () {
+      this.timeout(120000);
+      // The test lives in runner.md; badge-page.md has no test of its own — it
+      // is reached only by scanning the full detected input set, not the report.
+      write(
+        "runner.md",
+        [
+          "# Runner",
+          "",
+          '<!-- test {"testId": "cross-file-demo"} -->',
+          '<!-- step {"wait": 10} -->',
+          "<!-- test end -->",
+          "",
+        ].join("\n")
+      );
+      const prose = write("badge-page.md", "# Badge page\n\n<!-- verified id=cross-file-demo -->\n");
+      await runTests({ input: tmpDir, logLevel: "silent" });
+      expect(read(prose)).to.match(/<!-- verified id=cross-file-demo date=\d{4}-\d{2}-\d{2} -->/);
+    });
+  });
+
+  describe("front-matter scoping", function () {
+    it("targets doc-detective.verified, not an unrelated top-level verified: key", function () {
+      const f = write(
+        "a.md",
+        "---\nverified: true\ndoc-detective:\n  verified:\n    id: test~1\n---\n\n# Doc\n"
+      );
+      applyVerifiedMarkers({ config: silent, results: report(f) });
+      const out = read(f);
+      // The unrelated top-level scalar is untouched; the date lands under doc-detective.
+      expect(out).to.contain("verified: true");
+      expect(out).to.match(/doc-detective:\r?\n {2}verified:\r?\n {4}id: test~1\r?\n {4}date: "\d{4}-\d{2}-\d{2}"/);
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds a marker-driven **"Last Verified On"** write-back: authors place a static `verified` marker carrying a test or spec `id`; after a run Doc Detective resolves that id and — **only on PASS** — writes today's date back into the marker. On failure the date is left untouched, so a fresh date means "verified passing" and the badge silently ages.

End-user docs can surface a freshness/trust badge from this, and in CI the GitHub Action's existing `create_pr_on_change` turns the date edits into a PR with **zero Action changes**.

## How it works

- **Author owns the `id`; Doc Detective owns the `date`.** No content-hash guessing, no orphans, no inferred placement.
- **Two marker forms:**
  - Inline comment — markdown/MDX (`{/* … */}`, `<!-- … -->`, `[comment]: #`), AsciiDoc (`// ( … )`), HTML/DITA comments.
  - Page-level YAML front matter — `doc-detective.verified.{id → date}`.
- **Optional `badge`** — maintains a shields.io static badge image (`![Last verified …](https://img.shields.io/badge/…)`) on the line after the marker, so it renders with no theme work. DD only writes the URL; shields.io renders it client-side (no network call).
- **Idempotent & form-preserving** — re-runs are byte-identical; an MDX `{/* */}` marker is never rewritten as `<!-- -->` (which would break the MDX build).
- **Unknown id → warn and skip** (catches typos / deleted tests without failing the run).
- **Coverage** — the writer scans the **union** of the report's content paths and the full detected input set, so a prose-only page that produces no spec (referencing a test defined elsewhere) is still updated.

## Scope

- **No config object, no CLI flag, no schema change.** Always-on; acts only where a marker exists.
- Contained in `src/core`: pure helpers + `applyVerifiedMarkers` in `core/utils.ts`, wired into `runTests`; `qualifyFiles` side-channels the detected file set.

## Tests

- `test/verified-markers.test.js` — 21 unit tests (shields.io dash-doubling, MDX form preservation, idempotency, aging, id resolution).
- `test/verified-writeback.test.js` — 13 filesystem-integration tests (all formats, badge, front matter, spec-id vs test-id, PASS/FAIL/SKIPPED, unknown-id warning, byte-idempotency) + 2 real `runTests` E2Es (incl. the cross-file prose-only case).
- **34 passing**; clean `tsc` compile.

These are deliberately **not** committed `test/core-artifacts/*.spec.json` fixtures: the feature mutates source files, so a committed fixture would be rewritten with the current date every run and dirty the tree. Rationale is in the ADR.

## Docs impact

User-facing (new marker syntax + badge). Reference/how-to docs for the marker should follow; flagging here rather than silently. Design + decision recorded in `adrs/01046-last-verified-on-marker-writeback.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic “Last Verified On” write-back for passing results, updating inline verified markers and YAML front matter while preserving body content.
  * Added optional Shields.io verification badges with consistent, format-aware rendering and idempotent updates.
  * Supports marker ids mapped to test- or spec-level outcomes, including cross-file and prose-only inputs; unknown ids leave content unchanged with warnings.
* **Documentation**
  * Documented the marker-based write-back behavior in a new ADR.
* **Tests**
  * Added comprehensive unit and integration tests for marker/badge syntaxes, idempotency, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->