### PR TITLE
ci: enforce src/common coverage ratchet in the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,3 +74,30 @@ jobs:
           HERETTO_USERNAME: ${{ secrets.HERETTO_USERNAME }}
           HERETTO_TOKEN: ${{ secrets.HERETTO_TOKEN }}
           DOC_DETECTIVE_SKIP_AUTO_UPDATE: '1'
+
+  # Coverage ratchet for the doc-detective-common subpackage. The matrix above
+  # builds common on every cell but never measures coverage; this single
+  # platform-independent job does. It enforces coverage-thresholds.json — c8
+  # coverage must never fall below the baseline (see src/common/AGENTS.md).
+  # Kept out of the matrix because line coverage is OS/node-independent, so one
+  # run is enough. Both callers (PR gate + release gate) wait on this job, so a
+  # coverage regression blocks merges and releases alike.
+  coverage-ratchet:
+    name: Coverage ratchet (src/common)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci
+      # build:common compiles dist and runs `c8 mocha`, writing
+      # src/common/coverage/coverage-summary.json that the ratchet reads.
+      - run: npm run build:common
+      - run: npm run test:coverage:ratchet
+        working-directory: src/common


### PR DESCRIPTION
## What changed

Adds a `coverage-ratchet` job to the reusable [test.yml](.github/workflows/test.yml) workflow that runs the `doc-detective-common` coverage ratchet in CI.

## Why

The ratchet (`scripts/check-coverage-ratchet.cjs` vs. `coverage-thresholds.json`, 100% baseline) was only ever invoked **locally** — no CI job, no husky hook ran it. As a result, coverage silently drifted below the baseline on `main` (it sat at 99.67% lines/statements, 99.53% branches; fixed in #416) with zero CI signal. This wires it in so regressions are caught automatically.

## How it works

- A single `ubuntu-latest` / `node 22` job: `npm ci` → `npm run build:common` (compiles `dist` and runs `c8 mocha`, writing `coverage-summary.json`) → `npm run test:coverage:ratchet`.
- **Kept out of the cross-platform matrix** — line coverage is OS/node-independent, so one run suffices. The matrix already builds common on every cell but never measured coverage.
- Lives in the **reusable** `test.yml`, which is consumed by both `npm-test.yaml` (PR gate) and `release.yml` (release gate, via `needs: test`). So a coverage regression now blocks **both merges and releases**.

## Reviewer notes

- CI-only change — no product behavior change, no ADR / feature-fixture / docs obligation.
- Verified the exact CI step sequence locally: `build:common` → `test:coverage:ratchet` passes at a genuine 100% on all four metrics.
- Tradeoff worth a conscious nod: because this is in the release gate too, if coverage on `main` ever drops below baseline it will block releases until restored — which is the intended safety, but means the baseline must stay achievable. `main` is at 100% today.
- To make this a *hard* merge requirement (not just a visible check), the new `Coverage ratchet (src/common)` check would need to be added to branch protection — a repo setting outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a standalone coverage check to ensure test coverage stays above the expected baseline.
  * Coverage regressions will now fail in a dedicated job, improving reliability of the overall test pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->