### PR TITLE
ci: harden actions/checkout in CI test/build workflows

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -12,9 +12,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -100,7 +100,9 @@ jobs:
     outputs:
       base: ${{ steps.filter.outputs.base }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -138,7 +140,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -318,7 +322,9 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -461,7 +467,9 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/install-agents-integration.yml
+++ b/.github/workflows/install-agents-integration.yml
@@ -93,7 +93,9 @@ jobs:
             path_check: test -f .agents/skills/doc-detective-init/SKILL.md
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -63,7 +63,9 @@ jobs:
     outputs:
       action_version: ${{ steps.resolve.outputs.action_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -130,7 +132,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,9 @@ jobs:
           - 22
           - 24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -87,7 +89,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -122,7 +126,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## What & why

A CodeRabbit/zizmor **"artipacked"** security review (on #420) flagged that CI jobs check out the repo and then run repository-controlled build/test commands while leaving the checkout token persisted in `.git/config`, widening the credential-exfiltration surface.

The repo was **inconsistent**: `release.yml` and the docs workflows (`docs-schema-refs`, `preview-docs`, `publish-docs`, `vale`) already pin `actions/checkout` to a commit SHA and set `persist-credentials: false`, but the CI test/build workflows used plain `actions/checkout@v4`. This PR brings them in line.

## Changes

Pin `actions/checkout` to the repo-standard SHA (`de0fac2e…` # v6.0.2) and add `persist-credentials: false` to every checkout in:

| Workflow | Checkout steps hardened |
|---|---|
| `test.yml` | 3 (matrix, `coverage-ratchet`, `coverage-ratchet-root`) |
| `commitlint.yml` | 1 (kept `fetch-depth: 0`) |
| `install-agents-integration.yml` | 1 |
| `docker-build.yml` | 4 |
| `promote.yml` | 2 |

## Safety

- Verified none of these workflows run git write operations (`git push`/`commit`/`tag`), so dropping the persisted credential is safe — build/test/registry/npm steps use their own auth (`docker login`, npm registry token, etc.).
- `permissions: contents: read` is preserved where present.
- The v4→v6 checkout bump matches what `release.yml`/docs workflows already run successfully in this repo.
- All five workflow YAMLs validated as parseable.

## Deferred (intentionally not in this PR)

`claude.yml` and `claude-pr-review.yml` — the `@claude` action manages its own git credentials and can push commits, so those need separate verification that `persist-credentials: false` doesn't break the bot. Flagged for a follow-up.

This is the repo-wide follow-up to the checkout-hardening discussion on #420 (which deliberately deferred it to avoid a piecemeal one-job change). CI-only; no product behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use a pinned checkout version and stop persisting credentials after checkout.
  * Applied the change across build, test, promotion, commit lint, and integration workflows.
  * No build, test, or release behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->