### PR TITLE
fix(core): detect IPv4-mapped IPv6 private addresses in the SSRF guard

### DIFF
--- a/adrs/01010-ssrf-guard-ipv4-mapped-ipv6.md
+++ b/adrs/01010-ssrf-guard-ipv4-mapped-ipv6.md
@@ -51,9 +51,12 @@ not a contract change.
 
 ## Decision Outcome
 
-Chosen: **reconstruct the dotted IPv4 from the mapped tail in-place**. For a `::ffff:` address, take
-the tail and: if it is already dotted-decimal, recurse as before; otherwise parse the one-or-two hex
-groups as the low 32 bits and rebuild `a.b.c.d`, then recurse through the existing IPv4 range checks.
+Chosen: **reconstruct the dotted IPv4 from the mapped tail in-place**. For a `::ffff:` address (whose
+IPv6 validity is already established), parse the one-or-two hex groups the WHATWG URL parser leaves in
+the tail (`a00:1`, or `1` when the high group is zero) as the low 32 bits, rebuild `a.b.c.d`, and
+recurse through the existing IPv4 range checks. The parser always emits the hex form, so a
+dotted-decimal tail is never produced; the only non-hex path is a defensive `!hexMatch` guard that
+`net.isIPv6` already precludes (marked `c8 ignore`).
 
 ### Consequences
 

--- a/adrs/01010-ssrf-guard-ipv4-mapped-ipv6.md
+++ b/adrs/01010-ssrf-guard-ipv4-mapped-ipv6.md
@@ -1,0 +1,93 @@
+---
+status: accepted
+date: 2026-06-30
+decision-makers: doc-detective maintainers
+---
+
+# SSRF guard: detect IPv4-mapped IPv6 private addresses
+
+## Context and Problem Statement
+
+The SSRF guard `assertUrlHostIsPublic` / `isPrivateOrLoopbackAddress`
+([src/core/utils.ts](../src/core/utils.ts)) refuses binary URL fetches (`fetchFile`, and the
+`checkLink`/`httpRequest`-adjacent paths) whose host is a private/loopback/link-local address, so a
+documentation spec can't be used to reach internal infrastructure (incl. the
+`169.254.169.254` cloud-metadata endpoint).
+
+While writing coverage tests ([#426](https://github.com/doc-detective/doc-detective/pull/426)) we
+found a **bypass** ([#427](https://github.com/doc-detective/doc-detective/issues/427)): IPv4-mapped
+IPv6 addresses defeat the guard. The previous code recursed on the embedded v4 by string-stripping
+the prefix:
+
+```ts
+if (normalized.startsWith("::ffff:")) {
+  return isPrivateOrLoopbackAddress(normalized.replace("::ffff:", ""));
+}
+```
+
+The WHATWG `URL` parser normalizes `::ffff:10.0.0.1` to **hex** form `::ffff:a00:1`. After stripping
+`::ffff:`, the remainder is `a00:1`, which is neither a valid IPv4 (`net.isIPv4`) nor a standalone
+IPv6 (`net.isIPv6`), so the function returned `false` (treated as public). Every IPv4-mapped private
+address — e.g. `http://[::ffff:a00:1]/x` (10.0.0.1) or `http://[::ffff:a9fe:a9fe]/x`
+(169.254.169.254) — slipped past the guard.
+
+The documented contract ("refuses private/loopback") was always the intent; this is a parsing gap,
+not a contract change.
+
+## Decision Drivers
+
+* Close the bypass for the form real input actually arrives in (hex-normalized), not just the
+  dotted form.
+* No new dependency; keep the guard a small pure function.
+* Preserve existing behavior: public mapped addresses (e.g. `::ffff:8.8.8.8`) stay allowed, and all
+  existing private/public classifications are unchanged.
+* Make the fixed branch unit-testable and deterministic.
+
+## Considered Options
+
+* **Reconstruct the dotted IPv4 from the mapped tail in-place** (string/bitmath, no deps).
+* **Add an IP-parsing library** (e.g. `ipaddr.js`) to canonicalize mapped addresses.
+* **Reject all `::ffff:` addresses outright** (treat any IPv4-mapped host as suspicious).
+
+## Decision Outcome
+
+Chosen: **reconstruct the dotted IPv4 from the mapped tail in-place**. For a `::ffff:` address, take
+the tail and: if it is already dotted-decimal, recurse as before; otherwise parse the one-or-two hex
+groups as the low 32 bits and rebuild `a.b.c.d`, then recurse through the existing IPv4 range checks.
+
+### Consequences
+
+* Good: every IPv4-mapped private/loopback/link-local address is now refused, via the same IPv4
+  range table — one source of truth. No new dependency.
+* Good: public mapped addresses remain allowed (`::ffff:8.8.8.8` → `8.8.8.8` → public).
+* Neutral: a previously-(wrongly)-reachable URL shape is now refused. This is a security fix, so the
+  behavior change is intended; no valid public fetch is affected.
+* Trade-off: rejecting all `::ffff:` outright was simpler but would block legitimate public mapped
+  addresses, so it was not chosen.
+
+### Confirmation
+
+Unit tests in [test/core-utils-coverage.test.js](../test/core-utils-coverage.test.js) assert that
+`::ffff:a00:1` (10.0.0.1), `::ffff:7f00:1` (127.0.0.1), `::ffff:a9fe:a9fe` (169.254.169.254), and
+`::ffff:c0a8:1` (192.168.0.1) are rejected, while `::ffff:8.8.8.8` stays allowed. The full root
+coverage suite runs under the ratchet job.
+
+## Docs impact
+
+The SSRF guard's documented behavior ("refuses private/loopback hosts") is **unchanged** — this fix
+makes the implementation honor it for IPv4-mapped IPv6. No user-facing flag, option, or output
+changes; no documentation page requires updates.
+
+## Pros and Cons of the Options
+
+### Reconstruct dotted IPv4 in-place
+* Good: no dependency; reuses the existing range table; small and pure.
+* Bad: hand-rolled bit math (covered by tests).
+
+### IP-parsing library
+* Good: canonicalizes every IPv6 form robustly.
+* Bad: a new runtime dependency for a few lines of logic; larger surface.
+
+### Reject all `::ffff:` outright
+* Good: simplest.
+* Bad: blocks legitimate public IPv4-mapped addresses; over-broad.

--- a/adrs/01010-ssrf-guard-ipv4-mapped-ipv6.md
+++ b/adrs/01010-ssrf-guard-ipv4-mapped-ipv6.md
@@ -52,11 +52,12 @@ not a contract change.
 ## Decision Outcome
 
 Chosen: **reconstruct the dotted IPv4 from the mapped tail in-place**. For a `::ffff:` address (whose
-IPv6 validity is already established), parse the one-or-two hex groups the WHATWG URL parser leaves in
-the tail (`a00:1`, or `1` when the high group is zero) as the low 32 bits, rebuild `a.b.c.d`, and
-recurse through the existing IPv4 range checks. The parser always emits the hex form, so a
-dotted-decimal tail is never produced; the only non-hex path is a defensive `!hexMatch` guard that
-`net.isIPv6` already precludes (marked `c8 ignore`).
+IPv6 validity is already established), the WHATWG URL parser emits the embedded v4 as **two hex
+groups** (`::ffff:10.0.0.1` → `::ffff:a00:1`; `::ffff:0.0.0.1` → `::ffff:0:1`). Parse those two groups
+as the low 32 bits, rebuild `a.b.c.d`, and recurse through the existing IPv4 range checks. A
+dotted-decimal tail can't arrive via the URL-normalizing caller, but is still handled (fail **closed**)
+for defense in depth and marked `c8 ignore`. Any other `::ffff:` form (e.g. `::ffff:1`) is a normal
+IPv6 address, not IPv4-mapped, and falls through to the public classification.
 
 ### Consequences
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -922,8 +922,23 @@ function isPrivateOrLoopbackAddress(ip: string): boolean {
     if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true; // unique local
     if (normalized.startsWith("fe80:")) return true; // link-local
     if (normalized.startsWith("::ffff:")) {
-      // IPv4-mapped: recurse on the embedded v4
-      return isPrivateOrLoopbackAddress(normalized.replace("::ffff:", ""));
+      // IPv4-mapped IPv6. The embedded v4 may be dotted-decimal ("10.0.0.1")
+      // or — after WHATWG URL normalization, which is what real input arrives
+      // as — two hex groups ("a00:1"). Reconstruct the dotted form so the v4
+      // ranges above are actually applied; otherwise a mapped private address
+      // (e.g. http://[::ffff:a00:1]/x = 10.0.0.1) silently bypasses the guard.
+      const tail = normalized.slice("::ffff:".length);
+      if (net.isIPv4(tail)) {
+        return isPrivateOrLoopbackAddress(tail);
+      }
+      const hexMatch = tail.match(/^(?:([0-9a-f]{1,4}):)?([0-9a-f]{1,4})$/);
+      if (hexMatch) {
+        const hi = hexMatch[1] ? parseInt(hexMatch[1], 16) : 0;
+        const lo = parseInt(hexMatch[2], 16);
+        const dotted = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+        return isPrivateOrLoopbackAddress(dotted);
+      }
+      return false;
     }
     return false;
   }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -922,23 +922,19 @@ function isPrivateOrLoopbackAddress(ip: string): boolean {
     if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true; // unique local
     if (normalized.startsWith("fe80:")) return true; // link-local
     if (normalized.startsWith("::ffff:")) {
-      // IPv4-mapped IPv6. The embedded v4 may be dotted-decimal ("10.0.0.1")
-      // or — after WHATWG URL normalization, which is what real input arrives
-      // as — two hex groups ("a00:1"). Reconstruct the dotted form so the v4
-      // ranges above are actually applied; otherwise a mapped private address
-      // (e.g. http://[::ffff:a00:1]/x = 10.0.0.1) silently bypasses the guard.
+      // IPv4-mapped IPv6. The WHATWG URL parser normalizes the embedded v4 to
+      // hex (::ffff:10.0.0.1 → ::ffff:a00:1, and ::ffff:0.0.0.1 → ::ffff:1), so
+      // reconstruct the dotted v4 from the 1–2 hex groups and apply the v4
+      // ranges above; otherwise a mapped private address (e.g.
+      // http://[::ffff:a00:1]/x = 10.0.0.1) silently bypasses the guard.
       const tail = normalized.slice("::ffff:".length);
-      if (net.isIPv4(tail)) {
-        return isPrivateOrLoopbackAddress(tail);
-      }
       const hexMatch = tail.match(/^(?:([0-9a-f]{1,4}):)?([0-9a-f]{1,4})$/);
-      if (hexMatch) {
-        const hi = hexMatch[1] ? parseInt(hexMatch[1], 16) : 0;
-        const lo = parseInt(hexMatch[2], 16);
-        const dotted = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
-        return isPrivateOrLoopbackAddress(dotted);
-      }
-      return false;
+      /* c8 ignore next - net.isIPv6 above guarantees a 1–2 hex-group tail */
+      if (!hexMatch) return false;
+      const hi = hexMatch[1] ? parseInt(hexMatch[1], 16) : 0;
+      const lo = parseInt(hexMatch[2], 16);
+      const dotted = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+      return isPrivateOrLoopbackAddress(dotted);
     }
     return false;
   }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -928,13 +928,27 @@ function isPrivateOrLoopbackAddress(ip: string): boolean {
       // ranges above; otherwise a mapped private address (e.g.
       // http://[::ffff:a00:1]/x = 10.0.0.1) silently bypasses the guard.
       const tail = normalized.slice("::ffff:".length);
-      const hexMatch = tail.match(/^(?:([0-9a-f]{1,4}):)?([0-9a-f]{1,4})$/);
-      /* c8 ignore next - net.isIPv6 above guarantees a 1–2 hex-group tail */
-      if (!hexMatch) return false;
-      const hi = hexMatch[1] ? parseInt(hexMatch[1], 16) : 0;
-      const lo = parseInt(hexMatch[2], 16);
-      const dotted = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
-      return isPrivateOrLoopbackAddress(dotted);
+      // Defensive: a dotted-decimal tail (::ffff:10.0.0.1) is a valid IPv6
+      // literal but current callers pass URL-normalized hosts (always hex), so
+      // this path is unreachable in practice. Handle it anyway — fail CLOSED by
+      // classifying the embedded v4 rather than slipping past as "public".
+      /* c8 ignore start - URL normalization always yields the hex form below */
+      if (net.isIPv4(tail)) {
+        return isPrivateOrLoopbackAddress(tail);
+      }
+      /* c8 ignore stop */
+      // The genuine IPv4-mapped form the URL parser emits is two hex groups
+      // (::ffff:HHHH:LLLL = the embedded 32-bit v4); reconstruct and re-check.
+      const hexMatch = tail.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+      if (hexMatch) {
+        const hi = parseInt(hexMatch[1], 16);
+        const lo = parseInt(hexMatch[2], 16);
+        const dotted = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+        return isPrivateOrLoopbackAddress(dotted);
+      }
+      // Any other ::ffff: form (e.g. ::ffff:1) is a normal IPv6 address, not an
+      // IPv4-mapped one, and matches none of the private prefixes above → public.
+      return false;
     }
     return false;
   }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -923,8 +923,8 @@ function isPrivateOrLoopbackAddress(ip: string): boolean {
     if (normalized.startsWith("fe80:")) return true; // link-local
     if (normalized.startsWith("::ffff:")) {
       // IPv4-mapped IPv6. The WHATWG URL parser normalizes the embedded v4 to
-      // hex (::ffff:10.0.0.1 → ::ffff:a00:1, and ::ffff:0.0.0.1 → ::ffff:1), so
-      // reconstruct the dotted v4 from the 1–2 hex groups and apply the v4
+      // hex (::ffff:10.0.0.1 → ::ffff:a00:1, and ::ffff:0.0.0.1 → ::ffff:0:1),
+      // so reconstruct the dotted v4 from the two hex groups and apply the v4
       // ranges above; otherwise a mapped private address (e.g.
       // http://[::ffff:a00:1]/x = 10.0.0.1) silently bypasses the guard.
       const tail = normalized.slice("::ffff:".length);

--- a/test/core-utils-coverage.test.js
+++ b/test/core-utils-coverage.test.js
@@ -303,10 +303,11 @@ describe("core/utils coverage", function () {
     // URL parser normalizes ::ffff:10.0.0.1 to hex form (::ffff:a00:1); the guard
     // now reconstructs the dotted v4 from the hex tail before classifying.
     const mappedPrivate = [
-      "::ffff:a00:1", // 10.0.0.1
+      "::ffff:a00:1", // 10.0.0.1 (two hex groups)
       "::ffff:7f00:1", // 127.0.0.1
       "::ffff:a9fe:a9fe", // 169.254.169.254 (cloud metadata)
       "::ffff:c0a8:1", // 192.168.0.1
+      "::ffff:1", // 0.0.0.1 — single hex group (high group defaults to 0)
     ];
     for (const ip of mappedPrivate) {
       it(`rejects IPv4-mapped private literal [${ip}]`, async function () {

--- a/test/core-utils-coverage.test.js
+++ b/test/core-utils-coverage.test.js
@@ -299,16 +299,23 @@ describe("core/utils coverage", function () {
       });
     }
 
-    // KNOWN SECURITY GAP (issue #427): IPv4-mapped IPv6 private addresses bypass
-    // the SSRF guard. http://[::ffff:a00:1]/x is 10.0.0.1 mapped, but the source
-    // recurses on the hex tail "a00:1" (neither valid IPv4 nor IPv6) and returns
-    // "public". Unskip once src/core/utils.ts parses the mapped 32-bit tail.
-    it.skip("[#427] should reject the IPv4-mapped form of a private address", async function () {
-      await assert.rejects(
-        () => assertUrlHostIsPublic("http://[::ffff:a00:1]/x"), // ::ffff:10.0.0.1
-        /private\/loopback/
-      );
-    });
+    // #427 fix: IPv4-mapped IPv6 private addresses must be rejected. The WHATWG
+    // URL parser normalizes ::ffff:10.0.0.1 to hex form (::ffff:a00:1); the guard
+    // now reconstructs the dotted v4 from the hex tail before classifying.
+    const mappedPrivate = [
+      "::ffff:a00:1", // 10.0.0.1
+      "::ffff:7f00:1", // 127.0.0.1
+      "::ffff:a9fe:a9fe", // 169.254.169.254 (cloud metadata)
+      "::ffff:c0a8:1", // 192.168.0.1
+    ];
+    for (const ip of mappedPrivate) {
+      it(`rejects IPv4-mapped private literal [${ip}]`, async function () {
+        await assert.rejects(
+          () => assertUrlHostIsPublic(`http://[${ip}]/x`),
+          /private\/loopback/
+        );
+      });
+    }
   });
 
   describe("log (level filtering + 2-arg form)", function () {

--- a/test/core-utils-coverage.test.js
+++ b/test/core-utils-coverage.test.js
@@ -278,12 +278,8 @@ describe("core/utils coverage", function () {
       "fc00::1", // unique local fc
       "fd00::1", // unique local fd
       "fe80::1", // IPv6 link-local
-      // NOTE: the IPv4-mapped IPv6 private case (e.g. ::ffff:10.0.0.1) is NOT
-      // asserted here because it currently BYPASSES the guard — see the skipped
-      // test below and issue #427. The WHATWG URL parser normalizes
-      // ::ffff:10.0.0.1 to hex form ::ffff:a00:1; the source then strips
-      // "::ffff:" and re-tests "a00:1", which is neither a valid IPv4 nor IPv6,
-      // so isPrivateOrLoopbackAddress returns false (treated as public).
+      // IPv4-mapped IPv6 private addresses are asserted in the mappedPrivate
+      // set below (the #427 fix); historically they bypassed the guard.
     ];
     for (const ip of privateLiterals) {
       it(`rejects private literal ${ip}`, async function () {
@@ -291,7 +287,14 @@ describe("core/utils coverage", function () {
         await assert.rejects(() => assertUrlHostIsPublic(url), /refusing|private\/loopback/i);
       });
     }
-    const publicLiterals = ["8.8.8.8", "1.1.1.1", "2606:4700:4700::1111", "::ffff:8.8.8.8"];
+    const publicLiterals = [
+      "8.8.8.8",
+      "1.1.1.1",
+      "2606:4700:4700::1111",
+      "::ffff:8.8.8.8", // dotted public mapped (parser normalizes to hex)
+      "::ffff:808:808", // hex public mapped form (8.8.8.8) stays allowed
+      "::ffff:1", // a normal IPv6 address, not IPv4-mapped → not private
+    ];
     for (const ip of publicLiterals) {
       it(`allows public literal ${ip}`, async function () {
         const url = ip.includes(":") ? `http://[${ip}]/x` : `http://${ip}/x`;
@@ -303,11 +306,11 @@ describe("core/utils coverage", function () {
     // URL parser normalizes ::ffff:10.0.0.1 to hex form (::ffff:a00:1); the guard
     // now reconstructs the dotted v4 from the hex tail before classifying.
     const mappedPrivate = [
-      "::ffff:a00:1", // 10.0.0.1 (two hex groups)
+      "::ffff:a00:1", // 10.0.0.1
       "::ffff:7f00:1", // 127.0.0.1
       "::ffff:a9fe:a9fe", // 169.254.169.254 (cloud metadata)
       "::ffff:c0a8:1", // 192.168.0.1
-      "::ffff:1", // 0.0.0.1 — single hex group (high group defaults to 0)
+      "::ffff:0:1", // 0.0.0.1 (real mapped form of 0.0.0.x, high group is 0)
     ];
     for (const ip of mappedPrivate) {
       it(`rejects IPv4-mapped private literal [${ip}]`, async function () {


### PR DESCRIPTION
## Security fix — SSRF guard bypass (#427)

Fixes [#427](https://github.com/doc-detective/doc-detective/issues/427), an SSRF-guard bypass found while writing Phase 3 coverage tests.

### The bug
`isPrivateOrLoopbackAddress` ([src/core/utils.ts](src/core/utils.ts)) stripped the `::ffff:` prefix and recursed assuming dotted-decimal:
```ts
return isPrivateOrLoopbackAddress(normalized.replace("::ffff:", ""));
```
But the WHATWG URL parser normalizes `::ffff:10.0.0.1` → hex form `::ffff:a00:1`. The remainder `a00:1` is neither a valid IPv4 nor IPv6, so the guard returned `false` (public). **Every IPv4-mapped private/loopback/link-local address bypassed `assertUrlHostIsPublic`** — including `http://[::ffff:a9fe:a9fe]/x` (169.254.169.254, the cloud-metadata endpoint).

### The fix
Reconstruct the dotted IPv4 from the mapped tail (dotted form *or* one/two hex groups) before applying the existing IPv4 range checks — one source of truth, no new dependency. Verified:

| Host | Before | After |
|---|---|---|
| `::ffff:a00:1` (10.0.0.1) | ❌ allowed | ✅ rejected |
| `::ffff:7f00:1` (127.0.0.1) | ❌ allowed | ✅ rejected |
| `::ffff:a9fe:a9fe` (169.254.169.254) | ❌ allowed | ✅ rejected |
| `::ffff:c0a8:1` (192.168.0.1) | ❌ allowed | ✅ rejected |
| `::ffff:8.8.8.8` (public) | ✅ allowed | ✅ allowed |

### Scope
- Source fix + un-skipped/expanded the `#427` unit tests (now assert the mapped-private forms are refused).
- **ADR:** [01010-ssrf-guard-ipv4-mapped-ipv6.md](adrs/01010-ssrf-guard-ipv4-mapped-ipv6.md).
- **Docs impact:** none — the guard's documented contract ("refuses private/loopback hosts") is unchanged; this makes the implementation honor it. No flag/option/output/page changes.
- `fix:` → patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSRF protection for IPv4-mapped IPv6 addresses so private, loopback, and link-local hosts are correctly blocked.
  * Added safer handling for unusual mapped address formats to prevent bypasses caused by URL normalization.

* **Tests**
  * Expanded coverage for IP-literal checks, including rejected mapped private addresses and allowed public mapped addresses.

* **Documentation**
  * Added an ADR describing the issue, the fix approach, and the resulting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->