### PR TITLE
ci: add per-package noise tolerance to the coverage ratchet

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,6 +1,7 @@
 {
-  "description": "Coverage baseline thresholds for the root doc-detective package, measured from the full root test suite (test/*.test.js) under c8 in CI. These values should only increase, never decrease.",
+  "description": "Coverage baseline thresholds for the root doc-detective package, measured from the full root test suite (test/*.test.js) under c8 in CI. These values should only increase, never decrease. 'tolerance' absorbs sub-0.1pp run-to-run branch wobble from the non-deterministic E2E suite — a metric only fails when it drops MORE than this below baseline.",
   "lastUpdated": "2026-06-30",
+  "tolerance": 0.1,
   "lines": 82.71,
   "statements": 82.71,
   "functions": 86.32,

--- a/scripts/check-coverage-ratchet.cjs
+++ b/scripts/check-coverage-ratchet.cjs
@@ -60,6 +60,17 @@ function main() {
   const current = coverageSummary.total;
   const metrics = ['lines', 'statements', 'functions', 'branches'];
 
+  // Optional per-package noise tolerance (percentage points). A metric only
+  // fails when it drops MORE than `tolerance` below baseline, and is only
+  // suggested for a bump when it rises MORE than `tolerance` above. This
+  // absorbs sub-tolerance run-to-run wobble from a non-deterministic suite
+  // (the root package measures coverage over the full E2E run). Defaults to 0,
+  // so packages that omit it — e.g. src/common at a strict 100% — are exact.
+  const tolerance =
+    typeof thresholds.tolerance === 'number' && thresholds.tolerance >= 0
+      ? thresholds.tolerance
+      : 0;
+
   // Placeholder guard: thresholds of all-zero pass against any coverage, making
   // the gate a silent no-op. Warn loudly (but still run) so a forgotten baseline
   // surfaces in the CI log instead of quietly disabling enforcement.
@@ -86,13 +97,14 @@ function main() {
     const diff = (currentValue - baseline).toFixed(2);
     
     let status;
-    if (currentValue < baseline) {
+    if (currentValue < baseline - tolerance) {
       status = `FAIL (${diff}%)`;
       failed = true;
-    } else if (currentValue > baseline) {
+    } else if (currentValue > baseline + tolerance) {
       status = `PASS (+${diff}%)`;
     } else {
-      status = 'PASS';
+      // Within ±tolerance of baseline — neither a regression nor a real gain.
+      status = tolerance > 0 ? `PASS (~${diff}%)` : 'PASS';
     }
     
     const baselineStr = `${baseline.toFixed(2)}%`.padEnd(8);
@@ -118,8 +130,9 @@ function main() {
     process.exit(1);
   }
   
-  // Check if we can bump thresholds
-  const canBump = results.filter(r => r.current > r.baseline);
+  // Check if we can bump thresholds (only on a real gain beyond the tolerance,
+  // so sub-tolerance noise doesn't churn the baseline up and down).
+  const canBump = results.filter(r => r.current > r.baseline + tolerance);
   if (canBump.length > 0) {
     console.log('Coverage has improved! Consider updating thresholds:');
     console.log('');


### PR DESCRIPTION
## Why

The root coverage ratchet measures the **full E2E suite**, whose branch coverage wobbles ~0.01pp run-to-run (a flaky test occasionally taking a different branch). Against an exact baseline, that intermittently fails the gate on **noise, not regressions** — [#428](https://github.com/doc-detective/doc-detective/pull/428) hit exactly this (branches measured 81.11 vs. the 81.12 baseline, while lines/statements actually rose). This is the determinism risk called out when the root ratchet was first proposed.

## What

Add an optional `tolerance` field (percentage points) to `coverage-thresholds.json`, read by the shared `check-coverage-ratchet.cjs`:

- A metric **FAILs only when it drops more than `tolerance` below** baseline.
- A bump is **suggested only when it rises more than `tolerance` above** baseline (so sub-tolerance noise doesn't churn the locked numbers up and down).
- **Default 0** — packages that omit the field stay exact. `src/common` (strict 100%) is unchanged.
- Root `tolerance` set to **0.1pp** — ~10× the observed wobble, while still catching any real regression > 0.1pp.

## Verification

Self-tested the four cases (script-level):

| Scenario | Expected | Result |
|---|---|---|
| root: branch wobble 81.11 vs 81.12 (within tol) | PASS | ✅ |
| root: real regression branches 80.9 (−0.22) | FAIL | ✅ |
| common: 99.9% (strict, no tolerance) | FAIL | ✅ |
| common: exact 100% | PASS | ✅ |

## Notes
- CI-tooling change only — not product behavior or a public contract, so no ADR/fixtures/docs. Shared script stays backward-compatible (tolerance defaults to 0).
- Unblocks #428 once merged (that PR rebases onto this and the wobble falls within tolerance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coverage checks now allow a small built-in tolerance for run-to-run fluctuations, reducing noise from tiny percentage changes.

* **Bug Fixes**
  * Coverage ratchet results are now less likely to fail on insignificant drops.
  * Suggested threshold updates are now based on meaningful coverage gains, helping avoid unnecessary baseline churn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->