### PR TITLE
ci: polish coverage-ratchet output (no -0.00; generic tolerance wording)

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,5 +1,5 @@
 {
-  "description": "Coverage baseline thresholds for the root doc-detective package, measured from the full root test suite (test/*.test.js) under c8 in CI. These values should only increase, never decrease. 'tolerance' absorbs sub-0.1pp run-to-run branch wobble from the non-deterministic E2E suite — a metric only fails when it drops MORE than this below baseline.",
+  "description": "Coverage baseline thresholds for the root doc-detective package, measured from the full root test suite (test/*.test.js) under c8 in CI. These values should only increase, never decrease. 'tolerance' absorbs sub-tolerance run-to-run branch wobble from the non-deterministic E2E suite — a metric only fails when it drops MORE than 'tolerance' percentage points below baseline.",
   "lastUpdated": "2026-06-30",
   "tolerance": 0.1,
   "lines": 82.71,

--- a/scripts/check-coverage-ratchet.cjs
+++ b/scripts/check-coverage-ratchet.cjs
@@ -94,7 +94,10 @@ function main() {
       process.exit(1);
     }
     const currentValue = currentMetric.pct;
-    const diff = (currentValue - baseline).toFixed(2);
+    // Round to 2dp and fold -0 into 0 so a tiny negative delta doesn't print as
+    // a confusing "-0.00%" (e.g. PASS (~-0.00%)) within the tolerance band.
+    const rounded = Math.round((currentValue - baseline) * 100) / 100;
+    const diff = (rounded === 0 ? 0 : rounded).toFixed(2);
     
     let status;
     if (currentValue < baseline - tolerance) {

--- a/scripts/check-coverage-ratchet.cjs
+++ b/scripts/check-coverage-ratchet.cjs
@@ -94,10 +94,10 @@ function main() {
       process.exit(1);
     }
     const currentValue = currentMetric.pct;
-    // Round to 2dp and fold -0 into 0 so a tiny negative delta doesn't print as
-    // a confusing "-0.00%" (e.g. PASS (~-0.00%)) within the tolerance band.
-    const rounded = Math.round((currentValue - baseline) * 100) / 100;
-    const diff = (rounded === 0 ? 0 : rounded).toFixed(2);
+    // Keep toFixed's rounding, but rewrite a "-0.00" string (a tiny negative
+    // delta) to "0.00" so the table doesn't print a confusing "PASS (~-0.00%)"
+    // within the tolerance band.
+    const diff = (currentValue - baseline).toFixed(2).replace(/^-0\.00$/, "0.00");
     
     let status;
     if (currentValue < baseline - tolerance) {


### PR DESCRIPTION
Small follow-up addressing the two non-blocking review nits on #429 (which had already merged):

1. **`-0.00%` display** — in the new tolerance band, a tiny negative delta rounded to `-0.00`, printing confusing lines like `PASS (~-0.00%)`. Now folds `-0` into `0` so it reads `0.00`. Real deltas (`-0.01`, `+0.01`) are unchanged.
2. **Hard-coded "sub-0.1pp"** — the `coverage-thresholds.json` description said "sub-0.1pp" even though `tolerance` is a configurable field; reworded to generic "sub-tolerance".

CI-tooling/docs only; `src/common` (no tolerance field) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)