### PR TITLE
fix(core): emit the spec for runShell-fileType files (#435)

### DIFF
--- a/adrs/01011-fix-runshell-filetype-spec-drop.md
+++ b/adrs/01011-fix-runshell-filetype-spec-drop.md
@@ -1,0 +1,109 @@
+---
+status: accepted
+date: 2026-06-30
+decision-makers: doc-detective maintainers
+---
+
+# Fix: emit the spec for files matched by a custom runShell fileType
+
+## Context and Problem Statement
+
+A config `fileType` may carry a `runShell` template so that files with a given extension are turned
+into a single `runShell` step (with `$1` substituted for the file path). This lets a user point Doc
+Detective at, say, a `*.task` file and have it executed as a shell step. The detection pipeline for
+this lives in `parseTests` in [src/core/detectTests.ts](../src/core/detectTests.ts).
+
+While writing coverage tests we found that the `runShell` branch of the per-file loop
+[#435](https://github.com/doc-detective/doc-detective/issues/435) **silently drops its output spec**.
+The branch built the `runShell` step, validated it against `test_v3`, pushed the test onto
+`spec.tests`, and then `continue`d:
+
+```ts
+if (fileType?.runShell) {
+  ... build `test` with a runShell step, validate test_v3 ...
+  spec.tests.push(test);
+  continue;              // <-- skips the spec finalization below
+}
+```
+
+The `continue` jumps past the shared spec-finalization at the end of the loop — spec_v3 validation,
+`resolvePaths`, the `_phase` stamp, and `specs.push(spec)`. So the spec object was fully built and
+carried a valid test, but was **never pushed to `specs`**: a `runShell`-typed file produced no output
+spec, and therefore no test ever ran for it.
+
+The documented contract — a `runShell` fileType "performs a runShell step for this file type"
+([File type (executable)](../docs/fern/pages/reference/schemas/file-type-executable.md)) — was always
+the intent. This is a control-flow bug (a `continue` placed before the push), not a contract change.
+
+## Decision Drivers
+
+* Restore the documented behavior: a custom `runShell` fileType must actually emit a runnable test.
+* Reuse the existing finalization exactly — one source of truth for spec_v3 validation, path
+  resolution, and the phase stamp — so the runShell path can't drift from the text path.
+* Don't run `parseContent` for runShell files: they carry no inline test statements to parse, and the
+  step has already been built.
+* Keep behavior for non-runShell files byte-for-byte identical.
+
+## Considered Options
+
+* **Finalize in-branch, then `continue`** — after `spec.tests.push(test)`, run the same spec_v3
+  validate → `resolvePaths` → `_phase` stamp → `specs.push(spec)` sequence the text path uses, then
+  `continue` (skipping `parseContent`).
+* **Delete the `continue` and fall through to the shared finalization** — let the runShell branch
+  drop into the existing text finalization block instead of duplicating it.
+
+## Decision Outcome
+
+Chosen: **finalize in-branch, then `continue`**. After the test is validated and pushed, the branch
+now runs the identical finalization (spec_v3 validate; on success `resolvePaths`, re-stamp
+`spec._phase = config._phaseByFile?.get(path.resolve(file)) ?? "main"`, and `specs.push(spec)`) and
+only then `continue`s.
+
+Falling through was rejected because the shared block also calls `parseContent` and re-filters
+`spec.tests` — appropriate for text/markdown files, but wrong for a runShell file whose single step is
+already built. Falling through would run `parseContent` needlessly (and could append or drop steps),
+whereas the in-branch finalization keeps the runShell path minimal and self-contained.
+
+### Consequences
+
+* Good: a custom `runShell` fileType now emits exactly one spec, with one test containing one
+  `runShell` step — the documented behavior is restored.
+* Good: the finalization mirrors the text path (same validation, `resolvePaths`, and `_phase`
+  semantics), so runShell specs get the same path resolution and phase handling as every other spec.
+* Neutral: files that previously produced no spec now produce one. This is the intended, documented
+  behavior; no existing valid detection is altered. A runShell template that fails `test_v3` still
+  logs a warning and emits nothing, unchanged.
+* Trade-off: the finalization sequence is now written in two places (the runShell branch and the text
+  branch) rather than shared. Accepted deliberately to avoid running `parseContent` for runShell
+  files; the two copies are small and kept in sync by comment.
+
+### Confirmation
+
+A unit test in [test/detecttests-coverage.test.js](../test/detecttests-coverage.test.js) —
+"emits a spec with a runShell step from a custom runShell fileType (#435)" — asserts that a `*.task`
+file matched by a `runShell` fileType yields `specs.length === 1` whose single test's single step is a
+`runShell` step. The companion test asserting that an invalid runShell template still emits nothing is
+unchanged. Regression coverage in `test/spec-location.test.js` and `test/run-artifacts.test.js`
+confirms non-runShell detection is unaffected.
+
+## Docs impact
+
+This restores **user-facing behavior**: a custom `runShell` fileType now actually emits a runnable
+test rather than silently producing nothing. The generated reference page
+[File type (executable)](../docs/fern/pages/reference/schemas/file-type-executable.md) already
+documents the field as performing "a runShell step for this file type" — i.e. the page describes the
+now-honored contract, so **no documentation page requires changes**. No config/CLI flag, output
+format, or default is added or altered.
+
+## Pros and Cons of the Options
+
+### Finalize in-branch, then `continue`
+* Good: minimal and self-contained; never runs `parseContent` for runShell files; reuses the exact
+  validation/path/phase logic of the text path.
+* Bad: duplicates the small finalization sequence (kept in sync by comment).
+
+### Delete the `continue` and fall through
+* Good: no duplicated finalization code.
+* Bad: also runs `parseContent` and re-filters `spec.tests` — inappropriate for a runShell file whose
+  step is already built; risks appending/dropping steps and couples the runShell path to text-parsing
+  behavior.

--- a/src/core/detectTests.ts
+++ b/src/core/detectTests.ts
@@ -685,6 +685,35 @@ async function parseTests({ config, files }: { config: any; files: string[] }) {
         }
 
         spec.tests.push(test);
+
+        // Finalize the spec the same way the non-runShell path does below:
+        // validate spec_v3, then on success resolve paths, re-stamp the phase,
+        // and push. Previously this branch `continue`d straight past the
+        // shared finalization, so a runShell-typed file built a valid test but
+        // never emitted a spec (#435). Skip parseContent — runShell files carry
+        // no inline statements to parse.
+        const specValidation = validate({
+          schemaKey: "spec_v3",
+          object: spec,
+          addDefaults: false,
+        });
+        if (!specValidation.valid) {
+          log(
+            config,
+            "warning",
+            `Tests from ${file} don't create a valid test specification. Skipping.`
+          );
+        } else {
+          spec = await resolvePaths({
+            config: config,
+            object: spec,
+            filePath: file,
+          });
+          // Re-stamp the phase: resolvePaths isn't guaranteed to preserve
+          // unknown keys. Mirrors the JSON/YAML and text branches.
+          spec._phase = config._phaseByFile?.get(path.resolve(file)) ?? "main";
+          specs.push(spec);
+        }
         continue;
       }
 

--- a/test/detecttests-coverage.test.js
+++ b/test/detecttests-coverage.test.js
@@ -267,7 +267,7 @@ describe("detectTests coverage", function () {
       assert.equal(specs.length, 0);
     });
 
-    it("builds a runShell step from a custom runShell fileType (currently drops the spec — bug #435)", async function () {
+    it("emits a spec with a runShell step from a custom runShell fileType (#435)", async function () {
       const script = write("run.task", "echo task");
       const config = await makeConfig({
         input: [script],
@@ -275,13 +275,15 @@ describe("detectTests coverage", function () {
           { name: "task", extensions: ["task"], runShell: { command: "echo", args: ["ran"] } },
         ],
       });
-      // TODO(bug #435): the runShell branch builds + validates the test and
-      // pushes it onto spec.tests, but then `continue`s past the spec_v3
-      // validation + specs.push(spec) finalization — so a runShell-typed file
-      // produces NO output spec. We assert the current (buggy) behavior here;
-      // flip this to expect a 1-spec/1-runShell-step result once #435 is fixed.
+      // The runShell branch builds + validates the test, then finalizes the
+      // spec (spec_v3 validation + resolvePaths + specs.push) just like the
+      // non-runShell path — so a runShell-typed file emits one spec whose single
+      // test has a single runShell step.
       const specs = await parseTests({ config, files: [script] });
-      assert.deepEqual(specs, []);
+      assert.equal(specs.length, 1);
+      assert.equal(specs[0].tests.length, 1);
+      assert.equal(specs[0].tests[0].steps.length, 1);
+      assert.ok(specs[0].tests[0].steps[0].runShell, "step should be a runShell step");
     });
 
     it("skips a file when its runShell template produces an invalid step", async function () {


### PR DESCRIPTION
## Fix — runShell fileType specs were silently dropped (#435)

Fixes [#435](https://github.com/doc-detective/doc-detective/issues/435), a bug found while writing Phase 6 coverage tests.

### The bug
In `parseTests` ([src/core/detectTests.ts](src/core/detectTests.ts)), the `runShell` branch built and validated a step, pushed it onto `spec.tests`, then `continue`d **past** the shared spec-finalization at the bottom of the loop (spec_v3 validate → `resolvePaths` → `_phase` stamp → `specs.push(spec)`). So a file matched by a custom `runShell` fileType produced a valid test but **no output spec** — the spec was never pushed.

### The fix
Run that same finalization *in-branch* (guarded on spec_v3 validity, warn-on-invalid) before the `continue`, deliberately **not** calling `parseContent` (runShell files have no inline statements). Non-runShell paths are byte-for-byte unchanged.

### Also
- **Test:** flipped the Phase 6 `#435` TODO test — it now asserts one spec is produced with a single `runShell` step (was asserting `specs === []`).
- **ADR:** [01011-fix-runshell-filetype-spec-drop.md](adrs/01011-fix-runshell-filetype-spec-drop.md).
- **Docs impact:** the generated reference already documents `runShell` fileTypes as emitting a runShell step — this makes the implementation honor the documented contract; no doc page changes.
- `fix:` → patch release.

### Verification (local)
- `test/detecttests-coverage.test.js` — 32 passing (incl. the flipped test).
- `test/spec-location.test.js` + `test/run-artifacts.test.js` — 61 passing (other detection unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)