### PR TITLE
fix(core): reject responses with extra fields when allowAdditionalFields is false (#437)

### DIFF
--- a/adrs/01012-fix-http-allow-additional-fields.md
+++ b/adrs/01012-fix-http-allow-additional-fields.md
@@ -1,0 +1,123 @@
+---
+status: accepted
+date: 2026-06-30
+decision-makers: doc-detective maintainers
+---
+
+# Fix `allowAdditionalFields: false` to reject responses with extra fields
+
+## Context and Problem Statement
+
+The `httpRequest` step type exposes `allowAdditionalFields`. When set to `false`, the documented
+intent is that a response must **not** carry fields beyond those the author declared in
+`response.body` — extra keys should fail the step.
+
+The "no unexpected fields" check in [src/core/tests/httpRequest.ts](../src/core/tests/httpRequest.ts)
+computed the boolean like this ([#437](https://github.com/doc-detective/doc-detective/issues/437)):
+
+```ts
+const noUnexpectedFields =
+  expectedBody && typeof expectedBody === "object"
+    ? objectExistsInObject(expectedBody, response.data).result.status !== "FAIL"
+    : true;
+```
+
+`objectExistsInObject(expected, actual)` is a **subset** check: it verifies that `actual` contains
+every key in `expected`, but it never looks at keys present only in `actual`. So EXTRA keys in the
+response can never make it FAIL. With `expected = { a: 1 }` and `actual = { a: 1, extra: 99 }`, the
+subset check PASSes and `noUnexpectedFields` stayed `true`. The option silently did nothing — a
+response with additional fields was accepted even though the author asked for a strict shape.
+
+This is a contract bug, not a contract change: `allowAdditionalFields: false` was always meant to
+reject additional fields. The subset check was simply the wrong tool for the job.
+
+## Decision Drivers
+
+* Make `allowAdditionalFields: false` honor its documented meaning: reject responses whose keys
+  aren't declared in the expected body, recursively for nested objects.
+* Don't regress the guard for a non-object / undefined expected body, or for the **unset** body case
+  (`response.body` defaults to `{}`), where "no declared fields" must mean "no key constraint", never
+  "reject the whole response".
+* Keep value-mismatch handling where it already lives — the body-match check (5) — instead of
+  overloading the key-set check with value comparison.
+* Keep the new logic a small, pure, unit-testable function; no new dependency.
+
+## Considered Options
+
+* **Add the reverse subset direction** — also require `objectExistsInObject(response.data,
+  expectedBody)` to PASS (every actual key present in expected).
+* **Dedicated recursive key-set comparison** — a new `objectHasNoExtraKeys(expected, actual)` that
+  walks the actual object's keys and flags any not declared in expected, recursing into nested plain
+  objects.
+
+## Decision Outcome
+
+Chosen: **dedicated recursive key-set comparison** (`objectHasNoExtraKeys`). Reusing
+`objectExistsInObject` in reverse would conflate two concerns: that helper FAILs on value mismatches
+too, so `objectExistsInObject(actual, expected)` would flag a value disagreement as an "unexpected
+field", double-counting what the body-match check already reports and producing a misleading
+description. A purpose-built function keeps `noUnexpectedFields` strictly about the presence of
+undeclared **keys**.
+
+`objectHasNoExtraKeys`:
+
+* Compares key-by-key only when both sides are plain objects; if either side isn't (primitive,
+  array, `null`, mismatched shape), there are no object keys to compare, so it reports "no extra
+  keys" (`true`) and defers any shape/value disagreement to the body-match check.
+* Treats an **empty** expected object as "no declared fields ⇒ no key constraint" (`true`) at any
+  depth. This preserves the unset-body behavior: `response.body` defaults to `{}`, and an unset body
+  must never flag the entire response as unexpected.
+* Recurses into nested plain objects so extras are flagged at any depth.
+
+The guard for a non-object / undefined expected body (`noUnexpectedFields = true`) is unchanged.
+Behavior when `allowAdditionalFields` is `true` or absent is unchanged (the check block only runs
+when it is falsy).
+
+### Consequences
+
+* Good: `allowAdditionalFields: false` now rejects responses with fields beyond the expected body,
+  recursively — the option finally does what it says.
+* Good: value comparison stays in one place (body-match check). `noUnexpectedFields` is purely a
+  key-set verdict.
+* Neutral: a value mismatch on a same-key-set response now leaves `noUnexpectedFields === true` (the
+  step still FAILs, via `bodyMatches`). Previously the subset check drove `noUnexpectedFields` false
+  for that case — a coincidental side effect, not the intended signal. The coverage test that
+  asserted the old side effect was updated to assert the corrected split (FAIL via `bodyMatches`,
+  `noUnexpectedFields` true).
+* Neutral: a documentation spec that relied on the (buggy) lenient behavior — expecting a partial
+  body while setting `allowAdditionalFields: false` — will now FAIL. That is the point of the option;
+  authors who want lenient matching should leave `allowAdditionalFields` at its default (`true`).
+
+### Confirmation
+
+Unit coverage in [test/httprequest-coverage.test.js](../test/httprequest-coverage.test.js): the
+`[bug #437]` test now asserts that expected `{ a: 1 }` vs actual `{ a: 1, extra: 99 }` with
+`allowAdditionalFields: false` FAILs with `noUnexpectedFields === false` and a description mentioning
+unexpected fields. Sibling tests confirm an exact-match superset still PASSes, a non-object expected
+body still short-circuits to PASS, and a same-key-set value mismatch FAILs via `bodyMatches` with
+`noUnexpectedFields` true. Server-based tests in
+[test/httpRequest-assertions.test.js](../test/httpRequest-assertions.test.js) confirm the unset-body
+(`{}`) case still PASSes. All three files pass (`npm run build` then
+`npx mocha --exit test/httprequest-coverage.test.js test/httpRequest.test.js
+test/httpRequest-assertions.test.js`).
+
+## Docs impact
+
+`allowAdditionalFields` is a documented action option whose reference describes it as rejecting
+additional/unexpected fields when `false`. This change makes the implementation honor that
+documented meaning — the reference text does not need to change, but any example or guide that
+demonstrated a partial `response.body` alongside `allowAdditionalFields: false` and expected a PASS
+is now inaccurate and should be corrected. No new flag, output, or default is introduced.
+
+## Pros and Cons of the Options
+
+### Dedicated recursive key-set comparison
+* Good: strictly key-set semantics; no false coupling to value comparison; recurses cleanly; pure and
+  unit-testable; no dependency.
+* Bad: a small amount of new code to maintain (covered by tests).
+
+### Reverse subset direction (`objectExistsInObject(actual, expected)`)
+* Good: reuses an existing helper; no new function.
+* Bad: conflates value mismatches with unexpected fields (that helper FAILs on value disagreement),
+  double-reporting what the body-match check already covers and yielding a misleading verdict and
+  description.

--- a/adrs/01012-fix-http-allow-additional-fields.md
+++ b/adrs/01012-fix-http-allow-additional-fields.md
@@ -46,28 +46,34 @@ reject additional fields. The subset check was simply the wrong tool for the job
 
 * **Add the reverse subset direction** — also require `objectExistsInObject(response.data,
   expectedBody)` to PASS (every actual key present in expected).
-* **Dedicated recursive key-set comparison** — a new `objectHasNoExtraKeys(expected, actual)` that
-  walks the actual object's keys and flags any not declared in expected, recursing into nested plain
-  objects.
+* **Dedicated recursive key-collection** — a new `findUnexpectedKeys(expected, actual)` that walks
+  the actual object's keys, collects any not declared in expected (as dot-paths), and recurses into
+  nested plain objects.
 
 ## Decision Outcome
 
-Chosen: **dedicated recursive key-set comparison** (`objectHasNoExtraKeys`). Reusing
-`objectExistsInObject` in reverse would conflate two concerns: that helper FAILs on value mismatches
-too, so `objectExistsInObject(actual, expected)` would flag a value disagreement as an "unexpected
-field", double-counting what the body-match check already reports and producing a misleading
-description. A purpose-built function keeps `noUnexpectedFields` strictly about the presence of
-undeclared **keys**.
+Chosen: **dedicated recursive key-collection** (`findUnexpectedKeys`, plus a small `isPlainObject`
+helper). Reusing `objectExistsInObject` in reverse would conflate two concerns: that helper FAILs on
+value mismatches too, so `objectExistsInObject(actual, expected)` would flag a value disagreement as
+an "unexpected field", double-counting what the body-match check already reports and producing a
+misleading description. A purpose-built function keeps `noUnexpectedFields` strictly about the
+presence of undeclared **keys**.
 
-`objectHasNoExtraKeys`:
+`findUnexpectedKeys(expected, actual, prefix)` returns the list of undeclared keys as dot-paths
+(e.g. `user.extra`):
 
 * Compares key-by-key only when both sides are plain objects; if either side isn't (primitive,
-  array, `null`, mismatched shape), there are no object keys to compare, so it reports "no extra
-  keys" (`true`) and defers any shape/value disagreement to the body-match check.
-* Treats an **empty** expected object as "no declared fields ⇒ no key constraint" (`true`) at any
-  depth. This preserves the unset-body behavior: `response.body` defaults to `{}`, and an unset body
-  must never flag the entire response as unexpected.
-* Recurses into nested plain objects so extras are flagged at any depth.
+  array, `null`, mismatched shape), there are no object keys to compare, so it returns `[]` (no
+  extras) and defers any shape/value disagreement to the body-match check.
+* Recurses into nested plain objects so extras are flagged — and named — at any depth.
+* Does **not** special-case an empty expected object: a nested `{}` still constrains, so extras under
+  it are reported.
+
+The **root** empty/unset case is handled by the *caller*, not the helper: `findUnexpectedKeys` runs
+only when the expected body is a plain object with at least one key. This preserves the unset-body
+behavior (`response.body` defaults to `{}` ⇒ no key constraint ⇒ PASS) while still letting a nested
+`{}` reject extras. The verdict is `noUnexpectedFields = unexpectedKeys.length === 0`, and the
+failure description **names** the offending paths: `Response contained unexpected fields: <a, b.c>.`
 
 The guard for a non-object / undefined expected body (`noUnexpectedFields = true`) is unchanged.
 Behavior when `allowAdditionalFields` is `true` or absent is unchanged (the check block only runs
@@ -91,13 +97,17 @@ when it is falsy).
 ### Confirmation
 
 Unit coverage in [test/httprequest-coverage.test.js](../test/httprequest-coverage.test.js): the
-`[bug #437]` test now asserts that expected `{ a: 1 }` vs actual `{ a: 1, extra: 99 }` with
-`allowAdditionalFields: false` FAILs with `noUnexpectedFields === false` and a description mentioning
-unexpected fields. Sibling tests confirm an exact-match superset still PASSes, a non-object expected
-body still short-circuits to PASS, and a same-key-set value mismatch FAILs via `bodyMatches` with
-`noUnexpectedFields` true. Server-based tests in
+`[bug #437]` test asserts that expected `{ a: 1 }` vs actual `{ a: 1, extra: 99 }` with
+`allowAdditionalFields: false` FAILs with `noUnexpectedFields === false` and a description naming the
+unexpected field. A companion `[bug #437]` test drives the **recursion** path — expected
+`{ user: { name: "Jo" } }` vs actual `{ user: { name: "Jo", extra: 99 } }` FAILs with the dot-path
+`user.extra` in the description. A nested-empty test confirms the short-circuit is **root-only**:
+expected `{ user: {} }` vs actual `{ user: { id: 7 } }` FAILs (naming `user.id`), while an
+**unset** expected body accepts any response shape (PASS). Sibling tests confirm an exact key-set
+match PASSes, a non-object expected body short-circuits to PASS, and a same-key-set value mismatch
+FAILs via `bodyMatches` with `noUnexpectedFields` true. Server-based tests in
 [test/httpRequest-assertions.test.js](../test/httpRequest-assertions.test.js) confirm the unset-body
-(`{}`) case still PASSes. All three files pass (`npm run build` then
+(`{}`) case still PASSes. All pass (`npm run build` then
 `npx mocha --exit test/httprequest-coverage.test.js test/httpRequest.test.js
 test/httpRequest-assertions.test.js`).
 

--- a/src/core/tests/httpRequest.ts
+++ b/src/core/tests/httpRequest.ts
@@ -445,10 +445,17 @@ async function httpRequest({ config, step, openApiDefinitions = [] }: { config: 
     // true) — matching the prior outcome (FAIL only when there ARE unexpected
     // fields).
     const expectedBody = step.httpRequest.response?.body;
+    // `objectExistsInObject(expected, actual)` is a SUBSET check: it verifies the
+    // response CONTAINS every expected key, but ignores EXTRA keys, so it can
+    // never flag additional fields (#437). To honor allowAdditionalFields:false
+    // the response must contain NO keys absent from the expected body — checked
+    // recursively for nested objects by `objectHasNoExtraKeys`. A non-object /
+    // undefined expected body has no keys to compare against, so there are no
+    // "unexpected" fields to flag (PASS). Value mismatches remain the concern of
+    // the body-match check (5) below, not of this key-set check.
     const noUnexpectedFields =
       expectedBody && typeof expectedBody === "object"
-        ? objectExistsInObject(expectedBody, response.data).result.status !==
-          "FAIL"
+        ? objectHasNoExtraKeys(expectedBody, response.data)
         : true;
     result.outputs.noUnexpectedFields = noUnexpectedFields;
     specs.push({
@@ -775,6 +782,51 @@ function arrayExistsInArray(expected: any, actual: any): any {
   }
   const result = { status, description };
   return { result };
+}
+
+/**
+ * Returns true iff `actual` contains no keys that are absent from `expected`,
+ * recursively for nested plain objects. Used to enforce
+ * `allowAdditionalFields: false`: the response must not carry fields beyond
+ * those the spec author declared in `response.body`.
+ *
+ * Only object-vs-object shapes are compared key-by-key; when either side isn't a
+ * plain object (primitive, array, null, mismatched shape) there are no object
+ * keys to compare, so it reports no extra keys (true). Value comparison and
+ * type/shape matching are handled elsewhere (the body-match check); this
+ * function is concerned solely with the presence of unexpected keys.
+ *
+ * An EMPTY expected object declares no fields, so it imposes no key constraint:
+ * it reports no extra keys (true) at any depth. This preserves the unset-body
+ * behavior (`response.body` defaults to `{}`), where "no expected fields" must
+ * never flag the whole response as unexpected.
+ */
+function objectHasNoExtraKeys(expected: any, actual: any): boolean {
+  const isPlainObject = (value: any) =>
+    typeof value === "object" && value !== null && !Array.isArray(value);
+  // If either side isn't a plain object, there is no object key-set to compare;
+  // treat as "no extra keys" and defer any shape/value disagreement to the
+  // dedicated body-match check.
+  if (!isPlainObject(expected) || !isPlainObject(actual)) {
+    return true;
+  }
+  // No declared fields -> no constraint on which keys may appear.
+  if (Object.keys(expected).length === 0) {
+    return true;
+  }
+  for (const key of Object.keys(actual)) {
+    if (!Object.prototype.hasOwnProperty.call(expected, key)) {
+      // `actual` has a key the author didn't declare -> unexpected field.
+      return false;
+    }
+    // Recurse into nested plain objects to flag extras at any depth.
+    if (isPlainObject(expected[key]) && isPlainObject(actual[key])) {
+      if (!objectHasNoExtraKeys(expected[key], actual[key])) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 function objectExistsInObject(expected: any, actual: any): any {

--- a/src/core/tests/httpRequest.ts
+++ b/src/core/tests/httpRequest.ts
@@ -445,25 +445,25 @@ async function httpRequest({ config, step, openApiDefinitions = [] }: { config: 
     // true) — matching the prior outcome (FAIL only when there ARE unexpected
     // fields).
     const expectedBody = step.httpRequest.response?.body;
-    // `objectExistsInObject(expected, actual)` is a SUBSET check: it verifies the
-    // response CONTAINS every expected key, but ignores EXTRA keys, so it can
-    // never flag additional fields (#437). To honor allowAdditionalFields:false
-    // the response must contain NO keys absent from the expected body — checked
-    // recursively for nested objects by `objectHasNoExtraKeys`. A non-object /
-    // undefined expected body has no keys to compare against, so there are no
-    // "unexpected" fields to flag (PASS). Value mismatches remain the concern of
-    // the body-match check (5) below, not of this key-set check.
-    const noUnexpectedFields =
-      expectedBody && typeof expectedBody === "object"
-        ? objectHasNoExtraKeys(expectedBody, response.data)
-        : true;
+    // Honor allowAdditionalFields:false by reporting keys in the response that
+    // the author didn't declare (#437 — the old subset check ignored extras).
+    // An unset/empty ROOT body imposes no constraint (response.body defaults to
+    // {}), so only a non-empty expected object is checked; nested {} still
+    // rejects extras. Value mismatches stay the concern of the body-match check.
+    const unexpectedKeys =
+      isPlainObject(expectedBody) && Object.keys(expectedBody).length > 0
+        ? findUnexpectedKeys(expectedBody, response.data)
+        : [];
+    const noUnexpectedFields = unexpectedKeys.length === 0;
     result.outputs.noUnexpectedFields = noUnexpectedFields;
     specs.push({
       statement: `$$outputs.noUnexpectedFields == true`,
       severity: "fail",
     });
     if (!noUnexpectedFields) {
-      descriptions.push(`Response contained unexpected fields.`);
+      descriptions.push(
+        `Response contained unexpected fields: ${unexpectedKeys.join(", ")}.`
+      );
     }
   }
 
@@ -784,49 +784,45 @@ function arrayExistsInArray(expected: any, actual: any): any {
   return { result };
 }
 
+function isPlainObject(value: any): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
- * Returns true iff `actual` contains no keys that are absent from `expected`,
- * recursively for nested plain objects. Used to enforce
+ * Collects the dot-paths of keys present in `actual` but NOT declared in
+ * `expected`, recursing into nested plain objects. Used to enforce
  * `allowAdditionalFields: false`: the response must not carry fields beyond
- * those the spec author declared in `response.body`.
+ * those the spec author declared in `response.body`. An empty array means "no
+ * unexpected fields".
  *
  * Only object-vs-object shapes are compared key-by-key; when either side isn't a
- * plain object (primitive, array, null, mismatched shape) there are no object
- * keys to compare, so it reports no extra keys (true). Value comparison and
+ * plain object (primitive, array, null, mismatched shape) there is no object
+ * key-set to compare, so it contributes no extra keys. Value comparison and
  * type/shape matching are handled elsewhere (the body-match check); this
  * function is concerned solely with the presence of unexpected keys.
  *
- * An EMPTY expected object declares no fields, so it imposes no key constraint:
- * it reports no extra keys (true) at any depth. This preserves the unset-body
- * behavior (`response.body` defaults to `{}`), where "no expected fields" must
- * never flag the whole response as unexpected.
+ * NOTE: this does NOT special-case an empty `expected` object — an explicitly
+ * declared nested `{}` means "this object must be empty", so any key in the
+ * corresponding `actual` is reported as unexpected. The ROOT unset/empty body is
+ * handled by the caller (`response.body` defaults to `{}`, which must impose no
+ * constraint), not here.
  */
-function objectHasNoExtraKeys(expected: any, actual: any): boolean {
-  const isPlainObject = (value: any) =>
-    typeof value === "object" && value !== null && !Array.isArray(value);
-  // If either side isn't a plain object, there is no object key-set to compare;
-  // treat as "no extra keys" and defer any shape/value disagreement to the
-  // dedicated body-match check.
+function findUnexpectedKeys(expected: any, actual: any, prefix = ""): string[] {
   if (!isPlainObject(expected) || !isPlainObject(actual)) {
-    return true;
+    return [];
   }
-  // No declared fields -> no constraint on which keys may appear.
-  if (Object.keys(expected).length === 0) {
-    return true;
-  }
+  const extras: string[] = [];
   for (const key of Object.keys(actual)) {
+    const p = prefix ? `${prefix}.${key}` : key;
     if (!Object.prototype.hasOwnProperty.call(expected, key)) {
       // `actual` has a key the author didn't declare -> unexpected field.
-      return false;
-    }
-    // Recurse into nested plain objects to flag extras at any depth.
-    if (isPlainObject(expected[key]) && isPlainObject(actual[key])) {
-      if (!objectHasNoExtraKeys(expected[key], actual[key])) {
-        return false;
-      }
+      extras.push(p);
+    } else if (isPlainObject(expected[key]) && isPlainObject(actual[key])) {
+      // Recurse into nested plain objects to flag extras at any depth.
+      extras.push(...findUnexpectedKeys(expected[key], actual[key], p));
     }
   }
-  return true;
+  return extras;
 }
 
 function objectExistsInObject(expected: any, actual: any): any {

--- a/test/httprequest-coverage.test.js
+++ b/test/httprequest-coverage.test.js
@@ -756,11 +756,12 @@ describe("httpRequest coverage (stubbed axios)", function () {
   // allowAdditionalFields
   // ---------------------------------------------------------------------------
   describe("allowAdditionalFields", function () {
-    it("FAILs when an expected field's value does not match (drives noUnexpectedFields false)", async function () {
-      // NOTE: this is a VALUE mismatch (expected unexpected:3, actual :2), not an
-      // extra-field case — the object subset comparison FAILs, which drives
-      // noUnexpectedFields false. The genuine extra-field behavior is covered by
-      // the #437 test below.
+    it("FAILs on a value mismatch via the body-match check, not noUnexpectedFields", async function () {
+      // VALUE mismatch (expected unexpected:3, actual :2) with the SAME key-set.
+      // The corrected noUnexpectedFields check is purely about extra KEYS, so it
+      // stays true here — the step still FAILs, but via the body-match check
+      // (bodyMatches false), which owns value comparison. The genuine extra-field
+      // behavior is covered by the #437 test below.
       stubResponse({ status: 200, data: { a: 1, unexpected: 2 } });
       const result = await httpRequest({
         config,
@@ -775,16 +776,17 @@ describe("httpRequest coverage (stubbed axios)", function () {
         },
       });
       assert.equal(result.status, "FAIL");
-      assert.equal(result.outputs.noUnexpectedFields, false);
+      assert.equal(result.outputs.noUnexpectedFields, true);
+      assert.equal(result.outputs.bodyMatches, false);
     });
 
-    it("[bug #437] does not yet reject a response with fields beyond the expected body", async function () {
+    it("[bug #437] rejects a response with fields beyond the expected body", async function () {
       // Expected { a: 1 }, actual { a: 1, extra: 99 } — every expected value
-      // matches but the response has an EXTRA field. allowAdditionalFields:false
-      // SHOULD FAIL ("Response contained unexpected fields"), but the source uses
-      // a subset check (objectExistsInObject(expected, actual)) that ignores
-      // extras, so noUnexpectedFields stays true and the step PASSes. Documents
-      // current behavior; flip to expect FAIL once #437 is fixed.
+      // matches but the response has an EXTRA field. With allowAdditionalFields:
+      // false this MUST FAIL: the response contains a key absent from the
+      // expected body. Previously a subset check (objectExistsInObject(expected,
+      // actual)) ignored extras and wrongly PASSed (#437); the fixed check now
+      // flags the extra field.
       stubResponse({ status: 200, data: { a: 1, extra: 99 } });
       const result = await httpRequest({
         config,
@@ -798,9 +800,9 @@ describe("httpRequest coverage (stubbed axios)", function () {
           },
         },
       });
-      // TODO(bug #437): should be FAIL / noUnexpectedFields === false.
-      assert.equal(result.status, "PASS", result.description);
-      assert.equal(result.outputs.noUnexpectedFields, true);
+      assert.equal(result.status, "FAIL");
+      assert.equal(result.outputs.noUnexpectedFields, false);
+      assert.match(result.description, /unexpected fields/);
     });
 
     it("PASSes noUnexpectedFields when the expected body is a non-object (string)", async function () {

--- a/test/httprequest-coverage.test.js
+++ b/test/httprequest-coverage.test.js
@@ -825,7 +825,7 @@ describe("httpRequest coverage (stubbed axios)", function () {
       assert.equal(result.outputs.noUnexpectedFields, true);
     });
 
-    it("PASSes noUnexpectedFields when the expected body is a superset match", async function () {
+    it("PASSes noUnexpectedFields when the response exactly matches the expected keys", async function () {
       stubResponse({ status: 200, data: { a: 1, b: 2 } });
       const result = await httpRequest({
         config,
@@ -841,6 +841,71 @@ describe("httpRequest coverage (stubbed axios)", function () {
       });
       assert.equal(result.status, "PASS", result.description);
       assert.equal(result.outputs.noUnexpectedFields, true);
+    });
+
+    it("PASSes noUnexpectedFields when the expected body is unset (no key constraint)", async function () {
+      // response.body defaults to {} when omitted; an empty ROOT expectation
+      // imposes no key constraint, so any response shape is accepted.
+      stubResponse({ status: 200, data: { a: 1, b: 2 } });
+      const result = await httpRequest({
+        config,
+        step: {
+          httpRequest: {
+            url: "http://api.example.com/",
+            method: "get",
+            statusCodes: [200],
+            allowAdditionalFields: false,
+          },
+        },
+      });
+      assert.equal(result.status, "PASS", result.description);
+      assert.equal(result.outputs.noUnexpectedFields, true);
+    });
+
+    it("[bug #437] rejects an extra field nested inside an object and names its dot-path", async function () {
+      // The extra key lives one level deep (user.extra). A shallow key-set check
+      // would miss it; the recursive check must descend into matching objects and
+      // report the fully-qualified path.
+      stubResponse({
+        status: 200,
+        data: { user: { name: "Jo", extra: 99 } },
+      });
+      const result = await httpRequest({
+        config,
+        step: {
+          httpRequest: {
+            url: "http://api.example.com/",
+            method: "get",
+            statusCodes: [200],
+            allowAdditionalFields: false,
+            response: { body: { user: { name: "Jo" } } },
+          },
+        },
+      });
+      assert.equal(result.status, "FAIL");
+      assert.equal(result.outputs.noUnexpectedFields, false);
+      assert.match(result.description, /user\.extra/);
+    });
+
+    it("rejects extras under a nested empty object (short-circuit is root-only)", async function () {
+      // Expected { user: {} }: the empty object is NESTED, not the root, so it
+      // still constrains — the response's user.id is unexpected and must FAIL.
+      stubResponse({ status: 200, data: { user: { id: 7 } } });
+      const result = await httpRequest({
+        config,
+        step: {
+          httpRequest: {
+            url: "http://api.example.com/",
+            method: "get",
+            statusCodes: [200],
+            allowAdditionalFields: false,
+            response: { body: { user: {} } },
+          },
+        },
+      });
+      assert.equal(result.status, "FAIL");
+      assert.equal(result.outputs.noUnexpectedFields, false);
+      assert.match(result.description, /user\.id/);
     });
   });
 


### PR DESCRIPTION
## Fix — allowAdditionalFields:false didn't reject extra fields (#437)

Fixes [#437](https://github.com/doc-detective/doc-detective/issues/437), found while writing Phase 7 coverage tests.

### The bug
The `noUnexpectedFields` check used `objectExistsInObject(expectedBody, response.data)` — a **subset** check that only verifies the response contains every *expected* key. Extra keys in the response could never fail it, so `allowAdditionalFields: false` silently accepted responses with additional fields.

### The fix
Replace the subset check with a new pure recursive helper `objectHasNoExtraKeys(expected, actual)` that returns `false` when the response carries any key not declared in the expected body (recursing into nested plain objects). Key details preserved:
- Non-object / undefined expected body → short-circuits to `true` (no expected fields ⇒ nothing "unexpected").
- **Empty expected object `{}` also short-circuits to `true`** — `response.body` defaults to `{}` when unset, so this preserves the documented unset-body behavior (caught by the server-based tests during development).
- Value comparison stays in the separate body-match check.

### Also
- **Tests:** flipped the `[bug #437]` test to assert FAIL / `noUnexpectedFields === false`. One sibling test genuinely changed meaning — a *value* mismatch with the same key-set used to FAIL via the (buggy) subset check driving `noUnexpectedFields` false; under correct key-set semantics it now FAILs via `bodyMatches` instead (`noUnexpectedFields === true`, `bodyMatches === false`). Updated + documented in the ADR.
- **ADR:** [01012-fix-http-allow-additional-fields.md](adrs/01012-fix-http-allow-additional-fields.md).
- **Docs impact:** `$$noUnexpectedFields` is documented as "whether the response contained only expected fields" — this makes the implementation honor that. No reference text change (noted in ADR).
- `fix:` → patch release.

### Verification
`test/httprequest-coverage.test.js` + `test/httpRequest.test.js` + `test/httpRequest-assertions.test.js` — 80 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened `allowAdditionalFields: false` checks so responses now fail when they include extra fields beyond the expected body.
  * Preserved existing behavior for non-object or empty expected bodies, and kept value/shape mismatches handled separately.
* **Documentation**
  * Added an ADR describing the corrected response-body matching behavior and updated testing expectations.
* **Tests**
  * Updated coverage to reflect the new strict extra-field validation and the distinction between extra fields and value mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->