### PR TITLE
fix(expressions): preserve original {{...}} on embedded-expression failure

### DIFF
--- a/adrs/01014-expression-error-contract.md
+++ b/adrs/01014-expression-error-contract.md
@@ -1,0 +1,143 @@
+---
+status: accepted
+date: 2026-07-01
+decision-makers: doc-detective maintainers
+---
+
+# Expression error contract: preserve the original `{{…}}` on embedded-expression failure
+
+## Context and Problem Statement
+
+`src/core/expressions.ts` resolves runtime expressions in three shapes that share one resolver
+(`resolveExpression`): standalone `$$meta` / operator expressions (used by `step.variables`),
+embedded `{{…}}` interpolation, and the condition/assertion path (`evaluateAssertion`).
+
+Three linked defects were found while writing characterization tests for the Phase 2 coverage work
+([#422](https://github.com/doc-detective/doc-detective/issues/422)):
+
+- **[#424](https://github.com/doc-detective/doc-detective/issues/424)** — `resolveExpression`
+  wrapped its whole body in a `try/catch` that, on **any** error, logged at `error` level and
+  returned the *original `expression` argument verbatim*. Callers could not distinguish "resolved to
+  this string" from "failed, here is your input back."
+- **[#423](https://github.com/doc-detective/doc-detective/issues/423)** — because the resolver never
+  threw, the `{{…}}` loop in `resolveEmbeddedExpressions` never saw a failure. A failing embedded
+  expression such as `{{jq($$d, "@@@invalid")}}` therefore emitted the **half-resolved internal
+  sub-expression** — `jq($$d, "@@@invalid")` with `$$d` left unexpanded — leaking implementation
+  detail into user-facing output (`r=jq($$d, "@@@invalid")`). The loop's own `catch`, written to
+  preserve the original `{{…}}`, was **unreachable**.
+- **[#425](https://github.com/doc-detective/doc-detective/issues/425)** — that unreachable `catch`,
+  plus the `jq()` helper's *synchronous* `catch` (jq rejects **asynchronously**, so the sync `catch`
+  can never fire), plus a couple of defensive type-guards, were structurally dead — code that reads
+  as protection but does nothing, and blocked the file from an honest 100%.
+
+Root-cause chain: the swallow-and-return-input (#424) causes the leak (#423) and leaves the dead
+error arms (#425). One contract decision resolves all three.
+
+## Decision Drivers
+
+* **Don't leak internals.** A failed embedded expression must not emit a half-resolved internal
+  form; the author should see something intentional.
+* **Preserve the byte-identical happy path.** The dynamic-routing roadmap
+  ([docs/design/dynamic-routing-roadmap.md](../docs/design/dynamic-routing-roadmap.md)) pins that
+  `step.variables` and `{{…}}` interpolation must resolve unchanged: `"x > out.txt"` stays a literal
+  string; an unresolved `$$token` passes through as a literal. Only genuine evaluation errors reach
+  the `catch`, so the error behavior can change without touching that contract.
+* **Keep the standalone `step.variables` fallback non-breaking.** A malformed variable expression
+  should still degrade to literal text rather than crash the step.
+* **Make coverage honest.** Dead error arms must become reachable or be annotated with a reason.
+
+## Considered Options
+
+* **A — Preserve the original `{{…}}` on embedded failure** (make the existing loop `catch`
+  reachable via a throwing worker).
+* **B — Render an empty string** for a failed embedded expression.
+* **C — Propagate the error** so a failed expression fails the step (including `step.variables`).
+
+## Decision Outcome
+
+Chosen: **Option A — preserve the original `{{…}}`**, implemented by splitting the resolver into a
+**worker** and a **boundary**:
+
+* `resolveExpressionOrThrow(...)` — the core resolver, WITHOUT the swallow. Genuine evaluation errors
+  (a `jq` rejection, a `new Function` `SyntaxError`) propagate to the caller.
+* `resolveExpression(...)` — the public boundary. It wraps the worker in a `try/catch` that, for
+  back-compat on the standalone path (`step.variables` and direct callers), returns the input
+  unchanged and logs at `warning` (an intentional swallow, not a surfaced failure).
+* `resolveEmbeddedExpressions(...)` now calls the **worker** directly, so a genuine failure lands in
+  its existing `catch`, which pushes `m[0]` — the author's original `{{…}}` — plus a `warning` log.
+
+`jq()` errors are allowed to propagate: the dead synchronous `catch` around `jq.then(...)` (which
+could never catch an async rejection) is removed, so a bad jq query rejects, the awaiting worker
+surfaces it, and the embedded loop preserves `{{…}}` (while the standalone boundary swallows to the
+literal input, unchanged from today).
+
+Option B was rejected because an empty string silently drops the expression with no in-band signal —
+the author sees `r=` and must consult logs to know anything failed. Option C was rejected because it
+would make a malformed `step.variables` value crash the step, a breaking change to a path the
+roadmap requires to stay byte-identical.
+
+**Scope of the behavior change is narrow.** `evaluateAssertion` (condition path) and `step.variables`
+(standalone) both still call the **public** `resolveExpression`, so their behavior is unchanged
+(still swallow-and-return-input). Only the embedded `{{…}}` loop's failure output changes: from the
+leaked sub-expression to the preserved `{{…}}`.
+
+### Consequences
+
+* Good: a failed embedded expression now renders the author's original `{{…}}` — no internal leak
+  (#423). The embedded `catch` is reachable and tested (#425).
+* Good: the `error`-level log on an intentional swallow becomes `warning`, matching its meaning
+  (#424).
+* Good: expressions.ts reaches 100% lines/statements/functions; the two genuinely-unreachable
+  defensive guards (the non-string entry guard; the embedded object branch the worker already
+  JSON-stringifies away) are annotated `/* c8 ignore … */` with a reason (#425).
+* Neutral: a **synchronous** eval error inside an embedded expression (e.g. the malformed
+  `{{jq(}}`) still resolves to `undefined` and renders as an empty string — that path returns
+  `undefined` without throwing, so it is not the preserved-`{{…}}` path. Documented and tested.
+* Neutral: expressions.ts logging is a pre-existing latent no-op — `log` is imported as
+  `log(config, level, message)` but called `log(message, level)` (no `config` is threaded into
+  `resolveExpression`). Fixing the signature is out of scope here (it requires threading `config`
+  through the resolver); the new calls follow the file's existing 2-arg convention. Tracked
+  separately.
+
+### Confirmation
+
+Unit coverage in [test/expressions-coverage.test.js](../test/expressions-coverage.test.js):
+
+* `{{jq($$d, "@@@invalid")}}` resolves to the preserved `r={{jq($$d, "@@@invalid")}}` (was the
+  leaked `r=jq($$d, "@@@invalid")`).
+* A failed embedded expression is preserved while a sibling that resolves still resolves
+  (`ok={{$$n}} bad={{…}}`).
+* A synchronous eval error (`{{jq(}}`) renders empty.
+* Byte-identical happy-path pins: `"x > out.txt"` → itself; `value=$$missing` → literal;
+  `value=$$here` → interpolated.
+* The standalone boundary still returns the input on a genuine error
+  (`jq($$data, "@@@bad")` → itself).
+
+`npx c8 --include 'dist/core/expressions.js'` reports 100% lines/statements/functions for
+expressions.ts. A feature fixture
+([test/core-artifacts/expression-embedded-failure.spec.json](../test/core-artifacts/expression-embedded-failure.spec.json))
+exercises `step.variables` with a valid `{{…}}`, an invalid `{{…}}` (preserved), and an
+operator-like literal end-to-end through the runner (PASS/SKIPPED only).
+
+## Docs impact
+
+`{{…}}` interpolation and `step.variables` are user-facing. The observable change is limited to the
+failure case: a broken embedded expression now shows the original `{{…}}` rather than a leaked
+internal form. This is closer to what a reader expects and needs at most a short note in the
+variables/expressions reference; no flag, output field, or default changes. The happy path is
+byte-identical.
+
+## Pros and Cons of the Options
+
+### A — Preserve the original `{{…}}`
+* Good: no internal leak; least surprising; reuses the loop's already-written intent; keeps the
+  standalone and condition paths byte-identical.
+* Bad: a small worker/boundary refactor.
+
+### B — Render empty string
+* Good: cleanest output.
+* Bad: silently drops the expression; no in-band signal that anything failed.
+
+### C — Propagate / fail the step
+* Good: loudest; a broken expression can never produce wrong output.
+* Bad: breaking for `step.variables`, which the roadmap requires to stay byte-identical.

--- a/adrs/01014-expression-error-contract.md
+++ b/adrs/01014-expression-error-contract.md
@@ -97,11 +97,13 @@ leaked sub-expression to the preserved `{{…}}`.
 * Neutral: a **synchronous** eval error inside an embedded expression (e.g. the malformed
   `{{jq(}}`) still resolves to `undefined` and renders as an empty string — that path returns
   `undefined` without throwing, so it is not the preserved-`{{…}}` path. Documented and tested.
-* Neutral: expressions.ts logging is a pre-existing latent no-op — `log` is imported as
-  `log(config, level, message)` but called `log(message, level)` (no `config` is threaded into
-  `resolveExpression`). Fixing the signature is out of scope here (it requires threading `config`
-  through the resolver); the new calls follow the file's existing 2-arg convention. Tracked
-  separately.
+* Neutral: expressions.ts logging is a pre-existing latent no-op. `log(config, level, message)`
+  explicitly supports the 2-arg form the file uses — when `message` is `undefined` it shifts
+  (`message = config; config = {}`) — so `log(message, level)` is a *supported* call, not a
+  signature bug. The no-op is that the defaulted `config` (`{}`) carries no `logLevel`, so no level
+  ever matches and nothing is emitted. The fix is therefore to thread a real `config` (carrying
+  `logLevel`) into `resolveExpression` so these warnings actually surface — out of scope here and
+  tracked separately.
 
 ### Confirmation
 

--- a/adrs/01014-expression-error-contract.md
+++ b/adrs/01014-expression-error-contract.md
@@ -58,8 +58,12 @@ error arms (#425). One contract decision resolves all three.
 Chosen: **Option A — preserve the original `{{…}}`**, implemented by splitting the resolver into a
 **worker** and a **boundary**:
 
-* `resolveExpressionOrThrow(...)` — the core resolver, WITHOUT the swallow. Genuine evaluation errors
-  (a `jq` rejection, a `new Function` `SyntaxError`) propagate to the caller.
+* `resolveExpressionOrThrow(...)` — the core resolver, WITHOUT the swallow. Errors that escape
+  `evaluateExpression` propagate to the caller. In practice that is an **async** operator rejection
+  (a bad `jq()` query rejects *after* `evaluateExpression`'s synchronous `try/catch` has returned, so
+  the awaiting worker surfaces it). A **synchronous** eval error (e.g. a `new Function` `SyntaxError`)
+  is caught inside `evaluateExpression` and becomes `undefined`, so it does not propagate — see the
+  neutral consequence below.
 * `resolveExpression(...)` — the public boundary. It wraps the worker in a `try/catch` that, for
   back-compat on the standalone path (`step.variables` and direct callers), returns the input
   unchanged and logs at `warning` (an intentional swallow, not a surfaced failure).

--- a/src/core/expressions.ts
+++ b/src/core/expressions.ts
@@ -52,10 +52,16 @@ async function resolveExpression({ expression, context, allowOperators = false }
 
 /**
  * Core resolver: the real work behind resolveExpression, WITHOUT the back-compat
- * error swallow. Genuine evaluation errors (jq rejection, `new Function` throw)
- * propagate to the caller so structured callers can react to failure. The public
- * resolveExpression wraps this and swallows for back-compat; resolveEmbeddedExpressions
- * calls it directly so it can preserve the original {{...}} on failure.
+ * error swallow. Errors that escape evaluateExpression propagate to the caller so
+ * structured callers can react. In practice that means an ASYNC operator
+ * rejection — a bad jq() query rejects after evaluateExpression's synchronous
+ * try/catch has already returned, so the awaiting worker surfaces it. (A
+ * SYNCHRONOUS eval error, e.g. a `new Function` SyntaxError, is caught inside
+ * evaluateExpression and becomes `undefined`, which does NOT throw here — the
+ * embedded loop renders it as an empty string rather than preserving {{...}}.)
+ * The public resolveExpression wraps this and swallows for back-compat;
+ * resolveEmbeddedExpressions calls it directly so it can preserve the original
+ * {{...}} when an async failure propagates.
  * @param {string} expression - The expression to resolve.
  * @param {object} context - Context object containing meta values.
  * @returns {*} - The resolved value of the expression.

--- a/src/core/expressions.ts
+++ b/src/core/expressions.ts
@@ -32,48 +32,69 @@ const META_TOKEN_SOURCE = "\\$\\$([\\w.\\[\\]\\-~]+(?:#\\/[\\w\\/\\[\\]]+)*)";
  * @returns {*} - The resolved value of the expression.
  */
 async function resolveExpression({ expression, context, allowOperators = false }: { expression: any; context: any; allowOperators?: boolean }): Promise<any> {
+  try {
+    return await resolveExpressionOrThrow({ expression, context, allowOperators });
+  } catch (error: any) {
+    // Back-compat swallow for the STANDALONE path (step.variables and any direct
+    // caller): a malformed/failing expression degrades to its literal input text
+    // rather than crashing the step. Logged at "warning" (an intentional swallow,
+    // not a surfaced failure). The embedded {{...}} loop does NOT rely on this —
+    // it calls resolveExpressionOrThrow directly so it can preserve the author's
+    // original {{...}} on failure instead of leaking the internal sub-expression
+    // (#423/#424). See adrs/01014-expression-error-contract.md.
+    log(
+      `Could not resolve expression '${expression}': ${error.message}`,
+      "warning"
+    );
+    return expression;
+  }
+}
+
+/**
+ * Core resolver: the real work behind resolveExpression, WITHOUT the back-compat
+ * error swallow. Genuine evaluation errors (jq rejection, `new Function` throw)
+ * propagate to the caller so structured callers can react to failure. The public
+ * resolveExpression wraps this and swallows for back-compat; resolveEmbeddedExpressions
+ * calls it directly so it can preserve the original {{...}} on failure.
+ * @param {string} expression - The expression to resolve.
+ * @param {object} context - Context object containing meta values.
+ * @returns {*} - The resolved value of the expression.
+ */
+async function resolveExpressionOrThrow({ expression, context, allowOperators = false }: { expression: any; context: any; allowOperators?: boolean }): Promise<any> {
   if (typeof expression !== "string") {
     return expression;
   }
 
-  try {
-    // First check if this is a string with embedded expressions {{...}}
-    if (expression.includes("{{") && expression.includes("}}")) {
-      return await resolveEmbeddedExpressions(expression, context);
-    }
-
-    // For standalone expressions, replace all meta values
-    let resolvedExpression = replaceMetaValues(expression, context, allowOperators);
-
-    // Check if the expression is a single meta value with no operators
-    if (
-      resolvedExpression !== expression &&
-      !containsOperators(resolvedExpression, allowOperators)
-    ) {
-      return resolvedExpression;
-    }
-
-    // Evaluate the expression if it contains operators
-    if (containsOperators(resolvedExpression, allowOperators)) {
-      let evaluatedExpression = await evaluateExpression(
-        resolvedExpression,
-        context
-      );
-      // If the evaluated expression is an object, convert it to a string
-      if (typeof evaluatedExpression === "object") {
-        evaluatedExpression = JSON.stringify(evaluatedExpression);
-      }
-      return evaluatedExpression;
-    }
-
-    return resolvedExpression;
-  } catch (error: any) {
-    log(
-      `Error resolving expression '${expression}': ${error.message}`,
-      "error"
-    );
-    return expression;
+  // First check if this is a string with embedded expressions {{...}}
+  if (expression.includes("{{") && expression.includes("}}")) {
+    return await resolveEmbeddedExpressions(expression, context);
   }
+
+  // For standalone expressions, replace all meta values
+  let resolvedExpression = replaceMetaValues(expression, context, allowOperators);
+
+  // Check if the expression is a single meta value with no operators
+  if (
+    resolvedExpression !== expression &&
+    !containsOperators(resolvedExpression, allowOperators)
+  ) {
+    return resolvedExpression;
+  }
+
+  // Evaluate the expression if it contains operators
+  if (containsOperators(resolvedExpression, allowOperators)) {
+    let evaluatedExpression = await evaluateExpression(
+      resolvedExpression,
+      context
+    );
+    // If the evaluated expression is an object, convert it to a string
+    if (typeof evaluatedExpression === "object") {
+      evaluatedExpression = JSON.stringify(evaluatedExpression);
+    }
+    return evaluatedExpression;
+  }
+
+  return resolvedExpression;
 }
 
 /**
@@ -245,6 +266,7 @@ function resolvePathTemplateVariables(path: string, context: any): string {
  * @returns {string} - The string with embedded expressions replaced with their evaluated values.
  */
 async function resolveEmbeddedExpressions(str: any, context: any): Promise<any> {
+  /* c8 ignore next 3 - defensive: the only caller (resolveExpressionOrThrow) already guards typeof !== "string" before reaching here */
   if (typeof str !== "string") {
     return str;
   }
@@ -255,8 +277,11 @@ async function resolveEmbeddedExpressions(str: any, context: any): Promise<any> 
   for (const m of str.matchAll(expressionRegex)) {
     parts.push(str.slice(lastIdx, m.index));
     try {
-      // Resolve any meta values within the expression
-      const resolvedExpression = await resolveExpression({
+      // Resolve any meta values within the expression. Use the THROWING worker
+      // (not the swallowing public resolveExpression) so a genuine failure lands
+      // in the catch below and preserves the author's original {{...}}, rather
+      // than leaking the half-resolved internal sub-expression (#423/#424).
+      const resolvedExpression = await resolveExpressionOrThrow({
         expression: m[1].trim(),
         context: context,
       });
@@ -264,6 +289,7 @@ async function resolveEmbeddedExpressions(str: any, context: any): Promise<any> 
       // Convert the result to string for embedding
       if (resolvedExpression === undefined || resolvedExpression === null) {
         parts.push("");
+        /* c8 ignore next 2 - defensive: resolveExpressionOrThrow already JSON.stringifies any object result, so an object never reaches here */
       } else if (typeof resolvedExpression === "object") {
         parts.push(JSON.stringify(resolvedExpression));
       } else {
@@ -271,10 +297,10 @@ async function resolveEmbeddedExpressions(str: any, context: any): Promise<any> 
       }
     } catch (error: any) {
       log(
-        `Error evaluating embedded expression '${m[1]}': ${error.message}`,
-        "error"
+        `Could not evaluate embedded expression '${m[1]}'; preserving it verbatim: ${error.message}`,
+        "warning"
       );
-      parts.push(m[0]); // Return the original expression if evaluation fails
+      parts.push(m[0]); // Preserve the original {{...}} when evaluation fails.
     }
     lastIdx = m.index! + m[0].length;
   }
@@ -418,14 +444,12 @@ async function evaluateExpression(expression: string, context: any): Promise<any
           return null;
         }
       },
-      jq: (json: any, query: string) => {
-        try {
-          return jq.then((jq: any) => jq.json(json, query));
-        } catch (e: any) {
-          log(`jq error: ${e.message}`, "error");
-          return null;
-        }
-      },
+      // jq-web resolves to the module, then jq.json(...) does the query. A bad
+      // query REJECTS asynchronously, so a synchronous try/catch here could never
+      // catch it (it was dead code, #425). Let the rejection propagate: the
+      // awaiting resolveExpressionOrThrow surfaces it, so the embedded loop
+      // preserves the original {{...}} and the condition path fails closed.
+      jq: (json: any, query: string) => jq.then((j: any) => j.json(json, query)),
     };
 
     // Use Function constructor for safer evaluation. The expression's string

--- a/src/core/expressions.ts
+++ b/src/core/expressions.ts
@@ -454,7 +454,9 @@ async function evaluateExpression(expression: string, context: any): Promise<any
       // query REJECTS asynchronously, so a synchronous try/catch here could never
       // catch it (it was dead code, #425). Let the rejection propagate: the
       // awaiting resolveExpressionOrThrow surfaces it, so the embedded loop
-      // preserves the original {{...}} and the condition path fails closed.
+      // preserves the original {{...}}. (The condition path — evaluateAssertion —
+      // still calls the swallowing resolveExpression boundary, so a jq error
+      // there is unchanged by this PR; reconciling that path is out of scope.)
       jq: (json: any, query: string) => jq.then((j: any) => j.json(json, query)),
     };
 

--- a/test/core-artifacts/expression-embedded-failure.spec.json
+++ b/test/core-artifacts/expression-embedded-failure.spec.json
@@ -40,7 +40,7 @@
             "args": [
               "$BAD_VAR"
             ],
-            "output": "/keep-\\{\\{jq\\(/"
+            "output": "/keep-\\{\\{jq\\(\\$\\$result, \"@@@invalid\"\\)\\}\\}/"
           }
         }
       ]

--- a/test/core-artifacts/expression-embedded-failure.spec.json
+++ b/test/core-artifacts/expression-embedded-failure.spec.json
@@ -27,10 +27,10 @@
           }
         },
         {
-          "description": "An invalid embedded expression (jq syntax error) is preserved verbatim, not leaked.",
+          "description": "An invalid embedded expression (jq syntax error) is preserved verbatim, not leaked. The jq argument is a literal (no $$token), so consuming the value below via a $VAR arg can't collapse a $$ into $.",
           "runBrowserScript": "return 'xyz';",
           "variables": {
-            "BAD_VAR": "keep-{{jq($$result, \"@@@invalid\")}}"
+            "BAD_VAR": "keep-{{jq(1, \"@@@invalid\")}}"
           }
         },
         {
@@ -40,7 +40,7 @@
             "args": [
               "$BAD_VAR"
             ],
-            "output": "/keep-\\{\\{jq\\(\\$\\$result, \"@@@invalid\"\\)\\}\\}/"
+            "output": "/keep-\\{\\{jq\\(1, \"@@@invalid\"\\)\\}\\}/"
           }
         }
       ]

--- a/test/core-artifacts/expression-embedded-failure.spec.json
+++ b/test/core-artifacts/expression-embedded-failure.spec.json
@@ -1,0 +1,49 @@
+{
+  "specId": "expression-embedded-failure",
+  "description": "Exercise embedded {{...}} expression resolution end-to-end through step.variables. Covers a valid embedded expression (interpolated) and an invalid one whose evaluation fails (jq syntax error), which must PRESERVE the author's original {{...}} rather than leak the internal sub-expression (#423/#424, ADR 01014). Inherits the default firefox-headless contexts from config.json, so it is SKIPPED where no browser is available.",
+  "tests": [
+    {
+      "testId": "embedded-expression-variable-roundtrip",
+      "description": "Set variables from embedded expressions, then consume them to observe the resolved values.",
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "description": "Produce a value to feed the embedded expressions below.",
+          "runBrowserScript": "return 'abc';",
+          "variables": {
+            "OK_VAR": "got-{{$$result}}"
+          }
+        },
+        {
+          "description": "A valid embedded expression interpolates: OK_VAR resolves to 'got-abc'.",
+          "runBrowserScript": {
+            "script": "return arguments[0];",
+            "args": [
+              "$OK_VAR"
+            ],
+            "output": "got-abc"
+          }
+        },
+        {
+          "description": "An invalid embedded expression (jq syntax error) is preserved verbatim, not leaked.",
+          "runBrowserScript": "return 'xyz';",
+          "variables": {
+            "BAD_VAR": "keep-{{jq($$result, \"@@@invalid\")}}"
+          }
+        },
+        {
+          "description": "BAD_VAR keeps the original {{jq(...)}} text; the internal sub-expression never leaks.",
+          "runBrowserScript": {
+            "script": "return arguments[0];",
+            "args": [
+              "$BAD_VAR"
+            ],
+            "output": "/keep-\\{\\{jq\\(/"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/expressions-coverage.test.js
+++ b/test/expressions-coverage.test.js
@@ -195,16 +195,64 @@ describe("expressions coverage: resolveEmbeddedExpressions branches", function (
 
   // An embedded jq() whose query string is invalid (but quoted, so the inner
   // expression is still syntactically valid JS — exercising jq's error path, not
-  // a JS SyntaxError). The inner resolveExpression catches the jq failure and
-  // returns its original pre-substitution expression string (so $$d stays
-  // unexpanded), which the embedded loop renders in place — deterministic, no
-  // crash. Asserts the exact output, not a prefix.
-  it("an embedded jq with an invalid query renders the sub-expression verbatim", async function () {
+  // a JS SyntaxError). On failure the embedded loop preserves the author's
+  // ORIGINAL {{...}} text rather than leaking the half-resolved internal
+  // sub-expression (#423/#424). Asserts the exact output, not a prefix.
+  it("an embedded jq with an invalid query preserves the original {{...}}", async function () {
     const r = await resolveExpression({
       expression: 'r={{jq($$d, "@@@invalid")}}',
       context: { d: { a: 1 } },
     });
-    assert.equal(r, 'r=jq($$d, "@@@invalid")');
+    assert.equal(r, 'r={{jq($$d, "@@@invalid")}}');
+  });
+
+  // A failed embedded expression must not disturb the surrounding literal text
+  // or any sibling expressions that DO resolve. Only the failing {{...}} is
+  // preserved verbatim; the good one still resolves.
+  it("a failed embedded expression is preserved while a sibling still resolves", async function () {
+    const r = await resolveExpression({
+      expression: 'ok={{$$n}} bad={{jq($$d, "@@@invalid")}}',
+      context: { n: 5, d: { a: 1 } },
+    });
+    assert.equal(r, 'ok=5 bad={{jq($$d, "@@@invalid")}}');
+  });
+
+  // An embedded expression whose evaluation yields `undefined` (a synchronous
+  // SyntaxError inside evaluateExpression, e.g. the malformed operator call
+  // `jq(`) is rendered as an empty string — the undefined/null embedded branch.
+  // Unlike an async jq REJECTION (which propagates and preserves {{...}}), a sync
+  // eval error resolves to undefined without throwing, so it renders empty.
+  it("an embedded expression evaluating to undefined renders empty", async function () {
+    const r = await resolveExpression({
+      expression: "a={{jq(}}",
+      context: {},
+    });
+    assert.equal(r, "a=");
+  });
+});
+
+describe("expressions coverage: interpolation/variables happy path stays byte-identical (#424)", function () {
+  // The design roadmap pins the default (non-condition) path: a value containing
+  // operator-like text must resolve to its LITERAL string, and an unresolved
+  // $$token must pass through as a literal — the error contract change must not
+  // regress either. These are the byte-identical guarantees for step.variables.
+  it("operator-like literal resolves to itself (no operators active off the condition path)", async function () {
+    assert.equal(
+      await resolveExpression({ expression: "x > out.txt", context: {} }),
+      "x > out.txt"
+    );
+  });
+  it("an unresolved $$token passes through as a literal", async function () {
+    assert.equal(
+      await resolveExpression({ expression: "value=$$missing", context: {} }),
+      "value=$$missing"
+    );
+  });
+  it("a resolved $$token still interpolates normally", async function () {
+    assert.equal(
+      await resolveExpression({ expression: "value=$$here", context: { here: "ok" } }),
+      "value=ok"
+    );
   });
 });
 


### PR DESCRIPTION
Resolves the tangled expression error-contract bug surfaced during Phase 2 coverage work: **#423** (embedded `{{…}}` leaks the internal sub-expression), **#424** (`resolveExpression` swallows all errors and returns input), and **#425** (unreachable defensive error arms). One contract decision fixes all three.

## The problem
`resolveExpression`'s catch swallowed every error and returned the pristine input, so the `{{…}}` loop never saw failures — a failed `{{jq($$d,"@@@invalid")}}` emitted the half-resolved internal form `jq($$d, "@@@invalid")` (with `$$d` unexpanded). The loop's failure `catch`, the `jq()` sync catch, and a few guards were all dead code.

## The fix (ADR [01014](adrs/01014-expression-error-contract.md))
Split the resolver into a **worker** and a **boundary**:
- `resolveExpressionOrThrow` — propagates genuine evaluation errors.
- Public `resolveExpression` — keeps the back-compat swallow for `step.variables` (returns input, logs at `warning`).
- `resolveEmbeddedExpressions` calls the **worker**, so on failure its `catch` fires and **preserves the author's original `{{…}}`** (the decided behavior).
- Dead `jq()` sync catch removed (jq rejects async); two by-construction-unreachable guards annotated `/* c8 ignore … */`.

**Narrow blast radius:** the condition path (`evaluateAssertion`) and `step.variables` both still use the public swallowing boundary — unchanged. Only the embedded loop's *failure output* changes.

## Verification
- `test/expressions-coverage.test.js`: leak repro now asserts preserved `{{…}}`; failed-sibling isolation; sync-error → empty; **byte-identical happy-path pins** (`"x > out.txt"` literal, `$$missing` literal, `$$here` interpolated); standalone boundary still returns input on error.
- **expressions.ts: 100% lines/statements/functions** (branches 96.6→98.7).
- Browser-gated feature fixture [`expression-embedded-failure.spec.json`](test/core-artifacts/expression-embedded-failure.spec.json) exercises the valid + preserved-on-failure permutations end-to-end (PASS/SKIPPED only).

## Docs impact
Small: a broken embedded expression now shows the original `{{…}}` rather than a leaked internal form. Happy path byte-identical; no flag/output/default change. Noted for a short addition to the variables/expressions reference.

Closes #423, #424, #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Embedded expression failures now keep the original `{{...}}` text instead of exposing partial internal details.
  * Variable and condition handling remains unchanged for normal failures, preserving existing behavior.
  * Meta token parsing now handles a wider range of token characters more reliably.

* **Documentation**
  * Added an architecture note describing the expected behavior for embedded expression errors.

* **Tests**
  * Expanded coverage for successful interpolation, failed embedded expressions, and literal passthrough behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->