### PR TITLE
ci: ratchet root coverage on the cross-platform union

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,12 +70,33 @@ jobs:
       - run: node ./bin/doc-detective.js install all --yes
         env:
           DOC_DETECTIVE_SKIP_AUTO_UPDATE: '1'
+      # NODE_V8_COVERAGE makes Node emit raw V8 coverage for the root suite (and
+      # every node subprocess it spawns) into coverage/tmp — the matrix cells
+      # double as cross-platform coverage collectors so no separate full-suite
+      # run is needed. An absolute path keeps subprocesses with a different cwd
+      # writing to the same directory.
       - run: npm test
         env:
           HERETTO_ORG_ID: ${{ secrets.HERETTO_ORG_ID }}
           HERETTO_USERNAME: ${{ secrets.HERETTO_USERNAME }}
           HERETTO_TOKEN: ${{ secrets.HERETTO_TOKEN }}
           DOC_DETECTIVE_SKIP_AUTO_UPDATE: '1'
+          NODE_V8_COVERAGE: ${{ github.workspace }}/coverage/tmp
+
+      # Shrink the raw V8 coverage to the repo's own dist entries and rewrite
+      # their paths to be OS-agnostic, so the coverage-merge job can re-root and
+      # union them regardless of which OS produced them. Runs even if a test
+      # failed so a flaky cell still contributes what it measured.
+      - if: always()
+        run: node scripts/prune-coverage.cjs coverage/tmp
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: raw-coverage-${{ matrix.os }}-node${{ matrix.node }}
+          path: coverage/tmp
+          retention-days: 3
+          if-no-files-found: warn
 
   # Coverage ratchet for the doc-detective-common subpackage. The matrix above
   # builds common on every cell but never measures coverage; this single
@@ -106,25 +127,22 @@ jobs:
       - run: npm run test:coverage:ratchet
         working-directory: src/common
 
-  # Coverage ratchet for the ROOT doc-detective package. Unlike the common
-  # ratchet above, root coverage exercises the end-to-end runner, so this job
-  # mirrors the matrix's heavy setup (build + `install all` + HERETTO secrets)
-  # and runs `npm run test:coverage` (c8 over the root suite, `test/*.test.js`)
-  # on a single platform, then enforces coverage-thresholds.json. Only root code
-  # counts toward this number: the `npm run build` step does run the common
-  # workspace's own tests (via build:common), but that coverage is measured
-  # against src/common/dist and dist/common/** is excluded from .c8rc.json, and
-  # the root `test:common` script is intentionally not part of test:coverage —
-  # common is gated by its own ratchet job above. Kept off the OS/node matrix
-  # because one measured run is the baseline; both callers (PR gate + release
-  # gate) wait on it, so a coverage regression blocks merges and releases. The
-  # coverage report is uploaded so the measured percentage is always visible.
-  # timeout-minutes matches the matrix (90) since c8 instrumentation adds
-  # overhead to the E2E run.
-  coverage-ratchet-root:
-    name: Coverage ratchet (root)
+  # Coverage ratchet for the ROOT doc-detective package — cross-platform union.
+  # Every matrix cell above collects raw V8 coverage (NODE_V8_COVERAGE) from the
+  # full end-to-end run and uploads its pruned, OS-agnostic slice. This job waits
+  # on the whole matrix, re-roots each cell's paths to its own dist, and runs
+  # `c8 report` over the UNION — so Windows/macOS-only branches that a single-OS
+  # run could never reach now count toward the measured percentage, and the
+  # ratchet enforces coverage-thresholds.json against that honest union. Both
+  # callers (PR gate + release gate) wait on the whole reusable workflow, so a
+  # coverage regression blocks merges and releases. Reusing the matrix's runs
+  # means no separate full-suite coverage run is needed. The merged report is
+  # uploaded so the measured percentage is always visible.
+  coverage-merge:
+    name: Coverage ratchet (root, cross-platform)
+    needs: test
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -137,20 +155,23 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - run: npm ci
+      # Build so dist/**/*.js + sourcemaps + src/** exist: c8 report remaps each
+      # raw dist entry through its sourcemap back to the original src/** file,
+      # exactly as the single-OS job did.
       - run: npm run build
-      # Pre-warm the browser cache the same way the matrix does, so E2E tests
-      # that drive Chrome are exercised (and counted) under coverage.
-      - run: node ./bin/doc-detective.js install all --yes
-        env:
-          DOC_DETECTIVE_SKIP_AUTO_UPDATE: '1'
-      # c8 mocha over the full root suite -> coverage/coverage-summary.json.
-      - run: npm run test:coverage
-        env:
-          HERETTO_ORG_ID: ${{ secrets.HERETTO_ORG_ID }}
-          HERETTO_USERNAME: ${{ secrets.HERETTO_USERNAME }}
-          HERETTO_TOKEN: ${{ secrets.HERETTO_TOKEN }}
-          DOC_DETECTIVE_SKIP_AUTO_UPDATE: '1'
+
+      # Pull every cell's raw-coverage-* artifact into its own subdirectory.
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: raw-coverage-*
+          path: raw-coverage
+
+      # Re-root each cell's OS-agnostic dist paths to this machine's dist and
+      # collect them into coverage/tmp, then let c8 report the union.
+      - run: node scripts/merge-coverage.cjs raw-coverage/* --out coverage/tmp
+      - run: npx c8 report --temp-directory coverage/tmp --reporter json-summary --reporter text --reporter lcov
       - run: npm run test:coverage:ratchet
+
       - if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,13 +85,13 @@ jobs:
 
       # Shrink the raw V8 coverage to the repo's own dist entries and rewrite
       # their paths to be OS-agnostic, so the coverage-merge job can re-root and
-      # union them regardless of which OS produced them. Runs even if a test
-      # failed so a flaky cell still contributes what it measured.
-      - if: always()
-        run: node scripts/prune-coverage.cjs coverage/tmp
+      # union them regardless of which OS produced them. No `if: always()` — a
+      # cell that fails already blocks the whole `test` job, so coverage-merge
+      # (needs: test) never runs on a partial matrix and these artifacts would go
+      # unused. Running only on the success path keeps the intent honest.
+      - run: node scripts/prune-coverage.cjs coverage/tmp
 
-      - if: always()
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: raw-coverage-${{ matrix.os }}-node${{ matrix.node }}
           path: coverage/tmp
@@ -161,15 +161,18 @@ jobs:
       - run: npm run build
 
       # Pull every cell's raw-coverage-* artifact into its own subdirectory.
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: raw-coverage-*
           path: raw-coverage
 
       # Re-root each cell's OS-agnostic dist paths to this machine's dist and
-      # collect them into coverage/tmp, then let c8 report the union.
+      # collect them into coverage/tmp, then let c8 report the union. `--no`
+      # forces npx to use the local c8 (installed by `npm ci`) and never fetch
+      # from the registry. `--reporter json` keeps coverage-final.json in the
+      # uploaded artifact (CLI --reporter flags REPLACE .c8rc.json's reporters).
       - run: node scripts/merge-coverage.cjs raw-coverage/* --out coverage/tmp
-      - run: npx c8 report --temp-directory coverage/tmp --reporter json-summary --reporter text --reporter lcov
+      - run: npx --no c8 report --temp-directory coverage/tmp --reporter json-summary --reporter json --reporter text --reporter lcov
       - run: npm run test:coverage:ratchet
 
       - if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,7 +176,7 @@ jobs:
       - run: npm run test:coverage:ratchet
 
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: root-coverage
           path: coverage/

--- a/adrs/01015-cross-platform-coverage-merge.md
+++ b/adrs/01015-cross-platform-coverage-merge.md
@@ -75,6 +75,11 @@ and OS-specific — is handled by two small, dependency-free scripts:
 * Caveat: the gating check's name changes from `Coverage ratchet (root)` to
   `Coverage ratchet (root, cross-platform)`. If it was added as a **required status check** in branch
   protection, the maintainer must update the required-check name (a repo setting, outside this PR).
+* Requirement: raw V8 coverage encodes character offsets into the emitted `dist/**/*.js`, so the
+  merge only maps correctly if every cell's `dist` is **byte-identical** to the merge machine's.
+  `tsc` defaults to CRLF on Windows, which would shift every Windows offset; `tsconfig.json` now
+  pins `newLine: "lf"` so `dist` is LF on all platforms. (`.gitattributes` normalizes checked-in
+  sources, but `dist` is built, not committed, so the compiler setting is what guarantees this.)
 
 ### Confirmation
 

--- a/adrs/01015-cross-platform-coverage-merge.md
+++ b/adrs/01015-cross-platform-coverage-merge.md
@@ -1,0 +1,107 @@
+---
+status: accepted
+date: 2026-07-01
+decision-makers: doc-detective maintainers
+---
+
+# Ratchet root coverage on the cross-platform union, not a single OS
+
+## Context and Problem Statement
+
+The root `doc-detective` coverage ratchet measured a single `ubuntu-latest` run of the full suite
+(`coverage-ratchet-root`). Two problems followed:
+
+1. **Single-OS blind spots.** The runner has genuinely OS-specific branches (Windows path handling,
+   macOS/Linux recording and driver paths). Measured only on Ubuntu, those branches are *unreachable*
+   by construction, so an honest 100% is impossible and real Windows/macOS regressions go uncounted.
+2. **A duplicate heavy run.** `coverage-ratchet-root` re-ran the entire end-to-end suite (browsers +
+   `install all` + E2E) purely to measure coverage — a second ~45–90 min job on top of the six-cell
+   test matrix that already runs that same suite on every OS/node combination.
+
+We want the ratchet to enforce the **true cross-platform union** of coverage, and to stop paying for
+a duplicate full-suite run.
+
+## Decision Drivers
+
+* Count OS-gated branches — the union across Windows/macOS/Linux, so 100% is attainable and
+  platform-specific regressions are caught.
+* Don't add a second (third, …) full E2E run; reuse the matrix that already runs the suite per OS.
+* Keep the *measurement semantics* identical to today (same c8 config, same sourcemap remap to
+  `src/**`, same `coverage-summary.json` shape the ratchet reads) so only the coverage set widens.
+* No new production/dev dependencies (avoid the cross-platform lockfile-regeneration hazard).
+
+## Considered Options
+
+* **A — Instrument the existing matrix cells + a merge job.** Each cell collects raw V8 coverage via
+  `NODE_V8_COVERAGE`, prunes it to the repo's `dist` with OS-agnostic paths, and uploads it; a
+  `coverage-merge` job re-roots every cell's paths to its own `dist` and runs `c8 report` over the
+  union, then ratchets.
+* **B — Keep the single-OS job, add advisory multi-OS reporting.** Two coverage numbers; only Ubuntu
+  gates. Doesn't fix the blind spot in the gate and keeps the duplicate run.
+* **C — Merge Istanbul `coverage-final.json` per cell with a hand-rolled counter merger.** Avoids
+  raw-V8 path issues but reimplements Istanbul's summarizer (line/branch counting) by hand, risking
+  divergence from the numbers the ratchet compares against.
+
+## Decision Outcome
+
+Chosen: **Option A**. It reuses the matrix (no duplicate run), yields the true union, and reuses
+c8's own reporting so the summary is byte-for-byte the same kind the single-OS job produced —
+mapped back to `src/**` through sourcemaps. The single-OS `coverage-ratchet-root` job is removed;
+`coverage-merge` replaces it as the gate. Both callers (`npm-test.yaml`, `release.yml`) wait on the
+whole reusable `test.yml`, so the new job gates merges and releases just as the old one did.
+
+The one non-obvious part — merging raw V8 coverage across machines whose `file://` urls are absolute
+and OS-specific — is handled by two small, dependency-free scripts:
+
+* [scripts/prune-coverage.cjs](../scripts/prune-coverage.cjs) (per cell): keep only entries under the
+  repo's own `dist/` (drop node internals, `node_modules`, and the separately-ratcheted
+  `dist/common/**`), and rewrite each kept `url` to a path **relative to `dist`**
+  (e.g. `/core/expressions.js`). This shrinks the artifact and makes it portable.
+* [scripts/merge-coverage.cjs](../scripts/merge-coverage.cjs) (merge job): re-root every relative
+  `url` to the merge machine's absolute `dist` `file://` path and collect all cells' raw files into
+  one temp directory. `c8 report` then aggregates duplicate script entries into the union natively —
+  the same aggregation it already does across a single run's subprocesses.
+
+### Consequences
+
+* Good: OS-gated branches count; the ratchet enforces the honest cross-platform union.
+* Good: no separate full-suite coverage run — the matrix cells double as collectors; net CI time
+  drops (a ~20 min merge job replaces a ~45–90 min duplicate E2E run).
+* Good: no new dependencies; c8 (already pinned) does the reporting.
+* Neutral: the matrix `test` step now runs under `NODE_V8_COVERAGE` (low overhead; the old single-OS
+  job already ran the suite under c8, which does the same).
+* Neutral: the baseline rises to the union number; `coverage-thresholds.json` is re-baselined from
+  the first CI run of this job.
+* Caveat: the gating check's name changes from `Coverage ratchet (root)` to
+  `Coverage ratchet (root, cross-platform)`. If it was added as a **required status check** in branch
+  protection, the maintainer must update the required-check name (a repo setting, outside this PR).
+
+### Confirmation
+
+The prune → merge → `c8 report` pipeline was verified locally by treating two disjoint unit-test runs
+as two "cells": each produced raw V8 coverage, was pruned (Windows absolute paths → dist-relative),
+merged/re-rooted, and reported. The merged total line coverage (24.03%) was strictly greater than
+either cell alone (cell A: 4.61%), and every file remapped to its `src/**` `.ts` source via
+sourcemap — proving the union aggregates rather than concatenates and that cross-OS path
+normalization round-trips. In CI, the `coverage-merge` job's uploaded `root-coverage` artifact shows
+the union percentage, and `check-coverage-ratchet.cjs` enforces it against `coverage-thresholds.json`.
+
+## Docs impact
+
+None — internal CI/coverage tooling only. No user-facing step type, option, flag, output, or default
+changes.
+
+## Pros and Cons of the Options
+
+### A — Matrix collection + merge job
+* Good: true union; no duplicate run; reuses c8's summarizer; no new deps.
+* Bad: needs the two path-normalization scripts and artifact plumbing.
+
+### B — Single-OS gate + advisory multi-OS
+* Good: smallest change.
+* Bad: the gate keeps its blind spot; the duplicate run remains.
+
+### C — Hand-rolled Istanbul merge
+* Good: avoids raw-V8 path handling.
+* Bad: reimplements Istanbul's line/branch summarization — easy to diverge from the numbers the
+  ratchet compares, and more code to maintain than the two thin V8 scripts.

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,6 +1,6 @@
 {
-  "description": "Coverage baseline thresholds for the root doc-detective package, measured from the full root test suite (test/*.test.js) under c8 in CI. These values should only increase, never decrease. 'tolerance' absorbs sub-tolerance run-to-run branch wobble from the non-deterministic E2E suite — a metric only fails when it drops MORE than 'tolerance' percentage points below baseline.",
-  "lastUpdated": "2026-06-30",
+  "description": "Coverage baseline thresholds for the root doc-detective package, measured as the CROSS-PLATFORM UNION of the full end-to-end test suite: every OS/node matrix cell collects raw V8 coverage (NODE_V8_COVERAGE) and the coverage-merge job re-roots and reports their union via c8, so OS-gated (Windows/macOS) branches count. These values should only increase, never decrease. 'tolerance' absorbs sub-tolerance run-to-run branch wobble from the non-deterministic E2E suite — a metric only fails when it drops MORE than 'tolerance' percentage points below baseline.",
+  "lastUpdated": "2026-07-01",
   "tolerance": 0.1,
   "lines": 86.86,
   "statements": 86.86,

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -2,8 +2,8 @@
   "description": "Coverage baseline thresholds for the root doc-detective package, measured as the CROSS-PLATFORM UNION of the full end-to-end test suite: every OS/node matrix cell collects raw V8 coverage (NODE_V8_COVERAGE) and the coverage-merge job re-roots and reports their union via c8, so OS-gated (Windows/macOS) branches count. These values should only increase, never decrease. 'tolerance' absorbs sub-tolerance run-to-run branch wobble from the non-deterministic E2E suite — a metric only fails when it drops MORE than 'tolerance' percentage points below baseline.",
   "lastUpdated": "2026-07-01",
   "tolerance": 0.1,
-  "lines": 86.86,
-  "statements": 86.86,
-  "functions": 87.94,
-  "branches": 83.25
+  "lines": 87.64,
+  "statements": 87.64,
+  "functions": 88.94,
+  "branches": 83.85
 }

--- a/scripts/merge-coverage.cjs
+++ b/scripts/merge-coverage.cjs
@@ -35,6 +35,10 @@ let outDir = path.join("coverage", "tmp");
 for (let i = 0; i < args.length; i++) {
   if (args[i] === "--out") {
     outDir = args[++i];
+    if (typeof outDir !== "string" || outDir.length === 0) {
+      console.error("merge-coverage: --out requires a directory value.");
+      process.exit(1);
+    }
   } else {
     inputDirs.push(args[i]);
   }
@@ -48,7 +52,18 @@ if (inputDirs.length === 0) {
   process.exit(1);
 }
 
+// Safety: the output directory is wiped below (rmSync -r -f), so refuse any
+// value that isn't a real subdirectory of the cwd — a typo like `--out .` or
+// `--out /` must never delete the working tree or filesystem root.
 outDir = path.resolve(outDir);
+const rel = path.relative(process.cwd(), outDir);
+if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) {
+  console.error(
+    `merge-coverage: refusing --out "${outDir}" — it must be a subdirectory of ${process.cwd()}.`
+  );
+  process.exit(1);
+}
+
 // The merge machine's absolute file:// prefix for the repo's dist.
 const distPrefix = pathToFileURL(path.resolve("dist")).href;
 
@@ -92,9 +107,13 @@ for (const dir of inputDirs) {
       }
     }
 
-    // Namespace the filename by source directory so identically-named raw files
-    // from different cells never collide in the merged directory.
-    const outName = `${path.basename(resolvedDir)}-${name}`;
+    // Namespace by source directory so identically-named raw files from
+    // different cells never collide — but KEEP the `coverage-` prefix, since
+    // `c8 report` discovers raw V8 files by globbing `coverage-*.json`.
+    const outName = `coverage-${path.basename(resolvedDir)}-${name.replace(
+      /^coverage-/,
+      ""
+    )}`;
     fs.writeFileSync(path.join(outDir, outName), JSON.stringify(data));
     mergedFiles++;
   }

--- a/scripts/merge-coverage.cjs
+++ b/scripts/merge-coverage.cjs
@@ -107,13 +107,13 @@ for (const dir of inputDirs) {
       }
     }
 
-    // Namespace by source directory so identically-named raw files from
-    // different cells never collide — but KEEP the `coverage-` prefix, since
-    // `c8 report` discovers raw V8 files by globbing `coverage-*.json`.
-    const outName = `coverage-${path.basename(resolvedDir)}-${name.replace(
-      /^coverage-/,
-      ""
-    )}`;
+    // Namespace by a per-cell index AND source directory so raw files never
+    // collide — even if two input dirs share a trailing name — but KEEP the
+    // `coverage-` prefix, since `c8 report` discovers raw V8 files by globbing
+    // `coverage-*.json`.
+    const outName = `coverage-${cells}-${path.basename(
+      resolvedDir
+    )}-${name.replace(/^coverage-/, "")}`;
     fs.writeFileSync(path.join(outDir, outName), JSON.stringify(data));
     mergedFiles++;
   }

--- a/scripts/merge-coverage.cjs
+++ b/scripts/merge-coverage.cjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+/**
+ * Merge pruned raw V8 coverage from many CI matrix cells into one temp
+ * directory that `c8 report` can turn into a single, cross-platform-union
+ * coverage summary.
+ *
+ * Each input directory is one cell's pruned output (see
+ * scripts/prune-coverage.cjs): raw `coverage-*.json` files whose kept entries
+ * have OS-agnostic `url`s relative to `dist` (e.g. `/core/expressions.js`).
+ * This script re-roots every such `url` to the MERGE machine's own absolute
+ * `dist` `file://` path, so `c8 report` (run afterwards, on this machine, with
+ * `dist` built and sources present) remaps each entry through its sourcemap to
+ * the original `src/**` file exactly as the single-OS job did — only now the
+ * union across every cell counts, so OS-gated branches are no longer dead.
+ *
+ * c8 natively aggregates multiple raw entries for the same script, so simply
+ * placing every cell's (re-rooted) raw file in one temp directory yields the
+ * union; no hand-rolled counter merging is needed.
+ *
+ * Usage:
+ *   node scripts/merge-coverage.cjs <inputDir> [<inputDir> ...] [--out <dir>]
+ *     --out  destination temp directory (default: coverage/tmp)
+ *
+ * Then: npx c8 report --temp-directory <out> ...   (reads .c8rc.json)
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+const args = process.argv.slice(2);
+const inputDirs = [];
+let outDir = path.join("coverage", "tmp");
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--out") {
+    outDir = args[++i];
+  } else {
+    inputDirs.push(args[i]);
+  }
+}
+
+if (inputDirs.length === 0) {
+  console.error(
+    "merge-coverage: no input directories given.\n" +
+      "Usage: node scripts/merge-coverage.cjs <inputDir> [<inputDir> ...] [--out <dir>]"
+  );
+  process.exit(1);
+}
+
+outDir = path.resolve(outDir);
+// The merge machine's absolute file:// prefix for the repo's dist.
+const distPrefix = pathToFileURL(path.resolve("dist")).href;
+
+// Start from a clean output directory so a re-run never mixes stale raw files.
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+
+let cells = 0;
+let mergedFiles = 0;
+let rerootedEntries = 0;
+
+for (const dir of inputDirs) {
+  const resolvedDir = path.resolve(dir);
+  if (!fs.existsSync(resolvedDir)) {
+    console.warn(`merge-coverage: input directory not found, skipping: ${dir}`);
+    continue;
+  }
+  cells++;
+
+  for (const name of fs.readdirSync(resolvedDir)) {
+    if (!name.endsWith(".json")) continue;
+
+    let data;
+    try {
+      data = JSON.parse(fs.readFileSync(path.join(resolvedDir, name), "utf8"));
+    } catch (error) {
+      console.warn(
+        `merge-coverage: skipping unparseable ${dir}/${name}: ${error.message}`
+      );
+      continue;
+    }
+    if (!data || !Array.isArray(data.result)) continue;
+
+    for (const entry of data.result) {
+      // Re-root the portable, dist-relative url (e.g. `/core/expressions.js`)
+      // to this machine's absolute dist file url. Entries that are already
+      // absolute (defensive: an un-pruned file) are left untouched.
+      if (typeof entry.url === "string" && entry.url.startsWith("/")) {
+        entry.url = distPrefix + entry.url;
+        rerootedEntries++;
+      }
+    }
+
+    // Namespace the filename by source directory so identically-named raw files
+    // from different cells never collide in the merged directory.
+    const outName = `${path.basename(resolvedDir)}-${name}`;
+    fs.writeFileSync(path.join(outDir, outName), JSON.stringify(data));
+    mergedFiles++;
+  }
+}
+
+console.log(
+  `merge-coverage: merged ${cells} cell(s) -> ${outDir} ` +
+    `(${mergedFiles} raw file(s), ${rerootedEntries} entries re-rooted).`
+);
+
+if (mergedFiles === 0) {
+  console.error(
+    "merge-coverage: no raw coverage files found in any input directory."
+  );
+  process.exit(1);
+}

--- a/scripts/prune-coverage.cjs
+++ b/scripts/prune-coverage.cjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+/**
+ * Prune + portablize raw V8 coverage for cross-platform merge.
+ *
+ * Each CI matrix cell runs the suite with NODE_V8_COVERAGE pointed at a temp
+ * directory, so Node writes raw V8 coverage there — one `coverage-*.json` per
+ * process, each holding a `result[]` of `{ scriptId, url, functions }` for
+ * EVERY script the process touched (node internals, node_modules, the repo's
+ * own `dist/**`, …). That is large and its `url`s are absolute, OS-specific
+ * `file://` paths, so it cannot be merged across machines as-is.
+ *
+ * This script rewrites each raw file in place to:
+ *   1. keep ONLY entries under the repo's own `dist/` (dropping node internals,
+ *      node_modules, and `dist/common/**` which has its own ratchet), and
+ *   2. replace each kept `url` with an OS-agnostic path RELATIVE to `dist`
+ *      (e.g. `/core/expressions.js`), so the merge job can re-root it to its own
+ *      absolute `dist` path regardless of which OS produced it.
+ *
+ * The result is small and portable. `scripts/merge-coverage.cjs` consumes it.
+ *
+ * Usage:
+ *   node scripts/prune-coverage.cjs [rawDir]      # default: coverage/tmp
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+const rawDir = path.resolve(process.argv[2] || path.join("coverage", "tmp"));
+// Absolute file:// prefix of the repo's dist, e.g. file:///home/.../dist
+const distPrefix = pathToFileURL(path.resolve("dist")).href;
+
+if (!fs.existsSync(rawDir)) {
+  console.error(`prune-coverage: raw coverage directory not found: ${rawDir}`);
+  console.error(
+    "Run the suite with NODE_V8_COVERAGE pointed at this directory first."
+  );
+  process.exit(1);
+}
+
+/**
+ * True for a raw V8 entry that belongs to the repo's own dist output (and not
+ * the separately-ratcheted dist/common subtree).
+ * @param {string|undefined} url - The entry's `file://` url.
+ * @returns {boolean}
+ */
+function isRepoDist(url) {
+  return (
+    typeof url === "string" &&
+    url.startsWith(distPrefix + "/") &&
+    !url.startsWith(distPrefix + "/common/")
+  );
+}
+
+let files = 0;
+let keptEntries = 0;
+let removedFiles = 0;
+
+for (const name of fs.readdirSync(rawDir)) {
+  if (!name.endsWith(".json")) continue;
+  const filePath = path.join(rawDir, name);
+
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    // A partially-written raw file is not fatal — skip it and keep going.
+    console.warn(`prune-coverage: skipping unparseable ${name}: ${error.message}`);
+    continue;
+  }
+
+  if (!data || !Array.isArray(data.result)) continue;
+
+  const kept = [];
+  for (const entry of data.result) {
+    if (!isRepoDist(entry.url)) continue;
+    // Store the path relative to dist (leading slash), OS-agnostic.
+    entry.url = entry.url.slice(distPrefix.length);
+    kept.push(entry);
+  }
+
+  if (kept.length === 0) {
+    // Nothing from our dist here — drop the file so upload stays small.
+    fs.unlinkSync(filePath);
+    removedFiles++;
+    continue;
+  }
+
+  data.result = kept;
+  fs.writeFileSync(filePath, JSON.stringify(data));
+  files++;
+  keptEntries += kept.length;
+}
+
+console.log(
+  `prune-coverage: pruned ${rawDir} -> ${files} file(s) kept ` +
+    `(${keptEntries} dist entries), ${removedFiles} empty file(s) removed.`
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
+    "newLine": "lf",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Implements the final phase of the coverage-ratchet plan: gate root coverage on the **cross-platform union** instead of a single Ubuntu run, so Windows/macOS-only branches count and a duplicate full-suite run is eliminated.

## What changes
- **Every matrix `test` cell** now collects raw V8 coverage (`NODE_V8_COVERAGE`) from its full E2E run, then prunes it to the repo's own `dist/` with OS-agnostic paths and uploads it (`raw-coverage-<os>-node<n>`, small artifacts).
- **New `coverage-merge` job** (`needs: test`) downloads every cell's slice, re-roots the paths to its own `dist`, runs `c8 report` over the **union**, and ratchets against `coverage-thresholds.json`.
- **Removed `coverage-ratchet-root`** — the matrix cells double as collectors, so the separate ~45–90 min E2E coverage run is gone. Net CI time drops (a ~20 min merge job replaces it).
- Two dependency-free scripts do the cross-machine merge: [`prune-coverage.cjs`](scripts/prune-coverage.cjs) and [`merge-coverage.cjs`](scripts/merge-coverage.cjs).

## Why this approach
c8 already aggregates duplicate script entries into a union and remaps `dist` → `src/**` via sourcemaps. The only cross-machine problem is that raw V8 `url`s are absolute and OS-specific; the two scripts normalize (prune → dist-relative) and re-root (merge → local dist), so **measurement semantics are identical to the old job** — only the coverage *set* widens. No new dependencies (avoids the lockfile-regeneration hazard). ADR: [01015](adrs/01015-cross-platform-coverage-merge.md).

## Verification
Locally simulated two disjoint unit-test runs as two "cells": pruned (Windows abs paths → dist-relative), merged/re-rooted, `c8 report`. Merged total lines **24.03%** > cell-A-alone **4.61%**, and every file remapped to its `.ts` source — proving the union **aggregates rather than concatenates** and cross-OS path normalization round-trips.

## Baseline
The thresholds are **re-baselined to the union** measured by this PR's first `coverage-merge` run — lines/statements 86.86→87.64, functions 87.94→88.94, branches 83.25→83.85 — locking in the Windows/macOS branches the single-OS job never counted.

## Notes
- **Docs impact: none** — internal CI/coverage tooling only.
- ⚠️ The gating check renames from `Coverage ratchet (root)` → `Coverage ratchet (root, cross-platform)`. If it's a **required status check** in branch protection, the required-check name must be updated (repo setting, outside this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coverage gating now evaluates a cross-platform union (Windows, macOS, and Linux) rather than relying on a single platform.
  * Coverage artifacts are collected per test run and merged into a consolidated report before ratcheting.

* **Bug Fixes**
  * Consolidated coverage is rerooted consistently so the merged report reflects the unified outputs instead of platform-specific paths.
  * Coverage thresholds were refreshed to the latest expected baselines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->