### PR TITLE
ci: gate PR test matrix on src/** changes

### DIFF
--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -12,8 +12,9 @@ on:
       - opened
       - reopened
       - synchronize
-    # Only run the full matrix when product/test code or the build & dependency
-    # inputs change. Docs-only, samples-only, or test-fixture-only PRs skip it.
+    # Only run the full matrix when product code (src/**, which the test suite
+    # exercises) or the build & dependency inputs change. Docs-only,
+    # samples-only, or test-fixture-only (test/**) PRs skip it.
     # `src/**` also covers the doc-detective-common workspace (src/common).
     # Use `workflow_dispatch` to run the matrix on demand for excluded paths.
     paths:

--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -12,8 +12,18 @@ on:
       - opened
       - reopened
       - synchronize
-    paths-ignore:
-      - 'docs/**'
+    # Only run the full matrix when product/test code or the build & dependency
+    # inputs change. Docs-only, samples-only, or test-fixture-only PRs skip it.
+    # `src/**` also covers the doc-detective-common workspace (src/common).
+    # Use `workflow_dispatch` to run the matrix on demand for excluded paths.
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'bin/**'
+      - 'scripts/**'
+      - '.github/workflows/npm-test.yaml'
+      - '.github/workflows/test.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What

Scope the PR test gate ([`.github/workflows/npm-test.yaml`](.github/workflows/npm-test.yaml)) so the full cross-platform test matrix runs **only** when product/test code or build inputs change. Replaces the `paths-ignore: docs/**` denylist with a `paths` allowlist:

- `src/**` (also covers the `src/common` workspace)
- `package.json`, `package-lock.json`
- `bin/**`, `scripts/**`
- `.github/workflows/npm-test.yaml`, `.github/workflows/test.yml`

## Why

Previously the matrix — including the ~30-minute Doc Detective fixture pass (`test/core-core.test.js` → `test/core-artifacts/*.spec.json`) — ran on every PR except docs-only ones. That meant `test/`-only, `samples/`-only, and other unrelated PRs still spun up the whole Windows/macOS/Linux × Node 22/24 grid plus the coverage jobs. This gates it to changes that can actually affect test outcomes.

## Notes for reviewers

- **Release gate untouched.** [`release.yml`](.github/workflows/release.yml) still runs the full matrix on pushes to `main`/`next`/`feat/**` before publishing.
- **Manual override preserved.** `workflow_dispatch` still runs the matrix on demand for excluded paths (docs/test-only PRs a reviewer wants to smoke-test).
- **Branch protection:** if the `Test (…)` / coverage jobs are listed as *required* checks, a docs/test-only PR would sit "pending". Prior findings indicate only CodeQL is a true merge blocker, so this should be safe — worth a sanity check.
- **Internal CI-only change** — no user-facing behavior, config, CLI, or output change; no ADR or feature fixture required.
- This PR edits a path in the allowlist, so the Test workflow runs on it — self-verifying that the trigger still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated pull request checks so the main test suite runs only when relevant app, package, script, or workflow files change.
  * Added clearer guidance for when full test coverage is included, helping reduce unnecessary test runs and improve feedback speed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->