### PR TITLE
ci: re-baseline coverage thresholds after Phases 9-13

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -2,8 +2,8 @@
   "description": "Coverage baseline thresholds for the root doc-detective package, measured as the CROSS-PLATFORM UNION of the full end-to-end test suite: every OS/node matrix cell collects raw V8 coverage (NODE_V8_COVERAGE) and the coverage-merge job re-roots and reports their union via c8, so OS-gated (Windows/macOS) branches count. These values should only increase, never decrease. 'tolerance' absorbs run-to-run wobble of the non-deterministic E2E union — observed up to ~0.4pp (mostly browser/driver-dependent functions), so it is set to 0.4 and the four values sit below the lowest observed run.",
   "lastUpdated": "2026-07-01",
   "tolerance": 0.4,
-  "lines": 89.8,
-  "statements": 89.8,
-  "functions": 91,
-  "branches": 83.9
+  "lines": 91.3,
+  "statements": 91.3,
+  "functions": 91.5,
+  "branches": 85.2
 }


### PR DESCRIPTION
Consolidated threshold bump for the coverage work in Phases 9–13: `config.ts`, `integrations/index.ts`, `scroll.ts`, the four browser action files, agent adapters+prompts, `debug/index.ts`, and `findStrategies.ts`.

| metric | previous | new |
|---|---|---|
| lines / statements | 89.8 | **91.3** |
| functions | 91.0 | **91.5** |
| branches | 83.9 | **85.2** |
| tolerance | 0.4 | 0.4 |

The most recent main union run measured **91.7 / 91.96 / 85.64** (before adapters/debug/findStrategies, which raise it further). Values set **below** that with tolerance 0.4 to absorb the ~0.4pp E2E-union wobble — effective floors ~90.9 / 91.1 / 84.8. Verified against the full union via a `workflow_dispatch` matrix run on this branch (a coverage-thresholds-only PR otherwise skips the paths-filtered PR gate; `release.yml` also re-verifies on the main push).

Pure threshold config — no code/test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)