### PR TITLE
ci: run the test matrix on test/** and coverage-thresholds.json changes

### DIFF
--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -12,13 +12,19 @@ on:
       - opened
       - reopened
       - synchronize
-    # Only run the full matrix when product code (src/**, which the test suite
-    # exercises) or the build & dependency inputs change. Docs-only,
-    # samples-only, or test-fixture-only (test/**) PRs skip it.
-    # `src/**` also covers the doc-detective-common workspace (src/common).
-    # Use `workflow_dispatch` to run the matrix on demand for excluded paths.
+    # Run the full matrix when product code, tests, or the build/dependency
+    # inputs change. `test/**` is included so a PR that only adds or edits tests
+    # (e.g. coverage tests, fixtures) is actually exercised on every OS before
+    # merge — previously those PRs silently skipped the matrix and the
+    # coverage-merge ratchet, and had to be verified via `workflow_dispatch`.
+    # `coverage-thresholds.json` is included so a ratchet re-baseline is verified
+    # against the union too. `src/**` also covers the doc-detective-common
+    # workspace (src/common). Docs-only / samples-only PRs still skip; use
+    # `workflow_dispatch` on demand for those.
     paths:
       - 'src/**'
+      - 'test/**'
+      - 'coverage-thresholds.json'
       - 'package.json'
       - 'package-lock.json'
       - 'bin/**'


### PR DESCRIPTION
## Problem
`npm-test.yaml`'s `paths` filter only listed `src/**`, `package.json`, `package-lock.json`, `bin/**`, `scripts/**`, and the two workflow files. So a PR that **only** changes `test/**` (a new coverage test or fixture) or `coverage-thresholds.json` (a ratchet re-baseline) **skipped the whole matrix and coverage-merge** — its tests were never run on the OS matrix and the threshold was never verified against the union before merge. They only got checked post-merge on the main-push (`release.yml`), or had to be kicked off manually with `workflow_dispatch`.

This surfaced during the coverage-ratchet work: coverage PRs and threshold bumps weren't being verified on the PR.

## Fix
Add `test/**` and `coverage-thresholds.json` to the `paths` filter so those PRs run the full matrix + coverage-merge on the PR itself. Docs-only / samples-only PRs still skip (use `workflow_dispatch` on demand).

This PR changes `npm-test.yaml` (already in the filter), so the matrix runs here — self-verifying.

No product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)