### PR TITLE
ci: re-baseline coverage thresholds after Phases 14-15

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -2,8 +2,8 @@
   "description": "Coverage baseline thresholds for the root doc-detective package, measured as the CROSS-PLATFORM UNION of the full end-to-end test suite: every OS/node matrix cell collects raw V8 coverage (NODE_V8_COVERAGE) and the coverage-merge job re-roots and reports their union via c8, so OS-gated (Windows/macOS) branches count. These values should only increase, never decrease. 'tolerance' absorbs run-to-run wobble of the non-deterministic E2E union — observed up to ~0.4pp (mostly browser/driver-dependent functions), so it is set to 0.4 and the four values sit below the lowest observed run.",
   "lastUpdated": "2026-07-01",
   "tolerance": 0.4,
-  "lines": 91.3,
-  "statements": 91.3,
-  "functions": 91.5,
-  "branches": 85.2
+  "lines": 92.5,
+  "statements": 92.5,
+  "functions": 94.3,
+  "branches": 86.5
 }


### PR DESCRIPTION
Consolidated threshold bump for the recording/screenshot (#459) and runtime-helper (#460) coverage, plus the fuller gains from earlier phases now reflected in the union.

| metric | previous | new |
|---|---|---|
| lines / statements | 91.3 | **92.5** |
| functions | 91.5 | **94.3** |
| branches | 85.2 | **86.5** |
| tolerance | 0.4 | 0.4 |

The latest main union run measured **93.0 / 94.99 / 87.1**. Values set below that with tolerance 0.4 (extra margin on functions given the +3pp jump) — effective floors ~92.1 / 93.9 / 86.1. **Now that #461 fixed the paths filter, this PR runs the matrix + coverage-merge itself**, verifying the thresholds against the union.

Pure threshold config — no code/test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage baseline thresholds for the main package, raising the required minimums for lines, statements, functions, and branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->