### PR TITLE
fix(click): run click sub-effect for string shorthand

### DIFF
--- a/adrs/01016-fix-click-string-shorthand-never-clicks.md
+++ b/adrs/01016-fix-click-string-shorthand-never-clicks.md
@@ -1,0 +1,107 @@
+---
+status: accepted
+date: 2026-07-01
+decision-makers: doc-detective maintainers
+---
+
+# Fix `click` string shorthand verifying existence but never clicking
+
+## Context and Problem Statement
+
+The `click` action accepts three shapes: `true`, a detailed object (`{ "click": { "elementText": … } }`),
+and a **string shorthand** (`{ "click": "Some text" }`) that finds an element by selector / text /
+aria / id / test id and clicks it. All three are documented in
+[docs/fern/pages/reference/schemas/click.md](../docs/fern/pages/reference/schemas/click.md).
+
+`clickElement` ([src/core/tests/click.ts](../src/core/tests/click.ts)) delegates to `findElement`
+with `click: true` so the click runs as a sub-effect of the find. But `findElement`
+([src/core/tests/findElement.ts](../src/core/tests/findElement.ts)) handled the string shorthand in
+an early branch that returned immediately after evaluating the existence assertion — before the
+click sub-effect at the bottom of the function ever ran. Result: `{ "click": "Some text" }` only
+**verified the element exists** and reported PASS without clicking. A fixture step
+`{ "click": "Open child in new tab" }` against a `target="_blank"` link PASSed while no new tab
+opened; the object form clicked correctly.
+
+This is an execution bug, not a contract change: the documented contract has always been "find the
+element and click it".
+
+## Decision Drivers
+
+* Restore the documented string-shorthand semantics: the element must actually be clicked.
+* Keep the unified assertion model intact: existence is the single implicit assertion; the click
+  remains EXECUTION (a click failure sets FAIL with no extra assertion record), matching the
+  criteria path.
+* Don't change the object/criteria path or the not-found shorthand path.
+* Keep recording parity: the criteria path waits after interaction when a recording is active.
+
+## Considered Options
+
+* **Add the click sub-effect (and recording wait) to the shorthand branch**, mirroring the criteria
+  path's block.
+* **Restructure `findElement`** so the shorthand branch falls through into the shared sub-effect
+  tail (normalize `step.find` to an object after the shorthand search).
+* **Convert the shorthand in `clickElement`** to a detailed find object before delegating.
+
+## Decision Outcome
+
+Chosen: **add the click sub-effect to the shorthand branch**. When the shorthand finds an element
+and the caller requested a click (the `click` param `clickElement` passes), `findElement` now clicks
+the element with the left button (the string form carries no `button` field, so the default
+applies), appends "Clicked element." to the description, and on error sets FAIL with the same
+"Couldn't click element." description as the criteria path — with no extra assertion record. The
+recording-active wait also runs on this path for parity.
+
+The fall-through restructure was rejected as a larger refactor with more behavioral surface (the
+shorthand search strategy differs from the criteria search, so the branches can't share the finding
+step), and the `clickElement`-side conversion was rejected because shorthand strings resolve by a
+multi-strategy parallel search (`findElementByShorthand`) that the detailed criteria object cannot
+express.
+
+### Consequences
+
+* Good: `{ "click": "…" }` now clicks, matching the documented contract and the object form.
+* Good: assertion semantics are unchanged — found→PASS, not-found→FAIL, click-error→FAIL with the
+  single existence assertion record.
+* Neutral: specs whose string-form clicks previously "passed" as silent no-ops will now perform the
+  real click, which can surface real navigation or side effects. This is the intended, documented
+  behavior; such specs were reporting false PASSes.
+* Trade-off: a small amount of duplicated sub-effect code between the shorthand and criteria
+  branches, accepted to keep the fix minimal and reviewable.
+
+### Confirmation
+
+Stub-driver unit tests in [test/findElement.test.js](../test/findElement.test.js) assert that the
+shorthand path invokes `element.click` when a click is requested (red before the fix) and that a
+throwing click yields FAIL with the existence assertion still PASS and no extra record.
+[test/interaction-assertions.test.js](../test/interaction-assertions.test.js) asserts the same
+through `clickElement` with `{ "click": "Submit" }`. The feature fixture
+[test/core-artifacts/click-shorthand.spec.json](../test/core-artifacts/click-shorthand.spec.json)
+proves the click end-to-end: each button on
+[test/server/public/click-shorthand.html](../test/server/public/click-shorthand.html) appends a
+message only when actually clicked, and a following `find` step asserts the message — covering the
+text, selector, and regex shorthand permutations plus the object form for parity.
+
+## Docs impact
+
+None. The string shorthand is already documented as clicking the element
+([click.md](../docs/fern/pages/reference/schemas/click.md) example `{ "click": "Submit" }`); this fix
+restores the documented behavior. No page, flag, or output changes.
+
+## Pros and Cons of the Options
+
+### Add the click sub-effect to the shorthand branch
+
+* Good: minimal, targeted; preserves all existing branch behavior; easy to review.
+* Bad: duplicates the click try/catch between two branches.
+
+### Restructure `findElement` to a shared sub-effect tail
+
+* Good: single click code path.
+* Bad: larger refactor; the shorthand and criteria finding strategies differ, so unification only
+  covers the tail and risks subtle behavior drift (descriptions, defaults) in a bug-fix commit.
+
+### Convert the shorthand in `clickElement` before delegating
+
+* Good: `findElement` untouched.
+* Bad: impossible without losing behavior — the shorthand's multi-strategy search (selector OR text
+  OR aria OR id OR test id, plus regex) has no equivalent detailed-criteria representation.

--- a/src/core/tests/findElement.ts
+++ b/src/core/tests/findElement.ts
@@ -70,7 +70,26 @@ async function findElement({ config, step, driver, click }: { config: any; step:
       result.description += ` Found element by ${foundBy}.`;
       result.outputs = await setElementOutputs({ element });
       result.outputs.found = true;
-      return await finalizeFound({ result });
+      await finalizeFound({ result });
+      // Caller-requested click (e.g. `{ click: "text" }` delegating through
+      // clickElement) is an EXECUTION sub-effect, same as on the criteria
+      // path below. The shorthand string can't carry sub-effect fields of its
+      // own, so only the `click` param applies and the button defaults to
+      // left.
+      if (click) {
+        try {
+          await element.click({ button: "left" });
+          result.description += " Clicked element.";
+        } catch (error: any) {
+          result.status = "FAIL";
+          result.description += ` Couldn't click element. Error: ${error.message}`;
+          return result;
+        }
+      }
+      if (isRecordingActive(driver)) {
+        await wait({ config: config, step: { wait: 2000 }, driver: driver });
+      }
+      return result;
     } else {
       // No matching elements: expose found=false and still evaluate so the
       // existence assertion FAILs (don't early-return before the spec).

--- a/src/core/tests/findElement.ts
+++ b/src/core/tests/findElement.ts
@@ -71,11 +71,7 @@ async function findElement({ config, step, driver, click }: { config: any; step:
       result.outputs = await setElementOutputs({ element });
       result.outputs.found = true;
       await finalizeFound({ result });
-      // Caller-requested click (e.g. `{ click: "text" }` delegating through
-      // clickElement) is an EXECUTION sub-effect, same as on the criteria
-      // path below. The shorthand string can't carry sub-effect fields of its
-      // own, so only the `click` param applies and the button defaults to
-      // left.
+      // Shorthand carries no sub-effect fields, so button defaults to left.
       if (click) {
         try {
           await element.click({ button: "left" });

--- a/test/core-artifacts/click-shorthand.spec.json
+++ b/test/core-artifacts/click-shorthand.spec.json
@@ -1,0 +1,47 @@
+{
+  "specId": "clickStringShorthand",
+  "tests": [
+    {
+      "testId": "click-string-shorthand-permutations",
+      "steps": [
+        {
+          "goTo": "http://localhost:8092/click-shorthand.html"
+        },
+        {
+          "stepId": "click-shorthand-by-text",
+          "click": "Reveal by text"
+        },
+        {
+          "stepId": "assert-text-click-side-effect",
+          "find": "Text click landed"
+        },
+        {
+          "stepId": "click-shorthand-by-selector",
+          "click": "#reveal-by-selector"
+        },
+        {
+          "stepId": "assert-selector-click-side-effect",
+          "find": "Selector click landed"
+        },
+        {
+          "stepId": "click-shorthand-by-regex",
+          "click": "/Reveal via regex/"
+        },
+        {
+          "stepId": "assert-regex-click-side-effect",
+          "find": "Regex click landed"
+        },
+        {
+          "stepId": "click-object-form-parity",
+          "click": {
+            "elementText": "Reveal by object"
+          }
+        },
+        {
+          "stepId": "assert-object-click-side-effect",
+          "find": "Object click landed"
+        }
+      ]
+    }
+  ]
+}

--- a/test/findElement.test.js
+++ b/test/findElement.test.js
@@ -112,6 +112,46 @@ describe("findElement unified assertion model", function () {
     assert.equal(findAssertion(result.assertions, "found").result, "FAIL");
   });
 
+  it("shorthand string + caller click request → click sub-effect runs", async () => {
+    let clicks = 0;
+    const element = makeElement({
+      clickImpl: async () => {
+        clicks++;
+      },
+    });
+    const driver = makeDriver({ $impl: async () => element });
+    const result = await findElement({
+      config,
+      step: { find: "Submit" },
+      driver,
+      click: true,
+    });
+    assert.equal(result.status, "PASS");
+    assert.equal(result.outputs.found, true);
+    assert.equal(clicks, 1, "caller-requested click must fire on the shorthand path");
+    assert.ok(/Clicked element/.test(result.description));
+  });
+
+  it("shorthand string + click request, click throws → FAIL, found assertion still PASS", async () => {
+    const element = makeElement({
+      clickImpl: async () => {
+        throw new Error("not interactable");
+      },
+    });
+    const driver = makeDriver({ $impl: async () => element });
+    const result = await findElement({
+      config,
+      step: { find: "Submit" },
+      driver,
+      click: true,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.equal(result.outputs.found, true);
+    assert.equal(result.assertions.length, 1);
+    assert.equal(findAssertion(result.assertions, "found").result, "PASS");
+    assert.ok(/Couldn't click/.test(result.description));
+  });
+
   it("found but click sub-effect fails → status FAIL with NO extra assertion record", async () => {
     const element = makeElement({
       clickImpl: async () => {

--- a/test/interaction-assertions.test.js
+++ b/test/interaction-assertions.test.js
@@ -113,6 +113,43 @@ describe("click unified assertion model", function () {
     assert.equal(found.statement, "$$outputs.found == true");
   });
 
+  it("string shorthand → element is actually clicked, status PASS", async () => {
+    let clicks = 0;
+    const element = makeElement({
+      clickImpl: async () => {
+        clicks++;
+      },
+    });
+    const driver = makeDriver({ $impl: async () => element });
+    const result = await clickElement({
+      config,
+      step: { click: "Submit" },
+      driver,
+    });
+    assert.equal(result.status, "PASS");
+    assert.equal(result.outputs.found, true);
+    assert.equal(clicks, 1, "string shorthand must click the element, not just find it");
+    assert.ok(/Clicked element/.test(result.description));
+  });
+
+  it("string shorthand, click sub-effect fails → status FAIL, found assertion still PASS", async () => {
+    const element = makeElement({
+      clickImpl: async () => {
+        throw new Error("not interactable");
+      },
+    });
+    const driver = makeDriver({ $impl: async () => element });
+    const result = await clickElement({
+      config,
+      step: { click: "Submit" },
+      driver,
+    });
+    assert.equal(result.status, "FAIL");
+    assert.equal(result.outputs.found, true);
+    assert.equal(result.assertions.length, 1);
+    assert.equal(findAssertion(result.assertions, "found").result, "PASS");
+  });
+
   it("found but click sub-effect fails → status FAIL, found assertion still PASS (execution)", async () => {
     const element = makeElement({
       clickImpl: async () => {

--- a/test/server/public/click-shorthand.html
+++ b/test/server/public/click-shorthand.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Click String Shorthand Test Page</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        button { padding: 10px 20px; margin: 5px; cursor: pointer; }
+    </style>
+</head>
+<body>
+    <h1>Click String Shorthand Test Page</h1>
+    <!-- Each button appends a message paragraph when actually clicked, so a
+         following find step proves the click fired: a find-only no-op leaves
+         the message absent and the find FAILs. -->
+    <button onclick="reveal('Text click landed')">Reveal by text</button>
+    <button id="reveal-by-selector" onclick="reveal('Selector click landed')">Reveal by selector</button>
+    <button onclick="reveal('Regex click landed')">Reveal via regex match</button>
+    <button onclick="reveal('Object click landed')">Reveal by object</button>
+
+    <div id="messages"></div>
+
+    <script>
+        function reveal(text) {
+            const p = document.createElement("p");
+            p.textContent = text;
+            document.getElementById("messages").appendChild(p);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

The `click` string shorthand (`{ "click": "text" }`) verified the element existed but **never clicked it**. `clickElement` delegates through `findElement` with `click: true`, but findElement's string-shorthand branch returned right after evaluating the existence assertion — before the click sub-effect at the bottom of the function ran. String-form clicks reported PASS without clicking; the object form (`{ "click": { "elementText": … } }`) clicked correctly.

Repro: `{ "click": "Open child in new tab" }` against a `target="_blank"` link PASSed but no new tab opened; the object form opened it.

## Fix

Run the click sub-effect on the shorthand branch when the caller requests it (left button — the string form carries no `button` field), mirroring the criteria path's `try/catch → FAIL` semantics and recording-active wait. The existence assertion stays the single implicit record; a click failure sets FAIL with no extra assertion, preserving the unified model.

## Tests (red → green TDD)

- **Unit**: stub-driver tests on both the `findElement` shorthand path and the `clickElement` string path assert `element.click` fires, and that a throwing click → FAIL with the existence assertion still PASS and no extra record. Failed against unfixed code for the expected reason; pass after the fix (27 passing, 0 failing).
- **Feature fixture**: [`test/core-artifacts/click-shorthand.spec.json`](test/core-artifacts/click-shorthand.spec.json) + [`test/server/public/click-shorthand.html`](test/server/public/click-shorthand.html) cover every shorthand permutation (text / selector / regex match) plus object-form parity — each click followed by a `find` of a click-only side effect, so a no-op click would FAIL. Resolves **PASS** in the combined core pass (`summary.specs.fail === 0`).

## ADR

[`adrs/01016-fix-click-string-shorthand-never-clicks.md`](adrs/01016-fix-click-string-shorthand-never-clicks.md) (MADR 4.0) — decision, alternatives, and consequences (notes specs relying on the silent no-op may now surface real navigation — the intended fix).

## Docs impact

None. [`click.md`](docs/fern/pages/reference/schemas/click.md) already documents `{"click": "Submit"}` as clicking the element; this restores documented behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Click shorthand now performs the click action instead of only confirming the element exists, preventing false pass results.
  * Click failures are now reported as failures while preserving the single implicit existence check.

* **Tests**
  * Added coverage for successful and failing click shorthand behavior.
  * Added end-to-end verification for multiple click input forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->