### PR TITLE
test(debug): close reachable debug/* coverage gaps (ADR 01017)

### DIFF
--- a/src/debug/cache.ts
+++ b/src/debug/cache.ts
@@ -63,6 +63,11 @@ function nearestExistingPath(target: string): string {
     if (parent === current) return current;
     current = parent;
   }
+  /* c8 ignore next - defensive bound: reached only if 64 levels of
+   * path.dirname() ancestors all fail safeExists() AND never hit a
+   * filesystem root (whose dirname is itself, returning at the line above)
+   * -- not reproducible on a real filesystem, where the root always exists
+   * (ADR 01017). */
   return current;
 }
 
@@ -133,6 +138,15 @@ export function collectCacheStatus(config: any): CacheStatus {
     // done independently here (the appium collector calls it too) so each
     // collector is correct standalone and in any order — the second call in a
     // full dump is a cheap no-op, not an ordering dependency.
+    /* c8 ignore start - structurally dead by construction: setAppiumHome()'s
+     * only throw point is getRuntimeDir(ctx) -> getCacheDir(ctx) ->
+     * assertSafeRuntimePath(), called with the SAME ctx.cacheDir already
+     * validated (unthrown) by the getCacheDir/getRuntimeDir/getBrowsersDir
+     * calls a few lines above in this same outer try block -- so if ctx.cacheDir
+     * were invalid, the OUTER catch (below) would already have fired first.
+     * This inner catch, and the "unset" else-branch it guards, can never
+     * observe a genuine setAppiumHome() failure through this call site
+     * (ADR 01017). */
     try {
       setAppiumHome(ctx);
     } catch {
@@ -150,6 +164,7 @@ export function collectCacheStatus(config: any): CacheStatus {
         freeBytes: null,
       });
     }
+    /* c8 ignore stop */
   } catch (err: any) {
     return { entries, error: err?.message || String(err) };
   }

--- a/src/debug/tools.ts
+++ b/src/debug/tools.ts
@@ -86,9 +86,16 @@ export async function probeTool(
     const text = (stdout.trim() ? stdout : stderr || "").trim();
     const firstLine = text.split("\n")[0] || "<unknown>";
     return { name, version: firstLine };
+    /* c8 ignore start - real subprocess-dependent: runWithTimeout()'s own
+     * Promise never rejects (every code path resolves via settle()), and
+     * envWithoutNodeModulesBin()/spawn() have no injectable seam at this call
+     * site, so forcing this catch would require spawn() to throw synchronously
+     * for a real command -- not reproducible offline without corrupting the
+     * host shell (ADR 01017). */
   } catch (err: any) {
     return { name, version: "<probe failed>", notes: err?.message };
   }
+  /* c8 ignore stop */
 }
 
 function runWithTimeout(
@@ -106,11 +113,19 @@ function runWithTimeout(
     const settle = (result: { stdout: string; stderr: string; exitCode: number; timedOut: boolean }) => {
       if (settled) return;
       settled = true;
+      /* c8 ignore start - structurally defensive: child is a real
+       * ChildProcess spawned successfully (if spawn() itself failed, control
+       * never reaches settle() with a live child to kill), and Node's
+       * ChildProcess#kill() does not throw for an already-exited or
+       * already-killed process -- it returns false instead. No signal-
+       * permission/platform quirk hermetically reproduces a throw here
+       * (ADR 01017). */
       try {
         child.kill();
       } catch {
         // Best-effort kill.
       }
+      /* c8 ignore stop */
       resolve(result);
     };
     const t = setTimeout(() => settle({ stdout, stderr, exitCode: -1, timedOut: true }), timeoutMs);
@@ -120,10 +135,17 @@ function runWithTimeout(
     child.stderr?.on("data", (c) => {
       stderr += c.toString();
     });
+    /* c8 ignore start - real subprocess-dependent: with shell:true, a spawn
+     * that resolves to a live child essentially never emits 'error' -- the
+     * shell itself reports "not found" via a normal non-zero exit (the
+     * exitCode!==0 branch above), not an 'error' event. Forcing this
+     * hermetically would require the shell binary itself to be unresolvable,
+     * which is not reproducible without corrupting the host (ADR 01017). */
     child.on("error", (err) => {
       clearTimeout(t);
       settle({ stdout, stderr: stderr + (err.message || ""), exitCode: -1, timedOut: false });
     });
+    /* c8 ignore stop */
     child.on("close", (code) => {
       clearTimeout(t);
       settle({ stdout, stderr, exitCode: code ?? -1, timedOut: false });
@@ -172,9 +194,15 @@ function probeFfmpeg(): ToolResult {
       version: `@ffmpeg-installer/ffmpeg ${pkg.version}`,
       notes: `installer package: ${path.dirname(pkgPath)}`,
     };
+    /* c8 ignore start - install-state-dependent: @ffmpeg-installer/ffmpeg is
+     * a real, always-installed dependency of this repo (npm ci installs it
+     * identically on every CI matrix cell), so require.resolve() cannot
+     * hermetically fail without corrupting a shared, real dependency
+     * (ADR 01017). */
   } catch {
     return { name: "ffmpeg", version: "<bundled installer not found>" };
   }
+  /* c8 ignore stop */
 }
 
 // Resolve appium the same way the runtime does — shim node_modules OR
@@ -184,9 +212,15 @@ function probeFfmpeg(): ToolResult {
 // executes an appium binary.
 function probeAppium(cacheDir?: string): ToolResult {
   const resolved = resolveHeavyDepPath("appium", { cacheDir });
+  /* c8 ignore start - install-state-dependent: appium is a real,
+   * always-installed shim dependency of this repo (resolveHeavyDepPath()
+   * checks the shim node_modules FIRST, before any cacheDir), so this
+   * branch cannot be forced without uninstalling a shared, real dependency
+   * (ADR 01017). */
   if (!resolved) {
     return { name: "appium", version: "<not installed>" };
   }
+  /* c8 ignore stop */
   const version = resolveHeavyDepVersion("appium", { cacheDir });
   return {
     name: "appium",

--- a/test/debug-remaining-coverage.test.js
+++ b/test/debug-remaining-coverage.test.js
@@ -1,0 +1,474 @@
+// Hermetic offline coverage for the remaining src/debug/* gaps, per ADR
+// 01017 (adrs/01017-honest-100-percent-coverage-policy.md): test what's
+// reachable from Node; annotate what genuinely isn't. Extends test/debug.test.js
+// and test/debug-findstrategies-coverage.test.js, does not duplicate them.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import sinon from "sinon";
+
+function tmpDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+describe("debug/provenance", function () {
+  let collectCliOverrides, collectProvenance;
+  before(async function () {
+    ({ collectCliOverrides, collectProvenance } = await import(
+      "../dist/debug/provenance.js"
+    ));
+  });
+
+  it("collectCliOverrides degrades a spec whose present() check throws", function () {
+    // Every OVERRIDE_SPECS.present(args) reads a property off `args`; a
+    // Proxy that throws on any property access exercises the per-spec
+    // try/catch without needing a specific malformed shape.
+    const throwing = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("boom");
+        },
+      }
+    );
+    assert.deepEqual(collectCliOverrides(throwing), []);
+  });
+
+  it("collectProvenance defaults env to process.env when opts.env is omitted", function () {
+    const p = collectProvenance({ args: {} });
+    assert.equal(typeof p.docDetectiveConfigApplied, "boolean");
+  });
+});
+
+describe("debug/findings", function () {
+  let computeFindings;
+  before(async function () {
+    ({ computeFindings } = await import("../dist/debug/findings.js"));
+  });
+
+  it("skips a rule whose evaluation throws on malformed data", function () {
+    const data = {};
+    Object.defineProperty(data, "browsers", {
+      get() {
+        throw new Error("boom");
+      },
+    });
+    Object.defineProperty(data, "install", {
+      get() {
+        throw new Error("boom");
+      },
+    });
+    Object.defineProperty(data, "cache", {
+      get() {
+        throw new Error("boom");
+      },
+    });
+    Object.defineProperty(data, "network", {
+      get() {
+        throw new Error("boom");
+      },
+    });
+    Object.defineProperty(data, "appium", {
+      get() {
+        throw new Error("boom");
+      },
+    });
+    Object.defineProperty(data, "docDetective", {
+      get() {
+        throw new Error("boom");
+      },
+    });
+    const findings = computeFindings(data);
+    assert.ok(Array.isArray(findings));
+    assert.equal(findings.length, 0);
+  });
+});
+
+describe("debug/system", function () {
+  let collectSystemInfo;
+  before(async function () {
+    ({ collectSystemInfo } = await import("../dist/debug/system.js"));
+  });
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("degrades cpuCount to 0 when os.cpus() throws", function () {
+    sinon.stub(os, "cpus").throws(new Error("boom"));
+    const info = collectSystemInfo();
+    assert.equal(info.cpuCount, 0);
+    assert.equal(info.cpuModel, "<unknown>");
+  });
+
+  it("degrades timezone to <unknown> when Intl.DateTimeFormat throws", function () {
+    const orig = Intl.DateTimeFormat;
+    Intl.DateTimeFormat = function () {
+      throw new Error("boom");
+    };
+    try {
+      const info = collectSystemInfo();
+      assert.equal(info.timezone, "<unknown>");
+    } finally {
+      Intl.DateTimeFormat = orig;
+    }
+  });
+
+  it("degrades hostname/osVersion/cwd to <unknown> via the safe() wrapper", function () {
+    sinon.stub(os, "hostname").throws(new Error("boom"));
+    sinon.stub(os, "version").throws(new Error("boom"));
+    const info = collectSystemInfo();
+    assert.equal(info.hostname, "<unknown>");
+    assert.equal(info.osVersion, "<unknown>");
+  });
+});
+
+describe("debug/appium (collectAppiumDiagnostics)", function () {
+  let collectAppiumDiagnostics, registeredDriverPkgNames;
+  before(async function () {
+    ({ collectAppiumDiagnostics, registeredDriverPkgNames } = await import(
+      "../dist/debug/appium.js"
+    ));
+  });
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("swallows a setAppiumHome failure and still returns diagnostics (best-effort)", function () {
+    // A cacheDir containing a shell metacharacter makes getRuntimeDir() ->
+    // getCacheDir() -> assertSafeRuntimePath() throw inside setAppiumHome();
+    // that inner try/catch is best-effort, so the function must still
+    // return a full diagnostics object rather than propagating.
+    const result = collectAppiumDiagnostics({ cacheDir: "bad;dir" });
+    assert.equal(typeof result, "object");
+    assert.ok(Array.isArray(result.drivers));
+  });
+
+  it("degrades extensionsManifestPresent to false when fs.existsSync throws", function () {
+    sinon.stub(fs, "existsSync").throws(new Error("boom"));
+    const result = collectAppiumDiagnostics({});
+    assert.equal(result.extensionsManifestPresent, false);
+  });
+
+  it("sets manifestError when the manifest exists but fails to parse", function () {
+    sinon.stub(fs, "existsSync").returns(true);
+    sinon.stub(fs, "readFileSync").returns("::: not: valid: yaml: [[[");
+    const result = collectAppiumDiagnostics({});
+    assert.equal(typeof result.manifestError, "string");
+    assert.deepEqual(result.registeredDrivers, []);
+  });
+
+  it("registeredDriverPkgNames falls back to the driver key when pkgName is missing", function () {
+    const names = registeredDriverPkgNames(
+      "drivers:\n  chromium:\n    pkgName: appium-chromium-driver\n  geckodriver-no-pkg: {}\n"
+    );
+    assert.deepEqual(names.sort(), ["appium-chromium-driver", "geckodriver-no-pkg"]);
+  });
+
+  it("registeredDriverPkgNames returns [] when the document has no drivers section", function () {
+    assert.deepEqual(registeredDriverPkgNames("foo: bar"), []);
+  });
+});
+
+describe("debug/install (collectInstallStatus)", function () {
+  let collectInstallStatus;
+  before(async function () {
+    ({ collectInstallStatus } = await import("../dist/debug/install.js"));
+  });
+
+  it("returns an error marker when the cache dir is unsafe", function () {
+    const result = collectInstallStatus({ cacheDir: "bad;dir" });
+    assert.equal(typeof result.error, "string");
+    assert.equal(result.rows, undefined);
+  });
+});
+
+describe("debug/cache (collectCacheStatus)", function () {
+  let collectCacheStatus;
+  before(async function () {
+    ({ collectCacheStatus } = await import("../dist/debug/cache.js"));
+  });
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("returns a top-level error when getCacheDir itself throws (unsafe cacheDir)", function () {
+    const result = collectCacheStatus({ cacheDir: "bad;dir" });
+    assert.equal(typeof result.error, "string");
+  });
+
+  it("degrades exists=false when fs.existsSync throws (safeExists catch)", function () {
+    const dir = tmpDir("dd-cache-");
+    try {
+      sinon.stub(fs, "existsSync").throws(new Error("EACCES"));
+      const result = collectCacheStatus({ cacheDir: dir });
+      assert.ok(result.entries.every((e) => e.exists === false));
+    } finally {
+      sinon.restore();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks a probe not-writable when fs.accessSync throws", function () {
+    const dir = tmpDir("dd-cache-");
+    try {
+      sinon.stub(fs, "accessSync").throws(new Error("EACCES"));
+      const result = collectCacheStatus({ cacheDir: dir });
+      assert.ok(result.entries.every((e) => e.writable === false || e.writable === null));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports freeBytes null when statfsSync is unavailable or malformed", function () {
+    const dir = tmpDir("dd-cache-");
+    try {
+      const origStatfs = fs.statfsSync;
+      // Simulate an older Node without statfsSync.
+      // eslint-disable-next-line no-param-reassign
+      fs.statfsSync = undefined;
+      const result = collectCacheStatus({ cacheDir: dir });
+      assert.ok(result.entries.every((e) => e.freeBytes === null));
+      fs.statfsSync = origStatfs;
+
+      // Simulate a malformed stats shape.
+      sinon.stub(fs, "statfsSync").returns({});
+      const result2 = collectCacheStatus({ cacheDir: dir });
+      assert.ok(result2.entries.every((e) => e.freeBytes === null));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports freeBytes null when statfsSync throws", function () {
+    const dir = tmpDir("dd-cache-");
+    try {
+      sinon.stub(fs, "statfsSync").throws(new Error("boom"));
+      const result = collectCacheStatus({ cacheDir: dir });
+      assert.ok(result.entries.every((e) => e.freeBytes === null));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("debug/envvars", function () {
+  let findReferencedEnvVars, detectContainer, resolveDocExtensions, enumerateInputFiles;
+  before(async function () {
+    ({ findReferencedEnvVars, detectContainer, resolveDocExtensions, enumerateInputFiles } =
+      await import("../dist/debug/envvars.js"));
+  });
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("swallows a /.dockerenv existsSync failure (non-fatal probe)", function () {
+    sinon.stub(fs, "existsSync").throws(new Error("boom"));
+    const info = detectContainer();
+    assert.equal(typeof info.inContainer, "boolean");
+  });
+
+  it("adds a signal when /proc/1/cgroup matches a container runtime (linux only)", function () {
+    sinon.stub(process, "platform").value("linux");
+    sinon.stub(fs, "readFileSync").returns("12:pids:/docker/abcd1234");
+    const info = detectContainer();
+    assert.ok(info.signals.some((s) => s.includes("cgroup")));
+    assert.equal(info.inContainer, true);
+  });
+
+  it("swallows a /proc/1/cgroup read failure on linux (non-fatal probe)", function () {
+    sinon.stub(process, "platform").value("linux");
+    sinon.stub(fs, "readFileSync").throws(new Error("ENOENT"));
+    const info = detectContainer();
+    assert.equal(typeof info.inContainer, "boolean");
+  });
+
+  it("resolveDocExtensions ignores unknown file-type names and object entries without extensions", function () {
+    const exts = resolveDocExtensions([{ notAKnownKey: true }, "totally-unknown-type"]);
+    // Falls back to the union of all known extensions when nothing matched.
+    assert.ok(exts.has("md"));
+  });
+
+  it("enumerateInputFiles skips a directory whose realpathSync throws (falls back to the raw path)", function () {
+    const dir = tmpDir("dd-enum-");
+    try {
+      fs.writeFileSync(path.join(dir, "a.md"), "hello");
+      sinon.stub(fs, "realpathSync").throws(new Error("boom"));
+      const files = enumerateInputFiles([dir], 10);
+      assert.ok(files.some((f) => f.endsWith("a.md")));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("enumerateInputFiles skips a directory whose readdirSync throws", function () {
+    const dir = tmpDir("dd-enum-");
+    try {
+      sinon.stub(fs, "readdirSync").throws(new Error("EACCES"));
+      const files = enumerateInputFiles([dir], 10);
+      assert.deepEqual(files, []);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("debug/redact — extra branches", function () {
+  let redactArg;
+  before(async function () {
+    ({ redactArg } = await import("../dist/debug/redact.js"));
+  });
+  it("passes through non-string / empty-string args unchanged", function () {
+    assert.equal(redactArg(""), "");
+    assert.equal(redactArg(123), 123);
+    assert.equal(redactArg(null), null);
+  });
+});
+
+describe("debug/render — extra branches", function () {
+  let renderKeyValues;
+  before(async function () {
+    ({ renderKeyValues } = await import("../dist/debug/render.js"));
+  });
+  it("formats a plain string value verbatim and an object value as JSON", function () {
+    const lines = renderKeyValues([
+      ["a", "plain string"],
+      ["b", { x: 1 }],
+    ]);
+    assert.match(lines[0], /plain string$/);
+    assert.match(lines[1], /\{"x":1\}$/);
+  });
+});
+
+describe("debug/tools", function () {
+  let envWithoutNodeModulesBin, probeTool, probeAllTools;
+  before(async function () {
+    ({ envWithoutNodeModulesBin, probeTool, probeAllTools } = await import(
+      "../dist/debug/tools.js"
+    ));
+  });
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("envWithoutNodeModulesBin strips node_modules/.bin segments from PATH", function () {
+    const origPath = process.env.PATH;
+    process.env.PATH = ["/usr/bin", "/repo/node_modules/.bin", "/usr/local/bin"].join(
+      path.delimiter
+    );
+    try {
+      const env = envWithoutNodeModulesBin();
+      assert.ok(!env.PATH.includes("node_modules"));
+    } finally {
+      process.env.PATH = origPath;
+    }
+  });
+
+  it("probeTool reports <not found> for a genuinely nonexistent binary", async function () {
+    // Real (offline, no network) spawn of a command that cannot resolve on
+    // any platform's PATH -- the shell's own "not recognized"/"not found"
+    // message exercises the exitCode!==0 + notFoundNoise-suppressed branch.
+    this.timeout(10000);
+    const result = await probeTool(
+      "nonexistent",
+      "doc-detective-nonexistent-binary-xyz123 --version"
+    );
+    assert.equal(result.name, "nonexistent");
+    assert.equal(result.version, "<not found>");
+    assert.equal(result.notes, undefined);
+  });
+
+  it("probeTool times out and reports the configured timeout", async function () {
+    // A real long-running command (node's own REPL with no input, or a sleep
+    // equivalent) bounded by a very small timeoutMs -- exercises the
+    // timedOut branch without depending on a specific missing/present binary.
+    this.timeout(5000);
+    const sleepCmd =
+      process.platform === "win32"
+        ? "ping -n 5 127.0.0.1 >NUL"
+        : "sleep 5";
+    const result = await probeTool("slow", sleepCmd, { timeoutMs: 50 });
+    assert.match(result.version, /^<timed out after 50ms>$/);
+  });
+
+  it("probeAllTools resolves every probe concurrently and returns 9 rows", async function () {
+    // Real spawn-based probes against real (or absent) system binaries —
+    // deterministic in shape (9 named tools), not in exact version strings.
+    this.timeout(15000);
+    const results = await probeAllTools();
+    assert.equal(results.length, 9);
+    assert.ok(results.every((r) => typeof r.name === "string"));
+  });
+});
+
+describe("debug/command (debugCommand.handler CONFIG INVALID path)", function () {
+  let debugCommand;
+  before(async function () {
+    ({ debugCommand } = await import("../dist/debug/command.js"));
+  });
+
+  it("emits a CONFIG INVALID dump and sets exitCode=1 on a broken config", async function () {
+    this.timeout(15000);
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dd-debugcmd-"));
+    const badConfigPath = path.join(dir, "bad.json");
+    fs.writeFileSync(badConfigPath, "{ not valid json", "utf8");
+    const origCwd = process.cwd();
+    const origExitCode = process.exitCode;
+    process.chdir(dir);
+    try {
+      await debugCommand.handler({ config: badConfigPath, "include-env": false });
+      assert.equal(process.exitCode, 1);
+    } finally {
+      process.chdir(origCwd);
+      process.exitCode = origExitCode;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("debug/index (printDebug integration)", function () {
+  let printDebug;
+  before(async function () {
+    ({ printDebug } = await import("../dist/debug/index.js"));
+  });
+
+  it("propagates a bad cacheDir into the Install status and Cache sections' error branches", async function () {
+    this.timeout(15000);
+    const lines = [];
+    await printDebug({
+      config: { logLevel: "silent", input: ".", cacheDir: "bad;dir" },
+      configPath: null,
+      configError: null,
+      includeEnv: false,
+      print: (line) => lines.push(line),
+    });
+    const doc = lines.join("\n");
+    assert.match(doc, /Install status/);
+    assert.match(doc, /install status failed/);
+  });
+
+  it("swallows a write failure (writeFileSafe catch) when outDir is not a directory", async function () {
+    this.timeout(15000);
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dd-printdebug-"));
+    const notADir = path.join(dir, "im-a-file");
+    fs.writeFileSync(notADir, "x");
+    const lines = [];
+    try {
+      await printDebug({
+        config: { logLevel: "silent", input: "." },
+        configPath: null,
+        configError: null,
+        includeEnv: false,
+        // outDir resolves UNDER a plain file, so mkdirSync(..., {recursive:true})
+        // fails with ENOTDIR -- exercises writeFileSafe's outer catch.
+        outDir: path.join(notADir, "nested"),
+        print: (line) => lines.push(line),
+      });
+      const doc = lines.join("\n");
+      assert.match(doc, /failed to save/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Per [ADR 01017](adrs/01017-honest-100-percent-coverage-policy.md). 32 new hermetic tests across all of `src/debug/*`.

| file | lines |
|---|---|
| cache.ts, appium.ts, install.ts, provenance.ts, redact.ts, render.ts, system.ts, envvars.ts, command.ts, findings.ts | 100% (or 97%+) |
| tools.ts | 99% |
| index.ts | 92% (up from 91%) |

**Module union: ~93% → 97% lines.**

## What's tested
Real-error-path collectors (unsafe cacheDir triggering `assertSafeRuntimePath`, `fs`/`os` failures via sinon), `printDebug()` integration tests (bad-cacheDir error propagation into the Install/Cache render sections; a `writeFileSafe` failure via a plain-file `outDir`), and `debugCommand.handler`'s CONFIG INVALID path via a real broken config + `chdir`.

**Notable finding:** global `sinon.stub(childProcess, "spawn")` does **not** reliably intercept `tools.ts`'s named-import `spawn` binding in this codebase's compiled output — the established, working pattern elsewhere (`runtime-helpers-coverage.test.js`'s `selfUpdate`) is dependency injection via a `deps` parameter, which `tools.ts`'s spawn call sites don't expose (out of scope to add — would be a behavior change). Rewrote those tests to use real, offline, deterministic spawns (a genuinely-nonexistent binary; a short timeout against a real sleep command) instead.

## `c8 ignore` annotations
- **`tools.ts`** — `probeTool`'s outer catch / `kill()`-throws / child `'error'`-event handler (no injection seam; a real subprocess failing in these specific ways isn't reproducible offline without corrupting the host shell). `probeFfmpeg`/`probeAppium`'s not-found branches — both packages are real, always-installed shim dependencies of this repo; can't be forced without uninstalling a shared dependency.
- **`cache.ts`** — the `setAppiumHome` inner catch + "unset" branch (structurally dead: the same `ctx.cacheDir` is already validated by three earlier calls in the same outer `try` block, so an invalid cacheDir trips the outer catch first). The `nearestExistingPath` 64-level bound-exhausted fallback (unreachable on any real filesystem, whose root always exists).

`index.ts`'s remaining gap is mostly `render*Section` functions needing specific `DebugData` shapes only reachable by driving real collector state through more targeted `printDebug()` scenarios — genuinely reachable, not annotated, left as documented follow-up rather than force-completed in this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)