### PR TITLE
fix(core): tolerate missing config.environment on pre-resolved API configs

### DIFF
--- a/adrs/01018-tolerate-missing-environment-on-pre-resolved-api-config.md
+++ b/adrs/01018-tolerate-missing-environment-on-pre-resolved-api-config.md
@@ -1,0 +1,120 @@
+---
+status: accepted
+date: 2026-07-02
+decision-makers: doc-detective maintainers
+---
+
+# Tolerate a missing `config.environment` on pre-resolved DOC_DETECTIVE_API configs
+
+## Context and Problem Statement
+
+`DOC_DETECTIVE_API` lets a runner fetch a fully pre-resolved test bundle (`resolvedTests`) from an
+external orchestration API instead of resolving it locally (`getResolvedTestsFromEnv` in
+`src/utils.ts`). `runTests()` (`src/core/index.ts`) then passes `resolvedTests.config` straight
+into `runSpecs()`, deliberately skipping `setConfig()` — the orchestration API is the source of
+truth for that config, and `setConfig()` is where local file/env config resolution and validation
+normally live.
+
+`setConfig()` is also the only place that populates `config.environment` (`getEnvironment()` sets
+`arch`/`platform`, and `getAvailableApps()` fills in `apps`). Because the API path never calls
+`setConfig()`, `config.environment` is `undefined` for the whole run. `getAvailableApps()`
+(`src/core/config.ts`) unconditionally read `config.environment.platform === "mac"` to gate Safari
+detection, so any DOC_DETECTIVE_API run crashed with `Cannot read properties of undefined (reading
+'platform')` — before a single step executed, regardless of what schema-valid `resolvedTests` the
+orchestration API returned.
+
+Two contributing test hygiene issues let this ship unnoticed:
+
+1. `test/resolvedTests.test.js`'s `apiConfig.url` was set to the full `resolved-tests` endpoint
+   (`http://localhost:8093/api/resolved-tests`) instead of the base API URL. `getResolvedTestsFromEnv`
+   appends `/resolved-tests` itself, so every real request 404'd, `process.exit(1)` fired before the
+   crash site was ever reached, and the assertions after it never ran.
+2. The tests waited for an output file and skipped their assertions entirely
+   (`if (fs.existsSync(outputFile)) { ... }`) if the file never appeared, instead of failing. Combined
+   with (1), the suite reported green while never exercising a real DOC_DETECTIVE_API run.
+
+## Decision Drivers
+
+* A pre-resolved config from an external API must run correctly without requiring that API to
+  replicate every field `setConfig()` would normally compute locally.
+* The fix must not weaken `getAvailableApps()`'s existing Safari-detection behavior for the
+  locally-resolved path (where `config.environment` is always present).
+* Tests must fail loudly when the run they're supposed to validate didn't happen, not silently skip.
+
+## Considered Options
+
+* **A. Fall back to a fresh `getEnvironment()` platform read inside `getAvailableApps()` when
+  `config.environment` is absent** (chosen).
+* **B. Require the orchestration API to include a populated `environment` in `resolvedTests.config`.**
+* **C. Call `setConfig()` (or just `getEnvironment()`) on the pre-resolved config in `runTests()`
+  before it reaches `runSpecs()`.**
+
+## Decision Outcome
+
+Chosen option: **A**. `getAvailableApps()` already has exactly one caller-independent way to learn
+the current platform — `getEnvironment()` — and `runSpecs()` calls it independently anyway to build
+`runnerDetails.environment`. Reading `config?.environment?.platform ?? getEnvironment().platform`
+makes `getAvailableApps()` self-sufficient: it uses the caller-supplied value when present (the
+local path, and any future caller that does populate it) and computes the same value the local path
+would have computed otherwise. This mirrors an existing defensive read at
+`getBrowserDiagnostics`'s `config?.environment?.platform` a few hundred lines below in the same
+file — option A brings the outlier in line with the codebase's existing pattern instead of
+introducing a new one.
+
+B was rejected: it pushes an internal implementation detail (how the local runner happens to
+represent its own host) onto every orchestration API implementer, and a stale/absent value there
+would recreate the same bug at the integration layer instead of a single call site. C was rejected
+as broader than necessary — `runTests()` deliberately does not run `setConfig()` against
+API-supplied config (see the comment at `src/core/index.ts` around the `resolvedTests.config` merge)
+because that config is the orchestration API's contract, not something to re-derive or
+re-validate locally; a partial `setConfig()`-like call would blur that boundary for one field.
+
+### Consequences
+
+* Good: DOC_DETECTIVE_API runs no longer crash before executing any step, regardless of what the
+  orchestration API includes in `resolvedTests.config`.
+* Good: no behavior change for the locally-resolved path — `config.environment.platform` is always
+  present there, so the `??` fallback never triggers.
+* Neutral: `getAvailableApps()` now computes the platform twice per `runSpecs()` call in the API
+  path (once here, once in `runnerDetails.environment` in `src/core/tests.ts`) — `getEnvironment()`
+  is a cheap synchronous `os.arch()`/`process.platform` read, not worth memoizing further.
+
+### Confirmation
+
+* Red→green unit test in `test/config-coverage.test.js` ("does not throw when config.environment is
+  absent (pre-resolved API config)") exercises `getAvailableApps({ config: { cacheDir } })` with no
+  `environment` key.
+* `test/resolvedTests.test.js`'s `apiConfig.url` fixed to the base API URL, and its previously-silent
+  `if (fs.existsSync(outputFile))` guards replaced with hard assertions. Since a DOC_DETECTIVE_API
+  run reports results via `reportResults()` (a POST to the orchestration API), not
+  `outputResults()`/`-o`, the assertions now parse the results JSON that `runTests()` always logs to
+  stdout (the `(INFO) RESULTS:` marker) rather than waiting on a file that run mode never produces.
+  The suite's own fixture context (`test/server/index.js`'s `/api/resolved-tests` handler) has no
+  `platform` field, so this is the same shape a real orchestration API is expected to send.
+* Manual end-to-end repro: `test/server` API endpoint + `DOC_DETECTIVE_API=... node
+  ./bin/doc-detective.js` reproduced the crash before the fix and completed successfully
+  (including reporting results back via `/contexts`) after it.
+
+## Pros and Cons of the Options
+
+### A. Fresh `getEnvironment()` fallback inside `getAvailableApps()`
+* Good: single, self-contained fix; matches an existing defensive pattern in the same file.
+* Good: zero contract change for orchestration API implementers.
+* Bad: computes platform detection twice per run on the API path (cheap, synchronous).
+
+### B. Require the orchestration API to send a populated `environment`
+* Good: no runner code change.
+* Bad: leaks an internal field's shape into an external API contract; a stale value silently
+  misdetects Safari support instead of crashing loudly, which is worse.
+
+### C. Run `setConfig()` (or an equivalent) over pre-resolved config
+* Good: would also backfill any other field the local path assumes is present.
+* Bad: broader than the actual bug; blurs the deliberate boundary that API-supplied config skips
+  local config resolution/validation; higher risk of unintended side effects (e.g. re-detecting
+  `environment.apps`, which the API path already computes explicitly via `getAvailableApps`).
+
+## More Information
+
+See `getAvailableApps()` in `src/core/config.ts` and its existing `config?.environment?.platform`
+sibling read in `getBrowserDiagnostics()` a few hundred lines below. The pre-resolved-config merge
+this bug depends on is in `runTests()` in `src/core/index.ts`.

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -882,7 +882,13 @@ async function getAvailableApps({ config }: any) {
   }
 
   // Detect Safari
-  if (config.environment.platform === "mac") {
+  // config.environment is normally populated by setConfig() during local
+  // resolution. Tests resolved by the DOC_DETECTIVE_API orchestration path
+  // arrive with resolvedTests.config as-is, which never passes through
+  // setConfig() — fall back to a fresh detection instead of assuming it's
+  // there, so a pre-resolved config doesn't crash on the missing field.
+  const currentPlatform = config?.environment?.platform ?? getEnvironment().platform;
+  if (currentPlatform === "mac") {
     const safariVersion = await spawnCommand(
       "defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString"
     );

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -882,11 +882,8 @@ async function getAvailableApps({ config }: any) {
   }
 
   // Detect Safari
-  // config.environment is normally populated by setConfig() during local
-  // resolution. Tests resolved by the DOC_DETECTIVE_API orchestration path
-  // arrive with resolvedTests.config as-is, which never passes through
-  // setConfig() — fall back to a fresh detection instead of assuming it's
-  // there, so a pre-resolved config doesn't crash on the missing field.
+  // config.environment may be absent for a pre-resolved DOC_DETECTIVE_API
+  // config, which skips setConfig() — see ADR 01018.
   const currentPlatform = config?.environment?.platform ?? getEnvironment().platform;
   if (currentPlatform === "mac") {
     const safariVersion = await spawnCommand(

--- a/test/config-coverage.test.js
+++ b/test/config-coverage.test.js
@@ -195,6 +195,18 @@ describe("config.ts — getAvailableApps (empty cache dir)", function () {
     const apps = await getAvailableApps({ config });
     assert.ok(Array.isArray(apps));
   });
+
+  // Regression: tests resolved by the DOC_DETECTIVE_API orchestration path
+  // arrive with resolvedTests.config as-is — it never passes through
+  // setConfig(), so config.environment is never populated the way a locally
+  // resolved run's config is. getAvailableApps must tolerate that instead of
+  // throwing "Cannot read properties of undefined (reading 'platform')".
+  it("does not throw when config.environment is absent (pre-resolved API config)", async function () {
+    const cacheDir = trackedTmpDir();
+    const config = { cacheDir };
+    const apps = await getAvailableApps({ config });
+    assert.ok(Array.isArray(apps));
+  });
 });
 
 describe("config.ts — getBrowserDiagnostics", function () {

--- a/test/resolvedTests.test.js
+++ b/test/resolvedTests.test.js
@@ -2,11 +2,47 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnCommand } from "../dist/utils.js";
 import assert from "node:assert/strict";
-import fs from "node:fs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const artifactPath = path.resolve(__dirname, "./artifacts");
 const outputFile = path.resolve(`${artifactPath}/resolvedTestsResults.json`);
+
+// A DOC_DETECTIVE_API run never writes to `-o`/config.output — cli.ts routes
+// its results through reportResults() (a POST back to the orchestration
+// API's /contexts endpoint) instead of outputResults(). The results object is
+// still logged to stdout as a "(INFO) RESULTS:" marker followed by pretty
+// JSON, so tests recover it from there rather than waiting on a file that
+// this run mode never produces.
+function extractResultsJson(stdout) {
+  const marker = "(INFO) RESULTS:";
+  const markerIndex = stdout.indexOf(marker);
+  assert.ok(
+    markerIndex !== -1,
+    `Expected "${marker}" in stdout. Full stdout:\n${stdout}`
+  );
+  const jsonStart = stdout.indexOf("{", markerIndex);
+  assert.ok(
+    jsonStart !== -1,
+    `Expected a JSON results blob after "${marker}". Full stdout:\n${stdout}`
+  );
+  let depth = 0;
+  let jsonEnd = -1;
+  for (let i = jsonStart; i < stdout.length; i++) {
+    if (stdout[i] === "{") depth++;
+    else if (stdout[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        jsonEnd = i;
+        break;
+      }
+    }
+  }
+  assert.ok(
+    jsonEnd !== -1,
+    `Could not find the end of the JSON results blob. Full stdout:\n${stdout}`
+  );
+  return JSON.parse(stdout.slice(jsonStart, jsonEnd + 1));
+}
 
 describe("DOC_DETECTIVE_API environment variable", function () {
   // 5 minutes per test
@@ -15,7 +51,7 @@ describe("DOC_DETECTIVE_API environment variable", function () {
   it("Should fetch and run resolved tests from API", async () => {
     const apiConfig = {
       accountId: "test-account",
-      url: "http://localhost:8093/api/resolved-tests",
+      url: "http://localhost:8093/api",
       token: "test-token-123",
       contextIds: "test-context",
     };
@@ -29,25 +65,20 @@ describe("DOC_DETECTIVE_API environment variable", function () {
         `node ./bin/doc-detective.js -o ${outputFile}`
       );
 
-      // Wait until the file is written
-      let waitCount = 0;
-      while (!fs.existsSync(outputFile) && waitCount < 50) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        waitCount++;
-      }
+      assert.equal(
+        result.exitCode,
+        0,
+        `Expected a successful run. exitCode=${result.exitCode}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+      );
+      const testResult = extractResultsJson(result.stdout);
+      console.log(
+        "API Result summary:",
+        JSON.stringify(testResult.summary, null, 2)
+      );
 
-      if (fs.existsSync(outputFile)) {
-        const testResult = JSON.parse(fs.readFileSync(outputFile, "utf8"));
-        console.log(
-          "API Result summary:",
-          JSON.stringify(testResult.summary, null, 2)
-        );
-        fs.unlinkSync(outputFile);
-
-        // Check that tests were run
-        assert.ok(testResult.summary);
-        assert.ok(testResult.specs);
-      }
+      // Check that tests were run
+      assert.ok(testResult.summary);
+      assert.ok(testResult.specs);
     } finally {
       // Restore original env
       if (originalEnv !== undefined) {
@@ -87,7 +118,7 @@ describe("DOC_DETECTIVE_API environment variable", function () {
   it("Should reject unauthorized API requests", async () => {
     const apiConfigBadToken = {
       accountId: "test-account",
-      url: "http://localhost:8093/api/resolved-tests",
+      url: "http://localhost:8093/api",
       token: "wrong-token",
       contextIds: "test-context",
     };
@@ -115,7 +146,7 @@ describe("DOC_DETECTIVE_API environment variable", function () {
   it("Should apply config overrides from DOC_DETECTIVE_CONFIG to API-fetched tests", async () => {
     const apiConfig = {
       accountId: "test-account",
-      url: "http://localhost:8093/api/resolved-tests",
+      url: "http://localhost:8093/api",
       token: "test-token-123",
       contextIds: "test-context",
     };
@@ -130,25 +161,20 @@ describe("DOC_DETECTIVE_API environment variable", function () {
     process.env.DOC_DETECTIVE_CONFIG = JSON.stringify(configOverride);
 
     try {
-      await spawnCommand(
+      const result = await spawnCommand(
         `node ./bin/doc-detective.js -o ${outputFile}`
       );
 
-      // Wait until the file is written
-      let waitCount = 0;
-      while (!fs.existsSync(outputFile) && waitCount < 50) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        waitCount++;
-      }
+      assert.equal(
+        result.exitCode,
+        0,
+        `Expected a successful run. exitCode=${result.exitCode}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+      );
+      const testResult = extractResultsJson(result.stdout);
 
-      if (fs.existsSync(outputFile)) {
-        const testResult = JSON.parse(fs.readFileSync(outputFile, "utf8"));
-        fs.unlinkSync(outputFile);
-
-        // Check that tests were run
-        assert.ok(testResult.summary);
-        assert.ok(testResult.specs);
-      }
+      // Check that tests were run
+      assert.ok(testResult.summary);
+      assert.ok(testResult.specs);
     } finally {
       // Restore original env
       if (originalApiEnv !== undefined) {

--- a/test/resolvedTests.test.js
+++ b/test/resolvedTests.test.js
@@ -171,6 +171,14 @@ describe("DOC_DETECTIVE_API environment variable", function () {
       // Check that tests were run
       assert.ok(testResult.summary);
       assert.ok(testResult.specs);
+      // The API-fetched config sets logLevel "info"; only the
+      // DOC_DETECTIVE_CONFIG override raises it to "debug", which is the only
+      // thing that would make the runner emit "(DEBUG)"-prefixed log lines.
+      assert.match(
+        result.stdout,
+        /\(DEBUG\)/,
+        `Expected debug-level log output, indicating the DOC_DETECTIVE_CONFIG logLevel override was applied. Full stdout:\n${result.stdout}`
+      );
     } finally {
       // Restore original env
       if (originalApiEnv !== undefined) {

--- a/test/resolvedTests.test.js
+++ b/test/resolvedTests.test.js
@@ -1,11 +1,5 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { spawnCommand } from "../dist/utils.js";
 import assert from "node:assert/strict";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const artifactPath = path.resolve(__dirname, "./artifacts");
-const outputFile = path.resolve(`${artifactPath}/resolvedTestsResults.json`);
 
 // A DOC_DETECTIVE_API run never writes to `-o`/config.output — cli.ts routes
 // its results through reportResults() (a POST back to the orchestration
@@ -27,9 +21,19 @@ function extractResultsJson(stdout) {
   );
   let depth = 0;
   let jsonEnd = -1;
+  let inString = false;
+  let escaped = false;
   for (let i = jsonStart; i < stdout.length; i++) {
-    if (stdout[i] === "{") depth++;
-    else if (stdout[i] === "}") {
+    const char = stdout[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === "{") depth++;
+    else if (char === "}") {
       depth--;
       if (depth === 0) {
         jsonEnd = i;
@@ -61,9 +65,7 @@ describe("DOC_DETECTIVE_API environment variable", function () {
     process.env.DOC_DETECTIVE_API = JSON.stringify(apiConfig);
 
     try {
-      const result = await spawnCommand(
-        `node ./bin/doc-detective.js -o ${outputFile}`
-      );
+      const result = await spawnCommand("node ./bin/doc-detective.js");
 
       assert.equal(
         result.exitCode,
@@ -99,9 +101,7 @@ describe("DOC_DETECTIVE_API environment variable", function () {
     process.env.DOC_DETECTIVE_API = JSON.stringify(invalidApiConfig);
 
     try {
-      const result = await spawnCommand(
-        `node ./bin/doc-detective.js -o ${outputFile}`
-      );
+      const result = await spawnCommand("node ./bin/doc-detective.js");
 
       // Should exit with non-zero code
       assert.notEqual(result.exitCode, 0);
@@ -127,9 +127,7 @@ describe("DOC_DETECTIVE_API environment variable", function () {
     process.env.DOC_DETECTIVE_API = JSON.stringify(apiConfigBadToken);
 
     try {
-      const result = await spawnCommand(
-        `node ./bin/doc-detective.js -o ${outputFile}`
-      );
+      const result = await spawnCommand("node ./bin/doc-detective.js");
 
       // Should exit with non-zero code due to 401 response
       assert.notEqual(result.exitCode, 0);
@@ -161,9 +159,7 @@ describe("DOC_DETECTIVE_API environment variable", function () {
     process.env.DOC_DETECTIVE_CONFIG = JSON.stringify(configOverride);
 
     try {
-      const result = await spawnCommand(
-        `node ./bin/doc-detective.js -o ${outputFile}`
-      );
+      const result = await spawnCommand("node ./bin/doc-detective.js");
 
       assert.equal(
         result.exitCode,


### PR DESCRIPTION
## Summary
- Fixes a crash — `Cannot read properties of undefined (reading 'platform')` — on every `DOC_DETECTIVE_API` run. `getAvailableApps()` unconditionally read `config.environment.platform`, but `config.environment` is only populated by `setConfig()`, which the pre-resolved `DOC_DETECTIVE_API` path deliberately skips (the orchestration API's config is authoritative). Falls back to a fresh `getEnvironment().platform` read when absent, matching an existing defensive pattern a few hundred lines below in the same file.
- Fixes `test/resolvedTests.test.js`'s `apiConfig.url`, which was doubled up with the code's own `/resolved-tests` suffix — every real request 404'd and `process.exit(1)` fired before the crash site was ever reached, masking the bug.
- Replaces that test file's silent `if (fs.existsSync(outputFile))` guards with hard assertions. This surfaced that a `DOC_DETECTIVE_API` run never writes to `-o`/`config.output` at all (results are reported back via `reportResults()`'s POST to `/contexts`), so assertions now parse the results JSON the CLI always logs to stdout instead.
- Adds ADR [`01018`](adrs/01018-tolerate-missing-environment-on-pre-resolved-api-config.md) documenting the decision.

## Test plan
- [x] New unit test in `test/config-coverage.test.js`: `getAvailableApps` with no `config.environment` does not throw (red before the fix, green after).
- [x] `test/resolvedTests.test.js` (4/4 passing) exercises the exact repro shape end-to-end: the fixture server's `/api/resolved-tests` context has no `platform` field.
- [x] `test/context-resolution.test.js` (20/20) — no regression in related platform/browser-support logic.
- [x] Manual end-to-end repro against a live test server: crashed before the fix, completed successfully (including reporting results back via `/contexts`) after.
- No documentation impact — this restores already-documented `DOC_DETECTIVE_API` behavior; no new/changed config fields, flags, or contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resolved-test runs so they no longer fail when environment details are missing from pre-resolved API config.
  * Safari support detection now safely falls back to the current runtime platform when config data is incomplete.

* **Documentation**
  * Added an ADR documenting the accepted behavior and expected handling for missing environment information.

* **Tests**
  * Added regression coverage for missing environment data.
  * Updated resolved-tests validation to read results from command output and assert outcomes more directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->