### PR TITLE
fix(core): await Appium server tree-kill so browsers don't orphan

### DIFF
--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -117,6 +117,7 @@ export {
   resolveAutoRecord,
   buildAutoRecordStep,
   specIsRouted,
+  killTree,
 };
 // exports.appiumStart = appiumStart;
 // exports.appiumIsReady = appiumIsReady;
@@ -125,6 +126,24 @@ export {
 // Browser names getDriverCapabilities knows how to build caps for. `safari` is
 // rewritten to `webkit` during context resolution, so both appear here.
 const KNOWN_BROWSERS = ["firefox", "chrome", "safari", "webkit"];
+
+// Tree-kill a pid and resolve only once the kill has actually completed.
+// `tree-kill` is asynchronous (it shells out to `taskkill /T /F` on Windows,
+// or walks `ps` on POSIX) — callers that fire it without awaiting can move on
+// (and the process can exit) before the tree is actually gone, orphaning a
+// still-running browser that the pid's Appium server owned via its
+// chromedriver/geckodriver child. Every place that tears down an Appium
+// server process must await this instead of calling `kill()` bare.
+function killTree(pid?: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (!pid) return resolve();
+    try {
+      kill(pid, "SIGTERM", () => resolve());
+    } catch {
+      resolve();
+    }
+  });
+}
 
 /**
  * Stable identity for a "context combination" — the platform + browser pairing
@@ -1071,6 +1090,7 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   const xvfbProcesses: any[] = [];
   const useXvfbDisplays = concurrency.xvfbContexts.length > 0;
   let portToDisplay: Map<number, string> | undefined;
+
   if (driverJobCount > 0) {
     setAppiumHome({ cacheDir: config?.cacheDir });
     // Resolve appium's actual JS entrypoint via `require.resolve` (shim
@@ -1109,13 +1129,9 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
         );
       }
     } catch (error) {
-      for (const server of appiumServers) {
-        try {
-          kill(server.process.pid);
-        } catch {
-          // best-effort
-        }
-      }
+      await Promise.all(
+        appiumServers.map((server) => killTree(server.process?.pid))
+      );
       for (const xvfb of xvfbProcesses) {
         try {
           xvfb.kill();
@@ -1140,18 +1156,6 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   // survive across specs/tests and are torn down once — by a closeSurface step
   // or the run-end sweep in the `finally` below.
   const processRegistry = new Map<string, any>();
-
-  // Tree-kill a pid and resolve when the kill has actually completed (callback
-  // form), so callers can await termination before exiting/returning.
-  const killTree = (pid?: number) =>
-    new Promise<void>((resolve) => {
-      if (!pid) return resolve();
-      try {
-        kill(pid, "SIGTERM", () => resolve());
-      } catch {
-        resolve();
-      }
-    });
 
   // Kill every still-registered background process (and its child tree) and
   // remove any deferred temp scripts. Awaits the kills so the process tree is
@@ -1382,15 +1386,18 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     // stop (via closeSurface) so they don't leak. Awaited so the trees are gone
     // before runSpecs returns.
     await killAllRegistered();
-    // Close every Appium server we started.
-    for (const server of appiumServers) {
-      log(config, "debug", `Closing Appium server on port ${server.port}`);
-      try {
-        kill(server.process.pid);
-      } catch {
-        // Process may already be terminated
-      }
-    }
+    // Close every Appium server we started. Awaited (via killTree) so each
+    // server's chromedriver/geckodriver child — and the browser it in turn
+    // owns — is actually gone before runSpecs returns. tree-kill is async
+    // (shells out to `taskkill /T /F` on Windows); firing it without
+    // awaiting let the run finish before the browser was really dead,
+    // orphaning it.
+    await Promise.all(
+      appiumServers.map((server) => {
+        log(config, "debug", `Closing Appium server on port ${server.port}`);
+        return killTree(server.process?.pid);
+      })
+    );
     // Tear down any Xvfb virtual displays started for recording.
     for (const xvfb of xvfbProcesses) {
       try {
@@ -3589,12 +3596,10 @@ async function startAppiumServer(
   } catch (error) {
     // appiumIsReady threw or timed out — the spawned child is still alive and
     // would leak (orphan process, port still bound). Tear it down before
-    // propagating so subsequent runs don't trip on the stale state.
-    try {
-      if (proc && proc.pid) kill(proc.pid);
-    } catch {
-      // best-effort cleanup; the parent error is what matters
-    }
+    // propagating so subsequent runs don't trip on the stale state. Awaited
+    // so the process is confirmed gone before this function returns control
+    // to the caller.
+    await killTree(proc?.pid);
     throw error;
   }
   log(config, "debug", `Appium is ready on port ${port}.`);

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -152,6 +152,17 @@ function killTree(pid?: number, timeoutMs: number = 5000): Promise<void> {
       while (isPidAlive(pid) && Date.now() - start < timeoutMs) {
         await new Promise((r) => setTimeout(r, 50));
       }
+      // SIGTERM didn't finish the job within the timeout (e.g. a browser
+      // ignoring/slow to handle it) — escalate to SIGKILL as a last resort
+      // rather than silently giving up and reporting a false "torn down".
+      if (isPidAlive(pid)) {
+        try {
+          kill(pid, "SIGKILL", () => resolve());
+          return;
+        } catch {
+          // fall through to resolve below
+        }
+      }
       resolve();
     };
     try {
@@ -163,13 +174,16 @@ function killTree(pid?: number, timeoutMs: number = 5000): Promise<void> {
 }
 
 // Whether `pid` still refers to a live process. `process.kill(pid, 0)` sends
-// no signal — it just probes: it throws ESRCH once the pid no longer exists.
+// no signal — it just probes. It throws ESRCH once the pid no longer exists;
+// any other error (e.g. EPERM — the process exists but we lack permission to
+// signal it) means the process is still alive, just unsignalable, so treat
+// only ESRCH as "dead".
 function isPidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (error: any) {
+    return error?.code !== "ESRCH";
   }
 }
 

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -166,7 +166,12 @@ function killTree(pid?: number, timeoutMs: number = 5000): Promise<void> {
       resolve();
     };
     try {
-      kill(pid, "SIGTERM", () => waitForExit());
+      // Guard waitForExit(): it's async, so any future edit that lets it
+      // reject would otherwise become an unhandled rejection and leave the
+      // outer Promise pending forever, hanging teardown. Catch and resolve.
+      kill(pid, "SIGTERM", () => {
+        waitForExit().catch(() => resolve());
+      });
     } catch {
       resolve();
     }

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -127,22 +127,50 @@ export {
 // rewritten to `webkit` during context resolution, so both appear here.
 const KNOWN_BROWSERS = ["firefox", "chrome", "safari", "webkit"];
 
-// Tree-kill a pid and resolve only once the kill has actually completed.
+// Tree-kill a pid and resolve only once the target process is actually gone.
 // `tree-kill` is asynchronous (it shells out to `taskkill /T /F` on Windows,
-// or walks `ps` on POSIX) — callers that fire it without awaiting can move on
-// (and the process can exit) before the tree is actually gone, orphaning a
-// still-running browser that the pid's Appium server owned via its
-// chromedriver/geckodriver child. Every place that tears down an Appium
-// server process must await this instead of calling `kill()` bare.
-function killTree(pid?: number): Promise<void> {
+// or walks `ps`/sends signals on POSIX) — callers that fire it without
+// awaiting can move on (and the process can exit) before the tree is
+// actually gone, orphaning a still-running browser that the pid's Appium
+// server owned via its chromedriver/geckodriver child. Every place that
+// tears down an Appium server process must await this instead of calling
+// `kill()` bare.
+//
+// tree-kill's own completion callback isn't sufficient on its own: on
+// Windows it fires after `taskkill /T /F` (a forceful, synchronous
+// termination) exits, so the pid really is gone by then. On POSIX it fires
+// once the SIGTERM signal has been *sent* to every pid in the tree, not once
+// the OS has actually reaped them — a process can take a moment to exit
+// after receiving SIGTERM. So after tree-kill's callback, poll
+// `process.kill(pid, 0)` (which throws ESRCH once the pid no longer exists)
+// with a bounded timeout, rather than trusting the callback alone.
+function killTree(pid?: number, timeoutMs: number = 5000): Promise<void> {
   return new Promise<void>((resolve) => {
     if (!pid) return resolve();
+    const waitForExit = async () => {
+      const start = Date.now();
+      while (isPidAlive(pid) && Date.now() - start < timeoutMs) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      resolve();
+    };
     try {
-      kill(pid, "SIGTERM", () => resolve());
+      kill(pid, "SIGTERM", () => waitForExit());
     } catch {
       resolve();
     }
   });
+}
+
+// Whether `pid` still refers to a live process. `process.kill(pid, 0)` sends
+// no signal — it just probes: it throws ESRCH once the pid no longer exists.
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -1130,7 +1158,14 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
       }
     } catch (error) {
       await Promise.all(
-        appiumServers.map((server) => killTree(server.process?.pid))
+        appiumServers.map((server) => {
+          log(
+            config,
+            "debug",
+            `Closing Appium server on port ${server.port} after startup failure`
+          );
+          return killTree(server.process?.pid);
+        })
       );
       for (const xvfb of xvfbProcesses) {
         try {

--- a/test/core-tests-teardown.test.js
+++ b/test/core-tests-teardown.test.js
@@ -32,12 +32,14 @@ describe("killTree", function () {
 
       await killTree(proc.pid);
 
-      // No polling/setTimeout here on purpose: killTree() is supposed to only
-      // resolve once tree-kill's own completion callback fires, so the
-      // process must already be gone the instant the await returns. Before
-      // the fix, the run-end teardown fired `kill()` without awaiting this
-      // completion, so control returned (and the run could exit) while the
-      // process was still alive.
+      // No polling/setTimeout here on purpose: killTree() resolves only once
+      // the pid is confirmed gone — after tree-kill's callback it polls
+      // `process.kill(pid, 0)` on POSIX (where the callback only means the
+      // signal was sent, not that the process exited) until the pid no
+      // longer exists. So the process must already be dead the instant the
+      // await returns. Before the fix, the run-end teardown fired `kill()`
+      // without awaiting this at all, so control returned (and the run could
+      // exit) while the process was still alive.
       assert.equal(
         isAlive(proc.pid),
         false,

--- a/test/core-tests-teardown.test.js
+++ b/test/core-tests-teardown.test.js
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { killTree } from "../dist/core/tests.js";
+
+// Confirms a pid is alive (`process.kill(pid, 0)` doesn't throw) or dead.
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("killTree", function () {
+  this.timeout(15000);
+
+  it("resolves only after the process is actually terminated", async function () {
+    const tmp = path.join(os.tmpdir(), `dd-killtree-test-${process.pid}.js`);
+    fs.writeFileSync(tmp, `setInterval(() => {}, 100000);`);
+    const proc = spawn(process.execPath, [tmp], { stdio: "ignore" });
+    try {
+      // Wait for the child to actually be running before we try to kill it.
+      await new Promise((resolve) => {
+        if (proc.pid) return resolve();
+        proc.once("spawn", resolve);
+      });
+      assert.ok(isAlive(proc.pid), "expected the spawned process to be alive");
+
+      await killTree(proc.pid);
+
+      // No polling/setTimeout here on purpose: killTree() is supposed to only
+      // resolve once tree-kill's own completion callback fires, so the
+      // process must already be gone the instant the await returns. Before
+      // the fix, the run-end teardown fired `kill()` without awaiting this
+      // completion, so control returned (and the run could exit) while the
+      // process was still alive.
+      assert.equal(
+        isAlive(proc.pid),
+        false,
+        "expected the process to be terminated synchronously after killTree resolves"
+      );
+    } finally {
+      try {
+        process.kill(proc.pid, "SIGKILL");
+      } catch {
+        // already dead — expected on the happy path
+      }
+      fs.rmSync(tmp, { force: true });
+    }
+  });
+
+  it("resolves without throwing for an already-dead pid", async function () {
+    const tmp = path.join(os.tmpdir(), `dd-killtree-dead-${process.pid}.js`);
+    fs.writeFileSync(tmp, `process.exit(0);`);
+    const proc = spawn(process.execPath, [tmp], { stdio: "ignore" });
+    await new Promise((resolve) => proc.once("exit", resolve));
+
+    await assert.doesNotReject(() => killTree(proc.pid));
+
+    fs.rmSync(tmp, { force: true });
+  });
+
+  it("resolves immediately for an undefined pid", async function () {
+    await assert.doesNotReject(() => killTree(undefined));
+  });
+});


### PR DESCRIPTION
## Summary
- `runSpecs()`'s run-end teardown (and two related Appium-server kill sites) called `tree-kill` on each Appium server's pid without awaiting completion. `tree-kill` is async (shells out to `taskkill /T /F` on Windows), so a run could finish and hand control back to the caller before the chromedriver/geckodriver child — and the browser it owns — was actually terminated. Over repeated runs this left orphaned Chrome/Firefox processes accumulating on the machine.
- Centralized on a single exported, awaited `killTree()` helper and used it at every Appium-server teardown site: the run-end `finally` block, the Appium-startup-failure catch, and `startAppiumServer`'s own readiness-failure path.

## Docs impact
No user-facing surface change (no new/changed step type, config/CLI flag, engine, output format, or default) — internal teardown-timing fix only, so no ADR or docs update is required per the repo's docs-impact rule.

## Test plan
- [x] `npm run compile` — clean
- [x] New `test/core-tests-teardown.test.js` (3 cases covering `killTree()`'s await-until-dead contract) — passing
- [x] Full `test/core-core.test.js` suite (drives real Chrome/Firefox sessions) — 56 passing, 0 failing
- [x] Manually confirmed via `tasklist` that no `chrome.exe`/`chromedriver.exe`/`firefox.exe`/`geckodriver.exe` processes remain after that run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved teardown reliability by awaiting process-tree shutdown so child processes are fully terminated before runs finish.
  * Strengthened cleanup when startup fails, SIGINT/SIGTERM occurs, or processes have already exited by using bounded, Promise-based termination.
* **Tests**
  * Added integration tests validating `killTree` waits for real termination, resolves safely for already-dead PIDs, and handles undefined PID without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->