### PR TITLE
ci: re-baseline coverage thresholds after debug/adapters/goTo batches

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,9 +1,9 @@
 {
   "description": "Coverage baseline thresholds for the root doc-detective package, measured as the CROSS-PLATFORM UNION of the full end-to-end test suite: every OS/node matrix cell collects raw V8 coverage (NODE_V8_COVERAGE) and the coverage-merge job re-roots and reports their union via c8, so OS-gated (Windows/macOS) branches count. These values should only increase, never decrease. 'tolerance' absorbs run-to-run wobble of the non-deterministic E2E union — observed up to ~0.4pp (mostly browser/driver-dependent functions), so it is set to 0.4 and the four values sit below the lowest observed run.",
-  "lastUpdated": "2026-07-01",
+  "lastUpdated": "2026-07-02",
   "tolerance": 0.4,
-  "lines": 93.8,
-  "statements": 93.8,
-  "functions": 95,
-  "branches": 87.6
+  "lines": 95.8,
+  "statements": 95.8,
+  "functions": 96.2,
+  "branches": 91.6
 }


### PR DESCRIPTION
## Summary

Locks in the coverage gains from the three ADR-01017 batches now merged to main:

- #479 — `src/debug/*` to literal 100% across all metrics
- #477 — adapters / cli / agents-support
- #475 — goTo / dragAndDrop / ffmpegRecorder

## Measured cross-platform union (from #475's coverage-merge run against main+#475)

| Metric | Old threshold | New union | Δ |
|---|---|---|---|
| lines | 93.80 | **96.28** | +2.48 |
| statements | 93.80 | **96.28** | +2.48 |
| functions | 95.00 | **96.61** | +1.61 |
| branches | 87.60 | **92.04** | +4.44 |

## New thresholds

Set ~0.4pp below the observed union, `tolerance` unchanged at 0.4:

| Metric | Value | Effective floor (value − tolerance) | Observed |
|---|---|---|---|
| lines | 95.8 | 95.4 | 96.28 |
| statements | 95.8 | 95.4 | 96.28 |
| functions | 96.2 | 95.8 | 96.61 |
| branches | 91.6 | 91.2 | 92.04 |

The ~0.8pp margin from observed to effective floor absorbs the ~0.4pp run-to-run wobble of the non-deterministic E2E union (per the established discipline) while still ratcheting the floor up meaningfully from the prior 93.8/93.8/95.0/87.6.

## Docs impact

None — CI/threshold-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage baseline metadata and threshold targets.
  * Increased the required coverage levels for lines, statements, functions, and branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->