### PR TITLE
test(core): close reachable resolveTests context/openApi branches (ADR 01017)

### DIFF
--- a/test/resolvetests-coverage.test.js
+++ b/test/resolvetests-coverage.test.js
@@ -1,0 +1,150 @@
+// Coverage-closing tests for the reachable-but-unexercised branches in
+// `src/core/resolveTests.ts` (measured against compiled `dist/core/resolveTests.js`).
+//
+// Fully HERMETIC and OFFLINE:
+//   - `resolveContexts` is a pure transform — the browser/platform
+//     normalization branches (string form, bare-object form) are driven by
+//     passing hand-built context objects, no driver or schema round-trip.
+//   - `fetchOpenApiDocuments` (internal; reached through the public
+//     `resolveTests`) reads OpenAPI descriptions off disk via `loadDescription`
+//     -> `readFile`. The happy path points at a minimal JSON file written to a
+//     temp dir; the failure path points at a nonexistent file (readFile returns
+//     null -> dereference throws -> the collector's catch/continue runs); the
+//     name-dedup path pairs a config-provided doc with a spec-provided doc of
+//     the same name so the splice-then-replace branch executes.
+//
+// Every temp dir is removed in `afterEach`, so nothing leaks into the rest of
+// the combined suite.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  resolveContexts,
+  resolveTests,
+} from "../dist/core/resolveTests.js";
+
+const config = { logLevel: "silent" };
+
+describe("resolveTests coverage: resolveContexts normalization", function () {
+  // `goTo` is a browser/driver step, so browserRequired is true and each
+  // context expands into platform+browser pairs (the branch we want to hit).
+  const driverTest = { testId: "t", steps: [{ goTo: { url: "https://x" } }] };
+
+  it("normalizes a bare-string `browsers` value into a single-browser array", function () {
+    const contexts = [{ platforms: ["linux"], browsers: "chrome" }];
+    const resolved = resolveContexts({ contexts, test: driverTest, config });
+    assert.equal(resolved.length, 1);
+    assert.equal(resolved[0].platform, "linux");
+    assert.deepEqual(resolved[0].browser, { name: "chrome", explicit: true });
+  });
+
+  it("normalizes a bare-object `browsers` value into a single-browser array", function () {
+    const contexts = [{ platforms: ["linux"], browsers: { name: "firefox" } }];
+    const resolved = resolveContexts({ contexts, test: driverTest, config });
+    assert.equal(resolved.length, 1);
+    assert.deepEqual(resolved[0].browser, { name: "firefox", explicit: true });
+  });
+
+  it("normalizes a bare-string `platforms` value into an array", function () {
+    const contexts = [{ platforms: "linux", browsers: ["chrome"] }];
+    const resolved = resolveContexts({ contexts, test: driverTest, config });
+    assert.equal(resolved.length, 1);
+    assert.equal(resolved[0].platform, "linux");
+  });
+
+  it("rewrites a `safari` browser name to `webkit`", function () {
+    const contexts = [{ platforms: ["mac"], browsers: ["safari"] }];
+    const resolved = resolveContexts({ contexts, test: driverTest, config });
+    assert.equal(resolved[0].browser.name, "webkit");
+  });
+});
+
+describe("resolveTests coverage: fetchOpenApiDocuments", function () {
+  let tmp;
+  beforeEach(function () {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-resolve-oapi-"));
+  });
+  afterEach(function () {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function makeSpec(openApi) {
+    return {
+      specId: "docs/x.json",
+      contentPath: path.join(process.cwd(), "docs", "x.json"),
+      openApi,
+      runOn: [],
+      tests: [
+        {
+          testId: "t",
+          steps: [{ runShell: { command: "echo hi" } }],
+          openApi: [],
+        },
+      ],
+    };
+  }
+
+  it("loads a valid descriptionPath and attaches the dereferenced definition", async function () {
+    const file = path.join(tmp, "api.json");
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        openapi: "3.0.0",
+        info: { title: "t", version: "1" },
+        paths: {},
+      })
+    );
+    const spec = makeSpec([{ name: "api", descriptionPath: file }]);
+    const resolved = await resolveTests({ config, detectedTests: [spec] });
+    const docs = resolved.specs[0].openApi;
+    assert.equal(docs.length, 1);
+    assert.equal(docs[0].name, "api");
+    assert.ok(docs[0].definition, "dereferenced definition attached");
+  });
+
+  it("continues past a descriptionPath that fails to load", async function () {
+    const spec = makeSpec([
+      { name: "missing", descriptionPath: path.join(tmp, "does-not-exist.json") },
+    ]);
+    const resolved = await resolveTests({ config, detectedTests: [spec] });
+    // The failed definition is skipped via `continue`, so it never lands in
+    // the resolved openApi list.
+    assert.equal(resolved.specs[0].openApi.length, 0);
+  });
+
+  it("dedupes by name, replacing a config-provided doc with the spec-provided one", async function () {
+    const file = path.join(tmp, "api.json");
+    fs.writeFileSync(file, JSON.stringify({ openapi: "3.0.0" }));
+    const cfg = {
+      ...config,
+      integrations: { openApi: [{ name: "api", definition: { fromConfig: true } }] },
+    };
+    const spec = makeSpec([{ name: "api", descriptionPath: file }]);
+    const resolved = await resolveTests({ config: cfg, detectedTests: [spec] });
+    const apiDocs = resolved.specs[0].openApi.filter((d) => d.name === "api");
+    // The config-provided "api" was spliced out and replaced by the
+    // spec-provided one (which carries a descriptionPath).
+    assert.equal(apiDocs.length, 1);
+    assert.ok(
+      apiDocs[0].descriptionPath,
+      "kept the spec-provided doc, not the config stub"
+    );
+  });
+
+  it("assigns a random-UUID specId when neither specId nor contentPath is present", async function () {
+    const spec = {
+      openApi: [],
+      runOn: [],
+      tests: [
+        { testId: "t", steps: [{ runShell: { command: "echo hi" } }], openApi: [] },
+      ],
+    };
+    const resolved = await resolveTests({ config, detectedTests: [spec] });
+    assert.match(
+      resolved.specs[0].specId,
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Tier-2 coverage batch. Closes the reachable-but-unexercised branches in `src/core/resolveTests.ts` with a fully hermetic, offline test. **Test-only** — every gap was hermetically reachable, so no source edits or `c8 ignore` annotations were needed.

## Before / after (src/core/resolveTests.ts)

Measured against the hermetic suite (`resolvetests-coverage` + `run-artifacts` + `resolve-driver-required`):

| Metric | Before | After |
|---|---|---|
| lines | 90.47 | **100** |
| statements | 90.47 | **100** |
| functions | 100 | **100** |
| branches | 84.09 | **100** |

Previously-uncovered lines closed: **47-49, 65-66, 121-143** (plus branch gaps on 54 and 239).

## What the new test drives

- **`resolveContexts` normalization** (pure transform, hand-built context objects):
  - bare-string `browsers` (`"chrome"`) → single-browser array
  - bare-object `browsers` (`{name}`) → single-browser array
  - string `platforms` (`"linux"`) → array
  - `safari` → `webkit` rename
- **`fetchOpenApiDocuments`** (internal; reached through the public `resolveTests` with temp-dir fixtures):
  - valid `descriptionPath` → dereferenced definition attached (happy path)
  - missing file → `readFile` returns null → dereference throws → collector's catch/`continue` (skipped, not in output)
  - config-provided + spec-provided doc of the same name → dedup splice-then-replace
- **random-UUID specId fallback** when neither `specId` nor `contentPath` is present

## Hermetic / no-leak

No driver, no live network. OpenAPI fixtures are minimal JSON written to a per-test temp dir and removed in `afterEach`. The happy/fail/dedup paths are all driven with real offline file I/O (valid file, nonexistent file), matching the ADR-01017 "test what's reachable from Node hermetically" rule.

## Docs impact

None — test-only change, no user-facing behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage-focused tests for test resolution behavior.
  * Verified support for multiple input formats, browser name normalization, OpenAPI document loading, duplicate handling, and fallback ID generation.
  * Included cleanup between test runs to keep results isolated and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->