### PR TITLE
ci: re-baseline coverage thresholds after Tier-2 core batches

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,9 +1,9 @@
 {
   "description": "Coverage baseline thresholds for the root doc-detective package, measured as the CROSS-PLATFORM UNION of the full end-to-end test suite: every OS/node matrix cell collects raw V8 coverage (NODE_V8_COVERAGE) and the coverage-merge job re-roots and reports their union via c8, so OS-gated (Windows/macOS) branches count. These values should only increase, never decrease. 'tolerance' absorbs run-to-run wobble of the non-deterministic E2E union — observed up to ~0.4pp (mostly browser/driver-dependent functions), so it is set to 0.4 and the four values sit below the lowest observed run.",
-  "lastUpdated": "2026-07-02",
+  "lastUpdated": "2026-07-03",
   "tolerance": 0.4,
-  "lines": 95.8,
-  "statements": 95.8,
+  "lines": 96.0,
+  "statements": 96.0,
   "functions": 96.2,
-  "branches": 91.6
+  "branches": 91.9
 }


### PR DESCRIPTION
Locks in gains from Tier-2 batches #485/#487/#488/#489 (loadVariables/wait/click/appium guards, resolveTests, closeSurface, telem — each to 100%). Last measured main union: 96.43/96.43/96.37/92.26 (lines/statements/functions/branches). Raise lines/statements 95.8->96.0 and branches 91.6->91.9; hold functions at 96.2 (observed 96.37 is only +0.17 above the floor and functions wobbles most). Tolerance 0.4; effective floors 95.6/95.6/95.8/91.5 sit below the observed union and absorb the ~0.4pp wobble. This PR's own root coverage-merge job self-validates the new thresholds against current main. CI/threshold-only; no docs impact.