### PR TITLE
test(core): cover detectTests qualifyFiles error paths; annotate external deps (ADR 01017)

### DIFF
--- a/src/core/detectTests.ts
+++ b/src/core/detectTests.ts
@@ -185,6 +185,12 @@ async function processDitaMap({ config, source }: { config: any; source: string 
     return null;
   }
 
+  // Past the version guard: the `dita` CLI (Apache DITA-OT) is present and is
+  // invoked to transform the map. This success path shells out to a real
+  // external tool that isn't installed in the hermetic test env (the version
+  // guard above returns first there), so it can't be exercised offline — its
+  // outcome branches are covered only in an environment with DITA-OT (ADR 01017).
+  /* c8 ignore start */
   log(config, "info", `Processing DITA map: ${source}`);
   const ditaOutputDir = await spawnCommand("dita", [
     "-i",
@@ -199,6 +205,7 @@ async function processDitaMap({ config, source }: { config: any; source: string 
     return null;
   }
   return outputDir;
+  /* c8 ignore stop */
 }
 
 /**
@@ -264,6 +271,11 @@ async function qualifyFiles({ config }: { config: any }) {
         continue;
       }
 
+      // First-load branch: fetch+export the Heretto scenario over the network
+      // (loadHerettoContent hits the Heretto API). Not reproducible offline;
+      // the hermetic tests cover the no-integration and outputPath-reuse paths
+      // instead (ADR 01017).
+      /* c8 ignore start */
       if (!herettoConfig.outputPath) {
         try {
           const outputPath = await loadHerettoContent(herettoConfig, log, config);
@@ -278,6 +290,7 @@ async function qualifyFiles({ config }: { config: any }) {
         } catch (error: any) {
           log(config, "warning", `Failed to load Heretto content from "${herettoName}": ${error.message}`);
         }
+        /* c8 ignore stop */
       } else {
         config._herettoPathMapping[herettoConfig.outputPath] = herettoName;
         if (!ignoredDitaMaps.includes(herettoConfig.outputPath)) {
@@ -289,7 +302,11 @@ async function qualifyFiles({ config }: { config: any }) {
             phase,
           });
         }
-        // Hydrate resourceDependencies for uploadOnChange on reuse runs
+        // Hydrate resourceDependencies for uploadOnChange on reuse runs. This
+        // fans out to the Heretto API (createApiClient/findScenario/
+        // getResourceDependencies) — a network path not reproducible offline
+        // (ADR 01017).
+        /* c8 ignore start */
         if (herettoConfig.uploadOnChange && !herettoConfig.resourceDependencies) {
           try {
             const client = createApiClient(herettoConfig);
@@ -303,6 +320,7 @@ async function qualifyFiles({ config }: { config: any }) {
             log(config, "warning", `Failed to fetch resource dependencies for "${herettoName}": ${error.message}`);
           }
         }
+        /* c8 ignore stop */
       }
       continue;
     }
@@ -315,6 +333,9 @@ async function qualifyFiles({ config }: { config: any }) {
         log(config, "warning", fetch.message);
         continue;
       }
+      // Success means a remote file was downloaded — a network fetch, not
+      // reproducible offline (the hermetic tests exercise the error arm above).
+      /* c8 ignore next */
       source = fetch.path;
     }
     // Check if source is a file or directory
@@ -336,6 +357,10 @@ async function qualifyFiles({ config }: { config: any }) {
       config.processDitaMaps
     ) {
       const ditaOutput = await processDitaMap({ config, source });
+      // processDitaMap only returns a path when the `dita` CLI is installed and
+      // succeeds; in the hermetic env it returns null (handled by falling
+      // through to `continue`), so the splice branch needs real DITA-OT (ADR 01017).
+      /* c8 ignore next 5 */
       if (ditaOutput) {
         const currentIndex = sequence.findIndex((e) => e.source === source);
         sequence.splice(currentIndex + 1, 0, { source: ditaOutput, phase });

--- a/test/detecttests-qualify-coverage.test.js
+++ b/test/detecttests-qualify-coverage.test.js
@@ -1,0 +1,78 @@
+// Coverage-closing tests for src/core/detectTests.ts's qualifyFiles / processDitaMap
+// error + not-found branches (compiled dist/core/detectTests.js).
+//
+// These paths are union-uncovered (the E2E suite doesn't feed dita maps, URL
+// sources, or missing/heretto inputs), so covering them hermetically raises the
+// cross-platform union directly. All offline:
+//   - heretto:<name> with no matching integration -> warning + skip
+//   - an unreachable http(s) source -> fetchFile errors -> warning + skip
+//   - a nonexistent path -> statSync throws -> warning + skip
+//   - a real .ditamap file with processDitaMaps enabled -> processDitaMap runs;
+//     the `dita` CLI is not installed in the test env, so its `--version` probe
+//     returns nonzero and processDitaMap returns null (the not-found branch).
+//
+// qualifyFiles isn't exported, so it's driven through the public detectTests.
+// Every input here resolves to zero qualified files, so parseTests returns [].
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { detectTests } from "../dist/core/detectTests.js";
+
+const baseConfig = () => ({ logLevel: "silent" });
+
+describe("detectTests qualifyFiles coverage: skip/error branches", function () {
+  let tmp;
+  beforeEach(function () {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-detect-qualify-"));
+  });
+  afterEach(function () {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("skips a heretto: source with no matching integration", async function () {
+    const specs = await detectTests({
+      config: { ...baseConfig(), input: ["heretto:does-not-exist"] },
+    });
+    assert.deepEqual(specs, []);
+  });
+
+  it("skips an unreachable URL source (fetchFile error)", async function () {
+    this.timeout(20000);
+    // Connection-refused on a closed local port fails fast and offline.
+    const specs = await detectTests({
+      config: { ...baseConfig(), input: ["http://127.0.0.1:1/nope.md"] },
+    });
+    assert.deepEqual(specs, []);
+  });
+
+  it("skips a path that cannot be accessed", async function () {
+    const specs = await detectTests({
+      config: {
+        ...baseConfig(),
+        input: [path.join(tmp, "definitely", "missing", "x.md")],
+      },
+    });
+    assert.deepEqual(specs, []);
+  });
+
+  it("runs processDitaMap for a .ditamap input and skips when `dita` is unavailable", async function () {
+    this.timeout(20000);
+    const ditamap = path.join(tmp, "map.ditamap");
+    fs.writeFileSync(
+      ditamap,
+      '<?xml version="1.0"?>\n<map><topicref href="a.dita"/></map>\n'
+    );
+    const specs = await detectTests({
+      config: {
+        ...baseConfig(),
+        input: [ditamap],
+        processDitaMaps: true,
+      },
+    });
+    // dita CLI isn't installed in the test env -> processDitaMap returns null ->
+    // the ditamap contributes no files.
+    assert.deepEqual(specs, []);
+  });
+});


### PR DESCRIPTION
Tier-2 batch for src/core/detectTests.ts (88.61% union — gap entirely union-uncovered since E2E never feeds DITA maps/URL sources/missing/heretto inputs). Result: 88.61% -> 96.7% lines, 100% functions. New hermetic offline test drives qualifyFiles skip/error branches via public detectTests (heretto-not-found; unreachable http fetchFile error; nonexistent path statSync throw; .ditamap with processDitaMaps -> processDitaMap dita-CLI-absent not-found path). Annotated real external-dependency success paths per ADR 01017 (DITA-OT invocation, ditamap splice, URL-fetch success, two Heretto API branches). Build clean; 104 passing 0 failing across detecttests-* + run-artifacts. Comment-only annotations. No docs impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test coverage for paths that depend on external runtime conditions, including network access, local file availability, and DITA processing.
  * Clarified coverage reporting for branches that can’t be reliably exercised in hermetic environments.

* **Tests**
  * Added a new coverage-focused test suite that verifies no specs are returned for unreachable, unavailable, or unsupported inputs.
  * Expanded checks for offline and error-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->