### PR TITLE
test(runtime): cover heavyDeps satisfiesRange semver logic (ADR 01017)

### DIFF
--- a/test/heavydeps-satisfiesrange-coverage.test.js
+++ b/test/heavydeps-satisfiesrange-coverage.test.js
@@ -1,0 +1,68 @@
+// Coverage-closing tests for src/runtime/heavyDeps.ts's satisfiesRange (and its
+// parseSemverCore/compareTuple helpers) plus the _resetCacheForTests seam
+// (compiled dist/runtime/heavyDeps.js).
+//
+// Pure, hermetic, no I/O: satisfiesRange is a self-contained minimal semver
+// range check. The existing runtime-heavy-deps suite covers the manifest
+// resolution but not the range comparison, and the E2E union doesn't exercise
+// it either, so these directly raise the union.
+
+import assert from "node:assert/strict";
+import {
+  satisfiesRange,
+  _resetCacheForTests,
+} from "../dist/runtime/heavyDeps.js";
+
+describe("heavyDeps satisfiesRange", function () {
+  it("returns true when either range or installed is empty", function () {
+    assert.equal(satisfiesRange("", "^1.0.0"), true);
+    assert.equal(satisfiesRange("1.0.0", ""), true);
+  });
+
+  it("returns true when the installed version isn't a parseable semver core", function () {
+    assert.equal(satisfiesRange("not-a-version", "^1.0.0"), true);
+  });
+
+  it("caret: same non-zero major, >= wanted passes; lower fails", function () {
+    assert.equal(satisfiesRange("1.5.0", "^1.2.0"), true);
+    assert.equal(satisfiesRange("1.1.0", "^1.2.0"), false);
+  });
+
+  it("caret: a different major fails", function () {
+    assert.equal(satisfiesRange("2.0.0", "^1.2.0"), false);
+  });
+
+  it("caret with a 0 major pins the minor", function () {
+    assert.equal(satisfiesRange("0.2.5", "^0.2.0"), true);
+    assert.equal(satisfiesRange("0.3.0", "^0.2.0"), false);
+  });
+
+  it("caret: an unparseable wanted range degrades to true", function () {
+    assert.equal(satisfiesRange("1.0.0", "^not.a.version"), true);
+  });
+
+  it("tilde: same major.minor with >= patch passes; otherwise fails", function () {
+    assert.equal(satisfiesRange("1.2.5", "~1.2.0"), true);
+    assert.equal(satisfiesRange("1.3.0", "~1.2.0"), false);
+    assert.equal(satisfiesRange("1.2.0", "~1.2.5"), false);
+  });
+
+  it("tilde: an unparseable wanted range degrades to true", function () {
+    assert.equal(satisfiesRange("1.0.0", "~not.a.version"), true);
+  });
+
+  it("exact version: equality only", function () {
+    assert.equal(satisfiesRange("1.2.3", "1.2.3"), true);
+    assert.equal(satisfiesRange("1.2.4", "1.2.3"), false);
+  });
+
+  it("non-simple ranges (>=, ||, *) degrade to true so callers don't false-positive", function () {
+    assert.equal(satisfiesRange("1.0.0", ">=1.0.0"), true);
+    assert.equal(satisfiesRange("1.0.0", "1.2.3 || 2.0.0"), true);
+    assert.equal(satisfiesRange("1.0.0", "*"), true);
+  });
+
+  it("_resetCacheForTests runs without error", function () {
+    _resetCacheForTests();
+  });
+});


### PR DESCRIPTION
Tier-2 batch for src/runtime/heavyDeps.ts. satisfiesRange (and its parseSemverCore/compareTuple helpers) plus the _resetCacheForTests seam were untested by the runtime-heavy-deps suite and unexercised by the E2E union (70.37% branches). Pure semver logic — fully hermetic, no I/O.

New test covers every range shape: caret (same-major gte, major mismatch, 0-major minor pin, unparseable wanted), tilde (patch gte, unparseable wanted), exact equality, empty inputs, unparseable installed, and non-simple ranges (>=, ||, *) that degrade to 'matches'.

**Test-only; no source edits.** src/runtime/heavyDeps.ts now reaches 100% lines/statements/functions/branches. 24 passing across runtime-heavy-deps + the new test. No docs impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for version-range handling across common semver scenarios, including empty ranges, exact matches, caret and tilde rules, non-parseable versions, and wider range formats.
  * Verified the runtime cache reset path completes successfully without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->