### PR TITLE
ci: re-baseline coverage thresholds after detectTests/runCode/heavyDeps batches

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -2,8 +2,8 @@
   "description": "Coverage baseline thresholds for the root doc-detective package, measured as the CROSS-PLATFORM UNION of the full end-to-end test suite: every OS/node matrix cell collects raw V8 coverage (NODE_V8_COVERAGE) and the coverage-merge job re-roots and reports their union via c8, so OS-gated (Windows/macOS) branches count. These values should only increase, never decrease. 'tolerance' absorbs run-to-run wobble of the non-deterministic E2E union — observed up to ~0.4pp (mostly browser/driver-dependent functions), so it is set to 0.4 and the four values sit below the lowest observed run.",
   "lastUpdated": "2026-07-03",
   "tolerance": 0.4,
-  "lines": 96.0,
-  "statements": 96.0,
-  "functions": 96.2,
-  "branches": 91.9
+  "lines": 96.2,
+  "statements": 96.2,
+  "functions": 96.3,
+  "branches": 92.0
 }


### PR DESCRIPTION
## Summary

Locks in the gains from three merged Tier-2 batches:

- #494 — detectTests qualifyFiles (88.6 → 96.7%)
- #495 — runCode (→ 100%)
- #496 — heavyDeps satisfiesRange (→ 100%)

## Measured union (newest completed main coverage-merge run, post-#494)

| Metric | Old threshold | Observed union | New threshold | Effective floor (−tol) |
|---|---|---|---|---|
| lines | 96.0 | 96.61 | **96.2** | 95.8 |
| statements | 96.0 | 96.61 | **96.2** | 95.8 |
| functions | 96.2 | 96.55 | **96.3** | 95.9 |
| branches | 91.9 | 92.22 | **92.0** | 91.6 |

All four values are non-decreasing and sit ~0.4pp below the observed union; #495/#496 (both →100% files) only raise the union further, so the margins are conservative. Functions is nudged only modestly (wobbles most). `tolerance` unchanged at 0.4.

The `Coverage ratchet (root, cross-platform)` job on this PR self-validates the new thresholds against current main (which includes #494/#495/#496).

## Docs impact

None — CI/threshold-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project coverage thresholds, slightly raising the required minimums for lines, statements, functions, and branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->