### PR TITLE
feat(apps): bootstrap a portable JRE so Java isn't an Android prerequisite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+# [4.21.0-android-portable-jre.1](https://github.com/doc-detective/doc-detective/compare/v4.20.0...v4.21.0-android-portable-jre.1) (2026-07-05)
+
+
+### Bug Fixes
+
+* **apps:** address claude-bot review (robustness on the device layer) ([a4f648a](https://github.com/doc-detective/doc-detective/commit/a4f648a9a24c08d7c42e14effc3e50d3f11b6f40))
+* **apps:** address Copilot review (cache candidate, hermetic test, SHA pin) ([ee31ca8](https://github.com/doc-detective/doc-detective/commit/ee31ca8f4bebc0995a8b2d8b21cf5e6c6b667aa8))
+* **apps:** boot the managed emulator headless with a software GPU on CI ([f8de914](https://github.com/doc-detective/doc-detective/commit/f8de9149f608854028f9a9664e791f3371e274ee))
+* **apps:** capture emulator stdout; lazy AVD list on reuse; comment/CodeQL cleanup ([40516b8](https://github.com/doc-detective/doc-detective/commit/40516b838e584159049bd656df3597ca4638f1ea))
+* **apps:** error on a missing device session in ensureAppForeground ([4c202cd](https://github.com/doc-detective/doc-detective/commit/4c202cddae7a203323d9c35f49b0fb42be6daf02))
+* **apps:** gate (not crash) when the Android environment probe throws ([81f4599](https://github.com/doc-detective/doc-detective/commit/81f4599c46a3689bae230a17849d7b3157ff54ea))
+* **apps:** honest SKIP reason for android on macOS/Windows without an SDK ([c823b24](https://github.com/doc-detective/doc-detective/commit/c823b249155a09d9e9f951820ea1d076af6d75d0))
+* **apps:** map Android 12L to API 32 in androidVersionToApi ([142124a](https://github.com/doc-detective/doc-detective/commit/142124a8d816974079d4a773b4c2fb8a4720a417))
+* **apps:** pin ANDROID_AVD_HOME so avdmanager and the emulator agree ([90c8940](https://github.com/doc-detective/doc-detective/commit/90c8940a8d53624e22e23c592694aa62257a01e3))
+* **apps:** resolve CodeQL findings (ReDoS + shell-command barrier) ([34118b7](https://github.com/doc-detective/doc-detective/commit/34118b79d49b6eb7b54e32416c4b114227f75595))
+* **apps:** run Android .bat via cmd.exe args-array; capture emulator stderr ([8e20815](https://github.com/doc-detective/doc-detective/commit/8e20815cbfeaed4d6e397c106c2770e61eda9b9e))
+* **apps:** spawn sdkmanager/avdmanager .bat via shell on Windows ([daeec98](https://github.com/doc-detective/doc-detective/commit/daeec98d0b7b4e39ccc5815e8c03debf3167f8e0))
+* **apps:** surface installAndroid failure reasons + deterministic gating fixture ([3403768](https://github.com/doc-detective/doc-detective/commit/340376894a6385fd9fe7bcb33c8aa20da378dad7))
+* **ci:** single-line the emulator-runner doc-detective command ([2eb36fd](https://github.com/doc-detective/doc-detective/commit/2eb36fd1e7bc2ea4168393a0f54b66801b30735a))
+
+
+### Features
+
+* **apps:** add `doc-detective install android` toolchain installer ([6ee73ad](https://github.com/doc-detective/doc-detective/commit/6ee73ada086f46632e3eb96075d5d20be08bf461))
+* **apps:** bootstrap a portable Android SDK when none is available ([23c8c53](https://github.com/doc-detective/doc-detective/commit/23c8c53f03d7f42b10e890855739c4db1aa5b144))
+* **apps:** bootstrap a portable JRE so Java isn't an Android prerequisite ([3516484](https://github.com/doc-detective/doc-detective/commit/3516484ee2db3b54d0b840bcc71943d429ad40a4)), closes [#505](https://github.com/doc-detective/doc-detective/issues/505)
+* **apps:** gate android/ios target platforms and revise the device descriptor ([6da469a](https://github.com/doc-detective/doc-detective/commit/6da469ada40c80428774bdda38f829d0240b31c4))
+* **apps:** lazily install the Android toolchain when a run needs it ([2b6c520](https://github.com/doc-detective/doc-detective/commit/2b6c5202a461d02e355337a955e0c3d47eda2fe9))
+* **apps:** managed Android emulators + UiAutomator2 app surfaces (phase A3b) ([71f41c1](https://github.com/doc-detective/doc-detective/commit/71f41c18b743e810293768021b2476f6c023be81))
+* native macOS app surfaces via Mac2 (native-app phase A2) ([#502](https://github.com/doc-detective/doc-detective/issues/502)) ([faf5521](https://github.com/doc-detective/doc-detective/commit/faf552125640a64b46a30dad6621d5b44298a970)), closes [#501](https://github.com/doc-detective/doc-detective/issues/501)
+
+
+### Performance Improvements
+
+* **apps:** don't take the emulator mutex for android+browser contexts ([a213f89](https://github.com/doc-detective/doc-detective/commit/a213f8964f3c1af912fed5d7dc6f3f7b3e473c3f))
+
 # [4.20.0](https://github.com/doc-detective/doc-detective/compare/v4.19.0...v4.20.0) (2026-07-04)
 
 

--- a/adrs/01026-portable-jre-for-android-toolchain.md
+++ b/adrs/01026-portable-jre-for-android-toolchain.md
@@ -1,0 +1,98 @@
+---
+status: accepted
+date: 2026-07-04
+decision-makers: [hawkeyexl]
+---
+
+# Bootstrap a portable JRE for the Android toolchain instead of requiring one
+
+## Context and Problem Statement
+
+`sdkmanager` and `avdmanager` (used by `doc-detective install android` and the
+lazy install-at-test-time path) are Java programs. Phase A3 shipped with Java as
+a **host prerequisite**: if no JRE 17+ was found, `installAndroid` reported
+`java: missing` and stopped. That leaves a gap in the "zero-setup" story — a run
+on a minimal container, or a dev box without Java, hits a wall even though Doc
+Detective already bootstraps everything else (command-line tools, platform-tools,
+emulator, system image, AVD, UiAutomator2 driver). The GitHub Action's new
+`android` input (doc-detective/github-action#71) removes the *KVM* prerequisite
+on Linux; Java is the remaining one, and it applies everywhere, not just CI.
+
+## Decision Drivers
+
+- Match the existing "Doc Detective bootstraps the whole Android stack itself"
+  contract — Java is the one piece that was still the user's problem.
+- Keep the multi-GB-download discipline: never fetch anything before the `--yes`
+  confirmation (or the lazy path's explicit opt-in).
+- Stay hermetically testable — no real download in the unit suite.
+- Don't regress hosts that already have Java (system Java must win, with no
+  download and no surprise `JAVA_HOME` override).
+
+## Considered Options
+
+1. **Keep Java as a prerequisite** (status quo) — document it and rely on
+   `setup-java` in CI.
+2. **Bootstrap a portable Temurin JRE into the cache** when Java is absent,
+   mirroring the SDK bootstrap.
+3. **Bundle a JRE with the npm package** — rejected: bloats every install for a
+   feature only Android users need, and can't be right for every OS/arch.
+
+## Decision Outcome
+
+Chosen option: **2 — bootstrap a portable Temurin (Eclipse Adoptium) JRE 17**.
+`ensureJava` resolves Java in priority order: **system Java → cached
+Doc-Detective JRE → download**. On a cache/bootstrap hit it points `JAVA_HOME`
+and `PATH` at the managed JRE for the rest of the process, so the `sdkmanager` /
+`avdmanager` spawns that follow pick it up. It runs **after** the `--yes` guard in
+`installAndroid`, so the JRE download is part of the confirmed install, never a
+surprise. The download uses the Adoptium binary API
+(`/v3/binary/latest/17/ga/<os>/<arch>/jre/hotspot/normal/eclipse`) and reuses the
+existing redirect-following downloader and cross-platform extractor (its
+`tar -xf` fallback handles the POSIX `.tar.gz`; Windows gets the `.zip`).
+
+### Consequences
+
+- Good: `doc-detective install android` and the lazy install path now work with
+  **no host Java** — the zero-setup story is complete on any host with the SDK's
+  other needs met.
+- Good: system Java still short-circuits — no behavior change or download where
+  Java already exists.
+- Neutral: the JRE lands in `<cache>/jre` and is reused across runs; it's an
+  extra ~50–70 MB one-time download only on hosts that lack Java.
+- Limitation (follow-up): the **runtime** device-creation path
+  (`realCreateAvd` at boot, when a `device` descriptor needs a brand-new AVD on
+  an already-complete SDK that skipped `installAndroid`) does not yet call
+  `ensureJava`. The common paths (CLI install, lazy install) all route through
+  `installAndroid` and are covered; the reuse-then-create edge is tracked
+  separately.
+
+### Confirmation
+
+`ensureJava`'s branch logic (system / cache / bootstrap / failure) and the pure
+helpers (`jreDownloadUrl`, `jreArchiveFilename`, `resolveJavaHome`,
+`javaBinPath`) are unit-tested with injected effects — no real download. An
+`installAndroid` test asserts that an absent-Java host bootstraps the JRE and
+proceeds to create the AVD, and another asserts an unprovisionable Java still
+reports `java: missing`.
+
+## Pros and Cons of the Options
+
+### 1. Keep Java as a prerequisite
+
+- Good, because it's zero new code and no download.
+- Bad, because it breaks the zero-setup promise on minimal hosts and pushes
+  per-CI `setup-java` boilerplate onto every user.
+
+### 2. Bootstrap a portable Temurin JRE (chosen)
+
+- Good, because it completes the self-bootstrapping story and reuses the existing
+  download/extract machinery.
+- Good, because system Java still wins, so no regression where Java exists.
+- Bad, because it adds a one-time ~50–70 MB download on Java-less hosts and a
+  dependency on the Adoptium API being reachable.
+
+### 3. Bundle a JRE in the npm package
+
+- Good, because it needs no network at test time.
+- Bad, because it bloats every install regardless of Android use and can't cover
+  every OS/arch from one package.

--- a/docs/fern/pages/reference/cli/install.mdx
+++ b/docs/fern/pages/reference/cli/install.mdx
@@ -110,7 +110,7 @@ doc-detective install android --dry-run
 
 <Note>
 
-`install android` requires a **Java runtime (JRE 17+)** for `sdkmanager`/`avdmanager`. It is **not** part of `install all` — the multi-GB downloads are opt-in, so you install the Android toolchain deliberately, not as a side effect of preparing a general test environment.
+`sdkmanager`/`avdmanager` need a **Java runtime (JRE 17+)**. If your host already has one, `install android` uses it; if not, Doc Detective downloads a portable Temurin JRE into its cache as part of the (confirmed) install, so Java is not a prerequisite you have to set up yourself. `install android` is **not** part of `install all` — the multi-GB downloads are opt-in, so you install the Android toolchain deliberately, not as a side effect of preparing a general test environment.
 
 **Running this ahead of time is optional but recommended.** A test run that targets `android` on a **capable** host (one that can run the emulator) will **lazily install** the toolchain itself the first time it needs it, printing a clear warning to the terminal and the output report. Running `install android` beforehand simply pre-warms the cache so that cost isn't paid mid-run — ideal for CI images and containers. To forbid the lazy install entirely (e.g. an air-gapped host that must never auto-download), set `DOC_DETECTIVE_NO_ANDROID_AUTOINSTALL=1`; the context then SKIPs with a pointer back to this command. A host that *can't* run the emulator (no hardware acceleration) always SKIPs without downloading anything.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective",
-  "version": "4.20.0",
+  "version": "4.21.0-android-portable-jre.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective",
-      "version": "4.20.0",
+      "version": "4.21.0-android-portable-jre.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [
@@ -25503,7 +25503,7 @@
     },
     "src/common": {
       "name": "doc-detective-common",
-      "version": "4.20.0",
+      "version": "4.21.0-android-portable-jre.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective",
-  "version": "4.20.0",
+  "version": "4.21.0-android-portable-jre.1",
   "description": "Treat doc content as testable assertions to validate doc accuracy and product UX.",
   "workspaces": [
     "src/common"

--- a/src/common/package-lock.json
+++ b/src/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "4.20.0",
+  "version": "4.21.0-android-portable-jre.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "4.20.0",
+      "version": "4.21.0-android-portable-jre.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/src/common/package.json
+++ b/src/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "4.20.0",
+  "version": "4.21.0-android-portable-jre.1",
   "description": "Shared components for Doc Detective projects.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/runtime/androidInstaller.ts
+++ b/src/runtime/androidInstaller.ts
@@ -819,8 +819,9 @@ async function realRun(
 // zip, extract it, and relocate its inner `cmdline-tools/` to
 // `<destSdkRoot>/cmdline-tools/latest/` (the layout sdkmanager requires). This
 // is the "portable Android" install — a self-contained SDK root under the Doc
-// Detective cache, no system Android Studio needed. (A JRE 17+ is still a host
-// prerequisite for sdkmanager/avdmanager; checked before this runs.)
+// Detective cache, no system Android Studio needed. (sdkmanager/avdmanager need
+// a JRE 17+; installAndroid provisions one via ensureJava before this runs, so
+// Java isn't a host prerequisite either.)
 // Look for a previously downloaded Doc-Detective JRE under <cache>/jre and
 // return its JAVA_HOME if the `java` binary is present.
 function realDetectCachedJavaHome(cacheJreRoot: string): string | null {

--- a/src/runtime/androidInstaller.ts
+++ b/src/runtime/androidInstaller.ts
@@ -59,6 +59,62 @@ export function hostAbi(arch: string = process.arch): "x86_64" | "arm64-v8a" {
   return arch === "arm64" ? "arm64-v8a" : "x86_64";
 }
 
+// --- Portable JRE (so Java stops being a host prerequisite) ---
+//
+// sdkmanager/avdmanager are Java tools. Rather than require the user to install a
+// JRE, Doc Detective can download a portable Temurin JRE into its cache — the
+// same "bootstrap it ourselves" approach used for the SDK. These helpers build
+// the download URL and locate JAVA_HOME inside the extracted archive; the
+// effectful download/extract lives below with the other real effects.
+
+// Temurin (Eclipse Adoptium) LTS feature version to fetch. 17 is the current
+// baseline sdkmanager/avdmanager require.
+const JRE_FEATURE_VERSION = "17";
+
+// The Adoptium binary API redirects to the actual JRE archive for the host
+// (`.tar.gz` on Linux/macOS, `.zip` on Windows). arch: Adoptium uses `x64` and
+// `aarch64`; anything unusual falls back to x64.
+export function jreDownloadUrl(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch
+): string {
+  const os =
+    platform === "win32" ? "windows" : platform === "darwin" ? "mac" : "linux";
+  const adoptiumArch = arch === "arm64" ? "aarch64" : "x64";
+  return `https://api.adoptium.net/v3/binary/latest/${JRE_FEATURE_VERSION}/ga/${os}/${adoptiumArch}/jre/hotspot/normal/eclipse`;
+}
+
+// The temp filename to save the download as, so the extractor picks the right
+// tool by extension (a `.tar.gz` on POSIX, `.zip` on Windows).
+export function jreArchiveFilename(
+  platform: NodeJS.Platform = process.platform
+): string {
+  return platform === "win32" ? "jre.zip" : "jre.tar.gz";
+}
+
+// Given the directory a Temurin JRE was extracted into, resolve JAVA_HOME.
+// Temurin extracts a single top-level `jdk-<ver>-jre/` directory; on macOS the
+// runnable home is nested under `Contents/Home`. `entries` is the extracted
+// dir's top-level names (injected so this is pure/testable).
+export function resolveJavaHome(
+  extractDir: string,
+  entries: string[],
+  platform: NodeJS.Platform = process.platform
+): string | null {
+  const top = entries.find((e) => /jdk|jre/i.test(e));
+  if (!top) return null;
+  const base = path.join(extractDir, top);
+  return platform === "darwin" ? path.join(base, "Contents", "Home") : base;
+}
+
+// The `java` executable path under a JAVA_HOME, per platform.
+export function javaBinPath(
+  javaHome: string,
+  platform: NodeJS.Platform = process.platform
+): string {
+  return path.join(javaHome, "bin", platform === "win32" ? "java.exe" : "java");
+}
+
 // The commandline-tools download URL for a platform.
 export function cmdlineToolsUrl(platform: NodeJS.Platform): string {
   const token =
@@ -287,9 +343,74 @@ export interface AndroidInstallerDeps {
   ) => Promise<string>;
   // Downloads + unzips the cmdline-tools bootstrap into destSdkRoot.
   bootstrap?: (url: string, destSdkRoot: string) => Promise<void>;
+  // Portable-JRE provisioning (so Java isn't a host prerequisite). Defaults
+  // detect a cached JRE and, when absent, download a Temurin JRE into the cache.
+  detectCachedJavaHome?: (cacheJreRoot: string) => string | null;
+  bootstrapJava?: (cacheJreRoot: string) => Promise<string>;
+  setJavaEnv?: (javaHome: string, platform: NodeJS.Platform) => void;
   fs?: FsDeps;
   arch?: string;
   platform?: NodeJS.Platform;
+}
+
+export interface EnsureJavaResult {
+  ok: boolean;
+  source?: "system" | "cache" | "bootstrap";
+  javaHome?: string;
+  reason?: string;
+}
+
+// Point JAVA_HOME (and PATH) at a Doc-Detective-managed JRE so the sdkmanager /
+// avdmanager spawns that follow — in this process — pick it up.
+function applyJavaEnv(javaHome: string, platform: NodeJS.Platform): void {
+  process.env.JAVA_HOME = javaHome;
+  const bin = path.join(javaHome, "bin");
+  const sep = platform === "win32" ? ";" : ":";
+  if (!(process.env.PATH ?? "").split(sep).includes(bin)) {
+    process.env.PATH = `${bin}${sep}${process.env.PATH ?? ""}`;
+  }
+}
+
+/**
+ * Make a Java runtime available for sdkmanager/avdmanager without requiring one
+ * on the host: use the system Java if present, else a previously cached
+ * Doc-Detective JRE, else download a portable Temurin JRE into the cache. On a
+ * cache/bootstrap hit JAVA_HOME + PATH are pointed at it for the rest of this
+ * process. Effects are injected so the branch logic is unit-testable.
+ */
+export async function ensureJava(deps: {
+  javaPresent: () => boolean;
+  cacheJreRoot: string;
+  detectCachedJavaHome: (cacheJreRoot: string) => string | null;
+  bootstrapJava: (cacheJreRoot: string) => Promise<string>;
+  setJavaEnv?: (javaHome: string, platform: NodeJS.Platform) => void;
+  platform?: NodeJS.Platform;
+  logger?: Logger;
+}): Promise<EnsureJavaResult> {
+  const platform = deps.platform ?? process.platform;
+  const setEnv = deps.setJavaEnv ?? applyJavaEnv;
+  const log = deps.logger ?? (() => {});
+
+  if (deps.javaPresent()) return { ok: true, source: "system" };
+
+  const cached = deps.detectCachedJavaHome(deps.cacheJreRoot);
+  if (cached) {
+    setEnv(cached, platform);
+    return { ok: true, source: "cache", javaHome: cached };
+  }
+
+  log(
+    `No Java runtime found for sdkmanager/avdmanager. Downloading a portable Temurin JRE ${JRE_FEATURE_VERSION} into the Doc Detective cache — this is a one-time download.`,
+    "warn"
+  );
+  try {
+    const javaHome = await deps.bootstrapJava(deps.cacheJreRoot);
+    setEnv(javaHome, platform);
+    log(`Using a Doc-Detective-managed JRE at ${javaHome}.`, "info");
+    return { ok: true, source: "bootstrap", javaHome };
+  } catch (error) {
+    return { ok: false, reason: (error as Error)?.message ?? String(error) };
+  }
 }
 
 /**
@@ -368,17 +489,6 @@ export async function installAndroid({
     }));
   }
 
-  // A bootstrap or package install requires java; report the requirement
-  // rather than failing deep inside a spawn.
-  const javaPresent = deps.javaPresent ? deps.javaPresent() : realJavaPresent();
-  if (!javaPresent) {
-    logger(
-      "Android setup needs a Java runtime (JRE 17+) for sdkmanager/avdmanager. Install one (e.g. Temurin 17) and rerun.",
-      "error"
-    );
-    return [{ kind: "android", assetId: "java", action: "missing" }];
-  }
-
   if (!yes) {
     logger(
       "Refusing to download the multi-GB Android toolchain without confirmation. Rerun with --yes to proceed, or --dry-run to preview.",
@@ -389,6 +499,28 @@ export async function installAndroid({
       "info"
     );
     return [{ kind: "android", assetId: "confirmation", action: "declined" }];
+  }
+
+  // A bootstrap or package install needs Java for sdkmanager/avdmanager. Provide
+  // it without requiring one on the host: system Java, else a cached JRE, else a
+  // one-time portable Temurin download. Runs only after the --yes guard so the
+  // JRE download is part of the confirmed install, never a surprise.
+  const cacheJreRoot = path.join(getCacheDir(ctx), "jre");
+  const java = await ensureJava({
+    javaPresent: deps.javaPresent ?? realJavaPresent,
+    cacheJreRoot,
+    detectCachedJavaHome: deps.detectCachedJavaHome ?? realDetectCachedJavaHome,
+    bootstrapJava: deps.bootstrapJava ?? realBootstrapJava,
+    setJavaEnv: deps.setJavaEnv,
+    platform,
+    logger,
+  });
+  if (!java.ok) {
+    logger(
+      `Android setup needs a Java runtime and Doc Detective couldn't provision one automatically: ${java.reason}. Install a JRE 17+ (e.g. Temurin) and rerun.`,
+      "error"
+    );
+    return [{ kind: "android", assetId: "java", action: "missing" }];
   }
 
   // --- Real execution (yes && !dryRun). Effects are injected for tests. ---
@@ -689,6 +821,37 @@ async function realRun(
 // is the "portable Android" install — a self-contained SDK root under the Doc
 // Detective cache, no system Android Studio needed. (A JRE 17+ is still a host
 // prerequisite for sdkmanager/avdmanager; checked before this runs.)
+// Look for a previously downloaded Doc-Detective JRE under <cache>/jre and
+// return its JAVA_HOME if the `java` binary is present.
+function realDetectCachedJavaHome(cacheJreRoot: string): string | null {
+  if (!fs.existsSync(cacheJreRoot)) return null;
+  const entries = fs.readdirSync(cacheJreRoot);
+  const home = resolveJavaHome(cacheJreRoot, entries, process.platform);
+  return home && fs.existsSync(javaBinPath(home)) ? home : null;
+}
+
+// Download + extract a portable Temurin JRE into <cache>/jre and return its
+// JAVA_HOME. Reuses the redirect-following downloader and the cross-platform
+// extractor (its `tar -xf` handles the POSIX `.tar.gz`).
+async function realBootstrapJava(cacheJreRoot: string): Promise<string> {
+  const url = jreDownloadUrl();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dd-jre-"));
+  try {
+    const archive = path.join(tmpDir, jreArchiveFilename());
+    await downloadFile(url, archive);
+    fs.rmSync(cacheJreRoot, { recursive: true, force: true });
+    fs.mkdirSync(cacheJreRoot, { recursive: true });
+    await extractZip(archive, cacheJreRoot);
+    const home = realDetectCachedJavaHome(cacheJreRoot);
+    if (!home) {
+      throw new Error("extracted JRE has no runnable java binary");
+    }
+    return home;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
 async function realBootstrap(url: string, destSdkRoot: string): Promise<void> {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dd-android-cli-"));
   try {

--- a/test/android-installer.test.js
+++ b/test/android-installer.test.js
@@ -16,6 +16,11 @@ import {
   winShellCommand,
   DEFAULT_AVD_NAME,
   DEVICE_TYPE_PROFILES,
+  jreDownloadUrl,
+  jreArchiveFilename,
+  resolveJavaHome,
+  javaBinPath,
+  ensureJava,
 } from "../dist/runtime/androidInstaller.js";
 import fs from "node:fs";
 import os from "node:os";
@@ -288,14 +293,64 @@ describe("android installer: installAndroid orchestration", function () {
     });
   });
 
-  it("reports a missing Java runtime actionably", async function () {
+  it("reports a missing Java runtime when it can't provision one", async function () {
     await withTmpCache(async () => {
       const reports = await installAndroid({
         yes: true,
-        deps: { detect: () => detectedSdk, arch: "x64", javaPresent: () => false },
+        deps: {
+          detect: () => detectedSdk,
+          arch: "x64",
+          javaPresent: () => false,
+          // No cached JRE and the download fails -> actionable "missing".
+          detectCachedJavaHome: () => null,
+          bootstrapJava: () => Promise.reject(new Error("network down")),
+        },
       });
       expect(reports[0].assetId).to.equal("java");
       expect(reports[0].action).to.equal("missing");
+    });
+  });
+
+  it("bootstraps a portable JRE when Java is absent, then proceeds", async function () {
+    await withTmpCache(async () => {
+      const runCalls = [];
+      let bootstrappedJava = false;
+      const setHomes = [];
+      const reports = await installAndroid({
+        yes: true,
+        osVersion: "14",
+        deps: {
+          detect: () => detectedSdk,
+          arch: "x64",
+          javaPresent: () => false,
+          detectCachedJavaHome: () => null,
+          bootstrapJava: async () => {
+            bootstrappedJava = true;
+            return "/cache/jre";
+          },
+          // Capture (don't mutate the real process env) the JAVA_HOME we'd set.
+          setJavaEnv: (home) => setHomes.push(home),
+          fs: {
+            existsSync: (p) => p.replace(/\\/g, "/").endsWith("system-images"),
+            readdirSync: (p) => {
+              const norm = p.replace(/\\/g, "/");
+              if (norm.endsWith("system-images")) return ["android-34"];
+              if (norm.endsWith("android-34")) return ["google_apis"];
+              if (norm.endsWith("google_apis")) return ["x86_64"];
+              return [];
+            },
+          },
+          run: (command, args) => {
+            runCalls.push(args.join(" "));
+            return Promise.resolve("");
+          },
+        },
+      });
+      expect(bootstrappedJava).to.equal(true);
+      expect(setHomes).to.deep.equal(["/cache/jre"]);
+      // The install proceeded past Java to create the AVD.
+      expect(runCalls.join(" | ")).to.match(/create avd -n doc-detective/);
+      expect(reports.some((r) => r.assetId === "avd:doc-detective")).to.equal(true);
     });
   });
 
@@ -519,5 +574,96 @@ describe("android installer: installAndroid orchestration", function () {
       expect(text).to.match(/system image/i);
       expect(reports.every((r) => r.action === "planned")).to.equal(true);
     });
+  });
+});
+
+describe("android installer: portable JRE", function () {
+  it("builds the Temurin download URL per OS/arch", function () {
+    expect(jreDownloadUrl("linux", "x64")).to.match(
+      /api\.adoptium\.net\/v3\/binary\/latest\/17\/ga\/linux\/x64\/jre\/hotspot\/normal\/eclipse$/
+    );
+    expect(jreDownloadUrl("darwin", "arm64")).to.match(/\/mac\/aarch64\/jre\//);
+    expect(jreDownloadUrl("win32", "x64")).to.match(/\/windows\/x64\/jre\//);
+    // Unusual arch falls back to x64.
+    expect(jreDownloadUrl("linux", "ppc64")).to.match(/\/linux\/x64\/jre\//);
+  });
+
+  it("picks the archive extension by platform", function () {
+    expect(jreArchiveFilename("win32")).to.equal("jre.zip");
+    expect(jreArchiveFilename("linux")).to.equal("jre.tar.gz");
+    expect(jreArchiveFilename("darwin")).to.equal("jre.tar.gz");
+  });
+
+  it("resolves JAVA_HOME from the extracted layout (mac nests Contents/Home)", function () {
+    const entries = ["jdk-17.0.11+9-jre", "._meta"];
+    expect(resolveJavaHome("/x", entries, "linux")).to.equal(
+      path.join("/x", "jdk-17.0.11+9-jre")
+    );
+    expect(resolveJavaHome("/x", entries, "darwin")).to.equal(
+      path.join("/x", "jdk-17.0.11+9-jre", "Contents", "Home")
+    );
+    expect(resolveJavaHome("/x", ["nothing"], "linux")).to.equal(null);
+  });
+
+  it("locates the java binary per platform", function () {
+    expect(javaBinPath("/jh", "linux")).to.equal(path.join("/jh", "bin", "java"));
+    expect(javaBinPath("/jh", "win32")).to.equal(path.join("/jh", "bin", "java.exe"));
+  });
+
+  it("ensureJava short-circuits to system Java when present", async function () {
+    let bootstrapped = false;
+    const res = await ensureJava({
+      javaPresent: () => true,
+      cacheJreRoot: "/cache/jre",
+      detectCachedJavaHome: () => null,
+      bootstrapJava: async () => {
+        bootstrapped = true;
+        return "/x";
+      },
+      setJavaEnv: () => {},
+    });
+    expect(res).to.deep.equal({ ok: true, source: "system" });
+    expect(bootstrapped).to.equal(false);
+  });
+
+  it("ensureJava reuses a cached JRE and sets the env", async function () {
+    const set = [];
+    const res = await ensureJava({
+      javaPresent: () => false,
+      cacheJreRoot: "/cache/jre",
+      detectCachedJavaHome: () => "/cache/jre",
+      bootstrapJava: async () => "/should-not-run",
+      setJavaEnv: (home, platform) => set.push([home, platform]),
+      platform: "linux",
+    });
+    expect(res.source).to.equal("cache");
+    expect(res.javaHome).to.equal("/cache/jre");
+    expect(set).to.deep.equal([["/cache/jre", "linux"]]);
+  });
+
+  it("ensureJava downloads a JRE when none is present", async function () {
+    const res = await ensureJava({
+      javaPresent: () => false,
+      cacheJreRoot: "/cache/jre",
+      detectCachedJavaHome: () => null,
+      bootstrapJava: async () => "/cache/jre/jdk-17-jre",
+      setJavaEnv: () => {},
+    });
+    expect(res.source).to.equal("bootstrap");
+    expect(res.javaHome).to.equal("/cache/jre/jdk-17-jre");
+  });
+
+  it("ensureJava reports a reason when the download fails", async function () {
+    const res = await ensureJava({
+      javaPresent: () => false,
+      cacheJreRoot: "/cache/jre",
+      detectCachedJavaHome: () => null,
+      bootstrapJava: async () => {
+        throw new Error("network down");
+      },
+      setJavaEnv: () => {},
+    });
+    expect(res.ok).to.equal(false);
+    expect(res.reason).to.match(/network down/);
   });
 });


### PR DESCRIPTION
## What

Removes the last host prerequisite for Android tests: a Java runtime. `sdkmanager`/`avdmanager` are Java tools, and phase A3 stopped with `java: missing` when none was found. Now Doc Detective bootstraps a portable JRE the same way it bootstraps the SDK.

## How

`ensureJava` resolves Java in priority order:

1. **System Java** — if present, use it (no download, no `JAVA_HOME` override).
2. **Cached Doc-Detective JRE** — reuse `<cache>/jre` from a prior run.
3. **Download** — fetch a portable Temurin (Adoptium) JRE 17 into `<cache>/jre`.

On a cache/bootstrap hit it points `JAVA_HOME` + `PATH` at the managed JRE for the rest of the process, so the `sdkmanager`/`avdmanager` spawns pick it up. It runs **after** the `--yes` guard, so the JRE download is part of the confirmed install — never a surprise. Reuses the existing redirect-following downloader and cross-platform extractor (the `tar -xf` fallback handles the POSIX `.tar.gz`; Windows gets the `.zip`).

## Why it matters

Combined with [github-action#71](https://github.com/doc-detective/github-action/pull/71) (which removes the KVM prerequisite on Linux), a bare `npx doc-detective` on a Linux runner can now bootstrap **everything** — KVM (via the action), JRE, SDK, emulator, system image, AVD, and driver — and run Android tests with no manual setup.

## Tests

- Pure helpers (`jreDownloadUrl`, `jreArchiveFilename`, `resolveJavaHome`, `javaBinPath`) and `ensureJava`'s four branches (system / cache / bootstrap / failure) unit-tested with injected effects — **no real download**.
- `installAndroid` tests: absent-Java host bootstraps the JRE and proceeds to create the AVD; an unprovisionable Java still reports `java: missing`. 33/33 installer tests pass.

## Scope / notes

- **Stacks on #505** (base is that branch) since it extends `androidInstaller.ts`, which only exists there. Rebase onto `main` once #505 merges.
- ADR: `adrs/01026-portable-jre-for-android-toolchain.md`. Docs: `install.mdx` updated.
- **Follow-up:** the runtime reuse-then-create-AVD edge (a `device` descriptor needing a brand-new AVD at boot on an already-complete SDK that skipped `installAndroid`) doesn't yet call `ensureJava`. The common paths (CLI install, lazy install) are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)