### PR TITLE
ci: allow claude[bot]-triggered PRs through the auto-review guard

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -48,7 +48,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'promptless[bot]'
+          # Auto-review PRs opened/pushed by our own agents too: Promptless
+          # (doc updates) and claude[bot] (the actor agent-authored branches
+          # push under). Without the bot in this list the action hard-fails
+          # with "Workflow initiated by non-human actor" instead of reviewing.
+          # A posted review is not a push/synchronize event, so this can't loop.
+          allowed_bots: 'promptless[bot],claude[bot]'
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
The `Claude PR Review - Auto` workflow (`review` check) sets `allowed_bots: 'promptless[bot]'`. PRs pushed under the **claude[bot]** actor (every agent-authored branch, e.g. #517) hard-fail the check with:

```
Action failed with error: Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

instead of being reviewed. This adds `claude[bot]` alongside `promptless[bot]`.

For `pull_request` events the workflow definition is read from the **base branch**, so this only takes effect for PRs opened after it lands on `main` — which is why the affected PRs can't self-heal this check.

No loop risk: a posted review is not a `push`/`synchronize` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)