### PR TITLE
fix(runtime): self-repair transient Android SDK download flakes in installAndroid

### DIFF
--- a/adrs/01032-android-sdk-install-self-repair.md
+++ b/adrs/01032-android-sdk-install-self-repair.md
@@ -1,0 +1,123 @@
+---
+status: accepted
+date: 2026-07-06
+decision-makers: doc-detective maintainers
+---
+
+# Self-repair transient Android SDK download flakes inside the installer
+
+## Context and Problem Statement
+
+`doc-detective install android` — and the identical lazy-bootstrap path Doc Detective runs at test
+time — downloads system images and the command-line tools through `sdkmanager`
+([src/runtime/androidInstaller.ts](../src/runtime/androidInstaller.ts)). Google's SDK repository
+intermittently serves a **truncated/corrupt package**: `sdkmanager` aborts with
+`Warning: An error occurred while preparing SDK package … Error on ZipFile unknown archive` and exits
+non-zero. The whole step can die in ~30s, well before any boot timeout.
+
+Before this change, each package install was a bare `await run(sdkmanager, …)` with **no retry**, so
+a single transient flake failed the entire install. [PR #523](https://github.com/doc-detective/doc-detective/pull/523)
+mitigated this **only in CI**, by retrying the emulator legs at the workflow level. That does nothing
+for real users installing the toolchain on their own machines, and it is a blunt whole-leg re-run.
+
+A second, rarer failure mode exists: a partial extraction where `sdkmanager` exits **0** but leaves a
+structurally incomplete image on disk, which then fails to boot with a confusing downstream error.
+
+The question this ADR answers: rather than a CI-only retry, can the installer **validate and
+self-repair** a bad download in-process — the way the heavy-npm-dep loader already reinstalls a
+missing/stale runtime cache ([ADR 01025](01025-non-destructive-runtime-cache-installs.md),
+`ensureRuntimeInstalled` in [src/runtime/loader.ts](../src/runtime/loader.ts))?
+
+## Decision Drivers
+
+* Protect **real users** and the DD-owned CI legs (`apps-android` managed-boot + action/lazy), not
+  just the CI matrix.
+* A transient infra flake should self-heal; a **genuine** failure (bad license, unknown arg, no
+  matching image) must still fail — recovery must never mask a real error.
+* Keep the change confined to the installer with no new user-facing config/CLI surface and no
+  `config_v3` schema churn.
+* Stay hermetically unit-testable: the flake cannot be reproduced through the real runner (we cannot
+  make Google serve a truncated zip), so the behavior must be assertable with injected effects.
+
+## Considered Options
+
+1. **In-runtime bounded retry + post-install integrity probe** (both layers), wired into
+   `installAndroid` through the existing injected `run`/`fs` seams.
+2. Retry only (Layer 1), no integrity probe.
+3. Leave it at #523's CI-level retry.
+4. A user-facing `--retries` / config knob for install attempts.
+
+## Decision Outcome
+
+Chosen option: **1 — bounded retry + integrity probe, in the installer.**
+
+**Layer 1 — bounded retry on transient errors.** `runSdkInstallWithRetry` wraps a single
+sdkmanager package install. On rejection it retries **only** when `isTransientSdkError` matches a
+tight, documented signature list (`Error on ZipFile`, `unknown archive`, `An error occurred while
+preparing SDK package`, and the network transients `ECONNRESET`/`ETIMEDOUT`/`Connection reset`/
+`Read timed out`); anything else rethrows immediately. Up to `SDK_INSTALL_MAX_ATTEMPTS` (3) attempts
+with a short backoff (2s, 4s). sdkmanager re-downloads a fresh copy each invocation, so a retry is a
+genuine self-repair. The retry is logged at `warn` (surfaced, never silent). The platform-tools,
+emulator, and system-image installs all route through it.
+
+**Layer 2 — post-install integrity probe + one repair.** After a system image installs,
+`isSystemImageComplete` checks the extracted dir for the canonical markers `source.properties`
+(package manifest) **and** `system.img` (payload). If incomplete, the installer wipes just that
+package dir and reinstalls once; if it is **still** incomplete it returns a
+`{ assetId: "system-image", action: "corrupt" }` report and **stops before AVD creation**, rather
+than building an AVD from a bad image. The probe runs only on a freshly installed image, never on a
+user's pre-existing one (which is never wiped).
+
+Scope boundary: the reactivecircus `apps-android` **reuse** leg runs *its own* `sdkmanager`, not Doc
+Detective's, so it is **out of scope** here and stays covered by #523's workflow retry. #523's CI
+retries are retained as a belt-and-suspenders net.
+
+Option 2 was rejected because the silent-partial-extraction case is real and produces a worse,
+later, more confusing failure. Option 3 leaves real users unprotected. Option 4 adds user-facing
+surface and schema churn for a value nobody needs to tune; a module constant is sufficient.
+
+### Consequences
+
+* Good: the observed `ZipFile unknown archive` flake self-heals in-process on every DD-owned install
+  path, for users and CI alike; a partial extraction is caught and repaired before it can misboot.
+* Good: no new config/CLI/schema surface; the retry count is a module constant.
+* Neutral: a doubly-failing transient (or a genuine failure) now costs up to 3 attempts + backoff
+  before surfacing — bounded and short.
+* Neutral: one place (`isSystemImageComplete`) now encodes what "a complete image on disk" means; if
+  Google changes the package layout the marker list must follow.
+
+### Confirmation
+
+* [test/android-installer.test.js](../test/android-installer.test.js): `isTransientSdkError`
+  true/false table; `runSdkInstallWithRetry` returns on first success, self-repairs one transient
+  then succeeds (no real wait via injected `sleep`), rethrows a non-transient immediately, and gives
+  up after `SDK_INSTALL_MAX_ATTEMPTS`; `isSystemImageComplete` marker check; and through
+  `installAndroid`: a transient image install self-repairs then creates the AVD, an incomplete image
+  is wiped + reinstalled, and a still-incomplete image returns `corrupt` and skips the AVD. All
+  hermetic via injected `run`/`fs`/`sleep` — no spawn, download, or real backoff.
+* End-to-end, the existing `apps-android` managed-boot and action/lazy CI legs continue to exercise
+  the real install path; the corrupt-download flake itself is not reproducible on demand, so it is
+  covered by the injected-effect unit tests rather than a fixture.
+
+## Pros and Cons of the Options
+
+### Option 1 — retry + integrity probe (chosen)
+
+* Good: covers both failure modes (non-zero corrupt exit, and silent partial extraction); protects
+  users and CI; no user-facing surface.
+* Bad: two new behaviors and a marker list to maintain.
+
+### Option 2 — retry only
+
+* Good: smallest change; fixes the observed flake.
+* Bad: leaves the silent-partial-extraction case to fail later and more confusingly.
+
+### Option 3 — CI retry only (status quo, #523)
+
+* Good: already merged; zero runtime code.
+* Bad: does nothing for real users; blunt whole-leg re-run; only covers the CI matrix.
+
+### Option 4 — user-facing retries flag
+
+* Good: tunable.
+* Bad: config/CLI/schema surface and docs for a knob with no real use case; a constant suffices.

--- a/docs/fern/pages/reference/cli/install.mdx
+++ b/docs/fern/pages/reference/cli/install.mdx
@@ -103,7 +103,7 @@ Because the system image is multi-GB, this command **never downloads without `--
 doc-detective install android --dry-run
 ```
 
-Google's SDK repository occasionally serves a corrupt or truncated package. `install android` **self-heals** these transient download failures — it retries the affected `sdkmanager` download a few times, and if a system image lands incomplete it re-downloads it once before continuing — so a momentary flake no longer fails the whole install. A genuine failure (an unavailable image, a rejected license) still stops with a clear message.
+Google's SDK repository occasionally serves a corrupt or truncated package. `install android` **self-heals** these transient download failures: it retries the affected `sdkmanager` download a few times, and if a system image lands incomplete it re-downloads it once before continuing, so a momentary flake no longer fails the whole install. A genuine failure (an unavailable image, a rejected license) still stops with a clear message.
 
 | Option | Description |
 |--------|-------------|

--- a/docs/fern/pages/reference/cli/install.mdx
+++ b/docs/fern/pages/reference/cli/install.mdx
@@ -103,6 +103,8 @@ Because the system image is multi-GB, this command **never downloads without `--
 doc-detective install android --dry-run
 ```
 
+Google's SDK repository occasionally serves a corrupt or truncated package. `install android` **self-heals** these transient download failures — it retries the affected `sdkmanager` download a few times, and if a system image lands incomplete it re-downloads it once before continuing — so a momentary flake no longer fails the whole install. A genuine failure (an unavailable image, a rejected license) still stops with a clear message.
+
 | Option | Description |
 |--------|-------------|
 | `--os-version` | Android version for the system image and AVD (for example, `14`, or a raw API level like `34`). Default: the newest available. |

--- a/src/runtime/androidInstaller.ts
+++ b/src/runtime/androidInstaller.ts
@@ -193,6 +193,9 @@ export function pickSystemImage(
 interface FsDeps {
   existsSync?: (p: string) => boolean;
   readdirSync?: (p: string) => string[];
+  // Only used by the Layer-2 integrity repair to wipe a partial system-image
+  // dir before re-installing. Injectable so the repair path is hermetic.
+  rmSync?: (p: string, opts?: { recursive?: boolean; force?: boolean }) => void;
 }
 
 // Scan <sdkRoot>/system-images/<api>/<tag>/<abi> offline (no java, no network)
@@ -232,6 +235,54 @@ export function listInstalledSystemImages(
     }
   }
   return out;
+}
+
+// Canonical files sdkmanager writes into a fully-installed system-image dir.
+// A truncated/partial extraction that still exited 0 leaves these missing, so
+// their presence is the integrity signal: `source.properties` is the package
+// manifest sdkmanager writes, `system.img` is the image payload the emulator
+// boots. Both must be present for the image to count as healthy.
+const SYSTEM_IMAGE_MARKERS = ["source.properties", "system.img"];
+
+// The on-disk directory for a system-image package id
+// (`system-images;android-<API>;<tag>;<abi>` -> `<sdkRoot>/system-images/<API>/<tag>/<abi>`).
+function systemImageDir(sdkRoot: string, pkg: string): string | null {
+  const parts = pkg.split(";");
+  if (parts.length !== 4 || parts[0] !== "system-images") return null;
+  return path.join(sdkRoot, "system-images", parts[1], parts[2], parts[3]);
+}
+
+// Verify a just-installed system image is structurally complete (all marker
+// files present). Guards the rare case where sdkmanager exits 0 on a partial
+// extraction. Pure over injected fs so the repair path is hermetically testable.
+export function isSystemImageComplete(
+  sdkRoot: string,
+  pkg: string,
+  deps: FsDeps = {}
+): boolean {
+  const existsSync = deps.existsSync ?? fs.existsSync;
+  const dir = systemImageDir(sdkRoot, pkg);
+  if (!dir) return false;
+  return SYSTEM_IMAGE_MARKERS.every((marker) =>
+    existsSync(path.join(dir, marker))
+  );
+}
+
+// Remove a (partial/corrupt) system-image dir so the next sdkmanager install
+// re-downloads and re-extracts cleanly. Best-effort — a failed wipe still lets
+// the reinstall attempt proceed, and the post-repair integrity re-check is the
+// real gate.
+function wipeSystemImage(sdkRoot: string, pkg: string, deps: FsDeps = {}): void {
+  const rmSync = deps.rmSync ?? fs.rmSync;
+  const dir = systemImageDir(sdkRoot, pkg);
+  /* c8 ignore next — callers only pass a validated system-image id, so dir is non-null. */
+  if (!dir) return;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+    /* c8 ignore next 3 — best-effort; the post-repair integrity re-check is the gate. */
+  } catch {
+    /* swallow a failed wipe; the reinstall + re-check still runs */
+  }
 }
 
 export type AndroidInstallAction =
@@ -323,6 +374,99 @@ export function buildAndroidInstallPlan(
   return { sdkRoot, bootstrapped, actions, systemImage };
 }
 
+// --- Self-repair for transient SDK download flakes ---
+//
+// Google's SDK repo intermittently serves a truncated/corrupt package; sdkmanager
+// aborts with "Error on ZipFile unknown archive" (the #501/#523 flake) and exits
+// non-zero. sdkmanager re-downloads a fresh copy on the next invocation, so a
+// bounded retry genuinely self-repairs — the runtime equivalent of #523's CI
+// retry, but it also protects real users, not just CI. A NON-transient failure
+// (bad license, unknown arg) rethrows immediately so real errors are never masked.
+
+// Total attempts (initial + retries) for a single sdkmanager package install.
+export const SDK_INSTALL_MAX_ATTEMPTS = 3;
+
+// Transient signatures: corrupt/truncated download (sdkmanager) + the common
+// network-transient classes. Matched case-insensitively as a substring of the
+// error message. Kept deliberately tight — anything not listed is a real failure.
+const TRANSIENT_SDK_ERROR_SIGNATURES = [
+  "error on zipfile",
+  "unknown archive",
+  "an error occurred while preparing sdk package",
+  "econnreset",
+  "etimedout",
+  "connection reset",
+  "read timed out",
+];
+
+export function isTransientSdkError(message: unknown): boolean {
+  const lower = String(message ?? "").toLowerCase();
+  return TRANSIENT_SDK_ERROR_SIGNATURES.some((sig) => lower.includes(sig));
+}
+
+// The `run` effect shape (sdkmanager/avdmanager spawner), shared by the deps and
+// the retry wrapper.
+type SdkRun = (
+  command: string,
+  args: string[],
+  opts?: { input?: string; cwd?: string }
+) => Promise<string>;
+
+export interface SdkRetryDeps {
+  logger?: Logger;
+  sleep?: (ms: number) => Promise<void>;
+  maxAttempts?: number;
+}
+
+// Short, bounded backoff between attempts (2s, 4s…). Kept modest so a real user
+// isn't left waiting long, but enough to let a momentary CDN blip clear.
+function sdkRetryBackoffMs(attempt: number): number {
+  return attempt * 2000;
+}
+
+/* c8 ignore start */
+// Real inter-attempt wait; injected as a no-op in tests so they never block.
+function realSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    if (typeof timer.unref === "function") timer.unref();
+  });
+}
+/* c8 ignore stop */
+
+/**
+ * Run a single sdkmanager/avdmanager command with bounded self-repair for
+ * TRANSIENT download failures. On a transient rejection with attempts left, log
+ * a warn (the retry is surfaced, never silent) and retry after a short backoff;
+ * a non-transient failure — or the last attempt — rethrows unchanged.
+ */
+export async function runSdkInstallWithRetry(
+  run: SdkRun,
+  command: string,
+  args: string[],
+  opts: { input?: string; cwd?: string } = {},
+  deps: SdkRetryDeps = {}
+): Promise<string> {
+  const logger = deps.logger ?? (() => {});
+  const sleep = deps.sleep ?? realSleep;
+  const maxAttempts = deps.maxAttempts ?? SDK_INSTALL_MAX_ATTEMPTS;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await run(command, args, opts);
+    } catch (error) {
+      const message = (error as Error)?.message ?? String(error);
+      if (attempt >= maxAttempts || !isTransientSdkError(message)) throw error;
+      logger(
+        `Transient Android SDK download error (attempt ${attempt}/${maxAttempts}); retrying: ${message}`,
+        "warn"
+      );
+      await sleep(sdkRetryBackoffMs(attempt));
+    }
+  }
+  /* c8 ignore next 2 — the loop always returns or throws; this satisfies the type. */
+  throw new Error("unreachable");
+}
+
 export interface InstallReport {
   kind: "android";
   assetId: string;
@@ -351,6 +495,9 @@ export interface AndroidInstallerDeps {
   fs?: FsDeps;
   arch?: string;
   platform?: NodeJS.Platform;
+  // Inter-attempt backoff for the transient-install retry; injected as a no-op
+  // in tests so they never wait. Defaults to a real timer.
+  sleep?: (ms: number) => Promise<void>;
 }
 
 export interface EnsureJavaResult {
@@ -534,6 +681,8 @@ export async function installAndroid({
   const reports: InstallReport[] = [];
   const sdkRoot = plan.sdkRoot;
   const sdkArg = "--sdk_root=" + sdkRoot;
+  // Self-repair transient corrupt-download flakes on every package install.
+  const retryDeps: SdkRetryDeps = { logger, sleep: deps.sleep };
 
   // 1. Bootstrap the command-line tools when no SDK exists (the "portable
   //    Android" download: fetch + unzip + relocate into the cache).
@@ -568,7 +717,7 @@ export async function installAndroid({
       (pkg === "platform-tools" && detected?.adb) ||
       (pkg === "emulator" && detected?.emulator);
     if (alreadyHave) continue;
-    await run(sdkmanager, [sdkArg, pkg]);
+    await runSdkInstallWithRetry(run, sdkmanager, [sdkArg, pkg], {}, retryDeps);
     reports.push({ kind: "android", assetId: pkg, action: "installed" });
   }
 
@@ -596,7 +745,28 @@ export async function installAndroid({
       );
       return [...reports, { kind: "android", assetId: "system-image", action: "blocked" }];
     }
-    await run(sdkmanager, [sdkArg, systemImage]);
+    await runSdkInstallWithRetry(run, sdkmanager, [sdkArg, systemImage], {}, retryDeps);
+    // Integrity probe: a truncated extraction can still exit 0. If the freshly
+    // installed image is structurally incomplete, wipe it and reinstall once; if
+    // it's STILL incomplete, abort before building an AVD from a bad image.
+    if (!isSystemImageComplete(sdkRoot, systemImage, fsDeps)) {
+      logger(
+        `Installed system image ${systemImage} looks incomplete; wiping and reinstalling…`,
+        "warn"
+      );
+      wipeSystemImage(sdkRoot, systemImage, fsDeps);
+      await runSdkInstallWithRetry(run, sdkmanager, [sdkArg, systemImage], {}, retryDeps);
+      if (!isSystemImageComplete(sdkRoot, systemImage, fsDeps)) {
+        logger(
+          `System image ${systemImage} is still incomplete after reinstalling; aborting before AVD creation.`,
+          "error"
+        );
+        return [
+          ...reports,
+          { kind: "android", assetId: "system-image", action: "corrupt" },
+        ];
+      }
+    }
     reports.push({ kind: "android", assetId: systemImage, action: "installed" });
   }
 

--- a/src/runtime/androidInstaller.ts
+++ b/src/runtime/androidInstaller.ts
@@ -249,7 +249,17 @@ const SYSTEM_IMAGE_MARKERS = ["source.properties", "system.img"];
 function systemImageDir(sdkRoot: string, pkg: string): string | null {
   const parts = pkg.split(";");
   if (parts.length !== 4 || parts[0] !== "system-images") return null;
-  return path.join(sdkRoot, "system-images", parts[1], parts[2], parts[3]);
+  const base = path.join(sdkRoot, "system-images");
+  const dir = path.join(base, parts[1], parts[2], parts[3]);
+  // Containment guard: a `..` or absolute segment in the package id could
+  // otherwise resolve outside <sdkRoot>/system-images and, via wipeSystemImage's
+  // recursive rmSync, delete an unintended directory. Reject anything that
+  // escapes the images root (mirrors the loader's exports-target containment
+  // check). In practice the id is validated upstream; this is defense-in-depth
+  // for the destructive path.
+  const rel = path.relative(base, dir);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  return dir;
 }
 
 // Verify a just-installed system image is structurally complete (all marker

--- a/test/android-installer.test.js
+++ b/test/android-installer.test.js
@@ -935,4 +935,21 @@ describe("android installer: SDK install self-repair", function () {
       isSystemImageComplete("/sdk", "platform-tools", has(["source.properties", "system.img"]))
     ).to.equal(false);
   });
+
+  it("rejects a package id whose segments escape <sdkRoot>/system-images (rm safety)", function () {
+    // A traversal/absolute segment must never resolve outside the images root —
+    // wipeSystemImage does a recursive rm on this path. Even with markers
+    // "present", an escaping id is treated as not-a-valid-image (dir is null).
+    const anythingExists = { existsSync: () => true };
+    expect(
+      isSystemImageComplete("/sdk", "system-images;../../../../etc;x;y", anythingExists)
+    ).to.equal(false);
+    expect(
+      isSystemImageComplete(
+        "/sdk",
+        "system-images;android-34;google_apis;../../../../../../etc",
+        anythingExists
+      )
+    ).to.equal(false);
+  });
 });

--- a/test/android-installer.test.js
+++ b/test/android-installer.test.js
@@ -21,6 +21,10 @@ import {
   resolveJavaHome,
   javaBinPath,
   ensureJava,
+  isTransientSdkError,
+  runSdkInstallWithRetry,
+  isSystemImageComplete,
+  SDK_INSTALL_MAX_ATTEMPTS,
 } from "../dist/runtime/androidInstaller.js";
 import fs from "node:fs";
 import os from "node:os";
@@ -252,6 +256,16 @@ describe("android installer: installAndroid orchestration", function () {
     emulator: "/opt/android/emulator/emulator",
   };
 
+  // A post-install integrity probe checks for a system image's marker files
+  // (source.properties + system.img). Fixtures that install an image use this so
+  // the probe sees a COMPLETE extraction — it deliberately does not match the
+  // bare `system-images` dir, so listInstalledSystemImages still reports none
+  // installed and the `--list` path is exercised.
+  const isImageMarker = (p) => {
+    const n = String(p).replace(/\\/g, "/");
+    return n.endsWith("source.properties") || n.endsWith("system.img");
+  };
+
   it("dry-run reports the plan without running anything", async function () {
     await withTmpCache(async () => {
       const calls = [];
@@ -413,8 +427,10 @@ describe("android installer: installAndroid orchestration", function () {
           detect: () => detectedSdk,
           arch: "x64", // pin the ABI so the assertions hold on arm64 CI (macOS)
           javaPresent: () => true,
-          // No installed images -> must query available and install one.
-          fs: { existsSync: () => false, readdirSync: () => [] },
+          // No installed images -> must query available and install one. The
+          // marker files read present so the post-install integrity probe sees a
+          // complete extraction (models a successful download).
+          fs: { existsSync: (p) => isImageMarker(p), readdirSync: () => [] },
           run: (command, args) => {
             runCalls.push(args.join(" "));
             if (args.includes("--list")) return Promise.resolve(listOutput);
@@ -465,7 +481,9 @@ describe("android installer: installAndroid orchestration", function () {
           detect: () => null,
           arch: "x64", // pin the ABI so the assertions hold on arm64 CI (macOS)
           javaPresent: () => true,
-          fs: { existsSync: () => false, readdirSync: () => [] },
+          // Markers present so the freshly-installed image passes the integrity
+          // probe (models a complete extraction after the bootstrap).
+          fs: { existsSync: (p) => isImageMarker(p), readdirSync: () => [] },
           bootstrap: (url, dest) => {
             bootstrapCalls.push({ url, dest });
             return Promise.resolve();
@@ -575,6 +593,117 @@ describe("android installer: installAndroid orchestration", function () {
       expect(reports.every((r) => r.action === "planned")).to.equal(true);
     });
   });
+
+  // Discriminates the sdkmanager system-image install (`[--sdk_root=…, <image>]`)
+  // from the license/tool installs and the avdmanager create (which also carries
+  // the image id via `-k`).
+  const isImageInstallCall = (args) =>
+    args.length === 2 &&
+    String(args[0]).startsWith("--sdk_root=") &&
+    String(args[1]).startsWith("system-images;");
+
+  const availableImageList = [
+    "Available Packages:",
+    "  system-images;android-34;google_apis;x86_64 | 3 | Google APIs",
+  ].join("\n");
+
+  it("self-repairs a transient system-image install, then creates the AVD", async function () {
+    await withTmpCache(async () => {
+      let imageInstalls = 0;
+      const warns = [];
+      const reports = await installAndroid({
+        yes: true,
+        deps: {
+          detect: () => detectedSdk,
+          arch: "x64",
+          javaPresent: () => true,
+          sleep: () => Promise.resolve(), // no real backoff wait
+          logger: (msg, level) => warns.push([String(msg), level]),
+          // Markers present -> the (eventually) installed image is complete, so
+          // the retry (not the integrity repair) is what's under test here.
+          fs: { existsSync: (p) => isImageMarker(p), readdirSync: () => [] },
+          run: (command, args) => {
+            if (args.includes("--list")) return Promise.resolve(availableImageList);
+            if (isImageInstallCall(args)) {
+              imageInstalls++;
+              if (imageInstalls === 1)
+                return Promise.reject(
+                  new Error("Error on ZipFile unknown archive")
+                );
+            }
+            return Promise.resolve("");
+          },
+        },
+      });
+      expect(imageInstalls).to.equal(2); // failed once, retried, succeeded
+      expect(reports.some((r) => r.assetId === "avd:doc-detective")).to.equal(true);
+      expect(warns.some(([m, l]) => l === "warn" && /retry/i.test(m))).to.equal(true);
+    });
+  });
+
+  it("repairs a structurally-incomplete system image, then creates the AVD", async function () {
+    await withTmpCache(async () => {
+      let imageInstalls = 0;
+      const wiped = [];
+      const reports = await installAndroid({
+        yes: true,
+        deps: {
+          detect: () => detectedSdk,
+          arch: "x64",
+          javaPresent: () => true,
+          sleep: () => Promise.resolve(),
+          fs: {
+            // Markers only appear AFTER the repair install: the first extraction
+            // is partial (probe fails), the reinstall completes it.
+            existsSync: (p) => isImageMarker(p) && imageInstalls >= 2,
+            readdirSync: () => [],
+            rmSync: (p) => wiped.push(String(p).replace(/\\/g, "/")),
+          },
+          run: (command, args) => {
+            if (args.includes("--list")) return Promise.resolve(availableImageList);
+            if (isImageInstallCall(args)) imageInstalls++;
+            return Promise.resolve("");
+          },
+        },
+      });
+      expect(imageInstalls).to.equal(2); // partial install -> wiped -> reinstalled
+      expect(
+        wiped.some((p) =>
+          /system-images\/android-34\/google_apis\/x86_64$/.test(p)
+        )
+      ).to.equal(true);
+      expect(reports.some((r) => r.assetId === "avd:doc-detective")).to.equal(true);
+    });
+  });
+
+  it("returns a corrupt report and skips the AVD when a system image stays incomplete", async function () {
+    await withTmpCache(async () => {
+      let imageInstalls = 0;
+      const reports = await installAndroid({
+        yes: true,
+        deps: {
+          detect: () => detectedSdk,
+          arch: "x64",
+          javaPresent: () => true,
+          sleep: () => Promise.resolve(),
+          // Markers never appear -> image stays incomplete through the repair.
+          fs: { existsSync: () => false, readdirSync: () => [], rmSync: () => {} },
+          run: (command, args) => {
+            if (args.includes("--list")) return Promise.resolve(availableImageList);
+            if (isImageInstallCall(args)) imageInstalls++;
+            return Promise.resolve("");
+          },
+        },
+      });
+      expect(imageInstalls).to.equal(2); // initial install + one repair attempt
+      expect(
+        reports.some(
+          (r) => r.assetId === "system-image" && r.action === "corrupt"
+        )
+      ).to.equal(true);
+      expect(reports.some((r) => r.assetId === "avd:doc-detective")).to.equal(false);
+    });
+  });
 });
 
 describe("android installer: portable JRE", function () {
@@ -665,5 +794,145 @@ describe("android installer: portable JRE", function () {
     });
     expect(res.ok).to.equal(false);
     expect(res.reason).to.match(/network down/);
+  });
+});
+
+describe("android installer: SDK install self-repair", function () {
+  it("classifies only transient SDK download errors as retryable", function () {
+    // The #501/#523 corrupt-download signatures.
+    expect(isTransientSdkError("Error on ZipFile unknown archive")).to.equal(true);
+    expect(
+      isTransientSdkError(
+        "Warning: An error occurred while preparing SDK package Google APIs"
+      )
+    ).to.equal(true);
+    // Network transients (case-insensitive).
+    expect(isTransientSdkError("read ECONNRESET")).to.equal(true);
+    expect(isTransientSdkError("connect ETIMEDOUT 1.2.3.4:443")).to.equal(true);
+    expect(isTransientSdkError("Connection reset by peer")).to.equal(true);
+    expect(isTransientSdkError("Read timed out")).to.equal(true);
+    // Real failures must NOT be retried.
+    expect(isTransientSdkError("Accept? (y/N): license not accepted")).to.equal(
+      false
+    );
+    expect(isTransientSdkError("Unknown argument --nope")).to.equal(false);
+    expect(isTransientSdkError("")).to.equal(false);
+    expect(isTransientSdkError(undefined)).to.equal(false);
+  });
+
+  it("returns on first success without retrying", async function () {
+    let calls = 0;
+    const out = await runSdkInstallWithRetry(
+      () => {
+        calls++;
+        return Promise.resolve("ok");
+      },
+      "sdkmanager",
+      ["system-images;android-34;google_apis;x86_64"],
+      {},
+      { sleep: () => Promise.resolve() }
+    );
+    expect(out).to.equal("ok");
+    expect(calls).to.equal(1);
+  });
+
+  it("self-repairs a transient failure then succeeds (no real wait)", async function () {
+    let calls = 0;
+    const slept = [];
+    const warns = [];
+    const out = await runSdkInstallWithRetry(
+      () => {
+        calls++;
+        if (calls === 1)
+          return Promise.reject(new Error("Error on ZipFile unknown archive"));
+        return Promise.resolve("ok");
+      },
+      "sdkmanager",
+      ["system-images;android-34;google_apis;x86_64"],
+      {},
+      {
+        sleep: (ms) => {
+          slept.push(ms);
+          return Promise.resolve();
+        },
+        logger: (msg, level) => warns.push([String(msg), level]),
+      }
+    );
+    expect(out).to.equal("ok");
+    expect(calls).to.equal(2);
+    expect(slept).to.have.length(1); // backed off once
+    // The retry is surfaced, never silent.
+    expect(warns.some(([m, l]) => l === "warn" && /retry/i.test(m))).to.equal(true);
+  });
+
+  it("rethrows a non-transient failure immediately (no retry, no mask)", async function () {
+    let calls = 0;
+    let threw;
+    try {
+      await runSdkInstallWithRetry(
+        () => {
+          calls++;
+          return Promise.reject(new Error("license not accepted"));
+        },
+        "sdkmanager",
+        ["--licenses"],
+        {},
+        { sleep: () => Promise.resolve() }
+      );
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).to.be.an("error");
+    expect(threw.message).to.match(/license not accepted/);
+    expect(calls).to.equal(1); // never retried
+  });
+
+  it("gives up after SDK_INSTALL_MAX_ATTEMPTS on a persistent transient error", async function () {
+    let calls = 0;
+    let threw;
+    try {
+      await runSdkInstallWithRetry(
+        () => {
+          calls++;
+          return Promise.reject(new Error("unknown archive"));
+        },
+        "sdkmanager",
+        ["system-images;android-34;google_apis;x86_64"],
+        {},
+        { sleep: () => Promise.resolve() }
+      );
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).to.be.an("error");
+    expect(calls).to.equal(SDK_INSTALL_MAX_ATTEMPTS);
+  });
+
+  it("verifies a system image's integrity by its canonical marker files", function () {
+    const pkg = "system-images;android-34;google_apis;x86_64";
+    const imageDir = ["android-34", "google_apis", "x86_64"];
+    const has = (names) => ({
+      existsSync: (p) => {
+        const n = p.replace(/\\/g, "/");
+        // Only "complete" when the marker file under the exact image dir exists.
+        return names.some(
+          (name) => n.endsWith(`system-images/${imageDir.join("/")}/${name}`)
+        );
+      },
+    });
+    // Both markers present -> complete.
+    expect(
+      isSystemImageComplete("/sdk", pkg, has(["source.properties", "system.img"]))
+    ).to.equal(true);
+    // A truncated extraction missing the payload -> incomplete.
+    expect(
+      isSystemImageComplete("/sdk", pkg, has(["source.properties"]))
+    ).to.equal(false);
+    // Nothing extracted -> incomplete.
+    expect(isSystemImageComplete("/sdk", pkg, has([]))).to.equal(false);
+    // A non-image package id -> not a valid image, not complete.
+    expect(
+      isSystemImageComplete("/sdk", "platform-tools", has(["source.properties", "system.img"]))
+    ).to.equal(false);
   });
 });


### PR DESCRIPTION
## Problem

`doc-detective install android` — and the identical lazy-bootstrap path Doc Detective runs at test time — downloads system images and the command-line tools through `sdkmanager`. Google's SDK repo intermittently serves a **truncated/corrupt package**: `sdkmanager` aborts with `Warning: An error occurred while preparing SDK package … Error on ZipFile unknown archive` and exits non-zero. Each package install was a bare `await run(sdkmanager, …)` with **no retry**, so a single transient flake failed the whole install.

[#523](https://github.com/doc-detective/doc-detective/pull/523) mitigated this **only in CI**, by retrying the emulator legs at the workflow level — which does nothing for real users installing the toolchain on their own machines, and is a blunt whole-leg re-run.

This brings the heavy-npm-dep "validate + self-repair" philosophy ([ADR 01025](https://github.com/doc-detective/doc-detective/blob/main/adrs/01025-non-destructive-runtime-cache-installs.md), `ensureRuntimeInstalled` reinstalling a missing/stale cache) into the Android installer, **in-process**, so users and the DD-owned CI legs recover automatically.

## What ships (ADR 01032)

- **Layer 1 — bounded retry on transient errors.** `runSdkInstallWithRetry` + `isTransientSdkError` wrap the platform-tools/emulator and system-image installs. Retries **only** on a tight, documented signature list (`Error on ZipFile`, `unknown archive`, `An error occurred while preparing SDK package`, and network transients `ECONNRESET`/`ETIMEDOUT`/`Connection reset`/`Read timed out`); anything else rethrows immediately, so a genuine failure is never masked. Up to `SDK_INSTALL_MAX_ATTEMPTS` (3) attempts with a short backoff. sdkmanager re-downloads a fresh copy each invocation, so a retry is a true self-repair. The retry is logged at `warn` — surfaced, never silent.
- **Layer 2 — post-install integrity probe + one repair.** After a system image installs, `isSystemImageComplete` checks the extracted dir for its canonical markers (`source.properties` + `system.img`). A partial extraction that exited `0` is wiped and reinstalled once; if it is **still** incomplete, the install returns a `{ assetId: "system-image", action: "corrupt" }` report and **stops before AVD creation** rather than building an AVD from a bad image. The probe runs only on a freshly installed image — a user's pre-existing image is never wiped.

## Scope

The reactivecircus `apps-android` **reuse** leg runs its *own* `sdkmanager`, not Doc Detective's, so it is **out of scope** here and stays covered by #523's workflow retry. All of #523's CI retries are **retained** as a belt-and-suspenders net.

## Testing

TDD red→green throughout. New hermetic tests in [test/android-installer.test.js](https://github.com/doc-detective/doc-detective/blob/main/test/android-installer.test.js) inject `run`/`fs`/`sleep` (no spawn, download, or real backoff): the `isTransientSdkError` true/false table; `runSdkInstallWithRetry` returns on first success, self-repairs one transient then succeeds, rethrows a non-transient immediately, and gives up after `SDK_INSTALL_MAX_ATTEMPTS`; `isSystemImageComplete` marker check; and through `installAndroid` — a transient image install self-repairs then creates the AVD, an incomplete image is wiped + reinstalled, and a still-incomplete image returns `corrupt` and skips the AVD. **42 passing** in the installer suite.

The corrupt-download flake itself **cannot be reproduced through the real runner** (we can't make Google serve a truncated zip), so per CLAUDE.md this behavior is asserted with the injected-effect unit tests rather than a `*.spec.json` fixture; the existing `apps-android` legs remain the end-to-end coverage.

## Docs / ADR

- [ADR 01032](https://github.com/doc-detective/doc-detective/blob/main/adrs/01032-android-sdk-install-self-repair.md) records the retry/repair policy, the transient-signature list, the integrity sentinel choice, and the reuse-leg scope boundary.
- **Docs impact** (resilience only — no new config/CLI/output surface): a sentence added to the `install android` reference noting transient SDK downloads now self-heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)