### PR TITLE
fix(core): retry native session creation after client timeout abort

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -32,8 +32,10 @@ jobs:
     # The apps and iOS-flavored groups get headroom: the first Mac2/XCUITest
     # session on a macOS runner builds WebDriverAgent(Mac) via xcodebuild
     # (minutes on a cold runner). apps-ios and mobile-web-ios get the most:
-    # a cold WDA build precedes their first simulator session.
-    timeout-minutes: ${{ (matrix.group == 'apps-ios' || matrix.group == 'mobile-web-ios') && 45 || (matrix.group == 'apps' && 30 || 20) }}
+    # a cold WDA build precedes their first simulator session, and a session
+    # POST that aborts at the 15-minute startup ceiling is retried once
+    # (ADR 01033), so the worst case is two ceiling-length attempts.
+    timeout-minutes: ${{ (matrix.group == 'apps-ios' || matrix.group == 'mobile-web-ios') && 55 || (matrix.group == 'apps' && 30 || 20) }}
     strategy:
       fail-fast: false
       matrix:

--- a/adrs/01033-retry-native-session-creation-timeout.md
+++ b/adrs/01033-retry-native-session-creation-timeout.md
@@ -1,0 +1,110 @@
+---
+status: accepted
+date: 2026-07-06
+decision-makers: doc-detective maintainers
+---
+
+# Retry a timed-out session POST when the session declared a slow-startup ceiling
+
+## Context and Problem Statement
+
+`driverStart` ([src/core/tests.ts](../src/core/tests.ts)) creates every WebDriver session through
+`wdio.remote()`, whose `connectionRetryTimeout` bounds the `POST /session` HTTP request. Since
+phase A4, native sessions derive that bound from the slow-startup capabilities they declare
+(`appium:wdaLaunchTimeout` / `appium:wdaConnectionTimeout` / `appium:serverStartupTimeout` → the
+`startupCeiling`, floor 2 minutes), because the first XCUITest session on a cold host compiles
+WebDriverAgent via `xcodebuild` — routinely 10–25 minutes on a hosted macOS runner.
+
+Even with a 15-minute ceiling (`startSurface.timeout: 900000` in the iOS fixtures), CI showed the
+build losing the race: in run 28808626492, `fixtures / apps-ios (macos-latest)` restored the WDA
+build cache (`dd-wda-v1-darwin-Xcode-16.4`), yet the first session's `POST /session` aborted after
+the full 900 s ("The operation was aborted due to timeout when running
+"http://127.0.0.1:49216/session" with method "POST""). The restored cache was stale — its key
+carries only OS + Xcode version, while the JIT-installed `appium-xcuitest-driver` (and with it the
+WDA source) had moved on, so `xcodebuild` did a near-full rebuild.
+
+The decisive observation: **the very next spec in the same job created its session quickly.** The
+client abort does not stop the server-side `xcodebuild`; the build completes regardless, and a
+fresh `POST /session` then binds in seconds. But `driverStart` classified the abort as fatal — its
+transient-error list (`ECONNREFUSED`, `socket hang up`, "session not created", …) predates native
+sessions and does not include the wdio timeout abort — so the spec FAILed after 15 minutes of
+mostly-successful work.
+
+## Decision Drivers
+
+- The `apps-ios (macos-latest)` fixture leg gates on ≥1 PASS (`DD_FIXTURES_REQUIRE_PASS=1`), so
+  this flake fails PR CI outright; it repeatedly hit PR #517.
+- A retry after the abort is near-free: the WDA build the first attempt paid for is finished or
+  nearly finished when the second attempt starts.
+- Browser / Windows / Android sessions must keep today's fail-fast behavior: they declare no
+  slow-startup capabilities, and for them a 2-minute `POST /session` means something is genuinely
+  wrong — retrying would double the hang on a dead server.
+- Classification logic must be unit-testable without a driver or network (repo convention: pure
+  helpers in [src/core/utils.ts](../src/core/utils.ts)).
+
+## Considered Options
+
+1. **Classify the timeout abort as retryable only when a slow-startup ceiling was declared**
+   (`startupCeiling > 120000`), via a pure helper.
+2. Add "aborted due to timeout" to the transient list unconditionally.
+3. Raise the fixture timeouts further (e.g. `startSurface.timeout: 1500000`).
+4. Do nothing runner-side; fix only the WDA cache key in doc-detective/github-action.
+
+## Decision Outcome
+
+Chosen option: **1**. `isRetryableSessionError(message, startupCeiling)` in
+[src/core/utils.ts](../src/core/utils.ts) returns true for the pre-existing transient patterns at
+any ceiling, and additionally for the wdio timeout abort (`/aborted due to timeout/i`) when the
+session declared a ceiling above the 2-minute default. `driverStart` delegates its retry decision
+to the helper; nothing else about the retry loop (attempt counts, linear backoff, ceiling
+derivation) changes. App-surface and mobile-web callers already pass `maxAttempts: 2`, so the
+worst case for a native session is two ceiling-length attempts.
+
+### Consequences
+
+- Good: a stale-cache or cold WDA build that outruns one ceiling no longer fails the spec — the
+  second attempt binds against the completed build. The observed CI failure mode becomes a PASS.
+- Good: browser/Windows/Android sessions are bit-for-bit unchanged (no slow-startup caps → ceiling
+  stays at the 120000 floor → timeout aborts still propagate immediately).
+- Bad: a genuinely hung native server now takes up to 2× the ceiling (30 min at the fixtures' 900 s)
+  plus the second spec's budget to surface. The `apps-ios` / `mobile-web-ios` fixture jobs'
+  `timeout-minutes` rises 45 → 55 to keep headroom.
+- Neutral: the companion fix (driver-version-aware WDA cache key in doc-detective/github-action)
+  removes the main *cause* of >15-minute builds; this decision removes the *sensitivity* to them.
+
+### Confirmation
+
+- Unit: `isRetryableSessionError` cases in
+  [test/core-utils-coverage.test.js](../test/core-utils-coverage.test.js) — timeout abort retryable
+  at ceiling > 120000, fatal at the default ceiling, transient patterns unchanged, other errors
+  fatal.
+- End-to-end: the `fixtures / apps-ios (macos-latest)` job — on a stale-cache run the log shows one
+  abort followed by a successful session bind instead of a spec FAIL.
+
+## Pros and Cons of the Options
+
+### Option 1: ceiling-gated retryability (chosen)
+
+- Good: targets exactly the sessions where the abort is known-recoverable; zero behavior change
+  elsewhere.
+- Good: pure, unit-testable classification; `driverStart` stays boring.
+- Bad: doubles worst-case wall clock for genuinely hung native servers (bounded by
+  `maxAttempts: 2`).
+
+### Option 2: unconditionally retryable timeout abort
+
+- Good: one-line change.
+- Bad: a dead Appium/Chromedriver behind a browser session would hang 4 × 2 minutes instead of 2,
+  across every session `driverStart` creates — a regression for the overwhelmingly common path.
+
+### Option 3: raise fixture timeouts further
+
+- Good: no code change.
+- Bad: pays the full worst case (25 min) on every stale-cache run *serially before any retry*, and
+  still fails when a build exceeds the new number; job budgets balloon for everyone.
+
+### Option 4: cache-key fix only
+
+- Good: removes the dominant cause (stale WDA cache never refreshing).
+- Bad: leaves the runner brittle to every other source of slow first builds — new Xcode images,
+  cache evictions, cold keys after a `CACHE_VERSION` bump — all of which recur naturally.

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -32,6 +32,7 @@ import {
   runArchivesArtifacts,
   sanitizeFilesystemName,
   evaluateContextRequirements,
+  isRetryableSessionError,
 } from "./utils.js";
 import axios from "axios";
 import { instantiateCursor } from "./tests/moveTo.js";
@@ -4670,21 +4671,11 @@ async function driverStart(
   maxAttempts: number = 4,
   ctx: { cacheDir?: string } = {}
 ) {
-  // Two families of transient, retryable session-creation failures, both worse
-  // under concurrency (the TRANSIENT regex below enumerates the specific
-  // patterns):
-  //   1. POST /session races a just-spawned-or-still-dying Appium (Windows):
-  //      /status returns 200 from the outgoing process while /session no longer
-  //      accepts, or Appium's proxy to chromedriver drops the socket ->
-  //      ECONNREFUSED / ECONNRESET / "socket hang up" / "could not proxy command".
-  //   2. Several Chromes launching at once briefly starve resources and
-  //      ChromeDriver "crashed during startup" / "cannot connect to" /
-  //      "DevToolsActivePort" / "session not created". A staggered retry lets
-  //      the contention clear; it recovers on the next attempt in practice.
-  // Retry these with linear backoff; any other error is a real session-
-  // creation failure and propagates immediately.
-  const TRANSIENT =
-    /ECONNREFUSED|ECONNRESET|socket hang up|could not proxy command|crashed during startup|cannot connect to|DevToolsActivePort|session not created/i;
+  // Retryable session-creation failures (transient races/contention, plus the
+  // client-side timeout abort for slow-startup native sessions) are enumerated
+  // by isRetryableSessionError in ./utils.js. Retry those with linear backoff;
+  // any other error is a real session-creation failure and propagates
+  // immediately.
   const wdio = await loadHeavyDep<WdioModule>("webdriverio", { ctx });
   // The wdio client aborts the POST /session request after connectionRetryTimeout.
   // A cold native session can take far longer to create than the 2-minute
@@ -4723,7 +4714,8 @@ async function driverStart(
       return driver;
     } catch (err: any) {
       lastError = err;
-      if (!TRANSIENT.test(String(err && err.message))) throw err;
+      if (!isRetryableSessionError(String(err && err.message), startupCeiling))
+        throw err;
       if (attempt < maxAttempts) {
         await new Promise((r) => setTimeout(r, 500 * attempt));
       }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -45,6 +45,7 @@ export {
   assertUrlHostIsPublic,
   sanitizeFilesystemName,
   compileFilter,
+  isRetryableSessionError,
   matchesFilter,
   selectSpecsForRun,
   findFreePort,
@@ -736,6 +737,38 @@ async function waitForReady(
   for (const p of probes) p.catch(() => {});
 
   await Promise.race([ready, earlyExit]);
+}
+
+// Two families of transient, retryable session-creation failures, both worse
+// under concurrency:
+//   1. POST /session races a just-spawned-or-still-dying Appium (Windows):
+//      /status returns 200 from the outgoing process while /session no longer
+//      accepts, or Appium's proxy to chromedriver drops the socket ->
+//      ECONNREFUSED / ECONNRESET / "socket hang up" / "could not proxy command".
+//   2. Several Chromes launching at once briefly starve resources and
+//      ChromeDriver "crashed during startup" / "cannot connect to" /
+//      "DevToolsActivePort" / "session not created". A staggered retry lets
+//      the contention clear; it recovers on the next attempt in practice.
+const TRANSIENT_SESSION_ERROR =
+  /ECONNREFUSED|ECONNRESET|socket hang up|could not proxy command|crashed during startup|cannot connect to|DevToolsActivePort|session not created/i;
+
+// The wdio client aborts POST /session with "aborted due to timeout" when the
+// request exceeds connectionRetryTimeout. For native sessions that declared a
+// slow-startup ceiling (XCUITest's wdaLaunchTimeout / Mac2's
+// serverStartupTimeout raise it past the 2-minute default), the server-side
+// WebDriverAgent xcodebuild keeps running after the client gives up, so a
+// fresh POST typically binds quickly — retry it. Default-ceiling (browser /
+// Windows / Android) sessions keep today's fail-fast behavior: there a
+// 2-minute session POST means something is genuinely wrong.
+const SESSION_TIMEOUT_ABORT = /aborted due to timeout/i;
+
+function isRetryableSessionError(
+  message: string | undefined,
+  startupCeiling: number | undefined = 0
+): boolean {
+  if (typeof message !== "string" || !message) return false;
+  if (TRANSIENT_SESSION_ERROR.test(message)) return true;
+  return (startupCeiling ?? 0) > 120000 && SESSION_TIMEOUT_ABORT.test(message);
 }
 
 function compileFilter(patterns?: string[] | unknown): RegExp[] {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -768,7 +768,7 @@ function isRetryableSessionError(
 ): boolean {
   if (typeof message !== "string" || !message) return false;
   if (TRANSIENT_SESSION_ERROR.test(message)) return true;
-  return (startupCeiling ?? 0) > 120000 && SESSION_TIMEOUT_ABORT.test(message);
+  return startupCeiling > 120000 && SESSION_TIMEOUT_ABORT.test(message);
 }
 
 function compileFilter(patterns?: string[] | unknown): RegExp[] {

--- a/test/core-utils-coverage.test.js
+++ b/test/core-utils-coverage.test.js
@@ -26,6 +26,7 @@ import {
   assertUrlHostIsPublic,
   sanitizeFilesystemName,
   compileFilter,
+  isRetryableSessionError,
   matchesFilter,
   selectSpecsForRun,
   findFreePort,
@@ -748,6 +749,55 @@ describe("core/utils coverage", function () {
         server.once("error", reject);
         server.listen(port, "127.0.0.1", () => server.close(() => resolve()));
       });
+    });
+  });
+
+  describe("isRetryableSessionError", function () {
+    // The abort message webdriverio's fetch produces when POST /session
+    // exceeds connectionRetryTimeout (observed verbatim in CI).
+    const TIMEOUT_ABORT =
+      'WebDriverError: The operation was aborted due to timeout when running "http://127.0.0.1:49216/session" with method "POST"';
+
+    it("keeps the existing transient patterns retryable at any ceiling", function () {
+      for (const message of [
+        "connect ECONNREFUSED 127.0.0.1:4723",
+        "read ECONNRESET",
+        "socket hang up",
+        "unknown error: could not proxy command to the remote browser",
+        "unknown error: Chrome failed to start: crashed during startup",
+        "unknown error: cannot connect to chrome at 127.0.0.1:9222",
+        "unknown error: DevToolsActivePort file doesn't exist",
+        "session not created: This version of ChromeDriver only supports...",
+      ]) {
+        assert.equal(isRetryableSessionError(message, 0), true, message);
+        assert.equal(isRetryableSessionError(message, 120000), true, message);
+        assert.equal(isRetryableSessionError(message, 900000), true, message);
+      }
+    });
+
+    it("retries a session-creation timeout abort only when a slow-startup ceiling was declared", function () {
+      // Native sessions (XCUITest/Mac2) declare wdaLaunchTimeout etc., which
+      // raises the ceiling past the 2-minute default: the server-side WDA
+      // build keeps running after the client abort, so a retry binds quickly.
+      assert.equal(isRetryableSessionError(TIMEOUT_ABORT, 900000), true);
+      assert.equal(isRetryableSessionError(TIMEOUT_ABORT, 120001), true);
+    });
+
+    it("keeps the timeout abort fatal for default-ceiling (browser) sessions", function () {
+      assert.equal(isRetryableSessionError(TIMEOUT_ABORT, 120000), false);
+      assert.equal(isRetryableSessionError(TIMEOUT_ABORT, 0), false);
+      assert.equal(isRetryableSessionError(TIMEOUT_ABORT, undefined), false);
+    });
+
+    it("treats anything else as a real session-creation failure", function () {
+      for (const message of [
+        "invalid argument: unrecognized capability: appium:nope",
+        "An unknown server-side error occurred while processing the command",
+        "",
+      ]) {
+        assert.equal(isRetryableSessionError(message, 900000), false, message);
+      }
+      assert.equal(isRetryableSessionError(undefined, 900000), false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Remediates the recurring `fixtures / apps-ios (macos-latest)` flake (hit repeatedly on #517): a cold or stale-cache WebDriverAgent `xcodebuild` can outrun the 15-minute session startup ceiling, the wdio client aborts `POST /session`, and `driverStart` treated that abort as fatal — after 15 minutes of mostly-successful build work. The server-side build survives the client abort (the next spec's session in the same failed job bound in seconds), so a single retry converts the failure into a pass.

- New pure helper `isRetryableSessionError(message, startupCeiling)` in `src/core/utils.ts`: the existing transient patterns stay retryable at any ceiling; the wdio timeout abort (`aborted due to timeout`) becomes retryable **only when** the session declared a slow-startup ceiling (`appium:wdaLaunchTimeout` / `wdaConnectionTimeout` / `serverStartupTimeout` > the 2-minute floor). Browser/Windows/Android sessions are bit-for-bit unchanged.
- `driverStart` delegates its retry decision to the helper; attempt counts and backoff unchanged (app-surface/mobile-web callers already pass `maxAttempts: 2`).
- `apps-ios` / `mobile-web-ios` fixture job budget 45 → 55 min for the two-attempt worst case.

## Root cause & evidence

Run 28808626492, `apps-ios (macos-latest)`: WDA cache **hit** (`dd-wda-v1-darwin-Xcode-16.4`) at 17:19:02, simulator boot 17:19:34, `POST /session` aborted 17:38:02 — the full 900 s ceiling despite the "incremental" restore. The cache key tracks only OS + Xcode version while the JIT-installed `appium-xcuitest-driver` moves forward, so the restored derivedData was stale and xcodebuild did a near-full rebuild. Companion fix for that root cause (driver-version-aware cache key + refresh-on-stale-hit) is going to doc-detective/github-action separately; this PR removes the runner's sensitivity to slow first builds generally.

## ADR

`adrs/01033-retry-native-session-creation-timeout.md` (01032 is claimed by #524).

## Docs impact

None — internal resilience, no new user-facing knob, no schema/CLI/config change. No new fixture: the existing `apps-ios` fixtures exercise this path end-to-end in CI; classification is unit-tested (red → green) in `test/core-utils-coverage.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)