### PR TITLE
fix(runtime): sweep on-disk managed-dep orphans into the runtime manifest

### DIFF
--- a/adrs/01034-sweep-orphaned-managed-deps-into-runtime-manifest.md
+++ b/adrs/01034-sweep-orphaned-managed-deps-into-runtime-manifest.md
@@ -58,8 +58,8 @@ job, a crash mid-batch, or a `Ctrl+C` during first-run install. This is the rema
 ## Considered Options
 
 1. **Extend `recordRuntimeDependencies`' candidate set with the shim's full managed-dep universe**
-   (`HEAVY_NPM_DEPS` + peer companions), relying on the existing physical-presence filter to keep
-   only what is actually on disk.
+   (every name the shim declares as a runtime install source, plus peer companions), relying on
+   the existing physical-presence filter to keep only what is actually on disk.
 2. Record the requested specs in a `finally` block when an install batch fails, so a killed batch
    still records what it managed to extract.
 3. Scan `node_modules` top-level directories and record everything found.
@@ -69,10 +69,17 @@ job, a crash mid-batch, or a `Ctrl+C` during first-run install. This is the rema
 ## Decision Outcome
 
 Chosen option: **1 — sweep the managed-dep universe**. `managedDepNames()` (new export in
-[src/runtime/heavyDeps.ts](../src/runtime/heavyDeps.ts)) returns `HEAVY_NPM_DEPS` expanded with
-peer companions; `recordRuntimeDependencies` adds these names to its candidate set. The existing
-rules do the rest: only names with `node_modules/<name>/package.json` on disk are recorded, ranges
-come from the shim's declared constraint, and recording stays best-effort.
+[src/runtime/heavyDeps.ts](../src/runtime/heavyDeps.ts)) returns the union of `HEAVY_NPM_DEPS`
+and the keys of the shim manifest's `ddRuntimeDependencies` / `optionalDependencies` fields,
+expanded with peer companions. The manifest fields matter: the app-surface drivers
+(appium-novawindows-driver, appium-mac2-driver, appium-uiautomator2-driver) are JIT-installed by
+the platform preflights but declared **only** there, not in `HEAVY_NPM_DEPS` (gap flagged by
+Copilot in review). The manifest's regular `dependencies` field is deliberately excluded: its
+names can collide with transitives hoisted into the cache, and sweeping them would promote a
+hoisted transitive to a direct dependency. `recordRuntimeDependencies` adds these names to its
+candidate set. The existing rules do the rest: only names with
+`node_modules/<name>/package.json` on disk are recorded, ranges come from the shim's declared
+constraint, and recording stays best-effort.
 
 Every orphan a doc-detective install can create is by construction a shim-declared name (install
 specs come from `getDeclaredVersion`), so the universe sweep covers exactly the gap. Because the
@@ -93,7 +100,7 @@ prevent. Timeout tuning for the bulk path remains available as an independent la
   eliminated at the root.
 * Good: hard-kill scenarios (OOM, cancelled job) are covered with no extra bookkeeping at failure
   time.
-* Neutral: up to ~15 extra `existsSync` probes per install (the universe is small and static).
+* Neutral: up to ~25 extra `existsSync` probes per install (the universe is small).
 * Neutral: a *partially extracted* orphan (killed mid-package, `package.json` present but files
   missing) is recorded and included in the next ideal tree; npm's reify validates and repairs it.
 
@@ -115,8 +122,9 @@ prevent. Timeout tuning for the bulk path remains available as an independent la
 * Good: covers every interruption class, including hard kills, with one code path.
 * Good: reuses the presence filter, so no-resurrection and managed-set invariants hold by
   construction.
-* Bad: the universe is compile-time static; a legacy orphan the current shim no longer declares is
-  not swept (already covered by the `installed.json` candidate source in practice).
+* Bad: the universe is the *current* shim's declared set; a legacy orphan the current shim no
+  longer declares is not swept (already covered by the `installed.json` candidate source in
+  practice).
 
 ### Option 2 — record on failure in `finally`
 

--- a/adrs/01034-sweep-orphaned-managed-deps-into-runtime-manifest.md
+++ b/adrs/01034-sweep-orphaned-managed-deps-into-runtime-manifest.md
@@ -1,0 +1,135 @@
+---
+status: accepted
+date: 2026-07-06
+decision-makers: doc-detective maintainers
+---
+
+# Sweep on-disk managed-dep orphans into the runtime manifest before every JIT install
+
+## Context and Problem Statement
+
+[ADR 01025](01025-non-destructive-runtime-cache-installs.md) made runtime-cache installs additive:
+`recordRuntimeDependencies` writes every managed package into the runtime `package.json`'s
+`dependencies` before and after each `npm install`, so npm's reify no longer prunes siblings as
+extraneous. Its candidate set was `installed.json`'s package list ∪ the manifest's current
+`dependencies` — both written **only after a fully successful install batch**.
+
+That leaves a gap: a batch that is **interrupted after npm extracted packages but before it exited
+0** produces *orphans* — packages physically present in `node_modules` that neither recording
+source knows about. The very next JIT install prunes them all, because to arborist they are
+extraneous and to `recordRuntimeDependencies` they are invisible.
+
+This is not hypothetical. In doc-detective/github-action's `test.yml` "Pass tests (windows-latest)"
+jobs (runs [28828343936](https://github.com/doc-detective/github-action/actions/runs/28828343936)
+and [28828962220](https://github.com/doc-detective/github-action/actions/runs/28828962220), both
+on `doc-detective@4.23.0` — a release that already contains the ADR 01025 fix), the observed
+sequence in job 85498414593 was:
+
+1. `npx doc-detective@latest …` — npx installs the package; the postinstall pre-warm
+   ([scripts/postinstall.js](../scripts/postinstall.js)) spawns `doc-detective install all`.
+2. The bulk runtime batch exceeds `ensureRuntimeInstalled`'s **5-minute default npm timeout**
+   ([src/runtime/installer.ts](../src/runtime/installer.ts) passes no `installTimeoutMs`) on the
+   slow runner; the npm child is killed. The npx gap was 5 m 50 s — extraction time plus the
+   5-minute kill. ~1064 packages (appium, drivers, webdriverio transitives, …) are on disk;
+   `installed.json` and the manifest record none of them.
+3. The run's JIT preflight installs the few missing packages:
+   `npm[stdout]: added 9 packages, removed 1064 packages, and changed 55 packages in 1m`.
+   The orphaned appium tree is pruned mid-flight.
+4. `Starting Appium on port 64593` → `Appium server on port 64593 failed to start within 120
+   seconds` → exit 1.
+
+A manual rerun passed (the bulk finished under the timeout that time) — the classic
+timing-dependent flake. The same mechanism can be triggered by an OOM-killed npm, a cancelled CI
+job, a crash mid-batch, or a `Ctrl+C` during first-run install. This is the remaining
+"non-destructive installs" work item on
+[issue #501](https://github.com/doc-detective/doc-detective/issues/501).
+
+## Decision Drivers
+
+* **No install batch may prune a previously installed package** — including packages installed by
+  a batch that never completed. Interruption must degrade to "repair on next install", never
+  "destroy on next install".
+* Preserve ADR 01025's no-resurrection rule: a package whose install genuinely failed (best-effort
+  PTY backend on an exotic platform — not on disk) must never be wedged into future ideal trees.
+* Hoisted transitives must still never be promoted to direct dependencies — the candidate set must
+  stay doc-detective-managed.
+* Negligible cost on the hot path (every JIT install runs this).
+
+## Considered Options
+
+1. **Extend `recordRuntimeDependencies`' candidate set with the shim's full managed-dep universe**
+   (`HEAVY_NPM_DEPS` + peer companions), relying on the existing physical-presence filter to keep
+   only what is actually on disk.
+2. Record the requested specs in a `finally` block when an install batch fails, so a killed batch
+   still records what it managed to extract.
+3. Scan `node_modules` top-level directories and record everything found.
+4. Raise/remove the 5-minute npm timeout for the bulk path so the postinstall batch stops being
+   killed.
+
+## Decision Outcome
+
+Chosen option: **1 — sweep the managed-dep universe**. `managedDepNames()` (new export in
+[src/runtime/heavyDeps.ts](../src/runtime/heavyDeps.ts)) returns `HEAVY_NPM_DEPS` expanded with
+peer companions; `recordRuntimeDependencies` adds these names to its candidate set. The existing
+rules do the rest: only names with `node_modules/<name>/package.json` on disk are recorded, ranges
+come from the shim's declared constraint, and recording stays best-effort.
+
+Every orphan a doc-detective install can create is by construction a shim-declared name (install
+specs come from `getDeclaredVersion`), so the universe sweep covers exactly the gap. Because the
+sweep runs **before** the npm spawn, the very first install after the interruption already keeps —
+and, where the tree is incomplete, repairs — the orphans instead of pruning them.
+
+Option 2 was rejected as strictly weaker: it cannot cover hard kills (SIGKILL, OOM, power loss)
+where no `finally` runs, and option 1 subsumes it. Option 3 records packages doc-detective never
+managed (hoisted transitives, stray user installs), violating the managed-set invariant. Option 4
+treats the trigger, not the defect — any interruption (job cancel, crash, Ctrl+C) would still
+destroy the cache; it also re-opens the hung-npm-freezes-first-run problem the timeout exists to
+prevent. Timeout tuning for the bulk path remains available as an independent latency improvement.
+
+### Consequences
+
+* Good: an interrupted bulk install now degrades gracefully — the next run keeps the ~1000 already
+  extracted packages, installs the missing few, and Appium starts. The CI flake mode above is
+  eliminated at the root.
+* Good: hard-kill scenarios (OOM, cancelled job) are covered with no extra bookkeeping at failure
+  time.
+* Neutral: up to ~15 extra `existsSync` probes per install (the universe is small and static).
+* Neutral: a *partially extracted* orphan (killed mid-package, `package.json` present but files
+  missing) is recorded and included in the next ideal tree; npm's reify validates and repairs it.
+
+### Confirmation
+
+* Red→green unit test in [test/runtime-loader.test.js](../test/runtime-loader.test.js):
+  shim-declared orphans on disk with **no** `installed.json` entry and **no** manifest entry are
+  recorded before the npm child spawns; declared-but-absent names (including the best-effort PTY
+  backend) stay unrecorded.
+* Existing ADR 01025 tests still pass unchanged (sequential-install preservation, pre-fix-cache
+  seeding, no-resurrection).
+* Field confirmation: the github-action `test.yml` Windows legs, where the failure reproduced ~2/3
+  runs before the fix, once a release containing it reaches `@latest`.
+
+## Pros and Cons of the Options
+
+### Option 1 — sweep the managed-dep universe (chosen)
+
+* Good: covers every interruption class, including hard kills, with one code path.
+* Good: reuses the presence filter, so no-resurrection and managed-set invariants hold by
+  construction.
+* Bad: the universe is compile-time static; a legacy orphan the current shim no longer declares is
+  not swept (already covered by the `installed.json` candidate source in practice).
+
+### Option 2 — record on failure in `finally`
+
+* Good: records exactly what the failed batch touched.
+* Bad: never runs on hard kills — the highest-value scenario; redundant once option 1 exists.
+
+### Option 3 — record everything in `node_modules`
+
+* Good: catches even unmanaged strays.
+* Bad: promotes hoisted transitives to direct dependencies, permanently distorting future ideal
+  trees and violating the managed-set invariant.
+
+### Option 4 — raise/remove the bulk install timeout
+
+* Good: fewer interrupted batches in the first place; worth doing independently for latency.
+* Bad: does not make interruption safe; re-opens the hung-npm hang the timeout was added to stop.

--- a/src/runtime/heavyDeps.ts
+++ b/src/runtime/heavyDeps.ts
@@ -67,6 +67,19 @@ export function withPeerCompanions(names: string[]): string[] {
   return out;
 }
 
+/**
+ * Every npm package name the shim itself may install into <cacheDir>/runtime:
+ * the heavy deps plus their peer companions. This is the sweep list
+ * recordRuntimeDependencies uses to find packages physically on disk but
+ * missing from installed.json — the orphans an interrupted install batch
+ * (killed npm child, install timeout, cancelled CI job) leaves behind, which
+ * would otherwise be invisible to the recorded sources and pruned as
+ * extraneous by the next install's reify.
+ */
+export function managedDepNames(): string[] {
+  return withPeerCompanions([...HEAVY_NPM_DEPS]);
+}
+
 export interface ShimPackageJson {
   // The published manifest carries heavy-dep version constraints here:
   // the publish step moves `optionalDependencies` into this custom field so npm

--- a/src/runtime/heavyDeps.ts
+++ b/src/runtime/heavyDeps.ts
@@ -68,16 +68,39 @@ export function withPeerCompanions(names: string[]): string[] {
 }
 
 /**
- * Every npm package name the shim itself may install into <cacheDir>/runtime:
- * the heavy deps plus their peer companions. This is the sweep list
- * recordRuntimeDependencies uses to find packages physically on disk but
- * missing from installed.json — the orphans an interrupted install batch
- * (killed npm child, install timeout, cancelled CI job) leaves behind, which
- * would otherwise be invisible to the recorded sources and pruned as
- * extraneous by the next install's reify.
+ * Every npm package name the shim itself may install into <cacheDir>/runtime.
+ * This is the sweep list recordRuntimeDependencies uses to find packages
+ * physically on disk but missing from installed.json — the orphans an
+ * interrupted install batch (killed npm child, install timeout, cancelled CI
+ * job) leaves behind, which would otherwise be invisible to the recorded
+ * sources and pruned as extraneous by the next install's reify.
  */
 export function managedDepNames(): string[] {
-  return withPeerCompanions([...HEAVY_NPM_DEPS]);
+  return resolveManagedDepNames(readShimPackageJson());
+}
+
+/**
+ * Pure union of every field the shim declares runtime installs from, split
+ * out from managedDepNames so it can be unit-tested against synthetic
+ * manifests: HEAVY_NPM_DEPS (the loader's own list) plus the keys of
+ * `ddRuntimeDependencies` / `optionalDependencies` — the app-surface drivers
+ * (appium-novawindows-driver, appium-mac2-driver, appium-uiautomator2-driver)
+ * are JIT-installed by the platform preflights but live ONLY in those
+ * manifest fields, not in HEAVY_NPM_DEPS — expanded with peer companions.
+ *
+ * `dependencies` is deliberately EXCLUDED: those are the shim's regular
+ * runtime deps, whose names can collide with transitives hoisted into the
+ * cache's node_modules — sweeping them would promote a hoisted transitive to
+ * a direct dependency, distorting every future ideal tree. (It only exists
+ * as a legacy fallback in resolveDeclaredVersion, predating the cache.)
+ */
+export function resolveManagedDepNames(pkg: ShimPackageJson): string[] {
+  const names = new Set<string>([
+    ...HEAVY_NPM_DEPS,
+    ...Object.keys(pkg.ddRuntimeDependencies ?? {}),
+    ...Object.keys(pkg.optionalDependencies ?? {}),
+  ]);
+  return withPeerCompanions([...names]);
 }
 
 export interface ShimPackageJson {

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -3,7 +3,12 @@ import fs from "node:fs";
 import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
-import { getDeclaredVersion, satisfiesRange, withPeerCompanions } from "./heavyDeps.js";
+import {
+  getDeclaredVersion,
+  managedDepNames,
+  satisfiesRange,
+  withPeerCompanions,
+} from "./heavyDeps.js";
 import { isNpmNoiseLine } from "./installOutput.js";
 import {
   assertSafeRuntimePath,
@@ -287,13 +292,20 @@ function ensureRuntimePackageJson(runtimeDir: string): void {
 //
 // Called before each install (so this install's reify keeps existing
 // siblings) and again after a successful one (so the new arrivals are
-// protected from the NEXT install). Candidate names come from installed.json
-// and the manifest's current dependencies — both doc-detective-managed sets,
-// so hoisted transitives are never promoted to direct dependencies. Physical
-// presence on disk then filters the candidates: a package whose install
-// failed (e.g. the best-effort PTY backend on an exotic platform) is never
-// resurrected into future installs' ideal trees, where its permanent failure
-// would fail every subsequent install.
+// protected from the NEXT install). Candidate names come from installed.json,
+// the manifest's current dependencies, AND the shim's full managed-dep
+// universe (managedDepNames) — all doc-detective-managed sets, so hoisted
+// transitives are never promoted to direct dependencies. The universe sweep
+// covers orphans: an interrupted install batch (npm child killed by the
+// install timeout — the postinstall bulk pre-warm on a slow CI runner — or a
+// cancelled job) leaves packages physically installed that installed.json
+// never recorded, and without the sweep the next JIT install pruned them all
+// ("removed 1064 packages"), gutting e.g. the appium tree right before the
+// runner tried to start it. Physical presence on disk then filters the
+// candidates: a package whose install failed (e.g. the best-effort PTY
+// backend on an exotic platform) is never resurrected into future installs'
+// ideal trees, where its permanent failure would fail every subsequent
+// install.
 function recordRuntimeDependencies(
   runtimeDir: string,
   ctx: CacheDirContext
@@ -314,6 +326,7 @@ function recordRuntimeDependencies(
     const names = new Set<string>([
       ...Object.keys(record.npmPackages),
       ...Object.keys(prior),
+      ...managedDepNames(),
     ]);
     const deps: Record<string, string> = {};
     for (const name of [...names].sort()) {

--- a/test/runtime-heavy-deps.test.js
+++ b/test/runtime-heavy-deps.test.js
@@ -2,6 +2,7 @@ import {
   HEAVY_NPM_DEPS,
   getDeclaredVersion,
   resolveDeclaredVersion,
+  resolveManagedDepNames,
   withPeerCompanions,
   RUNTIME_PEER_COMPANIONS,
 } from "../dist/runtime/heavyDeps.js";
@@ -89,6 +90,34 @@ describe("runtime/heavyDeps", function () {
           expect(getDeclaredVersion(c), `${c} declared version`).to.be.a("string");
         }
       }
+    });
+  });
+
+  describe("resolveManagedDepNames", function () {
+    it("unions HEAVY_NPM_DEPS with ddRuntimeDependencies and optionalDependencies keys, plus peer companions", function () {
+      const pkg = {
+        ddRuntimeDependencies: { "appium-novawindows-driver": "^1.4.1" },
+        optionalDependencies: { webdriverio: "^9.0.0" },
+        dependencies: { lodash: "^4.17.21" },
+      };
+      const out = resolveManagedDepNames(pkg);
+      // The loader's own list…
+      for (const name of HEAVY_NPM_DEPS) expect(out).to.include(name);
+      // …plus everything the shim declares as a runtime install source —
+      // app-surface drivers live only in ddRuntimeDependencies.
+      expect(out).to.include("appium-novawindows-driver");
+      expect(out).to.include("webdriverio");
+      // …plus peer companions of the union.
+      expect(out).to.include("proxy-agent");
+      // Regular `dependencies` are EXCLUDED: their names can collide with
+      // transitives hoisted into the cache, and sweeping them would promote
+      // a hoisted transitive to a direct dependency.
+      expect(out).to.not.include("lodash");
+    });
+
+    it("tolerates a manifest with none of the runtime fields", function () {
+      const out = resolveManagedDepNames({});
+      for (const name of HEAVY_NPM_DEPS) expect(out).to.include(name);
     });
   });
 

--- a/test/runtime-loader.test.js
+++ b/test/runtime-loader.test.js
@@ -398,6 +398,71 @@ describe("runtime/loader", function () {
       expect(deps).to.not.have.property("some-pruned-pkg");
     });
 
+    it("protects on-disk shim-declared orphans that installed.json never recorded (interrupted bulk install)", async function () {
+      // The CI failure mode behind the Appium start timeouts: the postinstall
+      // bulk pre-warm's npm child gets killed (install timeout, OOM, job
+      // cancel) AFTER extracting most packages but BEFORE ensureRuntimeInstalled
+      // could write installed.json / record dependencies. Those packages are
+      // physically present but invisible to both recording sources, so the next
+      // JIT install pruned them all ("removed 1064 packages") — gutting the
+      // appium tree while the runner was about to start it. Shim-declared names
+      // found on disk must be swept into the manifest BEFORE this install's
+      // npm child runs, so its reify keeps them.
+      const runtimeDir = getRuntimeDir({});
+      for (const orphan of ["appium", "proxy-agent"]) {
+        const dir = path.join(runtimeDir, "node_modules", orphan);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(
+          path.join(dir, "package.json"),
+          JSON.stringify({ name: orphan, version: "1.0.0" })
+        );
+      }
+      // NO installed.json, NO prior dependencies in the manifest — the orphans
+      // exist on disk only.
+
+      let depsAtSpawnTime;
+      await ensureRuntimeInstalled(["pngjs"], {
+        deps: {
+          spawn: makeFakeSpawner({
+            onSpawn: ({ args }) => {
+              const prefix = args[args.indexOf("--prefix") + 1];
+              depsAtSpawnTime = JSON.parse(
+                fs.readFileSync(path.join(prefix, "package.json"), "utf8")
+              ).dependencies;
+              const target = path.join(prefix, "node_modules", "pngjs");
+              fs.mkdirSync(target, { recursive: true });
+              fs.writeFileSync(
+                path.join(target, "package.json"),
+                JSON.stringify({ name: "pngjs", version: "7.0.0" })
+              );
+            },
+          }),
+          logger: () => {},
+        },
+        force: true,
+      });
+
+      // Recorded BEFORE npm ran — protection must cover this very install.
+      expect(depsAtSpawnTime).to.have.property("appium");
+      expect(depsAtSpawnTime).to.have.property("proxy-agent");
+      const deps = JSON.parse(
+        fs.readFileSync(path.join(runtimeDir, "package.json"), "utf8")
+      ).dependencies;
+      expect(deps).to.have.property("appium");
+      // The recorded range mirrors the shim's declared constraint.
+      const shimPkg = JSON.parse(fs.readFileSync(path.resolve("package.json"), "utf8"));
+      const declaredAppium =
+        shimPkg.ddRuntimeDependencies?.appium ||
+        shimPkg.optionalDependencies?.appium ||
+        shimPkg.dependencies?.appium;
+      expect(deps.appium).to.equal(declaredAppium);
+      // Declared-but-absent names stay unrecorded: the orphan sweep is
+      // presence-filtered, so a genuinely failed install (e.g. the best-effort
+      // PTY backend on an exotic platform) is still never resurrected.
+      expect(deps).to.not.have.property("webdriverio");
+      expect(deps).to.not.have.property("@homebridge/node-pty-prebuilt-multiarch");
+    });
+
     it("drops npm deprecation/funding noise from install output but keeps real lines", async function () {
       // Even a verbose-style logger (records every level) must not see the
       // scary deprecation/funding noise — only the loader's filtered output.

--- a/test/runtime-loader.test.js
+++ b/test/runtime-loader.test.js
@@ -463,6 +463,53 @@ describe("runtime/loader", function () {
       expect(deps).to.not.have.property("@homebridge/node-pty-prebuilt-multiarch");
     });
 
+    it("sweeps orphans declared only in ddRuntimeDependencies (app-surface drivers), not just HEAVY_NPM_DEPS", async function () {
+      // The app-surface preflights JIT-install drivers that are declared in
+      // package.json#ddRuntimeDependencies but are NOT in HEAVY_NPM_DEPS
+      // (appium-novawindows-driver, appium-mac2-driver,
+      // appium-uiautomator2-driver). An interrupted install of one of those
+      // leaves the same kind of unrecorded on-disk orphan — the sweep list
+      // must cover the full declared universe, not only the loader's own
+      // constant.
+      const runtimeDir = getRuntimeDir({});
+      const orphan = path.join(
+        runtimeDir,
+        "node_modules",
+        "appium-novawindows-driver"
+      );
+      fs.mkdirSync(orphan, { recursive: true });
+      fs.writeFileSync(
+        path.join(orphan, "package.json"),
+        JSON.stringify({ name: "appium-novawindows-driver", version: "1.4.1" })
+      );
+
+      await ensureRuntimeInstalled(["pngjs"], {
+        deps: {
+          spawn: makeFakeSpawner({
+            onSpawn: ({ args }) => {
+              const prefix = args[args.indexOf("--prefix") + 1];
+              const target = path.join(prefix, "node_modules", "pngjs");
+              fs.mkdirSync(target, { recursive: true });
+              fs.writeFileSync(
+                path.join(target, "package.json"),
+                JSON.stringify({ name: "pngjs", version: "7.0.0" })
+              );
+            },
+          }),
+          logger: () => {},
+        },
+        force: true,
+      });
+
+      const deps = JSON.parse(
+        fs.readFileSync(path.join(runtimeDir, "package.json"), "utf8")
+      ).dependencies;
+      const shimPkg = JSON.parse(fs.readFileSync(path.resolve("package.json"), "utf8"));
+      expect(deps["appium-novawindows-driver"]).to.equal(
+        shimPkg.ddRuntimeDependencies["appium-novawindows-driver"]
+      );
+    });
+
     it("drops npm deprecation/funding noise from install output but keeps real lines", async function () {
       // Even a verbose-style logger (records every level) must not see the
       // scary deprecation/funding noise — only the loader's filtered output.


### PR DESCRIPTION
## Problem

`doc-detective@4.23.0` — which already contains the ADR 01025 non-destructive-install fix (#510) — still destroyed the runtime cache in doc-detective/github-action `test.yml` "Pass tests (windows-latest)" ([run 28828343936](https://github.com/doc-detective/github-action/actions/runs/28828343936), [run 28828962220](https://github.com/doc-detective/github-action/actions/runs/28828962220), job 85498414593):

```
(INFO) Installing dependencies…
(DEBUG) npm[stdout]: added 9 packages, removed 1064 packages, and changed 55 packages in 1m
…
Appium server on port 64593 failed to start within 120 seconds
```

A manual rerun passed — timing-dependent, not change-related.

## Root cause

`recordRuntimeDependencies` (ADR 01025) sourced its candidates from `installed.json` + the runtime manifest's prior `dependencies` — both written **only after a fully successful install batch**. An interrupted batch leaves *orphans* those sources never see:

1. `npx doc-detective@latest` → postinstall pre-warm spawns `doc-detective install all` (10-min outer ceiling), but the inner `ensureRuntimeInstalled` npm child has a **5-minute default timeout** (`installer.ts` passes no `installTimeoutMs`).
2. On the slow Windows runner npm is killed at 5:00 sharp (the npx gap in the log is 5 m 50 s) — **after** extracting ~1064 packages, **before** exit 0, so nothing is recorded.
3. The run's JIT preflight installs the few missing packages; to arborist the 1064 orphans are extraneous and to `recordRuntimeDependencies` they are invisible → pruned mid-run, gutting the appium tree right before `startAppium` → 120 s start-wait timeout.

Same mechanism as the #501 node-pty ConPTY freeze — this closes out the remaining "non-destructive installs" work item from #501 (refs #501). Any interruption (install-timeout kill, OOM, cancelled job, Ctrl+C) could trigger it.

## Fix

Extend the `recordRuntimeDependencies` candidate set with the shim's full managed-dep universe — new `managedDepNames()` export in `src/runtime/heavyDeps.ts` (`HEAVY_NPM_DEPS` + peer companions). The existing physical-presence filter keeps the ADR 01025 no-resurrection rule: only names actually on disk are recorded, so a genuinely failed best-effort dep (PTY backend on an exotic platform) is still never wedged into future ideal trees. Since the sweep runs before the npm spawn, the *first* install after an interruption keeps and repairs the orphans instead of pruning them — and it covers hard kills where no failure-time bookkeeping could run.

## Companions

- **ADR**: [adrs/01034-sweep-orphaned-managed-deps-into-runtime-manifest.md](https://github.com/doc-detective/doc-detective/blob/claude/elated-robinson-250f59/adrs/01034-sweep-orphaned-managed-deps-into-runtime-manifest.md) (extends ADR 01025; 01032/01033 are claimed by #524/#525/#526).
- **Tests** (red→green): new unit test in `test/runtime-loader.test.js` — shim-declared orphans on disk with no `installed.json`/manifest entry are recorded **before** the npm child spawns; declared-but-absent names stay unrecorded. Confirmed failing (`expected {} to have property 'appium'`) before the fix; 176/176 runtime tests pass after.
- **Docs impact: none.** Internal resilience fix — no user-visible flag, config, step, or output surface changes; the only observable change is that a timing-dependent CI failure mode disappears.
- **Feature fixtures: not applicable.** The trigger (an npm child killed mid-batch) cannot be expressed in the fixture harness; unit tests cover the contract. The existing `apps/app-then-tty.spec.json` fixture continues to pin the ADR 01025 interleaving end-to-end.

Possible independent follow-up (latency, not correctness): pass a larger `installTimeoutMs` for the bulk `install all` path so the postinstall pre-warm completes more often on slow runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved install recovery so partially completed runtime installs are detected and preserved for the next run instead of being removed.
  * Expanded runtime package tracking to better account for packages already present on disk.

* **Bug Fixes**
  * Prevented interrupted installs from causing valid runtime packages to be mistakenly pruned later.
  * Added coverage for recovering “orphaned” packages while still ignoring packages that are not actually present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->