### PR TITLE
ci: bump github-action pin for WDA cache key v2 (github-action#74)

### DIFF
--- a/.github/workflows/fixtures-debug.yml
+++ b/.github/workflows/fixtures-debug.yml
@@ -75,7 +75,7 @@ jobs:
         # `ios: auto` lets the action cache the WebDriverAgent build for the
         # apps-ios macOS leg (first cold WDA compile ~10 min; later runs restore
         # it), which replaces the workflow-level cache.
-        uses: doc-detective/github-action@0ce9fef5b3a533d9b2a1f22f02c4583ed904f416 # ios WDA cache (github-action#73)
+        uses: doc-detective/github-action@f2ec2be7f8aefbb9c2457b3211610364c7bd14b1 # ios WDA cache key v2 (github-action#74)
         with:
           version: ''
           ios: auto

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -136,7 +136,7 @@ jobs:
       # $RUNNER_TEMP/doc-detective-output.json. We gate on that file ourselves
       # (rather than exit_on_fail) so an empty / mis-pointed run also fails.
       - name: Run ${{ matrix.group }} fixtures
-        uses: doc-detective/github-action@0ce9fef5b3a533d9b2a1f22f02c4583ed904f416 # ios WDA cache (github-action#73)
+        uses: doc-detective/github-action@f2ec2be7f8aefbb9c2457b3211610364c7bd14b1 # ios WDA cache key v2 (github-action#74)
         # The general matrix only asserts the SKIP paths. Disable the android
         # lazy-install here so no general leg ever triggers a multi-GB SDK
         # download, and turn OFF the action's KVM setup (`android: false`) — the
@@ -432,7 +432,7 @@ jobs:
       - name: Run apps-android via the action (auto-KVM + lazy bootstrap)
         id: android-action
         continue-on-error: true
-        uses: doc-detective/github-action@0ce9fef5b3a533d9b2a1f22f02c4583ed904f416 # ios WDA cache (github-action#73)
+        uses: doc-detective/github-action@f2ec2be7f8aefbb9c2457b3211610364c7bd14b1 # ios WDA cache key v2 (github-action#74)
         with:
           version: ''
           working_directory: .
@@ -442,7 +442,7 @@ jobs:
 
       - name: Retry apps-android via the action
         if: steps.android-action.outcome == 'failure'
-        uses: doc-detective/github-action@0ce9fef5b3a533d9b2a1f22f02c4583ed904f416 # ios WDA cache (github-action#73)
+        uses: doc-detective/github-action@f2ec2be7f8aefbb9c2457b3211610364c7bd14b1 # ios WDA cache key v2 (github-action#74)
         with:
           version: ''
           working_directory: .


### PR DESCRIPTION
## Summary

Bumps the pinned `doc-detective/github-action` SHA from `0ce9fef5` (#73) to `f2ec2be7` — the merge commit of [github-action#74](https://github.com/doc-detective/github-action/pull/74), which keys the WebDriverAgent build cache on the JIT-installed `appium-xcuitest-driver` version and re-saves on stale prefix hits.

Updates all 4 pinned references: 3 in `.github/workflows/fixtures.yml`, 1 in `.github/workflows/fixtures-debug.yml`.

This is the final step of the apps-ios macOS flake remediation: #526 (merged ADR 01033 retry) removes the runner's *sensitivity* to slow WDA builds; this pin removes their main *cause* (a stale cache that never refreshed until the Xcode image moved).

## Docs impact

None — CI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned version of the workflow action used in fixture-related automation.
  * Applied the same pin update across multiple fixture and debug workflow steps for consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->