### PR TITLE
fix(install): 9-minute npm-child timeout for bulk runtime installs

### DIFF
--- a/adrs/01035-bulk-runtime-install-timeout.md
+++ b/adrs/01035-bulk-runtime-install-timeout.md
@@ -1,0 +1,90 @@
+---
+status: accepted
+date: 2026-07-06
+decision-makers: doc-detective maintainers
+---
+
+# Give bulk runtime installs a 9-minute npm-child timeout instead of the 5-minute single-package default
+
+## Context and Problem Statement
+
+`ensureRuntimeInstalled` caps its spawned npm child at 5 minutes
+(`DEFAULT_INSTALL_TIMEOUT_MS` in [src/runtime/loader.ts](../src/runtime/loader.ts)) so a hung
+npm/network can never freeze a first `doc-detective` run. `installRuntime`
+([src/runtime/installer.ts](../src/runtime/installer.ts)) inherited that default for the **bulk**
+batch — the full `HEAVY_NPM_DEPS` set, ~1000 packages — which is not a hang-protection scenario but
+a legitimately long install.
+
+On slow Windows CI runners the postinstall pre-warm ([scripts/postinstall.js](../scripts/postinstall.js)
+spawns `doc-detective install all` under a 10-minute outer ceiling) reliably had its npm child
+killed at 5:00 mid-extraction. [ADR 01034](01034-sweep-orphaned-managed-deps-into-runtime-manifest.md)
+made the resulting on-disk orphans safe (they are no longer pruned by the next install), but the
+pre-warm itself is still forfeited: the first real run re-pays the install cost it was meant to
+absorb, and in the observed github-action jobs that pushed total setup time toward the Appium
+start window.
+
+## Decision Drivers
+
+* The bulk batch must be allowed to take as long as a large install legitimately takes on a slow
+  runner, without removing hang protection entirely.
+* A genuinely hung npm inside the postinstall must still die — with a diagnosable error from
+  `ensureRuntimeInstalled` — *before* the postinstall's 10-minute outer ceiling silently tears the
+  whole child tree down (the ceiling's failure mode reports nothing per-batch).
+* Single-package JIT installs (`loadHeavyDep`, mid-run preflights) keep the 5-minute default: they
+  are small, block a live run, and the original hang rationale fully applies.
+
+## Considered Options
+
+1. **Pass a larger, bulk-specific timeout (9 minutes) from `installRuntime`**, overridable via a
+   new `installTimeoutMs` option.
+2. Raise the loader's global default for every install.
+3. Disable the timeout (`0`) for the bulk path and rely on the postinstall's outer ceiling.
+
+## Decision Outcome
+
+Chosen option: **1** — `BULK_INSTALL_TIMEOUT_MS = 9 * 60 * 1000` exported from
+[src/runtime/installer.ts](../src/runtime/installer.ts); `installRuntime` forwards it (or a
+caller-provided `installTimeoutMs`) to each npm child it spawns (the core batch and the
+failure-tolerant best-effort singles). 9 minutes sits above the observed legitimate bulk duration
+(the killed runs were extracting normally at 5:00) and below the postinstall's 10-minute ceiling,
+so the per-child timeout — with its "npm install timed out … see install.log" error — always fires
+first.
+
+Option 2 would weaken hang protection for every mid-run JIT install to serve one bulk path.
+Option 3 loses per-batch diagnosability: the outer ceiling kills the whole CLI child silently and
+can strand npm grandchildren, which is exactly what the inner timeout exists to prevent.
+
+### Consequences
+
+* Good: the postinstall pre-warm survives slow runners; first runs start with a warm cache and the
+  ADR 01034 orphan scenario becomes rare instead of routine.
+* Good: direct `doc-detective install all` / `install runtime` invocations get the same realistic
+  cap; programmatic callers can tune or disable it via `installTimeoutMs`.
+* Neutral: a genuinely hung bulk npm now takes up to 9 minutes to fail instead of 5 — accepted for
+  an explicit install command; mid-run JIT installs are unchanged.
+
+### Confirmation
+
+Red→green unit tests in [test/runtime-installer.test.js](../test/runtime-installer.test.js): a
+hanging npm child rejects with the forwarded `installTimeoutMs` (proving the plumbing per child),
+and the exported default is pinned at 9 minutes.
+
+## Pros and Cons of the Options
+
+### Option 1 — bulk-specific timeout, forwarded per child (chosen)
+
+* Good: scopes the relaxation to the one path whose workload justifies it; keeps every timeout's
+  error attributable to its batch.
+* Bad: one more constant whose relationship to the postinstall ceiling must be maintained by hand
+  (documented on both constants).
+
+### Option 2 — raise the global loader default
+
+* Bad: a hung single-package JIT install would block a live run 9 minutes instead of 5; the two
+  paths have different workloads and deserve different caps.
+
+### Option 3 — no inner timeout for bulk
+
+* Bad: on a hang, the postinstall ceiling SIGTERMs the CLI child with no per-batch error and
+  possible orphaned npm grandchildren; interactive `install all` (no outer ceiling) would hang
+  forever.

--- a/src/runtime/installer.ts
+++ b/src/runtime/installer.ts
@@ -59,16 +59,10 @@ const defaultLogger: Logger = (msg, level = "info") => {
 };
 
 /**
- * Per-npm-child wall-clock cap for bulk runtime installs. The full
- * HEAVY_NPM_DEPS batch is ~1000 packages and can legitimately outlast the
- * loader's 5-minute single-package default on slow CI runners — the
- * postinstall pre-warm's npm child was reliably killed at 5:00 there,
- * forfeiting the pre-warm and stranding the extracted packages as orphans
- * (ADR 01034 made the orphans safe; this cap stops the kill — ADR 01035).
- * Kept below the postinstall's 10-minute outer ceiling
- * (scripts/postinstall.js) so a genuinely hung npm still dies — and gets
- * reported by ensureRuntimeInstalled's timeout error — before the ceiling
- * silently tears the whole pre-warm down.
+ * Per-npm-child cap for bulk installs: the ~1000-package batch legitimately
+ * outlasts the loader's 5-minute single-package default on slow runners, and
+ * must stay under the postinstall's 10-minute outer ceiling so the
+ * diagnosable inner timeout fires first (ADR 01035).
  */
 export const BULK_INSTALL_TIMEOUT_MS = 9 * 60 * 1000;
 
@@ -78,11 +72,7 @@ export interface InstallRuntimeOptions {
   deps?: InstallerDeps;
   force?: boolean;
   dryRun?: boolean;
-  /**
-   * Wall-clock cap for each spawned npm child; defaults to
-   * BULK_INSTALL_TIMEOUT_MS (not the loader's smaller single-package
-   * default). Must be a non-negative number; pass `0` to disable.
-   */
+  /** Cap per spawned npm child; defaults to BULK_INSTALL_TIMEOUT_MS. Must be ≥ 0; `0` disables. */
   installTimeoutMs?: number;
 }
 

--- a/src/runtime/installer.ts
+++ b/src/runtime/installer.ts
@@ -81,7 +81,7 @@ export interface InstallRuntimeOptions {
   /**
    * Wall-clock cap for each spawned npm child; defaults to
    * BULK_INSTALL_TIMEOUT_MS (not the loader's smaller single-package
-   * default). Pass `0` to disable.
+   * default). Must be a non-negative number; pass `0` to disable.
    */
   installTimeoutMs?: number;
 }
@@ -103,6 +103,15 @@ export async function installRuntime(
     dryRun = false,
     installTimeoutMs = BULK_INSTALL_TIMEOUT_MS,
   } = options;
+  // ensureRuntimeInstalled treats any value ≤ 0 as "no timeout" (its
+  // `installTimeoutMs > 0` gate), so a negative/NaN value passed here by
+  // mistake would silently remove hang protection. Only an explicit 0 may
+  // disable; reject everything else that isn't a non-negative finite number.
+  if (!Number.isFinite(installTimeoutMs) || installTimeoutMs < 0) {
+    throw new Error(
+      `installTimeoutMs must be a non-negative number of milliseconds (0 disables the timeout); got ${installTimeoutMs}.`
+    );
+  }
   const logger = deps.logger ?? defaultLogger;
   const targets = packages && packages.length > 0
     ? packages

--- a/src/runtime/installer.ts
+++ b/src/runtime/installer.ts
@@ -58,12 +58,32 @@ const defaultLogger: Logger = (msg, level = "info") => {
   else console.log(msg);
 };
 
+/**
+ * Per-npm-child wall-clock cap for bulk runtime installs. The full
+ * HEAVY_NPM_DEPS batch is ~1000 packages and can legitimately outlast the
+ * loader's 5-minute single-package default on slow CI runners — the
+ * postinstall pre-warm's npm child was reliably killed at 5:00 there,
+ * forfeiting the pre-warm and stranding the extracted packages as orphans
+ * (ADR 01034 made the orphans safe; this cap stops the kill — ADR 01035).
+ * Kept below the postinstall's 10-minute outer ceiling
+ * (scripts/postinstall.js) so a genuinely hung npm still dies — and gets
+ * reported by ensureRuntimeInstalled's timeout error — before the ceiling
+ * silently tears the whole pre-warm down.
+ */
+export const BULK_INSTALL_TIMEOUT_MS = 9 * 60 * 1000;
+
 export interface InstallRuntimeOptions {
   packages?: string[];
   ctx?: CacheDirContext;
   deps?: InstallerDeps;
   force?: boolean;
   dryRun?: boolean;
+  /**
+   * Wall-clock cap for each spawned npm child; defaults to
+   * BULK_INSTALL_TIMEOUT_MS (not the loader's smaller single-package
+   * default). Pass `0` to disable.
+   */
+  installTimeoutMs?: number;
 }
 
 /**
@@ -81,6 +101,7 @@ export async function installRuntime(
     deps = {},
     force = false,
     dryRun = false,
+    installTimeoutMs = BULK_INSTALL_TIMEOUT_MS,
   } = options;
   const logger = deps.logger ?? defaultLogger;
   const targets = packages && packages.length > 0
@@ -120,6 +141,7 @@ export async function installRuntime(
     ctx,
     deps: { logger, spawn: deps.spawn },
     force,
+    installTimeoutMs,
   });
 
   const bestEffortFailed = new Set<string>();
@@ -129,6 +151,7 @@ export async function installRuntime(
         ctx,
         deps: { logger, spawn: deps.spawn },
         force,
+        installTimeoutMs,
       });
     } catch {
       // Non-fatal: the dep has no installable binary here; runtime SKIPs it.

--- a/test/runtime-installer.test.js
+++ b/test/runtime-installer.test.js
@@ -115,6 +115,40 @@ describe("runtime/installer", function () {
       expect(reports[0].installedVersion).to.equal("7.0.0");
     });
 
+    it("caps each npm child with the bulk timeout and forwards installTimeoutMs overrides", async function () {
+      // The full runtime batch (~1000 packages) can legitimately outlast the
+      // loader's 5-minute single-package default on slow CI runners — the
+      // postinstall pre-warm's npm child was reliably killed at 5:00 there,
+      // forfeiting the pre-warm (ADR 01034 made the resulting orphans safe;
+      // ADR 01035 stops the kill). installRuntime must own a larger bulk
+      // default and forward installTimeoutMs to its npm children. A hanging
+      // child plus a tiny override proves the plumbing end-to-end without
+      // waiting minutes: if the option is NOT forwarded, the loader falls
+      // back to its 5-minute default and this test times out instead.
+      const hangingSpawner = () => {
+        const child = new EventEmitter();
+        child.stdout = new EventEmitter();
+        child.stderr = new EventEmitter();
+        return child; // never emits 'close'
+      };
+      try {
+        await installRuntime({
+          packages: ["pngjs"],
+          force: true,
+          installTimeoutMs: 25,
+          deps: { spawn: hangingSpawner, logger: () => {} },
+        });
+        throw new Error("expected installRuntime to reject");
+      } catch (err) {
+        expect(String(err.message)).to.match(/timed out after 25ms/);
+      }
+    });
+
+    it("defaults the bulk npm-child timeout to 9 minutes — above the loader's 5-minute single-package default, below the postinstall's 10-minute outer ceiling", async function () {
+      const installer = await import("../dist/runtime/installer.js");
+      expect(installer.BULK_INSTALL_TIMEOUT_MS).to.equal(9 * 60 * 1000);
+    });
+
     it("reports installed peer companions, not just the requested package", async function () {
       // @puppeteer/browsers pulls in proxy-agent; the install report must list
       // both so it matches what was actually installed (and the dry-run).

--- a/test/runtime-installer.test.js
+++ b/test/runtime-installer.test.js
@@ -2,6 +2,7 @@ import {
   installRuntime,
   installBrowsers,
   status,
+  BULK_INSTALL_TIMEOUT_MS,
 } from "../dist/runtime/installer.js";
 import { resolveHeavyDepSource } from "../dist/runtime/loader.js";
 import { writeInstalledRecord } from "../dist/runtime/cacheDir.js";
@@ -116,15 +117,9 @@ describe("runtime/installer", function () {
     });
 
     it("caps each npm child with the bulk timeout and forwards installTimeoutMs overrides", async function () {
-      // The full runtime batch (~1000 packages) can legitimately outlast the
-      // loader's 5-minute single-package default on slow CI runners — the
-      // postinstall pre-warm's npm child was reliably killed at 5:00 there,
-      // forfeiting the pre-warm (ADR 01034 made the resulting orphans safe;
-      // ADR 01035 stops the kill). installRuntime must own a larger bulk
-      // default and forward installTimeoutMs to its npm children. A hanging
-      // child plus a tiny override proves the plumbing end-to-end without
-      // waiting minutes: if the option is NOT forwarded, the loader falls
-      // back to its 5-minute default and this test times out instead.
+      // A hanging child + tiny override proves the plumbing end-to-end: if the
+      // option is NOT forwarded, the loader falls back to its 5-minute default
+      // and this test times out instead (rationale in ADR 01035).
       const hangingSpawner = () => {
         const child = new EventEmitter();
         child.stdout = new EventEmitter();
@@ -144,9 +139,8 @@ describe("runtime/installer", function () {
       }
     });
 
-    it("defaults the bulk npm-child timeout to 9 minutes — above the loader's 5-minute single-package default, below the postinstall's 10-minute outer ceiling", async function () {
-      const installer = await import("../dist/runtime/installer.js");
-      expect(installer.BULK_INSTALL_TIMEOUT_MS).to.equal(9 * 60 * 1000);
+    it("defaults the bulk npm-child timeout to 9 minutes — above the loader's 5-minute single-package default, below the postinstall's 10-minute outer ceiling", function () {
+      expect(BULK_INSTALL_TIMEOUT_MS).to.equal(9 * 60 * 1000);
     });
 
     it("rejects a negative installTimeoutMs instead of silently disabling the timeout", async function () {

--- a/test/runtime-installer.test.js
+++ b/test/runtime-installer.test.js
@@ -149,6 +149,30 @@ describe("runtime/installer", function () {
       expect(installer.BULK_INSTALL_TIMEOUT_MS).to.equal(9 * 60 * 1000);
     });
 
+    it("rejects a negative installTimeoutMs instead of silently disabling the timeout", async function () {
+      // ensureRuntimeInstalled treats any value ≤ 0 as "no timeout" (its
+      // `installTimeoutMs > 0` gate), so a negative value passed here by
+      // mistake would silently remove hang protection. Only an explicit 0
+      // may disable; anything else negative (or NaN) must fail fast.
+      const spawner = fakeNpmSpawner({ materialize: { pngjs: "7.0.0" } });
+      for (const bad of [-5, Number.NaN]) {
+        try {
+          await installRuntime({
+            packages: ["pngjs"],
+            force: true,
+            installTimeoutMs: bad,
+            deps: { spawn: spawner, logger: () => {} },
+          });
+          throw new Error(
+            `expected installRuntime to reject for installTimeoutMs=${bad}`
+          );
+        } catch (err) {
+          expect(String(err.message)).to.match(/installTimeoutMs/);
+          expect(String(err.message)).to.match(/non-negative/);
+        }
+      }
+    });
+
     it("reports installed peer companions, not just the requested package", async function () {
       // @puppeteer/browsers pulls in proxy-agent; the install report must list
       // both so it matches what was actually installed (and the dry-run).


### PR DESCRIPTION
## Problem

`installRuntime` inherited `ensureRuntimeInstalled`'s **5-minute** `DEFAULT_INSTALL_TIMEOUT_MS` for the full `HEAVY_NPM_DEPS` bulk batch (~1000 packages) — a legitimately long install, not a hang. On slow Windows CI runners the postinstall pre-warm (`scripts/postinstall.js` spawns `doc-detective install all` under a **10-minute** outer ceiling) reliably had its npm child killed at 5:00 mid-extraction: the npx gap in the failing github-action job (85498414593, analyzed for #528) was exactly 5m50s. The kill forfeited the pre-warm and stranded ~1064 extracted packages as unrecorded orphans.

[PR #528](https://github.com/doc-detective/doc-detective/pull/528) (ADR 01034) made those orphans **safe** — this PR stops them from being **routine** and lets the pre-warm actually complete, so first runs start with a warm cache. Latency/reliability follow-up flagged in #528; independent of it code-wise (no shared files).

## Change

- New `BULK_INSTALL_TIMEOUT_MS = 9 min` exported from `src/runtime/installer.ts` — above the observed legitimate bulk duration, **below** the postinstall's 10-minute outer ceiling, so on a genuine hang the inner per-child timeout (with its diagnosable "npm install timed out … see install.log" error) always fires before the ceiling silently SIGTERMs the whole child tree.
- New `installTimeoutMs` option on `installRuntime`, defaulting to the bulk constant and forwarded to each npm child it spawns (core batch + failure-tolerant best-effort singles). Pass `0` to disable.
- Single-package JIT installs (`loadHeavyDep`, mid-run preflights) keep the 5-minute default — their hang-protection rationale is unchanged.

## Companions

- **ADR**: [adrs/01035-bulk-runtime-install-timeout.md](https://github.com/doc-detective/doc-detective/blob/claude/bulk-install-timeout/adrs/01035-bulk-runtime-install-timeout.md) (01034 is claimed by #528).
- **Tests** (red→green, `test/runtime-installer.test.js`): a hanging npm child rejects with the forwarded `installTimeoutMs` — on the pre-fix code the option is ignored and the test times out (confirmed red: 2 failing); the exported default is pinned at 9 minutes. 39/39 installer+loader+postinstall tests pass after.
- **Docs impact: none** — no user-facing flag/config surface; `installTimeoutMs` is a programmatic API refinement, and the observable change is a more reliable postinstall pre-warm.
- **Feature fixtures: not applicable** — a killed npm child's timing behavior isn't expressible in the fixture harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout for bulk runtime installs, with a longer default to better handle larger installations.
  * Bulk installs now use a 9-minute timeout by default, while single-package installs keep the shorter existing limit.

* **Bug Fixes**
  * Improved consistency so all parts of a runtime installation follow the same timeout setting.
  * Added validation to prevent invalid timeout values from being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->