### PR TITLE
test: raise mocha default per-test timeout to 10s (flake S3)

### DIFF
--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -29,6 +29,10 @@ on:
       - 'package-lock.json'
       - 'bin/**'
       - 'scripts/**'
+      # Mocha runner config governs how the whole suite executes (timeouts,
+      # hooks), so a change to it must re-run the matrix — otherwise a
+      # test-behavior change like the default-timeout bump ships unexercised.
+      - '.mocharc.yml'
       - '.github/workflows/npm-test.yaml'
       - '.github/workflows/test.yml'
   workflow_dispatch:

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,3 +1,10 @@
 require:
   - ./test/hooks.js
 exit: true
+# Raise mocha's default per-test timeout from 2000ms. On hosted CI runners the
+# root suite's real async work (env injection, schema validation, driver
+# preflight) occasionally exceeds 2s and trips a spurious "Timeout of 2000ms
+# exceeded" on whichever test is unlucky — an intermittent, test-agnostic flake
+# (see ADR 01037). 10s gives ample headroom while still catching genuine hangs.
+# Individual slow tests keep their own longer `this.timeout(...)`.
+timeout: 10000

--- a/adrs/01037-raise-mocha-default-timeout.md
+++ b/adrs/01037-raise-mocha-default-timeout.md
@@ -1,0 +1,71 @@
+---
+status: accepted
+date: 2026-07-06
+decision-makers: doc-detective maintainers
+---
+
+# Raise the mocha default per-test timeout to 10s to kill the 2000ms CI flake
+
+## Context and Problem Statement
+
+A 60-day audit of the `Test` workflow surfaced the most recurrent unaddressed **main-branch** flake
+(4 occurrences across 3 days, on macOS and Windows, node 22 and 24): a mocha
+`Error: Timeout of 2000ms exceeded` that lands on a **different, innocent test each time**
+(`Run tests successfully`, `Intelligent goTo behavior`, a `hints/context` case, the `findElement`
+app-surface branch). The failure is not in any one test — it is mocha's **default 2000ms per-test
+timeout** being too tight for the root suite on slow hosted runners, where real async work
+(env-variable injection, `config_v3` schema validation, driver preflight) legitimately takes 3–5s in
+adjacent passing lines. Whichever test is unlucky when the runner is loaded trips the timeout, FAILs
+the matrix cell, and blocks the run.
+
+The root `.mocharc.yml` sets no `timeout`, so every `test/*.test.js` case runs under the 2000ms
+default.
+
+## Decision Drivers
+
+* Eliminate an intermittent, test-agnostic CI failure that costs re-runs and erodes signal.
+* Keep catching genuine hangs / deadlocks — don't disable timeouts wholesale.
+* One central change; don't sprinkle `this.timeout()` across dozens of unrelated tests.
+* No product-behavior or public-contract change.
+
+## Considered Options
+
+* **A. Set a generous global `timeout: 10000` in `.mocharc.yml`** (chosen).
+* **B. Per-test `this.timeout(...)` on the tests observed failing.**
+* **C. `--timeout 0` (disable timeouts) for the root suite.**
+* **D. Leave at 2000ms and rely on CI re-runs.**
+
+## Decision Outcome
+
+Chosen option: **A**. A single, discoverable knob raises the floor for the whole root suite to a value
+comfortably above the observed 3–5s real work while still failing on a genuinely hung test (10s).
+**B** is whack-a-mole — the flake already hit four different tests, so any per-test list is
+incomplete by construction and the next unlucky test just reintroduces it. **C** removes the safety
+net entirely, so a real deadlock would hang the job until the 90-minute job timeout instead of failing
+fast. **D** keeps paying the flake tax. Individual slow tests that already set a longer
+`this.timeout(...)` are unaffected (per-test value wins over the global default).
+
+Mechanism: add `timeout: 10000` to `.mocharc.yml` (the root suite's config). The `src/common`
+suite has its own `.mocharc.yml` and was not implicated, so it is left unchanged.
+
+## Consequences
+
+* **Good** — the S3 2000ms flake can no longer trip on incidental slowness; the root suite has a 10s
+  floor uniformly across the matrix.
+* **Good** — genuine hangs still fail (at 10s per test) rather than being masked.
+* **Neutral** — a truly stuck test now takes up to 10s (vs 2s) to fail; negligible against the
+  suite's overall runtime and worth the flake elimination.
+* **Trade-off** — a real regression that makes a test *slow* (3–10s) would no longer be caught by the
+  timeout; that class of perf regression is out of scope here and better caught by dedicated timing
+  assertions if needed.
+
+## Confirmation
+
+* This is a CI-reliability config tuning (like the coverage-ratchet tolerance and the
+  `concurrentRunners` fixture setting), not a product-behavior change, so it carries no feature
+  fixtures and no user-facing docs impact. TDD's red→green does not cleanly apply to a probabilistic
+  timeout flake; the confirmation is operational.
+* The `Test` workflow runs green on the introducing PR, and the S3 signature does not recur across the
+  Phase-4 repeated main-branch dispatches (target: no `Timeout of 2000ms exceeded` in 3 consecutive
+  all-green dispatches).
+* Docs impact: **none user-facing** (test/CI-config only).


### PR DESCRIPTION
## What

Add `timeout: 10000` to the root `.mocharc.yml`, raising mocha's default per-test timeout from 2000ms to 10s.

## Why (flake audit finding S3)

A 60-day audit of the `Test` workflow identified this as the **top recurrent, unaddressed main-branch flake** — 4 occurrences in 3 days across macOS and Windows (node 22 and 24). Each time it hit a **different innocent test** (`Run tests successfully`, `Intelligent goTo behavior`, a `hints/context` case, the `findElement` app-surface branch). The failure is not in any one test: it is mocha's default 2000ms timeout being too tight for the root suite's real async work (env injection, `config_v3` validation, driver preflight, which take 3-5s in adjacent passing lines) on loaded hosted runners.

A per-test `this.timeout()` list would be whack-a-mole (the flake already hit 4 different tests). Disabling timeouts (`--timeout 0`) would let a real deadlock hang until the 90-min job cap. A 10s global floor removes the flake while still failing genuine hangs; per-test `this.timeout(...)` overrides still win.

## Scope

- **No product/behavior change, no schema change.** Root test-config only.
- `src/common` has its own `.mocharc.yml` and was not implicated — left unchanged.
- **Docs impact: none user-facing.**

## ADR

`adrs/01037-raise-mocha-default-timeout.md`

## Confirmation

Green `Test` run on this PR; the `Timeout of 2000ms exceeded` signature should not recur across the repeated main-branch dispatches that follow.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default test timeout to reduce intermittent CI test failures.
  * Updated test workflow triggers so configuration changes rerun the relevant test matrix.

* **Documentation**
  * Added an architecture decision record describing the timeout change and its expected impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->