### PR TITLE
fix(core): serialize native app-surface driver contexts under concurrency

### DIFF
--- a/adrs/01038-serialize-native-app-driver-contexts-under-concurrency.md
+++ b/adrs/01038-serialize-native-app-driver-contexts-under-concurrency.md
@@ -1,0 +1,116 @@
+---
+status: accepted
+date: 2026-07-07
+decision-makers: doc-detective maintainers
+---
+
+# Serialize native app-surface driver contexts under concurrency
+
+## Context and Problem Statement
+
+ADR 01001 introduced the resource-aware concurrency scheduler: each context job may declare a set of
+exclusive resource names, and two jobs sharing a resource never run concurrently while everything
+else stays parallel. ADR 01025 extended that pattern for Android — each managed emulator is
+heavyweight, so android app contexts take an `"android-emulator"` resource that bounds them to one at
+a time.
+
+Native **desktop** and **iOS-simulator** app surfaces were left out. macOS Mac2, Windows
+NovaWindows, and iOS/xcuitest each drive a native app through a **single, per-host Appium driver
+server**. When `concurrentRunners > 1`, two native app-driver contexts start at once and clobber that
+shared server. CI reproduced this on the `apps/macos` job of PR #532 (which sets the fixtures to
+`concurrentRunners: 2`):
+
+```
+App "/System/Applications/Calculator.app" launched but never became ready:
+... 'POST /element' cannot be proxied to Mac2 Driver server because its
+process is not running (probably crashed).
+```
+
+At `concurrentRunners: 1` the same fixtures pass, confirming the crash is concurrency-induced. In
+`jobDisplayResources` (`src/core/tests.ts`), a native desktop/iOS app-driver context took **no**
+exclusive resource unless the run also had a shared-display recording, so nothing serialized them.
+
+## Decision Drivers
+
+* **Reuse the ADR 01001 seam.** The scheduler already serializes on named resources; the fix should
+  be one more resource name, not new machinery — exactly how ADR 01025 added `"android-emulator"`.
+* **Only serialize contexts that actually drive a native app.** A context that deterministically
+  SKIPs or FAILs (wrong platform, mixed native-app+browser on mobile, unsupported) boots no driver,
+  so it must take nothing and never needlessly serialize other jobs — the same gating discipline as
+  the existing `attemptsEmulator` branch.
+* **Don't double-bound Android.** Android already serializes on `"android-emulator"`; the new
+  resource is for non-android native app surfaces only.
+* **Compose, don't collide.** A job may already hold `"display"` (recording) — the new resource must
+  union with it, not replace it.
+* **`concurrentRunners: 1` stays byte-identical.** The `limit === 1` path bypasses
+  `runResourceAware` entirely and must not change.
+
+## Considered Options
+
+* **A new `"native-app-driver"` exclusive resource for non-android native app-driver contexts**
+  (chosen). Mirrors the `"android-emulator"` branch; composes with `"display"` via the existing
+  `[...new Set([...])]` union.
+* **Force the whole run serial when any native app context is present.** Rejected: collapses all
+  parallelism (HTTP/shell/browser jobs too), the exact regression ADR 01001 was written to avoid.
+* **Per-context private Appium server for native app surfaces.** Rejected as out of scope: a larger
+  change to the driver-server lifecycle; the scheduler-level bound is minimal and sufficient. A
+  counted semaphore (>1 concurrent native app driver on beefier hosts) is possible future work, the
+  same way it is for `"android-emulator"`.
+
+## Decision Outcome
+
+Chosen option: **a new `"native-app-driver"` exclusive resource**.
+
+`jobDisplayResources` now tags a job with `"native-app-driver"` when the context (a) needs an app
+driver (`isAppDriverRequired`), (b) sits on a non-android native app-driver platform
+(`mac` / `windows` / `ios`, via `NATIVE_APP_DRIVER_PLATFORMS`), and (c) clears `mobileBrowserGate`
+(so a mixed native-app+browser mobile context, which deterministically SKIPs, takes nothing). The
+resource composes with `"android-emulator"` (never both — android is excluded) and with `"display"`
+through the existing set-union, so a native app context in a recording run holds
+`["native-app-driver", "display"]`. Android emulator contexts stay exempt from the display promotion,
+as before. At `concurrentRunners: 1` the code path is unchanged.
+
+### Consequences
+
+* Good: `concurrentRunners > 1` is now safe with native macOS/Windows/iOS app surfaces — two such
+  contexts queue on the shared driver instead of crashing it. Disjoint jobs (HTTP, shell, browser)
+  still run in parallel.
+* Good: The change is one predicate and one resource name, entirely inside the existing scheduler
+  contract; nothing downstream reads the new name specially.
+* Neutral: Native app contexts on one host now run one-at-a-time. That matches physical reality (one
+  shared driver server) and is no slower than the previously-required `concurrentRunners: 1`
+  workaround.
+* Neutral / future work: the bound is one-at-a-time (exclusive), not a counted semaphore, so a host
+  that could support N parallel native drivers still runs them serially — the same limitation
+  `"android-emulator"` carries.
+
+### Confirmation
+
+* Unit tests in `test/concurrency.test.js`: `jobDisplayResources` returns `["native-app-driver"]` for
+  a non-android native app context (mac / windows / ios), `["android-emulator"]` (not the new
+  resource) for an android app context, `[]` for a non-app (HTTP/shell), browser-only, and mixed
+  app+web mobile (gate-SKIP) context, and `["native-app-driver", "display"]` when a shared-display
+  recording is present. A `runResourceAware` test confirms two `"native-app-driver"` jobs never
+  overlap while a disjoint job does. These tests were written first (red → green).
+* End-to-end: the `apps/macos` fixtures job at `concurrentRunners: 2` (PR #532, which depends on this
+  change) exercises two concurrent Mac2 app contexts and must reach PASS/SKIPPED instead of the
+  proxied-crash FAIL.
+
+## Pros and Cons of the Options
+
+### A new `"native-app-driver"` exclusive resource (chosen)
+
+* Good: minimal — reuses ADR 01001's resource-aware scheduler and ADR 01025's gating discipline.
+* Good: composes cleanly with `"display"` and excludes already-bounded android.
+* Good: keeps all non-native-app parallelism intact.
+* Neutral: exclusive (one-at-a-time) rather than a counted semaphore.
+
+### Force the whole run serial when a native app context is present
+
+* Good: trivially correct.
+* Bad: destroys parallelism for every unrelated job — the regression ADR 01001 exists to prevent.
+
+### Per-context private Appium server for native app surfaces
+
+* Good: would allow real parallel native app drivers.
+* Bad: large change to driver-server lifecycle and resource use; far more than the crash requires.

--- a/adrs/01038-serialize-native-app-driver-contexts-under-concurrency.md
+++ b/adrs/01038-serialize-native-app-driver-contexts-under-concurrency.md
@@ -14,30 +14,50 @@ else stays parallel. ADR 01025 extended that pattern for Android — each manage
 heavyweight, so android app contexts take an `"android-emulator"` resource that bounds them to one at
 a time.
 
-Native **desktop** and **iOS-simulator** app surfaces were left out. macOS Mac2, Windows
-NovaWindows, and iOS/xcuitest each drive a native app through a **single, per-host Appium driver
-server**. When `concurrentRunners > 1`, two native app-driver contexts start at once and clobber that
-shared server. CI reproduced this on the `apps/macos` job of PR #532 (which sets the fixtures to
-`concurrentRunners: 2`):
+Native **desktop** and **iOS-simulator** driver contexts were left out. macOS Mac2, Windows
+NovaWindows, and iOS/xcuitest each drive their target through a **single, per-host driver stack**.
+When `concurrentRunners > 1`, two such contexts start at once and clobber that shared stack. CI
+reproduced this across **three** macOS jobs of PR #532 (which sets the fixtures to
+`concurrentRunners: 2`), each the same per-host contention class:
 
 ```
+# apps (Mac2):
 App "/System/Applications/Calculator.app" launched but never became ready:
 ... 'POST /element' cannot be proxied to Mac2 Driver server because its
 process is not running (probably crashed).
+
+# apps-ios (xcuitest):
+WebDriverError: Session does not exist ...
+Could not proxy command to the remote server. Original error:
+connect ECONNREFUSED 127.0.0.1:8100  (WebDriverAgent)
+
+# mobile-web-ios (Safari on the iOS simulator):
+WebDriverError: Missing parameter: appIdKey ... → "No elements matched
+selector or text."  (the session was clobbered mid-run by the second
+concurrent iOS-simulator session)
 ```
 
+The `apps-ios` and `mobile-web-ios` failures are decisive on the iOS point: **both** kinds of iOS
+context — native app (xcuitest) **and** mobile-web (Safari on the sim) — contend on the *same*
+per-host iOS simulator + WebDriverAgent, so two of *either* clobber each other. (The
+`mobile-web-ios` job passes on Windows, where iOS contexts SKIP — confirming it's per-host simulator
+contention, not an unrelated element-matching bug.)
+
 At `concurrentRunners: 1` the same fixtures pass, confirming the crash is concurrency-induced. In
-`jobDisplayResources` (`src/core/tests.ts`), a native desktop/iOS app-driver context took **no**
+`jobDisplayResources` (`src/core/tests.ts`), a native desktop/iOS driver context took **no**
 exclusive resource unless the run also had a shared-display recording, so nothing serialized them.
 
 ## Decision Drivers
 
 * **Reuse the ADR 01001 seam.** The scheduler already serializes on named resources; the fix should
   be one more resource name, not new machinery — exactly how ADR 01025 added `"android-emulator"`.
-* **Only serialize contexts that actually drive a native app.** A context that deterministically
-  SKIPs or FAILs (wrong platform, mixed native-app+browser on mobile, unsupported) boots no driver,
-  so it must take nothing and never needlessly serialize other jobs — the same gating discipline as
-  the existing `attemptsEmulator` branch.
+* **Only serialize contexts that actually boot the shared per-host driver.** On macOS/Windows that
+  means a native-**app** context (a plain desktop firefox/chrome browser uses its own browser session
+  and must still parallelize). On **iOS** it means *any* context that boots the simulator — native
+  app **or** mobile-web Safari — since they share one simulator + WDA. A context that
+  deterministically SKIPs or FAILs (wrong platform, mixed native-app+browser on mobile, unsupported)
+  boots nothing and must take nothing — the same gating discipline as the existing `attemptsEmulator`
+  branch.
 * **Don't double-bound Android.** Android already serializes on `"android-emulator"`; the new
   resource is for non-android native app surfaces only.
 * **Compose, don't collide.** A job may already hold `"display"` (recording) — the new resource must
@@ -61,24 +81,34 @@ exclusive resource unless the run also had a shared-display recording, so nothin
 
 Chosen option: **a new `"native-app-driver"` exclusive resource**.
 
-`jobDisplayResources` now tags a job with `"native-app-driver"` when the context (a) needs an app
-driver (`isAppDriverRequired`), (b) sits on a non-android native app-driver platform
-(`mac` / `windows` / `ios`, via `NATIVE_APP_DRIVER_PLATFORMS`), and (c) clears `mobileBrowserGate`
-(so a mixed native-app+browser mobile context, which deterministically SKIPs, takes nothing). The
-resource composes with `"android-emulator"` (never both — android is excluded) and with `"display"`
-through the existing set-union, so a native app context in a recording run holds
+`jobDisplayResources` now tags a job with `"native-app-driver"` when the context (a) sits on a
+non-android native app-driver platform (`mac` / `windows` / `ios`, via `NATIVE_APP_DRIVER_PLATFORMS`),
+(b) will actually boot the shared per-host driver, and (c) clears `mobileBrowserGate`. The
+"will actually boot" test is **platform-specific**:
+
+* **`mac` / `windows`** — requires `isAppDriverRequired` (a native app step). A plain desktop
+  firefox/chrome browser context takes **nothing** and keeps running in parallel.
+* **`ios`** — **any** context (app *or* mobile-web Safari), because both boot the single per-host iOS
+  simulator + WebDriverAgent and clobber each other. So an iOS browser context takes the resource
+  even though `isAppDriverRequired` is false.
+
+The resource composes with `"android-emulator"` (never both — android is excluded) and with
+`"display"` through the existing set-union, so a native app context in a recording run holds
 `["native-app-driver", "display"]`. Android emulator contexts stay exempt from the display promotion,
 as before. At `concurrentRunners: 1` the code path is unchanged.
 
 ### Consequences
 
-* Good: `concurrentRunners > 1` is now safe with native macOS/Windows/iOS app surfaces — two such
-  contexts queue on the shared driver instead of crashing it. Disjoint jobs (HTTP, shell, browser)
-  still run in parallel.
-* Good: The change is one predicate and one resource name, entirely inside the existing scheduler
-  contract; nothing downstream reads the new name specially.
-* Neutral: Native app contexts on one host now run one-at-a-time. That matches physical reality (one
-  shared driver server) and is no slower than the previously-required `concurrentRunners: 1`
+* Good: `concurrentRunners > 1` is now safe with native macOS/Windows app surfaces AND iOS-simulator
+  contexts (native app or mobile-web) — two such contexts queue on the shared driver instead of
+  crashing it. Disjoint jobs (HTTP, shell, **desktop** browser) still run in parallel.
+* Good: The change is one platform-aware predicate and one resource name, entirely inside the
+  existing scheduler contract; nothing downstream reads the new name specially.
+* Neutral: iOS mobile-web contexts on one host now run one-at-a-time alongside iOS app contexts —
+  they genuinely share the simulator, so this is physical reality, not over-serialization. Desktop
+  browser contexts are unaffected.
+* Neutral: Native driver contexts on one host now run one-at-a-time. That matches physical reality
+  (one shared driver stack) and is no slower than the previously-required `concurrentRunners: 1`
   workaround.
 * Neutral / future work: the bound is one-at-a-time (exclusive), not a counted semaphore, so a host
   that could support N parallel native drivers still runs them serially — the same limitation
@@ -87,14 +117,17 @@ as before. At `concurrentRunners: 1` the code path is unchanged.
 ### Confirmation
 
 * Unit tests in `test/concurrency.test.js`: `jobDisplayResources` returns `["native-app-driver"]` for
-  a non-android native app context (mac / windows / ios), `["android-emulator"]` (not the new
-  resource) for an android app context, `[]` for a non-app (HTTP/shell), browser-only, and mixed
-  app+web mobile (gate-SKIP) context, and `["native-app-driver", "display"]` when a shared-display
-  recording is present. A `runResourceAware` test confirms two `"native-app-driver"` jobs never
-  overlap while a disjoint job does. These tests were written first (red → green).
-* End-to-end: the `apps/macos` fixtures job at `concurrentRunners: 2` (PR #532, which depends on this
-  change) exercises two concurrent Mac2 app contexts and must reach PASS/SKIPPED instead of the
-  proxied-crash FAIL.
+  a non-android native app context (mac / windows / ios) **and** for an iOS mobile-web (Safari)
+  context, `["android-emulator"]` (not the new resource) for an android app context, and `[]` for a
+  non-app (HTTP/shell) context, a browser-only context, a **desktop (mac) browser** context (proving
+  desktop browsers still parallelize), and a mixed app+web mobile (gate-SKIP) context; it returns
+  `["native-app-driver", "display"]` when a shared-display recording is present. A `runResourceAware`
+  test confirms two `"native-app-driver"` jobs never overlap while a disjoint job does. These tests
+  were written first (red → green).
+* End-to-end: the `apps`, `apps-ios`, and `mobile-web-ios` macOS fixtures jobs at
+  `concurrentRunners: 2` (PR #532, which depends on this change) each exercise two concurrent
+  same-host native driver / iOS-simulator contexts and must reach PASS/SKIPPED instead of the
+  session-clobber FAIL those three jobs hit without this fix.
 
 ## Pros and Cons of the Options
 

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -458,24 +458,39 @@ function jobDisplayResources(
       hasBrowserStep: isBrowserRequired({ test: job.context }),
       hasAppStep: isAppDriverRequired({ test: job.context }),
     }).action === "proceed";
-  // Non-android native app-driver contexts (macOS Mac2, Windows, iOS/xcuitest
-  // simulators) share a per-host native driver server that two concurrent
-  // sessions clobber (a proxied step fails because the driver "process is not
-  // running (probably crashed)"). Serialize them against each other on one
-  // exclusive resource — the non-android sibling of the android-emulator bound
-  // (extending ADR 01001 the way ADR 01025 did for emulators). Android already
-  // has its own bound above, so it's excluded here (never double-tagged). As
-  // with attemptsEmulator, only a context that will actually drive a native app
-  // takes the resource: it must need an app driver, sit on a native app-driver
-  // platform, and — for mobile platforms where mixing native app + browser
-  // steps deterministically SKIPs — clear the mobile browser gate, so a
-  // SKIP/FAIL context boots nothing and never needlessly serializes other jobs.
+  // Non-android native app-driver contexts share a per-host driver stack that
+  // two concurrent sessions clobber (a proxied step fails because the driver
+  // "process is not running (probably crashed)" / "Session does not exist" /
+  // ECONNREFUSED to WebDriverAgent on :8100). Serialize them against each other
+  // on one exclusive resource — the non-android sibling of the android-emulator
+  // bound (extending ADR 01001 the way ADR 01025 did for emulators). Android
+  // already has its own bound above, so it's excluded here (never double-tagged).
+  //
+  // Which contexts contend depends on the platform:
+  //   - macOS Mac2 / Windows: only contexts that drive a NATIVE APP contend —
+  //     the driver launches the app under test, but a plain desktop browser
+  //     (firefox/chrome) uses a separate browser session and must STILL
+  //     parallelize. So these require isAppDriverRequired.
+  //   - iOS: the single per-host iOS simulator + WebDriverAgent is shared by
+  //     BOTH native-app (xcuitest) AND mobile-web (Safari-on-sim) contexts, so
+  //     two of EITHER kind clobber each other. So an ios context contends
+  //     whether or not it has an app step (mobile-web-ios failed the same way
+  //     apps-ios did under concurrency).
+  // As with attemptsEmulator, the context must also clear the mobile browser
+  // gate, so a context that deterministically SKIPs/FAILs (mixed app+web on
+  // mobile, unsupported browser, device-fixed config) boots nothing and never
+  // needlessly serializes other jobs.
+  const platform = job.context?.platform;
+  const contendsForNativeDriver =
+    platform === "ios"
+      ? true // any ios context boots the shared simulator (app OR web)
+      : isAppDriverRequired({ test: job.context }); // mac/windows: app only
   const attemptsNativeAppDriver =
-    job.context?.platform !== "android" &&
-    NATIVE_APP_DRIVER_PLATFORMS.includes(job.context?.platform) &&
-    isAppDriverRequired({ test: job.context }) &&
+    platform !== "android" &&
+    NATIVE_APP_DRIVER_PLATFORMS.includes(platform) &&
+    contendsForNativeDriver &&
     mobileBrowserGate({
-      platform: job.context?.platform,
+      platform,
       browser: job.context?.browser,
       hasBrowserStep: isBrowserRequired({ test: job.context }),
       hasAppStep: isAppDriverRequired({ test: job.context }),

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -413,6 +413,15 @@ function isDriverRequired({ test }: { test: any }) {
   return driverRequired;
 }
 
+// Non-android platforms whose native app surface is driven by a shared,
+// per-host Appium driver server (macOS Mac2, Windows NovaWindows, iOS/xcuitest
+// simulator). Two concurrent sessions against one of these clobber the shared
+// server, so app-driver contexts on these platforms serialize on the
+// "native-app-driver" resource. Mirrors the non-android keys of
+// APP_DRIVER_PLATFORMS in tests/appSurface.ts; android is excluded because it
+// already has its own "android-emulator" bound.
+const NATIVE_APP_DRIVER_PLATFORMS = ["mac", "windows", "ios"];
+
 // The exclusive resources a context job must hold to run safely under
 // concurrency. A shared-display ffmpeg recording holds "display" exclusively
 // (jobExclusiveResources). And once ANY such recording is in the run
@@ -449,15 +458,46 @@ function jobDisplayResources(
       hasBrowserStep: isBrowserRequired({ test: job.context }),
       hasAppStep: isAppDriverRequired({ test: job.context }),
     }).action === "proceed";
-  const extra = attemptsEmulator ? ["android-emulator"] : [];
-  if (base.length || extra.length) return [...new Set([...base, ...extra])];
-  if (
+  // Non-android native app-driver contexts (macOS Mac2, Windows, iOS/xcuitest
+  // simulators) share a per-host native driver server that two concurrent
+  // sessions clobber (a proxied step fails because the driver "process is not
+  // running (probably crashed)"). Serialize them against each other on one
+  // exclusive resource — the non-android sibling of the android-emulator bound
+  // (extending ADR 01001 the way ADR 01025 did for emulators). Android already
+  // has its own bound above, so it's excluded here (never double-tagged). As
+  // with attemptsEmulator, only a context that will actually drive a native app
+  // takes the resource: it must need an app driver, sit on a native app-driver
+  // platform, and — for mobile platforms where mixing native app + browser
+  // steps deterministically SKIPs — clear the mobile browser gate, so a
+  // SKIP/FAIL context boots nothing and never needlessly serializes other jobs.
+  const attemptsNativeAppDriver =
+    job.context?.platform !== "android" &&
+    NATIVE_APP_DRIVER_PLATFORMS.includes(job.context?.platform) &&
+    isAppDriverRequired({ test: job.context }) &&
+    mobileBrowserGate({
+      platform: job.context?.platform,
+      browser: job.context?.browser,
+      hasBrowserStep: isBrowserRequired({ test: job.context }),
+      hasAppStep: isAppDriverRequired({ test: job.context }),
+    }).action === "proceed";
+  const extra = [
+    ...(attemptsEmulator ? ["android-emulator"] : []),
+    ...(attemptsNativeAppDriver ? ["native-app-driver"] : []),
+  ];
+  // A run-wide shared-display recording promotes every driver context onto the
+  // "display" resource so its ffmpeg capture doesn't include their windows.
+  // This composes with the native-app-driver bound above — a native app
+  // context in such a run holds BOTH (e.g. ["native-app-driver","display"]).
+  // Android emulator contexts are exempt: an emulator renders off the host
+  // display, so it neither pollutes a screen capture nor needs the display
+  // mutex (it stays on "android-emulator" only, as before).
+  const displayPromotion =
+    !attemptsEmulator &&
     ctx.runHasDisplayRecording &&
     isDriverRequired({ test: { steps: job.context?.steps } })
-  ) {
-    return ["display"];
-  }
-  return [];
+      ? ["display"]
+      : [];
+  return [...new Set([...base, ...extra, ...displayPromotion])];
 }
 
 // Check if context is supported by current platform and available apps

--- a/test/concurrency.test.js
+++ b/test/concurrency.test.js
@@ -401,6 +401,38 @@ describe("jobDisplayResources", function () {
     expect(jobDisplayResources(browserJob, ctx)).to.deep.equal([]);
   });
 
+  it("takes nothing for a desktop (mac) browser context — desktop browsers parallelize", function () {
+    // A plain desktop firefox/chrome context on a native app-driver platform
+    // drives no simulator/native driver, so it must STILL run in parallel — the
+    // native-app-driver bound is only for contexts that boot the shared native
+    // driver (mac/windows require an app driver; ios boots the sim for web too).
+    const macBrowserJob = {
+      context: {
+        platform: "mac",
+        browser: { name: "firefox" },
+        steps: [{ goTo: "https://example.com" }],
+      },
+    };
+    expect(jobDisplayResources(macBrowserJob, ctx)).to.deep.equal([]);
+  });
+
+  it("tags an iOS mobile-web (Safari) context with 'native-app-driver'", function () {
+    // A Safari-on-iOS-simulator BROWSER context (isAppDriverRequired == false)
+    // still boots the single per-host iOS simulator/WDA, so two of them clobber
+    // each other's session the same way native app contexts do. It must take
+    // the resource despite having no app step.
+    const iosWebJob = {
+      context: {
+        platform: "ios",
+        browser: { name: "safari" },
+        steps: [{ goTo: "https://example.com" }],
+      },
+    };
+    expect(jobDisplayResources(iosWebJob, ctx)).to.deep.equal([
+      "native-app-driver",
+    ]);
+  });
+
   it("takes nothing for a mixed app+web mobile context (gate SKIPs it)", function () {
     // On a mobile platform, mixing native app + browser steps deterministically
     // SKIPs (mobileBrowserGate), so it drives no native app and must not

--- a/test/concurrency.test.js
+++ b/test/concurrency.test.js
@@ -5,7 +5,11 @@ import {
   rollUpResults,
   createAppiumPool,
 } from "../dist/core/utils.js";
-import { runSpecs, selectWarmUpTargets } from "../dist/core/tests.js";
+import {
+  runSpecs,
+  selectWarmUpTargets,
+  jobDisplayResources,
+} from "../dist/core/tests.js";
 import {
   getEnvironment,
   resolveConcurrentRunners,
@@ -328,6 +332,144 @@ describe("runResourceAware", function () {
     expect(completed).to.deep.equal(["d2"]);
     // Registry left clean.
     expect(reg.tryAcquire(["display"])).to.equal(true);
+  });
+});
+
+describe("jobDisplayResources", function () {
+  // The exclusivity context passed by runSpecs at limit>1. Native app-driver
+  // serialization must not depend on there being a recording in the run, so
+  // runHasDisplayRecording is false in these cases.
+  const ctx = {
+    platform: "darwin",
+    xvfbAvailable: false,
+    runHasDisplayRecording: false,
+  };
+  const nativeAppJob = (platform) => ({
+    context: {
+      platform,
+      steps: [
+        { startSurface: { app: "/System/Applications/Calculator.app" } },
+        { find: { elementText: "5", surface: { app: "Calculator" } } },
+      ],
+    },
+  });
+
+  it("tags a non-android native app-driver context with 'native-app-driver'", function () {
+    // A macOS Mac2 app context: two of these under concurrency clobber the
+    // shared driver server, so each must hold an exclusive resource.
+    expect(jobDisplayResources(nativeAppJob("mac"), ctx)).to.deep.equal([
+      "native-app-driver",
+    ]);
+  });
+
+  it("tags a Windows native app-driver context with 'native-app-driver'", function () {
+    expect(jobDisplayResources(nativeAppJob("windows"), ctx)).to.deep.equal([
+      "native-app-driver",
+    ]);
+  });
+
+  it("tags an iOS simulator app-driver context with 'native-app-driver'", function () {
+    // Two native iOS sims on one host also contend on the shared driver.
+    expect(jobDisplayResources(nativeAppJob("ios"), ctx)).to.deep.equal([
+      "native-app-driver",
+    ]);
+  });
+
+  it("keeps android app contexts on 'android-emulator', not 'native-app-driver'", function () {
+    // Android is already bounded by the emulator resource; it must not be
+    // double-tagged with the new resource.
+    expect(jobDisplayResources(nativeAppJob("android"), ctx)).to.deep.equal([
+      "android-emulator",
+    ]);
+  });
+
+  it("takes nothing for a non-app (HTTP/shell) context", function () {
+    const shellJob = {
+      context: { platform: "darwin", steps: [{ runShell: "echo hi" }] },
+    };
+    expect(jobDisplayResources(shellJob, ctx)).to.deep.equal([]);
+  });
+
+  it("takes nothing for a browser-only driver context (no app)", function () {
+    const browserJob = {
+      context: {
+        platform: "darwin",
+        browser: { name: "chrome" },
+        steps: [{ goTo: "https://example.com" }],
+      },
+    };
+    expect(jobDisplayResources(browserJob, ctx)).to.deep.equal([]);
+  });
+
+  it("takes nothing for a mixed app+web mobile context (gate SKIPs it)", function () {
+    // On a mobile platform, mixing native app + browser steps deterministically
+    // SKIPs (mobileBrowserGate), so it drives no native app and must not
+    // needlessly serialize other native-app jobs.
+    const mixedJob = {
+      context: {
+        platform: "ios",
+        steps: [
+          { startSurface: { app: "com.example.app" } },
+          { goTo: "https://example.com" },
+        ],
+      },
+    };
+    expect(jobDisplayResources(mixedJob, ctx)).to.deep.equal([]);
+  });
+
+  it("composes 'native-app-driver' with 'display' when a recording is present", function () {
+    // A native app context in a run that also has a shared-display recording
+    // holds BOTH the app-driver and the display resource.
+    expect(
+      jobDisplayResources(nativeAppJob("mac"), {
+        ...ctx,
+        runHasDisplayRecording: true,
+      })
+    ).to.deep.equal(["native-app-driver", "display"]);
+  });
+});
+
+describe("runResourceAware native-app-driver serialization", function () {
+  function tracker() {
+    const t = { perResource: {}, perResourceHigh: {}, total: 0, totalHigh: 0 };
+    return {
+      enter(resources) {
+        t.total++;
+        t.totalHigh = Math.max(t.totalHigh, t.total);
+        for (const r of resources) {
+          t.perResource[r] = (t.perResource[r] || 0) + 1;
+          t.perResourceHigh[r] = Math.max(
+            t.perResourceHigh[r] || 0,
+            t.perResource[r]
+          );
+        }
+      },
+      exit(resources) {
+        t.total--;
+        for (const r of resources) t.perResource[r]--;
+      },
+      stats: t,
+    };
+  }
+
+  it("never runs two native-app-driver jobs at once, but overlaps a disjoint job", async function () {
+    const reg = createResourceRegistry();
+    const tk = tracker();
+    const job = (id, exclusiveResources, ms) => ({ id, exclusiveResources, ms });
+    const items = [
+      job("app1", ["native-app-driver"], 40),
+      job("shell1", [], 40),
+      job("app2", ["native-app-driver"], 40),
+    ];
+    await runResourceAware(items, 3, reg, async (item) => {
+      tk.enter(item.exclusiveResources);
+      await sleep(item.ms);
+      tk.exit(item.exclusiveResources);
+    });
+    // The two native-app jobs never overlap...
+    expect(tk.stats.perResourceHigh["native-app-driver"]).to.equal(1);
+    // ...but overall parallelism still exceeded 1 (the shell job overlapped).
+    expect(tk.stats.totalHigh).to.be.above(1);
   });
 });
 


### PR DESCRIPTION
## The bug

Running the feature fixtures at `concurrentRunners: 2` crashed two concurrent **native macOS (Mac2) app-driver sessions**. From CI (PR #532, job `apps/macos`):

> App "/System/Applications/Calculator.app" launched but never became ready: ... `'POST /element' cannot be proxied to Mac2 Driver server because its process is not running (probably crashed)`.

At `concurrentRunners: 1` (current `main`) the same fixtures pass, so the failure is concurrency-induced: two native desktop app-driver contexts run at once and clobber the shared per-host driver server.

## Root cause

The resource-aware concurrency scheduler (ADR 01001) serializes jobs that declare a shared exclusive resource. `jobDisplayResources` (`src/core/tests.ts`) gave:

- **Android** app contexts the `"android-emulator"` exclusive resource (ADR 01025);
- driver contexts `"display"` only when a shared-display recording is in the run;
- **native desktop (macOS Mac2 / Windows) and iOS-simulator app-driver contexts nothing** otherwise → they ran concurrently and clobbered the single, per-host Mac2/NovaWindows/xcuitest driver server.

## The fix

Introduce a new exclusive resource **`native-app-driver`**. `jobDisplayResources` now tags a job with it when the context:

1. needs an app driver (`isAppDriverRequired`),
2. sits on a **non-android** native app-driver platform (`mac` / `windows` / `ios`, via `NATIVE_APP_DRIVER_PLATFORMS`), and
3. clears `mobileBrowserGate` — so a context that deterministically SKIPs/FAILs (mixed native-app+browser on mobile, unsupported) takes **nothing** and never needlessly serializes other jobs (same discipline as the existing `attemptsEmulator` branch).

Android keeps `"android-emulator"` (never double-tagged). The new resource composes with the `"display"` recording resource via the existing `[...new Set([...])]` union, so a native app context in a recording run holds `["native-app-driver", "display"]`. Android emulator contexts stay exempt from the display promotion (an emulator renders off-host). The `limit === 1` path bypasses `runResourceAware` and is unchanged (byte-identical).

Introduced resource name: **`native-app-driver`**.

## Tests (red → green)

`test/concurrency.test.js`, written failing first:

- `jobDisplayResources` returns `["native-app-driver"]` for a non-android native app context (mac / windows / ios), `["android-emulator"]` (not the new one) for an android app context, `[]` for non-app (HTTP/shell), browser-only, and mixed app+web mobile (gate-SKIP) contexts, and `["native-app-driver", "display"]` when a shared-display recording is present.
- Under `runResourceAware`, two `native-app-driver` jobs never overlap while a disjoint (shell) job does.

Red run: the 4 native-app-driver assertions failed (`expected [] to deeply equal [ 'native-app-driver' ]`). After the fix: **157 passing, 0 failing** across `test/concurrency.test.js` and `test/ffmpeg-recorder.test.js` (`npm run build && npx mocha --exit test/concurrency.test.js test/ffmpeg-recorder.test.js`).

## ADR

`adrs/01038-serialize-native-app-driver-contexts-under-concurrency.md` (MADR 4.0.0), framed as extending ADR 01001 the way ADR 01025 did for Android emulators.

## Docs-impact assessment

**No user-facing behavior change beyond removing a crash.** `concurrentRunners > 1` is now safe with native app surfaces (previously it crashed). The `concurrentRunners` config field, its meaning, values, and default are all unchanged. No schema (`config_v3`) change. The `config.md` reference is schema-generated and needs no edit. No docs change made.

## Feature fixtures

End-to-end coverage is the existing native-app (`apps/`) fixtures run at `concurrentRunners: 2`, which lands in **PR #532** (which sets `concurrentRunners: 2` in the fixture config and depends on this fix). No new fixtures are added here — this change adds no new user-facing surface (no new step type, flag, engine, or output format); it removes a concurrency crash in the scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter concurrency handling for native app runs on supported desktop and simulator platforms.
  * Native app jobs now get an additional exclusivity tag when they actually need a shared app driver, helping prevent parallel conflicts.
  * Display recording now combines cleanly with other exclusivity settings instead of replacing them.

* **Bug Fixes**
  * Reduced crashes and instability caused by overlapping native app sessions on the same host.
  * Kept Android behavior separate from the new native app scheduling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->