### PR TITLE
fix(core): assign a unique chromedriver port per browser driver

### DIFF
--- a/adrs/01039-unique-chromedriver-port-per-browser-driver.md
+++ b/adrs/01039-unique-chromedriver-port-per-browser-driver.md
@@ -1,0 +1,134 @@
+---
+status: accepted
+date: 2026-07-07
+decision-makers: doc-detective maintainers
+---
+
+# Assign a unique chromedriver port per browser-driver session under concurrency
+
+## Context and Problem Statement
+
+Each concurrent runner gets its own Appium server on its own free port (`startAppiumServer` /
+`createAppiumPool` in [src/core/tests.ts](../src/core/tests.ts)), so parallel contexts never share an
+Appium instance. For a Chrome context, that Appium server loads `appium-chromium-driver`, which spawns
+a **chromedriver** child and proxies WebDriver commands to it.
+
+The capabilities `getDriverCapabilities` builds for Chrome
+([src/core/tests.ts](../src/core/tests.ts)) set `appium:automationName: "Chromium"` and
+`appium:executable` (the chromedriver binary), but **no chromedriver port**. When
+`appium:chromedriverPort` is undefined, `appium-chromium-driver` passes `port: undefined` to
+`appium-chromedriver`, which falls back to its fixed `DEFAULT_PORT = 9515`. So every concurrent Chrome
+context's chromedriver tries to bind the **same** port. One binds; the other's chromedriver either
+fails to bind or the two Appium servers proxy to whichever chromedriver won 9515 — and a command later
+lands on the wrong / dead one.
+
+At `concurrentRunners: 2` (PR #532), `fixtures / capture (windows-latest)` FAILed exactly this way,
+mid-session rather than at session creation:
+
+```
+goTo action timed out after 4245ms
+✗ DOM stability timeout: WebDriverError: Could not proxy command to the remote server.
+  Original error: connect ECONNREFUSED 127.0.0.1:9515 when running "execute/sync" with method "POST"
+```
+
+`9515` is chromedriver's default port. The same suite passes at `concurrentRunners: 1`, where only one
+chromedriver ever exists, so the fixed port never collides.
+
+Two properties were missing on the browser-driver path:
+
+1. **A unique port per concurrent chromedriver.** Firefox is unaffected — `appium-geckodriver`
+   auto-selects a free `systemPort` from a range (and errors only if none is free); Safari has no such
+   port. Only the Chromium path pins the fixed default.
+2. **The Appium path's ECONNREFUSED retry, applied to the browser rebind race.** `driverStart` already
+   retries `isRetryableSessionError` failures (which include `ECONNREFUSED`), but on a *fixed* port a
+   retry just re-races the same 9515; a retry only helps if it lands on a fresh port.
+
+## Decision Drivers
+
+- The `fixtures / capture` job runs under `concurrentRunners: 2`; this collision fails PR CI outright
+  and is deterministic on Windows once two Chrome contexts overlap.
+- The `concurrentRunners: 1` path (and every non-Chrome engine) must stay behavior-preserving — no
+  spurious port churn where none is needed.
+- Port assignment must be unit-testable without webdriverio, a driver, or a network (repo convention:
+  small pure helpers).
+- Reuse the existing retry machinery (`isRetryableSessionError`, `findFreePort`) rather than adding a
+  parallel one.
+
+## Considered Options
+
+1. **Assign a unique free `appium:chromedriverPort` per Chromium session inside `driverStart`, with a
+   fresh port per retry attempt**, via a pure `withChromedriverPort` helper.
+2. Bake a free port into `getDriverCapabilities` at cap-build time (one port per context, not per
+   attempt).
+3. Serialize all Chrome contexts on a shared resource (like the native-app-driver bound in ADR 01038).
+4. Do nothing runner-side; only cap `concurrentRunners: 1` for browser groups.
+
+## Decision Outcome
+
+Chosen option: **1**. A pure `withChromedriverPort(capabilities, port)` helper in
+[src/core/tests.ts](../src/core/tests.ts) returns a copy with `appium:chromedriverPort` set **only**
+when the caps are Chromium and no explicit port was supplied; every other engine's caps pass through
+untouched. `driverStart` allocates a fresh `findFreePort()` for Chromium caps **on each attempt**
+before calling `wdio.remote`, so a retryable `ECONNREFUSED` (the rebind race the Appium path already
+retries) moves to a new free port instead of re-racing the same one. Nothing else about the retry loop
+(attempt counts, linear backoff, ceiling derivation) changes, and non-Chromium sessions skip the
+allocation entirely.
+
+### Consequences
+
+- Good: two concurrent Chrome contexts now bind distinct chromedriver ports, so the mid-session
+  `ECONNREFUSED 127.0.0.1:9515` collision cannot occur. The observed `capture (windows-latest)` failure
+  becomes a PASS at `concurrentRunners: 2`.
+- Good: Firefox/Safari/native/mobile-web sessions are bit-for-bit unchanged — `withChromedriverPort`
+  returns their caps object as-is and `driverStart` skips the port allocation for them.
+- Neutral: a Chrome session at `concurrentRunners: 1` now binds a specific free chromedriver port
+  instead of the default 9515. This is behavior-preserving (chromedriver works identically on any free
+  port); the wire caps gain one field. It is the minimal change that makes the port unique, and it is
+  by definition not byte-identical for Chrome — that is the fix.
+- Neutral: an explicit `appium:chromedriverPort` (a caller pinning a port) is preserved, not
+  overridden.
+
+### Confirmation
+
+- Unit: `withChromedriverPort` and `getDriverCapabilities` cases in
+  [test/context-resolution.test.js](../test/context-resolution.test.js) — Chrome caps carry no fixed
+  port; the helper assigns a port for Chromium, returns a copy, does not override an explicit port,
+  leaves non-Chromium caps untouched, and two concurrent allocations yield distinct ports.
+- Unit: `isRetryableSessionError` cases in
+  [test/core-utils-coverage.test.js](../test/core-utils-coverage.test.js) — the exact CI failure
+  string (`Could not proxy command … ECONNREFUSED 127.0.0.1:9515 … execute/sync`) and a bare
+  `ECONNREFUSED …:9515` are retryable, confirming the browser driver gets the Appium path's resilience.
+- End-to-end: the `fixtures / capture` job under `concurrentRunners: 2` — two Chrome contexts complete
+  instead of one FAILing with a 9515 proxy error.
+
+## Pros and Cons of the Options
+
+### Option 1: unique free chromedriver port per Chromium session, fresh per attempt (chosen)
+
+- Good: targets exactly the sessions that collide (Chromium); zero behavior change for every other
+  engine and for the single-runner path beyond the added port field.
+- Good: pure, unit-testable helper; `driverStart` stays boring and reuses `findFreePort` +
+  `isRetryableSessionError`.
+- Good: fresh port per attempt makes the existing ECONNREFUSED retry actually resolve the rebind race
+  instead of re-racing a fixed port.
+- Bad: one extra ephemeral bind/close (`findFreePort`) per Chromium attempt — negligible.
+
+### Option 2: bake a free port into `getDriverCapabilities`
+
+- Good: one place to change.
+- Bad: `getDriverCapabilities` is synchronous and pure; `findFreePort` is async — it would have to
+  become async or take an injected port at all four call sites. And a per-context (not per-attempt)
+  port means a retry re-uses a port that may have just been grabbed in the rebind window, losing the
+  retry's benefit.
+
+### Option 3: serialize Chrome contexts on a shared resource
+
+- Good: no port handling.
+- Bad: collapses browser concurrency to one at a time — the opposite of the `concurrentRunners` goal —
+  to work around a problem a unique port solves outright.
+
+### Option 4: cap browser groups at `concurrentRunners: 1`
+
+- Good: no code change.
+- Bad: permanently forfeits parallel browser execution to dodge a one-line-root-cause bug; leaves the
+  runner unable to ever run two Chrome contexts safely.

--- a/adrs/01039-unique-chromedriver-port-per-browser-driver.md
+++ b/adrs/01039-unique-chromedriver-port-per-browser-driver.md
@@ -25,7 +25,7 @@ lands on the wrong / dead one.
 At `concurrentRunners: 2` (PR #532), `fixtures / capture (windows-latest)` FAILed exactly this way,
 mid-session rather than at session creation:
 
-```
+```text
 goTo action timed out after 4245ms
 ✗ DOM stability timeout: WebDriverError: Could not proxy command to the remote server.
   Original error: connect ECONNREFUSED 127.0.0.1:9515 when running "execute/sync" with method "POST"

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -160,6 +160,7 @@ export {
   warmUpDecision,
   selectWarmUpTargets,
   getDriverCapabilities,
+  withChromedriverPort,
   getDefaultBrowser,
   buildFallbackCandidates,
   driverSkipDiagnostic,
@@ -397,6 +398,29 @@ function getDriverCapabilities({ runnerDetails, name, options }: { runnerDetails
   }
 
   return capabilities;
+}
+
+// Bind a Chromium (chromedriver-backed) session to a specific chromedriver
+// port. appium-chromium-driver hands `chromedriverPort` straight to
+// appium-chromedriver; when it is undefined, appium-chromedriver falls back to
+// its fixed DEFAULT_PORT (9515). Two concurrent browser contexts (own Appium
+// server each, from the pool) then both spawn chromedriver on 9515 — one binds,
+// the other's connection is REFUSED, surfacing later as a mid-session
+// `ECONNREFUSED 127.0.0.1:9515` when a command proxies to the wrong/dead
+// chromedriver (ADR 01039). Assigning a unique free port per session removes the
+// collision. Gecko/Safari are unaffected — geckodriver auto-selects a free
+// `systemPort` from a range, and Safari has no such port — so this only touches
+// Chromium caps, leaving every other engine's caps byte-identical. An explicit
+// `appium:chromedriverPort` (a caller opting into a fixed port) is preserved.
+function withChromedriverPort(capabilities: any, port: number): any {
+  if (
+    !capabilities ||
+    capabilities["appium:automationName"] !== "Chromium" ||
+    capabilities["appium:chromedriverPort"] !== undefined
+  ) {
+    return capabilities;
+  }
+  return { ...capabilities, "appium:chromedriverPort": port };
 }
 
 
@@ -4795,13 +4819,26 @@ async function driverStart(
   let lastError: any;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
+      // Chromium sessions get a unique free chromedriver port so concurrent
+      // browser contexts never collide on chromedriver's fixed default (9515);
+      // see withChromedriverPort (ADR 01039). A FRESH port is allocated per
+      // attempt so a retryable ECONNREFUSED — the very rebind-race the Appium
+      // path already retries — moves to a new free port instead of re-racing
+      // the same one. Only Chromium caps need a port; every other engine skips
+      // the allocation and keeps a byte-identical wdio.remote payload.
+      const needsChromedriverPort =
+        capabilities?.["appium:automationName"] === "Chromium" &&
+        capabilities?.["appium:chromedriverPort"] === undefined;
+      const attemptCaps = needsChromedriverPort
+        ? withChromedriverPort(capabilities, await findFreePort())
+        : capabilities;
       const driver: any = await wdio.remote({
         protocol: "http",
         hostname: "127.0.0.1",
         port,
         path: "/",
         logLevel: "error",
-        capabilities,
+        capabilities: attemptCaps,
         connectionRetryTimeout: startupCeiling,
         waitforTimeout: 120000, // 2 minutes
       });

--- a/test/context-resolution.test.js
+++ b/test/context-resolution.test.js
@@ -3,11 +3,13 @@ import {
   isSupportedContext,
   getDefaultBrowser,
   getDriverCapabilities,
+  withChromedriverPort,
   combinationKey,
   warmUpDecision,
   contextRequirementsSkipMessage,
 } from "../dist/core/tests.js";
 import { resolveContexts } from "../dist/core/resolveTests.js";
+import { findFreePort } from "../dist/core/utils.js";
 
 // A step that requires a browser driver, and one that doesn't.
 const driverStep = { goTo: "https://example.com" };
@@ -427,5 +429,78 @@ describe("getDriverCapabilities", function () {
       options,
     });
     assert.equal(caps.browserName, "Safari");
+  });
+
+  it("does not pin a fixed chromedriver port in chrome capabilities", function () {
+    // The chromedriver port must be assigned per-driver (a unique free port),
+    // never baked into the caps at a fixed default. Two concurrent browser
+    // contexts that shared the chromedriver default port (9515) would collide
+    // — one driver's connection is refused mid-session (ECONNREFUSED :9515).
+    const caps = getDriverCapabilities({
+      runnerDetails: baseRunner,
+      name: "chrome",
+      options,
+    });
+    assert.equal(caps["appium:chromedriverPort"], undefined);
+  });
+});
+
+describe("withChromedriverPort", function () {
+  const chromeCaps = {
+    "appium:automationName": "Chromium",
+    browserName: "chrome",
+  };
+
+  it("assigns a chromedriver port for a Chromium session", function () {
+    const out = withChromedriverPort(chromeCaps, 51234);
+    assert.equal(out["appium:chromedriverPort"], 51234);
+  });
+
+  it("returns a copy, leaving the input capabilities untouched", function () {
+    const input = { ...chromeCaps };
+    const out = withChromedriverPort(input, 51235);
+    assert.equal(input["appium:chromedriverPort"], undefined);
+    assert.notStrictEqual(out, input);
+  });
+
+  it("assigns distinct ports on repeated calls (fresh free port per attempt)", function () {
+    const a = withChromedriverPort(chromeCaps, 40001);
+    const b = withChromedriverPort(chromeCaps, 40002);
+    assert.notEqual(
+      a["appium:chromedriverPort"],
+      b["appium:chromedriverPort"]
+    );
+  });
+
+  it("does not override an explicitly supplied chromedriver port", function () {
+    const out = withChromedriverPort(
+      { ...chromeCaps, "appium:chromedriverPort": 9999 },
+      51236
+    );
+    assert.equal(out["appium:chromedriverPort"], 9999);
+  });
+
+  it("leaves non-Chromium capabilities untouched", function () {
+    const gecko = { "appium:automationName": "Gecko", browserName: "firefox" };
+    const out = withChromedriverPort(gecko, 51237);
+    assert.equal(out["appium:chromedriverPort"], undefined);
+    // Gecko/Safari pick their own free port internally; nothing to assign.
+    assert.deepEqual(out, gecko);
+  });
+
+  it("gives two concurrent Chromium driver starts distinct chromedriver ports", async function () {
+    // Model the two concurrent browser contexts that collided on 9515: each
+    // driverStart allocates its own free chromedriver port, so their caps must
+    // never share a port. This is the concurrency invariant the fix restores.
+    const build = async () =>
+      withChromedriverPort(
+        { "appium:automationName": "Chromium", browserName: "chrome" },
+        await findFreePort()
+      );
+    const [a, b] = await Promise.all([build(), build()]);
+    assert.notEqual(
+      a["appium:chromedriverPort"],
+      b["appium:chromedriverPort"]
+    );
   });
 });

--- a/test/core-utils-coverage.test.js
+++ b/test/core-utils-coverage.test.js
@@ -772,6 +772,11 @@ describe("core/utils coverage", function () {
     it("keeps the existing transient patterns retryable at any ceiling", function () {
       for (const message of [
         "connect ECONNREFUSED 127.0.0.1:4723",
+        // The concurrent-chromedriver collision on the fixed default port
+        // (9515) that ADR 01039 fixes: the browser driver must retry this the
+        // same way the Appium path does.
+        "connect ECONNREFUSED 127.0.0.1:9515",
+        'WebDriverError: Could not proxy command to the remote server. Original error: connect ECONNREFUSED 127.0.0.1:9515 when running "execute/sync" with method "POST"',
         "read ECONNRESET",
         "socket hang up",
         "unknown error: could not proxy command to the remote browser",


### PR DESCRIPTION
## Root cause

At `concurrentRunners: 2` (PR #532), `fixtures / capture (windows-latest)` FAILed mid-session:

```
goTo action timed out after 4245ms
✗ DOM stability timeout: WebDriverError: Could not proxy command to the remote server.
  Original error: connect ECONNREFUSED 127.0.0.1:9515 when running "execute/sync" with method "POST"
```

`9515` is chromedriver's default port. Each concurrent runner gets its **own** Appium server on its own free port (`startAppiumServer`/`createAppiumPool`), and for a Chrome context that server loads `appium-chromium-driver`, which spawns a **chromedriver** child. But `getDriverCapabilities` built Chrome caps with **no** chromedriver port (`src/core/tests.ts`, the `chrome` case). With `appium:chromedriverPort` undefined, `appium-chromium-driver` passes `port: undefined` to `appium-chromedriver`, which falls back to `DEFAULT_PORT = 9515`. So every concurrent Chrome context's chromedriver tried to bind the same 9515 -> one bound, the other's connection was refused -> the surviving command later proxied to the wrong/dead chromedriver (`ECONNREFUSED ...:9515` on `execute/sync` during `goTo`). Passes at `concurrentRunners: 1` because only one chromedriver ever exists.

Firefox is unaffected: `appium-geckodriver` auto-selects a free `systemPort` from a range. Safari has no such port. **Only the Chromium path pinned the fixed default.**

## Fix

- New pure helper `withChromedriverPort(capabilities, port)` in `src/core/tests.ts`: returns a copy with `appium:chromedriverPort` set **only** for Chromium caps with no explicit port; every other engine's caps pass through untouched; an explicit port is preserved.
- `driverStart` allocates a **fresh** `findFreePort()` for Chromium sessions **per attempt** before `wdio.remote`. This gives the browser path the Appium path's ECONNREFUSED resilience where it actually helps: a retryable `ECONNREFUSED` moves to a new free port instead of re-racing the same fixed one. Non-Chromium sessions skip the allocation and keep a **byte-identical** `wdio.remote` payload.

`concurrentRunners: 1`: byte-identical for every non-Chrome engine; a Chrome session now binds a specific free chromedriver port instead of 9515 (behavior-preserving -- chromedriver works on any free port). That is the fix and cannot be byte-identical for Chrome by definition.

## Tests (red -> green)

- `test/context-resolution.test.js`: `getDriverCapabilities` chrome caps carry no fixed port; `withChromedriverPort` assigns a port for Chromium, returns a copy, does not override an explicit port, leaves non-Chromium caps untouched, and **two concurrent allocations yield distinct ports**.
- `test/core-utils-coverage.test.js`: the exact CI failure string (`Could not proxy command ... ECONNREFUSED 127.0.0.1:9515 ... execute/sync`) and a bare `ECONNREFUSED ...:9515` are retryable -- the browser driver gets the Appium path's resilience.
- Red confirmed: without the source change the module has no `withChromedriverPort` export and the new tests fail to load. Green: 144 passing, 0 failing in these two files. The unrelated browser/surface-driver tests that FAIL in this environment fail identically on the base commit (no local `appium` package) -- verified via base-commit stash.

## ADR

`adrs/01039-unique-chromedriver-port-per-browser-driver.md` (MADR 4.0.0). Next-free number above `origin/main` was 01039. Note: a sibling PR (native-app-group fix) may also pick 01039 -- renumber at merge if they collide.

## Docs impact

**None.** Internal runtime detail; `appium:chromedriverPort` is neither set nor seen by users. This removes a concurrency crash in an existing feature (browser capture under `concurrentRunners > 1`), not a new user-facing surface. No schema change.

## Fixtures

The existing `capture` fixture group already runs under `concurrentRunners: 2` (PR #532), which is exactly the path that exercises this end-to-end -- no new fixture permutation needed for a correctness fix to an existing feature.

Does **not** touch PR #532.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chrome session startup under concurrent runs by automatically selecting a unique chromedriver port when none is provided.
  * Retry attempts now avoid reusing the same conflicting default port, reducing transient connection errors.
  * Non-Chromium browsers keep their existing behavior.

* **Tests**
  * Added new coverage for chromedriver port assignment, immutability of capability inputs, retryable error detection, and concurrent session startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->