### PR TITLE
fix(core): serialize recording native-app contexts under concurrency

### DIFF
--- a/adrs/01040-serialize-recording-native-app-contexts-under-concurrency.md
+++ b/adrs/01040-serialize-recording-native-app-contexts-under-concurrency.md
@@ -1,0 +1,132 @@
+---
+status: accepted
+date: 2026-07-07
+decision-makers: doc-detective maintainers
+---
+
+# Serialize recording native-app contexts under concurrency
+
+## Context and Problem Statement
+
+ADR 01001 introduced the resource-aware concurrency scheduler: each context job declares a set of
+exclusive resource names, and two jobs sharing a resource never run concurrently while everything
+else stays parallel. ADR 01025 added `"android-emulator"` for heavyweight emulators, and
+**ADR 01038** added `"native-app-driver"` so two non-android native app-driver contexts (macOS Mac2,
+Windows NovaWindows, iOS/xcuitest) never boot the single per-host driver stack at once — two
+concurrent sessions clobber it.
+
+ADR 01038 fixed iOS and the plain (non-recording) macOS/Windows app flows, but the `apps` fixture
+group **still** failed at `concurrentRunners: 2` with the same per-host contention class, now on the
+**recording** app fixtures:
+
+```
+# apps (macos-latest) — rec-app-macos-default-window (record + stopRecord on TextEdit):
+App "com.apple.TextEdit" launched but never became ready:
+... WebDriverError: Session does not exist when running "element" with method "POST"
+
+# apps (windows-latest) — rec-app-default-window (record + stopRecord on charmap):
+No element matched {"elementText":"Select","surface":{"app":"charmap"}} within 5000ms
+```
+
+The CI timelines are decisive: the recording app context (`rec-app-*`) and a **plain** native-app
+context (`app-env-launch` on macOS, `app-then-tty-app` on Windows) started within seconds of each
+other and ran concurrently — both driving the single per-host Mac2 / NovaWindows driver — and one
+session was clobbered mid-run. At `concurrentRunners: 1` the same fixtures pass.
+
+The root cause is in `jobDisplayResources` (`src/core/tests.ts`). ADR 01038 gated the
+`"native-app-driver"` tag on `mobileBrowserGate(...).action === "proceed"`, borrowing the
+`attemptsEmulator` gating discipline. That gate is meaningful only on **mobile** targets, where a
+context that mixes native-app and device-browser steps deterministically SKIPs. But the gate reads
+`hasBrowserStep = isBrowserRequired(context)`, and `isBrowserRequired` classifies any
+`BROWSER_STEP_KEYS` step that is **not app-targeting** as a browser step. A **recording** app context
+carries `record` (object payload with `surface: { app }` — correctly app-targeting) **and**
+`stopRecord: true` (a bare `true` payload — *not* app-targeting). So `isBrowserRequired` reports a
+"browser step", `mobileBrowserGate` returns `skip` (interpreting it as mixed native-app + device
+browser), and the desktop recording app context **loses** the `"native-app-driver"` bound — it holds
+only `"display"`. A plain app context holds `"native-app-driver"`. The two resource sets are
+**disjoint**, so the scheduler runs them concurrently and they clobber the shared driver.
+
+There is no device browser on desktop to mix with, so the gate never should have run there.
+
+## Decision Drivers
+
+* **Fix the actual seam, minimally.** The tag is otherwise correct; only the desktop gating is wrong.
+  One predicate change, no new machinery, composing with ADR 01038/01025/01001 exactly as before.
+* **Only serialize contexts that actually boot the shared driver.** A desktop context contends iff
+  `isAppDriverRequired` — a plain desktop browser (firefox/chrome) still parallelizes.
+* **Keep mobile gating intact.** On ios/android the gate genuinely SKIPs mixed app+web contexts and
+  those must still take nothing; only desktop must bypass the gate.
+* **Compose, don't collide.** A recording app context holds BOTH `"native-app-driver"` and
+  `"display"`; the union order must stay the canonical `["native-app-driver", "display"]`.
+* **`concurrentRunners: 1` stays byte-identical.** The `limit === 1` path bypasses the resource-aware
+  pool entirely and must not change.
+
+## Considered Options
+
+* **Apply `mobileBrowserGate` only on mobile targets (chosen).** On mac/windows a native-app context
+  (`isAppDriverRequired`) always contends for the shared driver, so it always takes
+  `"native-app-driver"`. The gate still runs on ios/android. Order the resource union driver-bound
+  first so the display bound composes as `["native-app-driver", "display"]` no matter which path
+  added `"display"`.
+* **Teach `isBrowserRequired` / `stepTargetsAppSurface` that `record`/`stopRecord` are app-driven.**
+  Rejected: `stopRecord: true` has no surface to inspect, and `record`/`stopRecord` legitimately run
+  on browser contexts too, so this would mis-tag real browser recordings and touches the runtime
+  browser-need inference shared with `inferRuntimeNeeds` — far more blast radius than the crash needs.
+* **Force the whole run serial when any native-app recording is present.** Rejected: collapses all
+  parallelism — the regression ADR 01001 exists to prevent.
+
+## Decision Outcome
+
+Chosen: **restrict `mobileBrowserGate` to mobile targets in `jobDisplayResources`.**
+
+`jobDisplayResources` now computes `gateProceeds = !isMobileTarget || mobileBrowserGate(...) ===
+"proceed"`, where `isMobileTarget` is `ios`/`android`. `attemptsNativeAppDriver` then tags a desktop
+app-driver context (`isAppDriverRequired`, mac/windows) with `"native-app-driver"` unconditionally,
+while mobile keeps the SKIP-aware gate (an ios context still contends for the simulator whether app
+or web; a mixed-mobile SKIP context still takes nothing). The final union is ordered
+`[...extra, ...base, ...displayPromotion]` so a recording app context resolves to
+`["native-app-driver", "display"]`. At `concurrentRunners: 1` the code path is unchanged.
+
+### Consequences
+
+* Good: `concurrentRunners > 1` is now safe for **recording** native macOS/Windows app surfaces —
+  a recording app context queues on `"native-app-driver"` against every other native app context
+  instead of clobbering the shared driver. iOS and plain-app flows (ADR 01038) are unaffected.
+* Good: desktop browser contexts still parallelize (they aren't `isAppDriverRequired`); mobile gating
+  is untouched.
+* Neutral: recording app contexts on one host now run one-at-a-time alongside other native app
+  contexts — physical reality (one shared driver stack), no slower than the `concurrentRunners: 1`
+  workaround.
+* Neutral / future work: the bound is exclusive (one-at-a-time), not a counted semaphore — the same
+  limitation `"android-emulator"` and ADR 01038 carry.
+
+### Confirmation
+
+* Unit tests in `test/concurrency.test.js` (written first, red → green): `jobDisplayResources` returns
+  `["native-app-driver", "display"]` for a **macOS** and a **Windows** recording app context
+  (`startSurface` + `record` + `stopRecord`) when a display recording is present — previously it
+  returned `["display"]` only. A `runResourceAware` test confirms a recording app context and a plain
+  app context, tagged by the real `jobDisplayResources`, never overlap on `"native-app-driver"`. The
+  existing ADR 01038 cases (ios/android/browser/mixed/desktop-browser) still pass unchanged.
+* End-to-end: the `apps` macOS and Windows fixtures jobs at `concurrentRunners: 2` (PR #532) exercise
+  a recording app context concurrently with a plain app context and must reach PASS/SKIPPED instead of
+  the session-clobber FAIL those two jobs hit without this fix.
+
+## Pros and Cons of the Options
+
+### Restrict `mobileBrowserGate` to mobile targets (chosen)
+
+* Good: minimal — one predicate, reuses ADR 01001's scheduler and ADR 01038's resource name.
+* Good: composes with `"display"`; keeps desktop-browser and mobile parallelism/SKIP semantics intact.
+* Neutral: exclusive (one-at-a-time) rather than a counted semaphore.
+
+### Teach `isBrowserRequired` that `record`/`stopRecord` are app-driven
+
+* Good: would fix the misclassification at its source for app contexts.
+* Bad: `stopRecord: true` has no surface to key on; `record`/`stopRecord` also run on real browser
+  contexts, so this mis-tags browser recordings and touches shared runtime browser-need inference.
+
+### Force the whole run serial when a native-app recording is present
+
+* Good: trivially correct.
+* Bad: destroys parallelism for every unrelated job — the regression ADR 01001 exists to prevent.

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -485,16 +485,31 @@ function jobDisplayResources(
     platform === "ios"
       ? true // any ios context boots the shared simulator (app OR web)
       : isAppDriverRequired({ test: job.context }); // mac/windows: app only
-  const attemptsNativeAppDriver =
-    platform !== "android" &&
-    NATIVE_APP_DRIVER_PLATFORMS.includes(platform) &&
-    contendsForNativeDriver &&
+  // The mobileBrowserGate check only makes sense on MOBILE targets (ios/android):
+  // it SKIPs a context that deterministically won't boot the shared driver
+  // (mixed native-app + device-browser, unsupported/misconfigured mobile
+  // browser). On DESKTOP (mac/windows) there is no device browser to mix with, so
+  // the gate must NOT run: a desktop app context that also RECORDS carries
+  // `record`/`stopRecord` steps (BROWSER_STEP_KEYS) whose non-object payloads
+  // aren't app-targeting, so isBrowserRequired reports a "browser step" and the
+  // gate would wrongly SKIP — dropping the native-app-driver bound and letting a
+  // recording app context run concurrently with another native app context,
+  // clobbering the single per-host Mac2 / NovaWindows driver. Desktop app
+  // contexts always boot that driver, so they always contend. (ADR 01040.)
+  const isMobileTarget = platform === "ios" || platform === "android";
+  const gateProceeds =
+    !isMobileTarget ||
     mobileBrowserGate({
       platform,
       browser: job.context?.browser,
       hasBrowserStep: isBrowserRequired({ test: job.context }),
       hasAppStep: isAppDriverRequired({ test: job.context }),
     }).action === "proceed";
+  const attemptsNativeAppDriver =
+    platform !== "android" &&
+    NATIVE_APP_DRIVER_PLATFORMS.includes(platform) &&
+    contendsForNativeDriver &&
+    gateProceeds;
   const extra = [
     ...(attemptsEmulator ? ["android-emulator"] : []),
     ...(attemptsNativeAppDriver ? ["native-app-driver"] : []),
@@ -512,7 +527,12 @@ function jobDisplayResources(
     isDriverRequired({ test: { steps: job.context?.steps } })
       ? ["display"]
       : [];
-  return [...new Set([...base, ...extra, ...displayPromotion])];
+  // Order the union driver-bound first (native-app-driver / android-emulator),
+  // then the display resource — whether "display" arrived via `base` (this job's
+  // own ffmpeg recording) or `displayPromotion` (a recording elsewhere in the
+  // run). This keeps the canonical `["native-app-driver", "display"]` shape
+  // stable regardless of which path added the display bound.
+  return [...new Set([...extra, ...base, ...displayPromotion])];
 }
 
 // Check if context is supported by current platform and available apps

--- a/test/concurrency.test.js
+++ b/test/concurrency.test.js
@@ -459,6 +459,53 @@ describe("jobDisplayResources", function () {
       })
     ).to.deep.equal(["native-app-driver", "display"]);
   });
+
+  // A desktop native-app context that ALSO records: its `record` step names the
+  // app surface (object form), but the paired `stopRecord: true` (and any
+  // non-object record payload) does NOT — so isBrowserRequired sees a
+  // BROWSER_STEP_KEYS step that isn't app-targeting and reports a browser step.
+  // On mac/windows that must NOT drop the native-app-driver bound (there is no
+  // device browser to mix with on desktop): the context still boots the shared
+  // Mac2 / NovaWindows driver and MUST serialize against other native-app
+  // contexts, or two concurrent sessions clobber the per-host driver
+  // ("Session does not exist" / "process is not running (probably crashed)" /
+  // "No element matched"). Regression for the apps-group macOS+Windows failures
+  // at concurrentRunners: 2 (recording app context overlapped a plain app one).
+  const recordingAppJob = (platform) => ({
+    context: {
+      platform,
+      steps: [
+        { startSurface: { app: "com.apple.TextEdit" } },
+        { record: { path: "x.mp4", surface: { app: "TextEdit" } } },
+        { type: { keys: ["x"], surface: { app: "TextEdit" } } },
+        { stopRecord: true },
+        { closeSurface: { app: "TextEdit" } },
+      ],
+    },
+  });
+
+  it("tags a macOS recording app context (record + stopRecord) with 'native-app-driver'", function () {
+    // The stopRecord step is a BROWSER_STEP_KEY that isn't app-targeting, so the
+    // old mobileBrowserGate path SKIPped the native-app-driver bound and let this
+    // context run concurrently with another native app context.
+    expect(
+      jobDisplayResources(recordingAppJob("mac"), {
+        ...ctx,
+        allowOverlappingCaptures: false,
+        runHasDisplayRecording: true,
+      })
+    ).to.deep.equal(["native-app-driver", "display"]);
+  });
+
+  it("tags a Windows recording app context (record + stopRecord) with 'native-app-driver'", function () {
+    expect(
+      jobDisplayResources(recordingAppJob("windows"), {
+        ...ctx,
+        allowOverlappingCaptures: false,
+        runHasDisplayRecording: true,
+      })
+    ).to.deep.equal(["native-app-driver", "display"]);
+  });
 });
 
 describe("runResourceAware native-app-driver serialization", function () {
@@ -502,6 +549,59 @@ describe("runResourceAware native-app-driver serialization", function () {
     expect(tk.stats.perResourceHigh["native-app-driver"]).to.equal(1);
     // ...but overall parallelism still exceeded 1 (the shell job overlapped).
     expect(tk.stats.totalHigh).to.be.above(1);
+  });
+
+  it("serializes a recording app context against a plain app context (real apps-group tags)", async function () {
+    // The exact apps-group scenario: a recording native-app context (tagged via
+    // jobDisplayResources with an explicit display recording in the run) and a
+    // plain native-app context must NOT overlap — before the fix the recording
+    // one was tagged ["display"] only, disjoint from the plain one's
+    // ["native-app-driver"], so they ran concurrently and clobbered the shared
+    // per-host driver.
+    const displayCtx = {
+      platform: "darwin",
+      xvfbAvailable: false,
+      allowOverlappingCaptures: false,
+      runHasDisplayRecording: true,
+    };
+    const recCtx = {
+      context: {
+        platform: "mac",
+        steps: [
+          { startSurface: { app: "com.apple.TextEdit" } },
+          { record: { path: "x.mp4", surface: { app: "TextEdit" } } },
+          { stopRecord: true },
+          { closeSurface: { app: "TextEdit" } },
+        ],
+      },
+    };
+    const plainCtx = {
+      context: {
+        platform: "mac",
+        steps: [{ startSurface: { app: "com.apple.calculator" } }],
+      },
+    };
+    recCtx.exclusiveResources = jobDisplayResources(recCtx, displayCtx);
+    plainCtx.exclusiveResources = jobDisplayResources(plainCtx, displayCtx);
+    // Both must hold the native-app-driver bound (the recording one also holds
+    // display) so the pool serializes them on the shared driver.
+    expect(recCtx.exclusiveResources).to.include("native-app-driver");
+    expect(plainCtx.exclusiveResources).to.include("native-app-driver");
+
+    const reg = createResourceRegistry();
+    const tk = tracker();
+    await runResourceAware(
+      [recCtx, plainCtx],
+      2,
+      reg,
+      async (item) => {
+        tk.enter(item.exclusiveResources);
+        await sleep(30);
+        tk.exit(item.exclusiveResources);
+      }
+    );
+    // The two native-app driver sessions never ran at the same time.
+    expect(tk.stats.perResourceHigh["native-app-driver"]).to.equal(1);
   });
 });
 


### PR DESCRIPTION
## Problem

The `apps` fixture group still FAILed at `concurrentRunners: 2` after ADR 01038 (which serialized native app-driver contexts on a `native-app-driver` resource), with a *different* concurrency vector on both desktop platforms:

- **`apps (macos-latest)`** — `rec-app-macos-default-window`: `App "com.apple.TextEdit" launched but never became ready: … WebDriverError: Session does not exist` (Passed 33, Failed 1).
- **`apps (windows-latest)`** — `rec-app-default-window`: `No element matched {"elementText":"Select","surface":{"app":"charmap"}} within 5000ms` (Passed 33, Failed 1).

Both pass at `concurrentRunners: 1`. CI timelines (run 28872730206, which includes ADR 01038) show the **recording** app context (`rec-app-*`) and a **plain** native-app context (`app-env-launch` on macOS, `app-then-tty-app` on Windows) starting seconds apart and running concurrently — both driving the single per-host Mac2 / NovaWindows driver — with one session clobbered mid-run.

## Root cause

`jobDisplayResources` (`src/core/tests.ts`) gated the `"native-app-driver"` tag on `mobileBrowserGate(...).action === "proceed"`. That gate reads `hasBrowserStep = isBrowserRequired(context)`, which classifies any `BROWSER_STEP_KEYS` step that is **not app-targeting** as a browser step. A recording app context carries `record` (object payload with `surface: { app }` — app-targeting, fine) **and** `stopRecord: true` (a bare-boolean payload — *not* app-targeting). So `isBrowserRequired` reports a "browser step", `mobileBrowserGate` returns `skip` (as if mixing native-app + device browser), and the desktop recording app context **loses** the `native-app-driver` bound — holding only `["display"]`. A plain app context holds `["native-app-driver"]`. The two sets are **disjoint**, so `runResourceAware` runs them concurrently, clobbering the shared driver.

`mobileBrowserGate` is only meaningful on **mobile** targets (there is no device browser to mix with on desktop), so it should never have gated the desktop decision.

## Fix

Restrict `mobileBrowserGate` to mobile targets in `jobDisplayResources`: a desktop native-app context (`isAppDriverRequired`, mac/windows) always contends for the shared driver, so it always takes `native-app-driver`. Mobile SKIP-aware gating (ios/android) is unchanged; desktop browser contexts still parallelize (they aren't `isAppDriverRequired`). The resource union is ordered driver-bound-first so a recording app context composes to the canonical `["native-app-driver", "display"]`. `concurrentRunners: 1` is byte-identical (tagging only runs at `limit > 1`).

## Tests (red then green)

New unit tests in `test/concurrency.test.js`:
- `jobDisplayResources` returns `["native-app-driver", "display"]` for a **macOS** and a **Windows** recording app context (`startSurface` + `record` + `stopRecord`) — previously `["display"]` only.
- `runResourceAware` confirms a recording app context and a plain app context, tagged by the real `jobDisplayResources`, never overlap on `native-app-driver`.
- All existing ADR 01038 cases (ios / android / browser-only / mixed-mobile-SKIP / desktop-browser) still pass unchanged.

60 concurrency tests pass; `ffmpeg-recorder`, `app-surface`, `app-recording`, `app-actions-coverage` suites regression-clean.

## Classification of the two failures

- **macOS `Session does not exist`** — real concurrency bug, fixed here.
- **Windows `Select not found within 5000ms`** — real concurrency bug, fixed here (same mechanism; the recording charmap session was clobbered by a concurrent charmap app context, surfacing as a find timeout). This is **not** the `trySetForegroundWindow(NaN)` / physical-click-miss bug that #536 fixes — the failing step is the recording context's `find`, failing because its session was stolen, not because a click missed.
- Neither is irreducible load.

## Relationship to #536

Zero changed-file overlap with #536 (`src/core/tests.ts`, `test/concurrency.test.js`, `adrs/01040-*.md` — none are in #536's list). #536 rewrites the appWindows/appSurface/ffmpegRecorder files but does **not** touch `jobDisplayResources`, `isBrowserRequired`, `runResourceAware`, or the scheduler — orthogonal; should merge cleanly before or after #536.

## ADR number

`adrs/01040-serialize-recording-native-app-contexts-under-concurrency.md` — next free above `origin/main` (highest is 01038). A sibling browser-driver fix may take 01039; picked 01040 to avoid collision. Renumber at merge if needed.

## Docs impact

**None.** Internal scheduler-correctness fix — no user-facing step/option/flag/engine/output/default/platform/skip surface changes.
