### PR TITLE
refactor(start-surface): address phase 6 review nits

### DIFF
--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -123,6 +123,7 @@ import {
   activeDriver,
   sweepSessions,
   type BrowserSessionRegistry,
+  type BrowserOpenOverrides,
 } from "./tests/browserSessions.js";
 import path from "node:path";
 import { spawn } from "node:child_process";
@@ -3676,11 +3677,7 @@ async function runContext({
       // precedent).
       const startDriverForBrowser = async (
         browserName: string,
-        overrides?: {
-          headless?: boolean;
-          size?: { width?: number; height?: number };
-          driverOptions?: Record<string, any>;
-        }
+        overrides?: BrowserOpenOverrides
       ): Promise<
         | { ok: true; driver: any; headless: boolean }
         | { ok: false; error: string }
@@ -3855,7 +3852,7 @@ async function runContext({
       // stamps driver.state.engine and back-links driver.state.sessionRegistry.
       if (driver) {
         browserSessions = createSessionRegistry({
-          open: async (engine: string, overrides?: any) => {
+          open: async (engine: string, overrides?: BrowserOpenOverrides) => {
             const res = await startDriverForBrowser(engine, overrides);
             if (!res.ok) throw new Error(res.error);
             return res.driver;

--- a/src/core/tests/browserSessions.ts
+++ b/src/core/tests/browserSessions.ts
@@ -69,8 +69,11 @@ function engineKeywordNameConflict(
 
 export interface BrowserSessionEntry {
   name: string;
-  // Lowercased engine as launched (edge stays "edge"; normalization happens
-  // at comparison time only).
+  // Lowercased engine as launched. openSession normalizes edge → chrome
+  // BEFORE registering (edge rides the chromedriver stack), so a browser
+  // surface opened as edge registers with engine "chrome". A session created
+  // through registerSession directly stores whatever engine it's handed
+  // (lowercased), so comparisons still route through normalizeEngine.
   engine: string;
   driver: any;
   // Monotonic focus stamp: bumped whenever the session is activated. The

--- a/src/core/tests/startSurface.ts
+++ b/src/core/tests/startSurface.ts
@@ -238,12 +238,10 @@ async function startSurfaceStep({
 
   // --- Array form: three lanes, all concurrent. ---
 
-  const indexed = descriptors.map((d: any, i: number) => ({
-    d,
-    i,
-    kind: descriptorKind(d) as Kind,
-    name: intendedName(d, descriptorKind(d) as Kind),
-  }));
+  const indexed = descriptors.map((d: any, i: number) => {
+    const kind = descriptorKind(d) as Kind;
+    return { d, i, kind, name: intendedName(d, kind) };
+  });
   const results: LaneResult[] = new Array(indexed.length);
 
   const record = (slot: (typeof indexed)[number], r: any) => {
@@ -338,8 +336,14 @@ async function startSurfaceStep({
       ? "SKIPPED"
       : "PASS";
 
+  // Tolerate a hole the same way the roll-up above does: an unclassifiable
+  // descriptor (schema-unreachable, but defensive) never lands in a lane, so
+  // its slot stays undefined rather than throwing here.
   const description = results
-    .map((r) => `${r.name} (${r.kind}): ${r.status} — ${r.description}`)
+    .map(
+      (r) =>
+        `${r?.name ?? "?"} (${r?.kind ?? "?"}): ${r?.status ?? "FAIL"} — ${r?.description ?? "No result."}`
+    )
     .join("\n");
 
   return {

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -1243,6 +1243,22 @@ describe("collectDeviceDescriptors() device planning", function () {
       [undefined]
     );
   });
+
+  it("falls back to [undefined] for a parallel array with only browser/process descriptors (no app boots a device)", function () {
+    assert.deepEqual(
+      collectDeviceDescriptors({
+        steps: [
+          {
+            startSurface: [
+              { browser: "chrome" },
+              { process: "srv", name: "srv" },
+            ],
+          },
+        ],
+      }),
+      [undefined]
+    );
+  });
 });
 
 describe("getRunner() function", function () {


### PR DESCRIPTION
## What

Non-blocking review nits from [#539](https://github.com/doc-detective/doc-detective/pull/539) (multi-surface Phase 6) that the bots flagged and Claude's APPROVE review deferred to a follow-up. All cosmetic/defensive — **no behavior change**.

- **[src/core/tests/startSurface.ts](src/core/tests/startSurface.ts)** — `indexed.map` computes `descriptorKind(d)` once per slot (`const kind = …`) instead of twice in the same object literal, reusing it for `intendedName(d, kind)`.
- **[src/core/tests/startSurface.ts](src/core/tests/startSurface.ts)** — null-guard the array-form description builder the same way the status roll-up already does (`r?.name ?? "?"`, `r?.status ?? "FAIL"`, …). A `results` hole from an unclassifiable descriptor (schema-unreachable, but defensive) would otherwise throw a `TypeError`. (CodeRabbit cr-comment b47eeafe)
- **[src/core/tests/browserSessions.ts](src/core/tests/browserSessions.ts)** — correct the stale `BrowserSessionEntry.engine` comment. Since f477c0d, `openSession` normalizes edge→chrome **before** registering, so edge surfaces register with `engine:"chrome"`; the comment previously claimed edge stays `"edge"`.
- **[src/core/tests.ts](src/core/tests.ts)** — reuse the exported `BrowserOpenOverrides` type for the `createSessionRegistry({ open })` callback (was `overrides?: any`) and `startDriverForBrowser`, so the launch-override call sites are type-checked against the exported shape and can't drift.
- **[test/core-core.test.js](test/core-core.test.js)** — add a `collectDeviceDescriptors()` test for a parallel array with only browser/process descriptors, asserting the `[undefined]` device-planning fallback (no app ⇒ no device boots).

## Why

Close out the deferred review feedback on Phase 6 without changing any observable behavior.

## Testing

- `npm run compile` — clean (confirms the `BrowserOpenOverrides` reuse type-checks).
- `test/start-surface-dispatch.test.js` + `test/browserSessions.test.js` — **50 passing**.
- `collectDeviceDescriptors` suite in `test/core-core.test.js` — **3 passing**, including the new case.

## Notes for reviewers

- **No ADR** and **no docs impact**: purely internal cosmetic/defensive cleanup with no user-facing surface change.
- No new feature fixtures needed — no new user-facing feature; the added coverage is a unit test for existing `collectDeviceDescriptors` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser/session launch handling so additional launch options are interpreted more consistently.
  * Made run summaries more resilient when some entries are missing, reducing unexpected failures and showing fallback values instead.
  * Clarified how browser engine names are normalized in session tracking.

* **Tests**
  * Added coverage for planning cases where no app boots are present, ensuring device collection returns an empty placeholder as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->