### PR TITLE
docs(actions): add inline Doc Detective tests for the goTo guide

### DIFF
--- a/docs/.doc-detective.json
+++ b/docs/.doc-detective.json
@@ -1,5 +1,7 @@
 {
   "detectSteps": false,
+  "beforeAny": "./test-setup/start-server.spec.json",
+  "afterAll": "./test-setup/stop-server.spec.json",
   "telemetry": {
     "send": true
   }

--- a/docs/fern/pages/docs/actions/goTo.mdx
+++ b/docs/fern/pages/docs/actions/goTo.mdx
@@ -22,7 +22,13 @@ You can specify the target URL directly as a string, or use an object for more o
 
 Here are a few ways you might use the `goTo` action:
 
+{/* test {"testId":"goto-server-setup","detectSteps":false} */}
+{/* step {"stepId":"start-test-server","description":"Start the local test server in the background","runShell":{"command":"node test/server/start.js","background":{"name":"goto-server","waitUntil":{"port":8092}},"timeout":30000}} */}
+{/* test end */}
+
 ### Navigate to a full URL (string shorthand)
+
+{/* test {"testId":"goto-string-shorthand","detectSteps":false} */}
 
 ```json
 {
@@ -38,6 +44,10 @@ Here are a few ways you might use the `goTo` action:
   ]
 }
 ```
+
+{/* step {"stepId":"goto-string","description":"Navigate to the local test server using the string shorthand","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"verify-heading-string","description":"Confirm the test server page loaded","find":"Common HTML Elements"} */}
+{/* test end */}
 
 ### Navigate to a relative path (string shorthand)
 
@@ -60,6 +70,8 @@ Assumes the browser is currently at `https://example.com` or a global `origin` i
 
 ### Navigate using an object with a full URL
 
+{/* test {"testId":"goto-object-format","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -76,6 +88,11 @@ Assumes the browser is currently at `https://example.com` or a global `origin` i
   ]
 }
 ```
+
+{/* step {"stepId":"goto-object","description":"Navigate to the local test server using object format","goTo":{"url":"http://localhost:8092"}} */}
+{/* step {"stepId":"verify-heading-object","description":"Confirm the test server page loaded","find":"Common HTML Elements"} */}
+{/* step {"stepId":"stop-test-server","description":"Stop the local test server","closeSurface":"goto-server"} */}
+{/* test end */}
 
 ### Navigate using an object with a relative path and specific origin
 

--- a/docs/fern/pages/docs/actions/goTo.mdx
+++ b/docs/fern/pages/docs/actions/goTo.mdx
@@ -22,10 +22,6 @@ You can specify the target URL directly as a string, or use an object for more o
 
 Here are a few ways you might use the `goTo` action:
 
-{/* test {"testId":"goto-server-setup","detectSteps":false} */}
-{/* step {"stepId":"start-test-server","description":"Start the local test server in the background","runShell":{"command":"node test/server/start.js","background":{"name":"goto-server","waitUntil":{"port":8092}},"timeout":30000}} */}
-{/* test end */}
-
 ### Navigate to a full URL (string shorthand)
 
 {/* test {"testId":"goto-string-shorthand","detectSteps":false} */}
@@ -91,11 +87,6 @@ Assumes the browser is currently at `https://example.com` or a global `origin` i
 
 {/* step {"stepId":"goto-object","description":"Navigate to the local test server using object format","goTo":{"url":"http://localhost:8092"}} */}
 {/* step {"stepId":"verify-heading-object","description":"Confirm the test server page loaded","find":"Common HTML Elements"} */}
-{/* test end */}
-
-{/* Cleanup runs as its own test so the server is stopped even if a test above fails. */}
-{/* test {"testId":"goto-server-cleanup","detectSteps":false} */}
-{/* step {"stepId":"stop-test-server","description":"Stop the local test server","closeSurface":"goto-server"} */}
 {/* test end */}
 
 ### Navigate using an object with a relative path and specific origin

--- a/docs/fern/pages/docs/actions/goTo.mdx
+++ b/docs/fern/pages/docs/actions/goTo.mdx
@@ -91,6 +91,10 @@ Assumes the browser is currently at `https://example.com` or a global `origin` i
 
 {/* step {"stepId":"goto-object","description":"Navigate to the local test server using object format","goTo":{"url":"http://localhost:8092"}} */}
 {/* step {"stepId":"verify-heading-object","description":"Confirm the test server page loaded","find":"Common HTML Elements"} */}
+{/* test end */}
+
+{/* Cleanup runs as its own test so the server is stopped even if a test above fails. */}
+{/* test {"testId":"goto-server-cleanup","detectSteps":false} */}
 {/* step {"stepId":"stop-test-server","description":"Stop the local test server","closeSurface":"goto-server"} */}
 {/* test end */}
 

--- a/docs/test-setup/start-server.spec.json
+++ b/docs/test-setup/start-server.spec.json
@@ -9,6 +9,7 @@
           "description": "Start the local test server in the background for docs tests",
           "runShell": {
             "command": "node test/server/start.js",
+            "workingDirectory": "../..",
             "background": {
               "name": "docs-test-server",
               "waitUntil": {

--- a/docs/test-setup/start-server.spec.json
+++ b/docs/test-setup/start-server.spec.json
@@ -1,0 +1,24 @@
+{
+  "tests": [
+    {
+      "testId": "start-docs-test-server",
+      "detectSteps": false,
+      "steps": [
+        {
+          "stepId": "start-test-server",
+          "description": "Start the local test server in the background for docs tests",
+          "runShell": {
+            "command": "node test/server/start.js",
+            "background": {
+              "name": "docs-test-server",
+              "waitUntil": {
+                "port": 8092
+              }
+            },
+            "timeout": 30000
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/test-setup/stop-server.spec.json
+++ b/docs/test-setup/stop-server.spec.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "testId": "stop-docs-test-server",
+      "detectSteps": false,
+      "steps": [
+        {
+          "stepId": "stop-test-server",
+          "description": "Stop the local test server after docs tests",
+          "closeSurface": "docs-test-server"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

Adds "docs-as-tests" coverage to the [`goTo` action reference page](docs/fern/pages/docs/actions/goTo.mdx) and wires the shared local test server into the docs config so **any** docs page can reach it.

- **[docs/fern/pages/docs/actions/goTo.mdx](docs/fern/pages/docs/actions/goTo.mdx)** — two inline tests (`goto-string-shorthand`, `goto-object-format`) navigate to `http://localhost:8092` using the documented string and object forms, then assert the page loaded with `find: "Common HTML Elements"` (the `<h1>` in the server's `index.html`).
- **[docs/.doc-detective.json](docs/.doc-detective.json)** — `beforeAny` starts the server before all input tests; `afterAll` stops it after them.
- **[docs/test-setup/start-server.spec.json](docs/test-setup/start-server.spec.json)** — background `runShell` that runs `node test/server/start.js`, waiting on port `8092`. `workingDirectory: "../.."` pins it to the repo root (resolved relative to the spec file, since `relativePathBase` defaults to `"file"`), so it is CWD-independent.
- **[docs/test-setup/stop-server.spec.json](docs/test-setup/stop-server.spec.json)** — `closeSurface: "docs-test-server"` teardown.

## Why

The `goTo` reference page had example specs but nothing proving they work. These inline tests run the real runner against the two main `goTo` shapes and verify navigation + presence detection. Putting the server lifecycle in the config (rather than inline in one page) means every docs test can share a single server instance.

## Reviewer notes

- **Hermetic, no CI changes.** The internal server is the same one the fixture jobs use (`test/server/instances.js`, ports 8092/8093). `test-docs.yml` is untouched — the config's `beforeAny`/`afterAll` own the server for the whole run.
- **Teardown always runs.** The run-level process registry keeps the background server alive across the `beforeAny → main → afterAll` phases, and `afterAll` runs after every main test regardless of pass/fail — so the server is always stopped, even if a page's test fails.
- **The example/test split is intentional.** The visible JSON examples on the page still teach `https://example.com` (clearer documentation); only the executable inline steps target `http://localhost:8092`.
- **detectSteps.** All inline tests set `detectSteps: false`, matching the docs config, so no steps are auto-synthesized from prose.
- **Verified** with the real docs config (`docs/.doc-detective.json`): `3 specs / 4 tests / 6 steps, all PASS` (server started in `beforeAny`, both navigations + finds, stopped in `afterAll`), including a run from the `docs/` directory to confirm CWD-independence.

## Docs impact

This *is* a docs change; no user-facing behavior/API change. No ADR or feature fixture needed (no runtime behavior changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
