### PR TITLE
docs(actions): add inline Doc Detective tests for the click guide

### DIFF
--- a/docs/fern/pages/docs/actions/click.mdx
+++ b/docs/fern/pages/docs/actions/click.mdx
@@ -35,6 +35,8 @@ Here are a few ways you might use the `click` action:
 
 ### Click by element text (string shorthand)
 
+{/* test {"testId":"click-by-text","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -50,7 +52,14 @@ Here are a few ways you might use the `click` action:
 }
 ```
 
+{/* step {"stepId":"goto-click-text","description":"Open the click test page","goTo":"http://localhost:8092/click-shorthand.html"} */}
+{/* step {"stepId":"click-text","description":"Click the button by its display text","click":"Reveal by text"} */}
+{/* step {"stepId":"verify-click-text","description":"The button appends a message only when actually clicked","find":"Text click landed"} */}
+{/* test end */}
+
 ### Click by selector (string shorthand)
+
+{/* test {"testId":"click-by-selector","detectSteps":false} */}
 
 ```json
 {
@@ -67,7 +76,14 @@ Here are a few ways you might use the `click` action:
 }
 ```
 
+{/* step {"stepId":"goto-click-selector","description":"Open the click test page","goTo":"http://localhost:8092/click-shorthand.html"} */}
+{/* step {"stepId":"click-selector","description":"Click the button by its CSS selector","click":"#reveal-by-selector"} */}
+{/* step {"stepId":"verify-click-selector","description":"Confirm the selector click fired","find":"Selector click landed"} */}
+{/* test end */}
+
 ### Click an element by text (object format)
+
+{/* test {"testId":"click-by-object","detectSteps":false} */}
 
 ```json
 {
@@ -86,6 +102,11 @@ Here are a few ways you might use the `click` action:
   ]
 }
 ```
+
+{/* step {"stepId":"goto-click-object","description":"Open the click test page","goTo":"http://localhost:8092/click-shorthand.html"} */}
+{/* step {"stepId":"click-object","description":"Left-click the button using object format","click":{"elementText":"Reveal by object","button":"left"}} */}
+{/* step {"stepId":"verify-click-object","description":"Confirm the object-format click fired","find":"Object click landed"} */}
+{/* test end */}
 
 ### Click an element by selector (object format)
 


### PR DESCRIPTION
## What changed

Adds inline Doc Detective tests to the [`click` action reference page](docs/fern/pages/docs/actions/click.mdx), so the page exercises the action it documents — following the same docs-as-tests pattern as the `goTo` page (#557).

Three inline tests, one per click permutation, run against the shared docs test server's [`click-shorthand.html`](test/server/public/click-shorthand.html) fixture:

- **`click-by-text`** — click by element text (string shorthand)
- **`click-by-selector`** — click by CSS selector (string shorthand)
- **`click-by-object`** — click by element text (object format, left button)

Each test does `goTo` → `click` → `find`. The fixture's buttons append a message **only when actually clicked**, so the follow-up `find` proves the click fired, not just that the selector resolved.

## Why

The `click` reference page had example specs but nothing proving they work. These run the real runner against the three main `click` shapes and verify the click had an effect.

## Reviewer notes

- **No per-page setup.** Reuses the shared server wired into `docs/.doc-detective.json` via `beforeAny`/`afterAll` (landed in #557). This page just navigates to `http://localhost:8092/click-shorthand.html`.
- **The example/test split is intentional.** The visible JSON examples still teach realistic targets (`Submit`, `#submit-button`); only the executable inline steps point at the fixture.
- **Scope.** Covers the three headless-reliable permutations. The middle-click, both-selector-and-text, and mobile long-press examples aren't wired (middle/right-click need the W3C actions endpoint and aren't reliable headless; long-press is a mobile-app-surface path that would `SKIP` here).
- **detectSteps.** All tests set `detectSteps: false`, matching the docs config.
- **Verified** with the real docs config (`docs/.doc-detective.json`): `3 specs / 5 tests / 11 steps, all PASS` (server started in `beforeAny`, each click verified via `find`, stopped in `afterAll`).

## Docs impact

This *is* a docs change; no user-facing behavior/API change. No ADR or feature fixture needed (no runtime behavior changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
