### PR TITLE
fix(platform): surface /spec fetch failures in finalize instead of an uncaught crash

### DIFF
--- a/adrs/01045-surface-spec-fetch-failures-in-finalize.md
+++ b/adrs/01045-surface-spec-fetch-failures-in-finalize.md
@@ -1,0 +1,103 @@
+---
+status: accepted
+date: 2026-07-09
+decision-makers: doc-detective maintainers
+---
+
+# Surface `/spec` fetch failures via finalize instead of an uncaught crash
+
+## Context and Problem Statement
+
+`bin/runner-entrypoint.js`'s `main()` calls `fetchSpec(apiBase, runId, token)` as its first
+network operation, with no try/catch around the call. Every failure mode downstream of it
+(`provisionWorkspace`, `runChild`) is wrapped in a try/catch that logs, ships a stderr line, and
+posts a `failed` finalize with a specific `summary.reason` before returning a non-zero exit code.
+`fetchSpec` had none of that: a network-level failure (DNS hiccup, connection reset, timeout) threw
+uncaught, propagated out of `main()`, and was only caught by the top-level
+`.catch(err => { localLog('fatal', ...); process.exit(1); })` — which never calls `postFinalize`.
+
+In production this meant: the run row stayed at `status='starting'` for its entire lifetime, the
+runner process exited (code 1, or in observed cases eventually surfacing as a clean-looking
+lifecycle in Fly's own logs with no visible error), and the *only* signal the platform or a human
+operator ever got was the watchdog's generic Sweep A reap — `summary.reason: 'cold_start_exceeded'`
+— which is indistinguishable from "the machine never got far enough to attempt `/spec` at all."
+Diagnosing an actual `/spec`-fetch failure required either platform-server log access (which may not
+even show the request, since a fully-failed network call never reaches the server) or Fly log
+access, neither of which reveal the *client-side* fetch error itself. This was discovered while
+debugging exactly this symptom against the doc-detective.com platform: machines booted, ran, and
+exited quickly, but every run finalized as `cold_start_exceeded` with no way to tell why.
+
+## Decision Drivers
+
+* A run's `summary` field is the *only* diagnostic surface a platform operator can see without
+  server-side log access (Fly logs, Vercel/host runtime logs) — it should carry the real cause
+  whenever the runner is in any position to report one.
+* Must not change behavior for the already-handled failure modes (workspace provision, spawn) —
+  only close the one gap.
+* Must remain best-effort: if the underlying failure is a total network blackout, the finalize POST
+  (same host) may also fail. That's acceptable — postFinalize already swallows its own errors and
+  returns `false` — but every failure mode *short of* a total blackout (a one-off timeout, a
+  transient 5xx, a blip that clears moments later) should no longer disappear into an opaque
+  generic reap message.
+
+## Considered Options
+
+* **A. Wrap `fetchSpec()` in the same try/catch pattern already used for `provisionWorkspace` /
+  `runChild`, posting `{status: 'failed', summary: {reason: 'spec_fetch_failed', error: String(e)}}`**
+  (chosen).
+* **B. Leave `fetchSpec()` unwrapped; rely on Sweep A's `cold_start_exceeded` reap as the only
+  signal.** Status quo — exactly the gap that made a real production incident hard to diagnose.
+* **C. Have the watchdog distinguish "never called `/spec`" from "called `/spec` but the process
+  then crashed" server-side**, e.g. via a heartbeat column. More invasive, requires a schema change,
+  and doesn't capture the *client-side* error text (DNS failure detail, TLS error, etc.) that only
+  the runner process ever sees.
+
+## Decision Outcome
+
+Chosen option: **A**. `fetchSpec()`'s call site in `main()` is now wrapped in a try/catch matching
+the existing pattern: on failure, log locally via `localLog`, attempt a best-effort
+`postFinalize(..., {status: 'failed', exit_code: 1, summary: {reason: 'spec_fetch_failed', error:
+String(e)}})`, and return `1`. Option B is the status quo this ADR fixes. Option C would help but is
+strictly more invasive for less diagnostic value than capturing the actual client-side error text,
+which A already provides for free.
+
+## Consequences
+
+* **Good** — a `/spec`-fetch failure that isn't a total network blackout now surfaces its real cause
+  (e.g. `TypeError: fetch failed` plus the underlying cause) directly in the run's `summary`, visible
+  on the run detail page with no server-log access required.
+* **Good** — matches the existing, already-reviewed try/catch/postFinalize/return-1 shape used for
+  `provisionWorkspace` and `runChild` failures; no new pattern introduced.
+* **Neutral** — if the failure genuinely is a total network blackout, the finalize POST may also
+  fail; the run still finalizes eventually via Sweep A's `cold_start_exceeded` reap exactly as
+  before. No regression, just no additional signal in that specific worst case.
+
+## Confirmation
+
+* New regression test in `test/runner-entrypoint.test.js` (`runner-entrypoint: main()` describe
+  block): simulates a `/spec` GET that has its socket destroyed mid-request (a real network-level
+  failure, not an HTTP error status), asserts `main()` returns `1`, and asserts the `/finalize` POST
+  received `{status: 'failed', exit_code: 1, summary: {reason: 'spec_fetch_failed', error: <string>}}`.
+* Full `test/runner-entrypoint.test.js` suite green (52/52) plus the broader Chrome-free suite
+  (79 passing) with no regressions to the existing `provisionWorkspace`/`runChild`/410-cancel paths.
+
+## Pros and Cons of the Options
+
+### A. Wrap `fetchSpec()` in a try/catch, report via finalize
+
+* Good: matches existing patterns exactly; minimal diff.
+* Good: captures the real client-side error text for free.
+* Neutral: still best-effort under a total network blackout (same as every other finalize call).
+
+### B. Leave unwrapped (status quo)
+
+* Bad: exactly the diagnostic gap this ADR closes — a real production incident took an extended,
+  multi-round debugging session to even localize to "the runner's first callback," because nothing
+  in the system reported the actual failure.
+
+### C. Server-side heartbeat / staged-status distinction
+
+* Good: would let the watchdog itself distinguish "never called /spec" from "crashed after
+  calling it," without relying on the runner successfully phoning home again.
+* Bad: requires a schema change and new watchdog logic; doesn't capture the client-side error text,
+  which is the more actionable piece of information for a human debugging the incident.

--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -611,7 +611,32 @@ async function main() {
 	process.on('SIGTERM', onPreSpawnSigterm);
 
 	// Step 1: fetch spec.
-	const { canceled, spec } = await fetchSpec(apiBase, runId, token);
+	//
+	// Unlike provisionWorkspace/runChild below, this call previously had
+	// no try/catch: any failure (network blip, DNS hiccup, timeout) blew
+	// up main() uncaught, and the platform never learned why — the run
+	// just sat at 'starting' until Sweep A reaped it as a generic
+	// 'cold_start_exceeded' with zero indication of the real cause. Report
+	// the actual error into finalize's summary so it's visible on the
+	// run detail page without needing Fly or platform-server log access.
+	let canceled, spec;
+	try {
+		({ canceled, spec } = await fetchSpec(apiBase, runId, token));
+	} catch (e) {
+		localLog('error', 'spec fetch failed', { err: String(e) });
+		// Best-effort: if this failure is a total network blackout, the
+		// finalize POST below (same host) may also fail — postFinalize
+		// swallows that and just returns false. Any case that isn't a
+		// total blackout (transient blip, one-off timeout, a 5xx that
+		// clears on retry) now gets its real cause surfaced instead of
+		// disappearing into Sweep A's generic reap message.
+		await postFinalize(apiBase, runId, token, {
+			status: 'failed',
+			exit_code: 1,
+			summary: { reason: 'spec_fetch_failed', error: String(e) }
+		});
+		return 1;
+	}
 	if (canceled) {
 		localLog('info', 'run canceled before spec fetch (410); exiting cleanly');
 		// Nothing to finalize — the row is already terminal on the server.

--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -610,26 +610,16 @@ async function main() {
 	};
 	process.on('SIGTERM', onPreSpawnSigterm);
 
-	// Step 1: fetch spec.
-	//
-	// Unlike provisionWorkspace/runChild below, this call previously had
-	// no try/catch: any failure (network blip, DNS hiccup, timeout) blew
-	// up main() uncaught, and the platform never learned why — the run
-	// just sat at 'starting' until Sweep A reaped it as a generic
-	// 'cold_start_exceeded' with zero indication of the real cause. Report
-	// the actual error into finalize's summary so it's visible on the
-	// run detail page without needing Fly or platform-server log access.
+	// Step 1: fetch spec. See ADR 01045 — an uncaught failure here used
+	// to crash silently, leaving Sweep A's generic 'cold_start_exceeded'
+	// as the only signal.
 	let canceled, spec;
 	try {
 		({ canceled, spec } = await fetchSpec(apiBase, runId, token));
 	} catch (e) {
 		localLog('error', 'spec fetch failed', { err: String(e) });
-		// Best-effort: if this failure is a total network blackout, the
-		// finalize POST below (same host) may also fail — postFinalize
-		// swallows that and just returns false. Any case that isn't a
-		// total blackout (transient blip, one-off timeout, a 5xx that
-		// clears on retry) now gets its real cause surfaced instead of
-		// disappearing into Sweep A's generic reap message.
+		// Best-effort (see postFinalize) — surfaces the real cause instead
+		// of disappearing into Sweep A's generic reap message.
 		await postFinalize(apiBase, runId, token, {
 			status: 'failed',
 			exit_code: 1,

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -836,6 +836,48 @@ describe("runner-entrypoint: main()", () => {
     assert.equal(observed.finalize, null, "no finalize POST expected on 410");
   });
 
+  it("posts failed finalize with spec_fetch_failed reason and the real error when /spec's network call fails", async function () {
+    if (isWindows) this.skip();
+    // Regression: previously an uncaught fetchSpec() failure crashed
+    // main() with zero report back to the platform — the run just sat
+    // at 'starting' until Sweep A reaped it as a generic
+    // 'cold_start_exceeded' with no indication of the real cause. This
+    // simulates a network-level failure (connection reset, no
+    // response) on GET /spec specifically, while /finalize is still
+    // served normally by the same loopback server — mirroring a Fly
+    // machine whose outbound call intermittently fails on the very
+    // first hop but can still reach the platform moments later.
+    observed = { logs: [], finalize: null, specReturned: false };
+    api = await makeApiServer((req, res, body) => {
+      const url = req.url;
+      if (req.method === "GET" && url.endsWith("/spec")) {
+        observed.specReturned = true;
+        req.socket.destroy();
+        return;
+      }
+      if (req.method === "POST" && url.endsWith("/finalize")) {
+        observed.finalize = JSON.parse(body);
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    envForRun();
+    const code = await main();
+    assert.equal(code, 1);
+    assert.ok(observed.specReturned, "expected /spec to have been hit");
+    assert.equal(observed.finalize.status, "failed");
+    assert.equal(observed.finalize.exit_code, 1);
+    assert.equal(observed.finalize.summary.reason, "spec_fetch_failed");
+    assert.ok(
+      typeof observed.finalize.summary.error === "string" &&
+        observed.finalize.summary.error.length > 0,
+      "expected the real fetch error to be captured in summary.error"
+    );
+  });
+
   it("posts succeeded finalize when child exits 0", async function () {
     if (isWindows) this.skip();
     await writeRunnerFixture(

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -759,11 +759,11 @@ describe("runner-entrypoint: main()", () => {
   let runnerScriptPath;
 
   async function setupSpec(spec) {
-    observed = { logs: [], finalize: null, specReturned: false };
+    observed = { logs: [], finalize: null, specHit: false };
     api = await makeApiServer((req, res, body) => {
       const url = req.url;
       if (req.method === "GET" && url.endsWith("/spec")) {
-        observed.specReturned = true;
+        observed.specHit = true;
         if (spec === 410) {
           res.writeHead(410);
           res.end();
@@ -847,11 +847,11 @@ describe("runner-entrypoint: main()", () => {
     // served normally by the same loopback server — mirroring a Fly
     // machine whose outbound call intermittently fails on the very
     // first hop but can still reach the platform moments later.
-    observed = { logs: [], finalize: null, specReturned: false };
+    observed = { logs: [], finalize: null, specHit: false };
     api = await makeApiServer((req, res, body) => {
       const url = req.url;
       if (req.method === "GET" && url.endsWith("/spec")) {
-        observed.specReturned = true;
+        observed.specHit = true;
         req.socket.destroy();
         return;
       }
@@ -867,7 +867,7 @@ describe("runner-entrypoint: main()", () => {
     envForRun();
     const code = await main();
     assert.equal(code, 1);
-    assert.ok(observed.specReturned, "expected /spec to have been hit");
+    assert.ok(observed.specHit, "expected /spec to have been hit");
     assert.equal(observed.finalize.status, "failed");
     assert.equal(observed.finalize.exit_code, 1);
     assert.equal(observed.finalize.summary.reason, "spec_fetch_failed");

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -868,6 +868,7 @@ describe("runner-entrypoint: main()", () => {
     const code = await main();
     assert.equal(code, 1);
     assert.ok(observed.specHit, "expected /spec to have been hit");
+    assert.ok(observed.finalize, "expected a /finalize POST to have been received");
     assert.equal(observed.finalize.status, "failed");
     assert.equal(observed.finalize.exit_code, 1);
     assert.equal(observed.finalize.summary.reason, "spec_fetch_failed");


### PR DESCRIPTION
## Summary

Found while debugging a live incident on the doc-detective.com platform: Fly machines were booting, running `doc-detective-runner`, and exiting quickly and cleanly (`Main child exited normally with code: 0` in Fly's logs) — yet every one of those runs finalized with `summary.reason: "cold_start_exceeded"`, and neither the Fly logs nor the platform's own server-side logs showed any error at all.

Root cause: `main()`'s call to `fetchSpec()` (the runner's very first callback, `GET /spec`) had no try/catch around it. A network-level failure there (DNS hiccup, connection reset, timeout) threw uncaught, propagated straight past `main()`, and was only caught by the top-level handler — which exits `1` **without ever calling `postFinalize`**. The run row just sat at `status='starting'` for its whole lifetime; the only signal anyone ever got was the watchdog's generic Sweep A reap two minutes later, indistinguishable from "the machine never even attempted `/spec`."

## Fix

Wrap `fetchSpec()` in the same try/catch → `postFinalize` → `return 1` pattern already used for `provisionWorkspace` and `runChild` failures elsewhere in this file — just closing the one gap, not introducing a new shape:

```js
let canceled, spec;
try {
  ({ canceled, spec } = await fetchSpec(apiBase, runId, token));
} catch (e) {
  localLog('error', 'spec fetch failed', { err: String(e) });
  await postFinalize(apiBase, runId, token, {
    status: 'failed',
    exit_code: 1,
    summary: { reason: 'spec_fetch_failed', error: String(e) }
  });
  return 1;
}
```

Best-effort by nature: if the underlying failure is a total network blackout, the finalize POST (same host) may also fail silently — same as it always has (`postFinalize` already swallows its own errors). But any failure short of a total blackout (a one-off timeout, a transient blip that clears moments later, anything the client can actually observe) now surfaces its **real cause** directly in the run's own `summary` field — visible on the run detail page, no Fly or platform-server log access required.

## Docs impact

None — `bin/runner-entrypoint.js` / `doc-detective-runner` is only ever invoked by the doc-detective.com platform's Fly Machine `init.entrypoint` override; it isn't part of the documented CLI surface a regular `doc-detective` user interacts with.

## ADR

[`adrs/01045-surface-spec-fetch-failures-in-finalize.md`](adrs/01045-surface-spec-fetch-failures-in-finalize.md)

## Test plan

- [x] Red → green: new regression test destroys the socket mid-`GET /spec` (a real network-level failure, not an HTTP error status) and asserts `main()` returns `1` with `/finalize` receiving `{status: 'failed', exit_code: 1, summary: {reason: 'spec_fetch_failed', error: <string>}}`.
- [x] `npx mocha --exit test/runner-entrypoint.test.js` — 52/52 ✓
- [x] `npx mocha --exit test/runner-entrypoint.test.js test/findFreePort.test.js test/checkLink.test.js` — 79 passing, no regressions.

https://claude.ai/code/session_01Ncx411jEevDgGyvoEeBJVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ncx411jEevDgGyvoEeBJVs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runner startup reliability when spec fetching fails due to network issues.
  * Failed starts are now reported with a clear failure status and error details instead of leaving runs stuck in a starting state.
  * Added coverage to confirm the runner exits cleanly and records the expected failure information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->