### PR TITLE
docs: require rebasing new worktrees onto main before work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,19 @@ Repo-wide guidance for AI agents. Package-specific rules live alongside the code
 
 ## Environment setup (required)
 
+**Rebase onto `main` before doing anything else.** When you start work in a new worktree cut from
+`main`, the base may already be stale. Before installing dependencies or making any change, bring the
+branch up to date:
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+Do this *first* — before `npm ci`, before browser/driver installs, before touching code — so you build
+and test against the current tree rather than a stale snapshot. Resolve any conflicts, then proceed to
+dependency install below.
+
 **Install dependencies before you start working.** A fresh clone or git worktree has no
 `node_modules` (it's gitignored and not shared between worktrees), so tests, the local
 `doc-detective` CLI, husky commit hooks (`commitlint`), and `npm run build` all fail until you


### PR DESCRIPTION
## Summary
- Add a rule to CLAUDE.md's "Environment setup" section requiring `git fetch origin && git rebase origin/main` before installing dependencies or making any change in a new worktree cut from `main`.
- Prevents building/testing against a stale base when a worktree's `main` snapshot has drifted from origin.

## Test plan
- [x] Docs-only change (no code/behavior change) — no ADR or fixtures required per CLAUDE.md's own policy.
- [x] Reviewed rendered markdown for formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup guidance requiring worktrees to be rebased onto the latest `main` branch before installing dependencies or making changes.
  * Included instructions for fetching updates and resolving conflicts first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->