### PR TITLE
docs(actions): add inline Doc Detective tests for the type guide

### DIFF
--- a/docs/fern/pages/docs/actions/type.mdx
+++ b/docs/fern/pages/docs/actions/type.mdx
@@ -178,6 +178,8 @@ App surfaces run on Windows only. See [`startSurface`](/docs/actions/startsurfac
 
 ### Perform a search (array shorthand)
 
+{/* test {"testId":"type-array-shorthand","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -203,6 +205,12 @@ App surfaces run on Windows only. See [`startSurface`](/docs/actions/startsurfac
   ]
 }
 ```
+
+{/* step {"stepId":"goto-type-array","description":"Open the type test page","goTo":"http://localhost:8092/type-echo.html"} */}
+{/* step {"stepId":"focus-input-array","description":"Focus the input","find":{"selector":"#type-input","click":true}} */}
+{/* step {"stepId":"type-array","description":"Type text and a space as an array of keys","type":["Doc","$SPACE$","Detective"]} */}
+{/* step {"stepId":"verify-type-array","description":"The input echoes its value only when text is actually typed","find":"Doc Detective"} */}
+{/* test end */}
 
 ### Fill credentials from environment variables (string shorthand)
 
@@ -243,6 +251,8 @@ App surfaces run on Windows only. See [`startSurface`](/docs/actions/startsurfac
 
 ### Type with an increased delay (object format)
 
+{/* test {"testId":"type-object-format","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -280,7 +290,15 @@ App surfaces run on Windows only. See [`startSurface`](/docs/actions/startsurfac
 }
 ```
 
+{/* step {"stepId":"goto-type-object","description":"Open the type test page","goTo":"http://localhost:8092/type-echo.html"} */}
+{/* step {"stepId":"focus-input-object","description":"Focus the input","find":{"selector":"#type-input","click":true}} */}
+{/* step {"stepId":"type-object","description":"Type using the object format with no delay","type":{"keys":"Typed with the object format","inputDelay":0}} */}
+{/* step {"stepId":"verify-type-object","description":"Confirm the typed text was entered","find":"Typed with the object format"} */}
+{/* test end */}
+
 ### Drive an interactive REPL (process surface)
+
+{/* test {"testId":"type-repl-process-surface","detectSteps":false} */}
 
 This example starts `node -i` in the background, waits until the prompt appears, types an expression, and waits until the REPL prints `42`. It then closes the process with a [`closeSurface`](/docs/actions/closesurface) step.
 
@@ -321,6 +339,11 @@ This example starts `node -i` in the background, waits until the prompt appears,
   ]
 }
 ```
+
+{/* step {"stepId":"start-repl","description":"Start a Node REPL in the background","runShell":{"command":"node -i","background":{"name":"type-repl","waitUntil":{"stdio":"/>/"}},"timeout":30000}} */}
+{/* step {"stepId":"eval-in-repl","description":"Evaluate an expression and wait for the result","type":{"keys":["6 * 7","$ENTER$"],"surface":"type-repl","waitUntil":{"stdio":"/42/"},"timeout":10000}} */}
+{/* step {"stepId":"stop-repl","description":"Close the REPL","closeSurface":"type-repl"} */}
+{/* test end */}
 
 ### Send Ctrl+C to a process
 

--- a/docs/fern/pages/docs/actions/type.mdx
+++ b/docs/fern/pages/docs/actions/type.mdx
@@ -292,7 +292,7 @@ App surfaces run on Windows only. See [`startSurface`](/docs/actions/startsurfac
 
 {/* step {"stepId":"goto-type-object","description":"Open the type test page","goTo":"http://localhost:8092/type-echo.html"} */}
 {/* step {"stepId":"focus-input-object","description":"Focus the input","find":{"selector":"#type-input","click":true}} */}
-{/* step {"stepId":"type-object","description":"Type using the object format with no delay","type":{"keys":"Typed with the object format","inputDelay":0}} */}
+{/* step {"stepId":"type-object","description":"Type using the object format with an increased delay","type":{"keys":"Typed with the object format","inputDelay":150}} */}
 {/* step {"stepId":"verify-type-object","description":"Confirm the typed text was entered","find":"Typed with the object format"} */}
 {/* test end */}
 

--- a/test/server/public/type-echo.html
+++ b/test/server/public/type-echo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Type Echo Test Page</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        input { padding: 8px; width: 300px; }
+    </style>
+</head>
+<body>
+    <h1>Type Echo Test Page</h1>
+    <!-- The input mirrors its current value into #echo on every keystroke, so a
+         following find step proves the type action actually entered the text: a
+         focus-only no-op leaves #echo empty and the find FAILs. -->
+    <label for="type-input">Type here:</label>
+    <input id="type-input" type="text"
+           oninput="document.getElementById('echo').textContent = this.value">
+
+    <p id="echo"></p>
+</body>
+</html>


### PR DESCRIPTION
## What changed

Adds inline Doc Detective tests to the [`type` action reference page](docs/fern/pages/docs/actions/type.mdx), continuing the docs-as-tests pattern from the `goTo` (#557) and `click` (#558) pages.

Three inline tests, one per documented permutation:

- **`type-array-shorthand`** — types text plus a special key (`["Doc", "$SPACE$", "Detective"]`) into a browser input, then asserts the result with `find`.
- **`type-object-format`** — types via the object format (`keys` + `inputDelay`) into the same input, then asserts.
- **`type-repl-process-surface`** — drives a background `node -i` REPL: starts it with `runShell`, sends `6 * 7` + `$ENTER$` to the process `surface`, and asserts the printed result via `waitUntil: { stdio: "/42/" }`, then closes it. Fully self-contained — no browser or server needed.

Also adds **[test/server/public/type-echo.html](test/server/public/type-echo.html)**, a small fixture whose input mirrors its value into a `<p>` on every keystroke.

## Why

The `type` page had example specs but nothing proving they work. The existing test-server fixtures have inputs but nothing that reflects typed text, so a browser `type` couldn't be *meaningfully* verified — a step that merely focuses an element would still "pass". The echo fixture fixes that: the follow-up `find` only succeeds if the text was actually typed (a focus-only no-op leaves the paragraph empty and the `find` FAILs). Same prove-the-effect design as the existing `click-shorthand.html`.

## Reviewer notes

- **No per-page setup.** The browser tests reuse the shared static server wired into `docs/.doc-detective.json` via `beforeAny`/`afterAll` (#557), hitting `http://localhost:8092/type-echo.html`.
- **The REPL test needs nothing.** It's hermetic and cross-platform (`node -i`), and it asserts real output rather than just "the step ran".
- **New fixture is additive.** `type-echo.html` is a static file in the test server's `public/` dir; nothing else references it, so no existing test or fixture job is affected.
- **The example/test split is intentional.** The visible JSON examples still teach realistic targets (Google, credentials from `.env`); only the executable inline steps point at the local fixtures.
- **Scope.** Covers array shorthand, object format, and process surface. The credentials example (needs `.env`/`loadVariables`), the recording variant (`record`/`stopRecord`), the Ctrl+C snippet (needs a live process), and the app-surface example (Windows-only, would `SKIP`) aren't wired.
- **detectSteps.** All tests set `detectSteps: false`, matching the docs config.
- **Verified** with the real docs config: `3 specs / 5 tests / 13 steps, all PASS`.

## Docs impact

This *is* a docs change, plus one additive test fixture. No user-facing behavior/API change; no ADR or feature fixture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added structured test and step annotations to the action type documentation examples, including explicit test/step markers and readiness/wait metadata, without changing visible instructions or code sample content.

* **Tests**
  * Added a static HTML test page that mirrors user typing into an on-page echo element on every keystroke to validate typing vs. focus-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->