### PR TITLE
docs(actions): add inline Doc Detective tests for the find guide

### DIFF
--- a/docs/fern/pages/docs/actions/find.mdx
+++ b/docs/fern/pages/docs/actions/find.mdx
@@ -48,6 +48,8 @@ Here are a few ways you might use the `find` action:
 
 ### Find an element by its text (string shorthand)
 
+{/* test {"testId":"find-by-text","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -63,7 +65,13 @@ Here are a few ways you might use the `find` action:
 }
 ```
 
+{/* step {"stepId":"goto-find-text","description":"Open the test page","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"find-text","description":"Find a button by its display text","find":"Standard Button"} */}
+{/* test end */}
+
 ### Find an element by its selector (string shorthand)
+
+{/* test {"testId":"find-by-selector","detectSteps":false} */}
 
 ```json
 {
@@ -80,7 +88,13 @@ Here are a few ways you might use the `find` action:
 }
 ```
 
+{/* step {"stepId":"goto-find-selector","description":"Open the test page","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"find-selector","description":"Find an input by its CSS selector","find":"#text-input"} */}
+{/* test end */}
+
 ### Find an element by selector and click it (object format)
+
+{/* test {"testId":"find-selector-click","detectSteps":false} */}
 
 ```json
 {
@@ -100,7 +114,14 @@ Here are a few ways you might use the `find` action:
 }
 ```
 
+{/* step {"stepId":"goto-find-click","description":"Open the click test page","goTo":"http://localhost:8092/click-shorthand.html"} */}
+{/* step {"stepId":"find-click","description":"Find a button by selector and click it","find":{"selector":"#reveal-by-selector","click":true}} */}
+{/* step {"stepId":"verify-find-click","description":"The button appends a message only when actually clicked","find":"Selector click landed"} */}
+{/* test end */}
+
 ### Find an element by selector, click it, and type into it (object format)
+
+{/* test {"testId":"find-selector-click-type","detectSteps":false} */}
 
 ```json
 {
@@ -121,7 +142,14 @@ Here are a few ways you might use the `find` action:
 }
 ```
 
+{/* step {"stepId":"goto-find-type","description":"Open the type test page","goTo":"http://localhost:8092/type-echo.html"} */}
+{/* step {"stepId":"find-click-type","description":"Find the input by selector, click, and type into it","find":{"selector":"#type-input","click":true,"type":"find action"}} */}
+{/* step {"stepId":"verify-find-type","description":"The input echoes its value only when text is actually typed","find":"find action"} */}
+{/* test end */}
+
 ### Find an element combining selector and text with a timeout
+
+{/* test {"testId":"find-selector-and-text","detectSteps":false} */}
 
 ```json
 {
@@ -141,6 +169,10 @@ Here are a few ways you might use the `find` action:
   ]
 }
 ```
+
+{/* step {"stepId":"goto-find-nav","description":"Open the test page","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"find-nav-link","description":"Find a nav link matching both selector and text","find":{"selector":"nav > ul > li > a","elementText":"Buttons","timeout":10000}} */}
+{/* test end */}
 
 ### Find an element and right-click it
 

--- a/docs/fern/pages/docs/actions/type.mdx
+++ b/docs/fern/pages/docs/actions/type.mdx
@@ -178,6 +178,8 @@ App surfaces run on Windows only. See [`startSurface`](/docs/actions/startsurfac
 
 ### Perform a search (array shorthand)
 
+{/* test {"testId":"type-array-shorthand","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -203,6 +205,12 @@ App surfaces run on Windows only. See [`startSurface`](/docs/actions/startsurfac
   ]
 }
 ```
+
+{/* step {"stepId":"goto-type-array","description":"Open the type test page","goTo":"http://localhost:8092/type-echo.html"} */}
+{/* step {"stepId":"focus-input-array","description":"Focus the input","find":{"selector":"#type-input","click":true}} */}
+{/* step {"stepId":"type-array","description":"Type text and a space as an array of keys","type":["Doc","$SPACE$","Detective"]} */}
+{/* step {"stepId":"verify-type-array","description":"The input echoes its value only when text is actually typed","find":"Doc Detective"} */}
+{/* test end */}
 
 ### Fill credentials from environment variables (string shorthand)
 
@@ -243,6 +251,8 @@ App surfaces run on Windows only. See [`startSurface`](/docs/actions/startsurfac
 
 ### Type with an increased delay (object format)
 
+{/* test {"testId":"type-object-format","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -280,7 +290,15 @@ App surfaces run on Windows only. See [`startSurface`](/docs/actions/startsurfac
 }
 ```
 
+{/* step {"stepId":"goto-type-object","description":"Open the type test page","goTo":"http://localhost:8092/type-echo.html"} */}
+{/* step {"stepId":"focus-input-object","description":"Focus the input","find":{"selector":"#type-input","click":true}} */}
+{/* step {"stepId":"type-object","description":"Type using the object format with no delay","type":{"keys":"Typed with the object format","inputDelay":0}} */}
+{/* step {"stepId":"verify-type-object","description":"Confirm the typed text was entered","find":"Typed with the object format"} */}
+{/* test end */}
+
 ### Drive an interactive REPL (process surface)
+
+{/* test {"testId":"type-repl-process-surface","detectSteps":false} */}
 
 This example starts `node -i` in the background, waits until the prompt appears, types an expression, and waits until the REPL prints `42`. It then closes the process with a [`closeSurface`](/docs/actions/closesurface) step.
 
@@ -321,6 +339,11 @@ This example starts `node -i` in the background, waits until the prompt appears,
   ]
 }
 ```
+
+{/* step {"stepId":"start-repl","description":"Start a Node REPL in the background","runShell":{"command":"node -i","background":{"name":"type-repl","waitUntil":{"stdio":"/>/"}},"timeout":30000}} */}
+{/* step {"stepId":"eval-in-repl","description":"Evaluate an expression and wait for the result","type":{"keys":["6 * 7","$ENTER$"],"surface":"type-repl","waitUntil":{"stdio":"/42/"},"timeout":10000}} */}
+{/* step {"stepId":"stop-repl","description":"Close the REPL","closeSurface":"type-repl"} */}
+{/* test end */}
 
 ### Send Ctrl+C to a process
 

--- a/docs/fern/pages/docs/actions/type.mdx
+++ b/docs/fern/pages/docs/actions/type.mdx
@@ -292,7 +292,7 @@ App surfaces run on Windows only. See [`startSurface`](/docs/actions/startsurfac
 
 {/* step {"stepId":"goto-type-object","description":"Open the type test page","goTo":"http://localhost:8092/type-echo.html"} */}
 {/* step {"stepId":"focus-input-object","description":"Focus the input","find":{"selector":"#type-input","click":true}} */}
-{/* step {"stepId":"type-object","description":"Type using the object format with no delay","type":{"keys":"Typed with the object format","inputDelay":0}} */}
+{/* step {"stepId":"type-object","description":"Type using the object format with an increased delay","type":{"keys":"Typed with the object format","inputDelay":150}} */}
 {/* step {"stepId":"verify-type-object","description":"Confirm the typed text was entered","find":"Typed with the object format"} */}
 {/* test end */}
 

--- a/test/server/public/type-echo.html
+++ b/test/server/public/type-echo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Type Echo Test Page</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        input { padding: 8px; width: 300px; }
+    </style>
+</head>
+<body>
+    <h1>Type Echo Test Page</h1>
+    <!-- The input mirrors its current value into #echo on every keystroke, so a
+         following find step proves the type action actually entered the text: a
+         focus-only no-op leaves #echo empty and the find FAILs. -->
+    <label for="type-input">Type here:</label>
+    <input id="type-input" type="text"
+           oninput="document.getElementById('echo').textContent = this.value">
+
+    <p id="echo"></p>
+</body>
+</html>


### PR DESCRIPTION
## Stacked on #564

This PR is based on `claude/doc-detective-inline-tests-type` (#564), not `main` — the "find, click, and type" test below depends on `test/server/public/type-echo.html`, which #564 adds. Merge #564 first; this PR's diff will shrink to just the `find.mdx` change once that lands and this branch is retargeted/rebased onto `main`.

## What changed

Adds inline Doc Detective tests to the [`find` action reference page](docs/fern/pages/docs/actions/find.mdx), continuing the docs-as-tests pattern from `goTo` (#557), `click` (#558), and `type` (#564).

Five inline tests, one per documented permutation:

- **`find-by-text`** — find by display text (string shorthand)
- **`find-by-selector`** — find by CSS selector (string shorthand)
- **`find-selector-click`** — find by selector and click it (object format), verified via `click-shorthand.html`'s click-only-reveals-message fixture
- **`find-selector-click-type`** — find by selector, click, and type into it (object format), verified via `type-echo.html`'s type-only-echoes-value fixture
- **`find-selector-and-text`** — find combining `selector` + `elementText` + `timeout`, against the nav links in the static server's `index.html`

## Reviewer notes

- **No per-page setup.** Reuses the shared static server wired into `docs/.doc-detective.json` via `beforeAny`/`afterAll` (#557).
- **Scope.** Skips the right-click and middle-click examples, matching the precedent set in #558 (`click.mdx`) — non-left clicks need the W3C actions endpoint and aren't reliable headless.
- **The example/test split is intentional.** Visible JSON still teaches realistic targets (`Login`, `#username`, `Downloads`); only the executable inline steps point at the local fixtures.
- **detectSteps.** All tests set `detectSteps: false`, matching the docs config.
- **Verified** with the real docs config (`docs/.doc-detective.json`, on top of #564's branch so `type-echo.html` is present): `3 specs / 7 tests / 14 steps, all PASS`.

## Docs impact

This *is* a docs change; no user-facing behavior/API change. No ADR or feature fixture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
