### PR TITLE
docs(actions): add inline Doc Detective tests for the wait guide

### DIFF
--- a/docs/fern/pages/docs/actions/wait.mdx
+++ b/docs/fern/pages/docs/actions/wait.mdx
@@ -41,7 +41,7 @@ The value assigned to the `wait` key is the duration to pause in milliseconds. Y
 
 {/* step {"stepId":"goto-wait-seconds","description":"Open a page whose content appears 2 seconds after load","goTo":"http://localhost:8092/wait-delay.html"} */}
 {/* step {"stepId":"wait-seconds","description":"Wait for 3000 milliseconds (3 seconds), as documented","wait":3000} */}
-{/* step {"stepId":"verify-wait-seconds","description":"Use a short timeout so this only passes because the preceding wait already elapsed, not because find's own retry covers for a missing wait","find":{"elementText":"Loaded after 2 seconds","timeout":300}} */}
+{/* step {"stepId":"verify-wait-seconds","description":"Use a short timeout so this only passes because the preceding wait already elapsed, not because find's own retry compensates for a missing wait","find":{"elementText":"Loaded after 2 seconds","timeout":300}} */}
 {/* test end */}
 
 ### Wait for 500 milliseconds
@@ -77,7 +77,7 @@ The value assigned to the `wait` key is the duration to pause in milliseconds. Y
 {/* step {"stepId":"goto-wait-ms","description":"Open the wait delay test page","goTo":"http://localhost:8092/wait-delay.html"} */}
 {/* step {"stepId":"click-wait-trigger","description":"Click something","find":{"selector":"#click-trigger","click":true}} */}
 {/* step {"stepId":"wait-ms","description":"Wait for half a second","wait":500} */}
-{/* step {"stepId":"verify-wait-ms","description":"Use a short timeout so this only passes because the preceding wait already elapsed, not because find's own retry covers for a missing wait","find":{"elementText":"Action complete!","timeout":100}} */}
+{/* step {"stepId":"verify-wait-ms","description":"Use a short timeout so this only passes because the preceding wait already elapsed, not because find's own retry compensates for a missing wait","find":{"elementText":"Action complete!","timeout":100}} */}
 {/* test end */}
 
 

--- a/docs/fern/pages/docs/actions/wait.mdx
+++ b/docs/fern/pages/docs/actions/wait.mdx
@@ -39,7 +39,7 @@ The value assigned to the `wait` key is the duration to pause in milliseconds. Y
 }
 ```
 
-{/* step {"stepId":"goto-wait-seconds","description":"Open a page whose content appears 2 seconds after load","goTo":"http://localhost:8092/wait-delay.html"} */}
+{/* step {"stepId":"goto-wait-seconds","description":"Open a page whose content appears 2 seconds after the page's script runs","goTo":"http://localhost:8092/wait-delay.html"} */}
 {/* step {"stepId":"wait-seconds","description":"Wait for 3000 milliseconds (3 seconds), as documented","wait":3000} */}
 {/* step {"stepId":"verify-wait-seconds","description":"Use a short timeout so this only passes because the preceding wait already elapsed, not because find's own retry compensates for a missing wait","find":{"elementText":"Loaded after 2 seconds","timeout":300}} */}
 {/* test end */}

--- a/docs/fern/pages/docs/actions/wait.mdx
+++ b/docs/fern/pages/docs/actions/wait.mdx
@@ -40,8 +40,8 @@ The value assigned to the `wait` key is the duration to pause in milliseconds. Y
 ```
 
 {/* step {"stepId":"goto-wait-seconds","description":"Open a page whose content appears 2 seconds after load","goTo":"http://localhost:8092/wait-delay.html"} */}
-{/* step {"stepId":"wait-seconds","description":"Wait long enough for the delayed content to appear","wait":2500} */}
-{/* step {"stepId":"verify-wait-seconds","description":"The message only renders after its 2-second delay elapses","find":"Loaded after 2 seconds"} */}
+{/* step {"stepId":"wait-seconds","description":"Wait for 3000 milliseconds (3 seconds), as documented","wait":3000} */}
+{/* step {"stepId":"verify-wait-seconds","description":"Use a short timeout so this only passes because the preceding wait already elapsed, not because find's own retry covers for a missing wait","find":{"elementText":"Loaded after 2 seconds","timeout":300}} */}
 {/* test end */}
 
 ### Wait for 500 milliseconds
@@ -77,7 +77,7 @@ The value assigned to the `wait` key is the duration to pause in milliseconds. Y
 {/* step {"stepId":"goto-wait-ms","description":"Open the wait delay test page","goTo":"http://localhost:8092/wait-delay.html"} */}
 {/* step {"stepId":"click-wait-trigger","description":"Click something","find":{"selector":"#click-trigger","click":true}} */}
 {/* step {"stepId":"wait-ms","description":"Wait for half a second","wait":500} */}
-{/* step {"stepId":"verify-wait-ms","description":"Check the result","find":"Action complete!"} */}
+{/* step {"stepId":"verify-wait-ms","description":"Use a short timeout so this only passes because the preceding wait already elapsed, not because find's own retry covers for a missing wait","find":{"elementText":"Action complete!","timeout":100}} */}
 {/* test end */}
 
 

--- a/docs/fern/pages/docs/actions/wait.mdx
+++ b/docs/fern/pages/docs/actions/wait.mdx
@@ -14,6 +14,8 @@ The value assigned to the `wait` key is the duration to pause in milliseconds. Y
 
 ### Wait for 3 seconds
 
+{/* test {"testId":"wait-seconds","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -37,7 +39,14 @@ The value assigned to the `wait` key is the duration to pause in milliseconds. Y
 }
 ```
 
+{/* step {"stepId":"goto-wait-seconds","description":"Open a page whose content appears 2 seconds after load","goTo":"http://localhost:8092/wait-delay.html"} */}
+{/* step {"stepId":"wait-seconds","description":"Wait long enough for the delayed content to appear","wait":2500} */}
+{/* step {"stepId":"verify-wait-seconds","description":"The message only renders after its 2-second delay elapses","find":"Loaded after 2 seconds"} */}
+{/* test end */}
+
 ### Wait for 500 milliseconds
+
+{/* test {"testId":"wait-milliseconds","detectSteps":false} */}
 
 ```json
 {
@@ -64,5 +73,11 @@ The value assigned to the `wait` key is the duration to pause in milliseconds. Y
   ]
 }
 ```
+
+{/* step {"stepId":"goto-wait-ms","description":"Open the wait delay test page","goTo":"http://localhost:8092/wait-delay.html"} */}
+{/* step {"stepId":"click-wait-trigger","description":"Click something","find":{"selector":"#click-trigger","click":true}} */}
+{/* step {"stepId":"wait-ms","description":"Wait for half a second","wait":500} */}
+{/* step {"stepId":"verify-wait-ms","description":"Check the result","find":"Action complete!"} */}
+{/* test end */}
 
 

--- a/test/server/public/wait-delay.html
+++ b/test/server/public/wait-delay.html
@@ -16,16 +16,25 @@
          before the delay elapses will not see it; a preceding wait of 2
          seconds or more proves the wait action's effect. -->
     <p id="auto-message"></p>
-    <script>
-        setTimeout(function () {
-            document.getElementById("auto-message").textContent = "Loaded after 2 seconds";
-        }, 2000);
-    </script>
 
     <!-- Reveals its message 200ms after the button is clicked, simulating a
          short animation/transition. A find step immediately after the click
          (with no wait) would race the timeout; a short wait proves it out. -->
-    <button id="click-trigger" onclick="setTimeout(function () { document.getElementById('click-message').textContent = 'Action complete!'; }, 200)">Trigger delayed action</button>
+    <button id="click-trigger" onclick="revealClickMessage()">Trigger delayed action</button>
     <p id="click-message"></p>
+
+    <script>
+        function revealAutoMessage() {
+            document.getElementById("auto-message").textContent = "Loaded after 2 seconds";
+        }
+
+        function revealClickMessage() {
+            setTimeout(function () {
+                document.getElementById("click-message").textContent = "Action complete!";
+            }, 200);
+        }
+
+        setTimeout(revealAutoMessage, 2000);
+    </script>
 </body>
 </html>

--- a/test/server/public/wait-delay.html
+++ b/test/server/public/wait-delay.html
@@ -12,7 +12,8 @@
 <body>
     <h1>Wait Delay Test Page</h1>
 
-    <!-- Reveals its message 2 seconds after load. A find step that runs
+    <!-- Reveals its message 2 seconds after this page's script runs (near the
+         end of parsing, just before the load event). A find step that runs
          before the delay elapses will not see it; a preceding wait of 2
          seconds or more proves the wait action's effect. -->
     <p id="auto-message"></p>

--- a/test/server/public/wait-delay.html
+++ b/test/server/public/wait-delay.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wait Delay Test Page</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        button { padding: 10px 20px; margin: 5px; cursor: pointer; }
+    </style>
+</head>
+<body>
+    <h1>Wait Delay Test Page</h1>
+
+    <!-- Reveals its message 2 seconds after load. A find step that runs
+         before the delay elapses will not see it; a preceding wait of 2
+         seconds or more proves the wait action's effect. -->
+    <p id="auto-message"></p>
+    <script>
+        setTimeout(function () {
+            document.getElementById("auto-message").textContent = "Loaded after 2 seconds";
+        }, 2000);
+    </script>
+
+    <!-- Reveals its message 200ms after the button is clicked, simulating a
+         short animation/transition. A find step immediately after the click
+         (with no wait) would race the timeout; a short wait proves it out. -->
+    <button id="click-trigger" onclick="setTimeout(function () { document.getElementById('click-message').textContent = 'Action complete!'; }, 200)">Trigger delayed action</button>
+    <p id="click-message"></p>
+</body>
+</html>


### PR DESCRIPTION
## What changed

Adds inline Doc Detective tests to the [`wait` action reference page](docs/fern/pages/docs/actions/wait.mdx), continuing the docs-as-tests pattern from `goTo` (#557), `click` (#558), `type` (#564), and `find` (#565).

Two inline tests, one per documented example, both genuinely timing-dependent:

- **`wait-seconds`** — navigates to a new fixture where a message appears 2 seconds after load, waits 2500ms, then asserts the message with `find`.
- **`wait-milliseconds`** — clicks a button whose click reveals a message 200ms later, waits 500ms, then asserts it.

Adds **[test/server/public/wait-delay.html](test/server/public/wait-delay.html)**: a page with an auto-delayed reveal (`setTimeout`, 2s) and a click-triggered delayed reveal (`setTimeout`, 200ms after click).

## Why

Unlike `click`/`type` (where the fixture proves the action had *an* effect regardless of timing), `wait`'s entire purpose is timing — so the fixture needed to make the wait's duration matter. Both tests wait exactly long enough for delayed content to render, then assert it: if the wait were removed or shortened below the delay, the `find` would fail. That's a meaningfully stronger test than "the step ran without error."

## Reviewer notes

- **No per-page setup.** Reuses the shared static server wired into `docs/.doc-detective.json` via `beforeAny`/`afterAll` (#557). No fixture-dependency on other open PRs — this branches from `main` directly.
- **Screenshot sub-step intentionally not wired inline.** The first example's visible JSON ends with a `screenshot` call; I didn't add an executable `screenshot` step here, to avoid writing generated image artifacts into the docs source tree (`docs/fern/pages/docs/actions/`). The `wait` step itself is still fully exercised and verified via the follow-up `find`.
- **detectSteps.** Both tests set `detectSteps: false`, matching the docs config.
- **Verified** with the real docs config: `3 specs / 4 tests / 9 steps, all PASS`.

## Docs impact

This *is* a docs change, plus one additive test fixture. No user-facing behavior/API change; no ADR or feature fixture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the `wait` action examples with clearer, testable scenarios.
  - Added guidance for waiting on delayed page content and confirming delayed actions.

- **Tests**
  - Added coverage for automatic delayed messages and button-triggered completion messages.
  - Verified wait behavior for both multi-second and sub-second delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->