### PR TITLE
docs(actions): add inline Doc Detective tests for the dragAndDrop guide

### DIFF
--- a/docs/fern/pages/docs/actions/dragAndDrop.mdx
+++ b/docs/fern/pages/docs/actions/dragAndDrop.mdx
@@ -53,6 +53,8 @@ Here are several ways you might use the `dragAndDrop` action:
 
 ### Drag and drop using selectors or element text
 
+{/* test {"testId":"dragdrop-selector-text","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -71,7 +73,13 @@ Here are several ways you might use the `dragAndDrop` action:
 }
 ```
 
+{/* step {"stepId":"goto-dragdrop-text","description":"Open the drag and drop test page","goTo":"http://localhost:8092/drag-drop-test.html"} */}
+{/* step {"stepId":"dragdrop-text","description":"Drag a widget by selector and drop it onto a zone by text","dragAndDrop":{"source":".draggable[data-widget='text']","target":"Drop Zone 1"}} */}
+{/* test end */}
+
 ### Drag and drop with detailed element objects
+
+{/* test {"testId":"dragdrop-detailed-objects","detectSteps":false} */}
 
 ```json
 {
@@ -96,6 +104,10 @@ Here are several ways you might use the `dragAndDrop` action:
   ]
 }
 ```
+
+{/* step {"stepId":"goto-dragdrop-object","description":"Open the drag and drop test page","goTo":"http://localhost:8092/drag-drop-test.html"} */}
+{/* step {"stepId":"dragdrop-object","description":"Drag and drop using detailed source and target objects","dragAndDrop":{"source":{"selector":".draggable","elementText":"Widget Item 1"},"target":{"selector":".drop-zone","elementText":"Drop Zone 2"}}} */}
+{/* test end */}
 
 ## Related actions
 


### PR DESCRIPTION
## What changed

Adds inline Doc Detective tests to the [`dragAndDrop` action reference page](docs/fern/pages/docs/actions/dragAndDrop.mdx), continuing the docs-as-tests pattern.

Two inline tests, reusing the existing **[test/server/public/drag-drop-test.html](test/server/public/drag-drop-test.html)** fixture (already used by `test/core-artifacts/interactions/dragAndDrop.spec.json`):

- **`dragdrop-selector-text`** — string shorthand: source by CSS selector, target by element text.
- **`dragdrop-detailed-objects`** — detailed objects: both source and target as `{selector, elementText}`.

## Why / a scoping note

I initially tried verifying the drop with a follow-up `find` on the fixture's own status line (which updates via its page-level `dragstart`/`dragover`/`drop` listeners) — the same "prove the effect" pattern used for `click`/`type`. That follow-up `find` failed consistently, even though the `dragAndDrop` step itself reported success.

Looking at `src/core/tests/dragAndDrop.ts` and this repo's own `dragAndDrop.spec.json` fixture explains why: Doc Detective's drag implementation tries WebDriver's native `dragAndDrop()` first, falling back to synthetic `DragEvent` dispatch only if the source element's bounding box didn't change. Native HTML5 drag-and-drop simulated through WebDriver is inconsistent about firing real events a page's own JS listeners observe — and the repo's own fixture spec doesn't attempt to verify that side effect either; it relies solely on the action's own implicit assertions (`sourceFound`/`targetFound` + a successful drag execution).

So these tests do the same: they exercise the real action against real elements from the real fixture and assert on the action's own outcome, rather than chasing an observable this repo has already found unreliable to check that way.

## Reviewer notes

- **No per-page setup, no new fixture.** Reuses the shared static server (#557) and the existing `drag-drop-test.html`.
- **detectSteps.** Both tests set `detectSteps: false`.
- **Verified** with the real docs config: `3 specs / 4 tests / 6 steps, all PASS`.

## Docs impact

This *is* a docs change. No user-facing behavior/API change; no ADR or feature fixture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced drag-and-drop documentation examples with metadata that improves automated step detection.
  * Existing JSON example content remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->