### PR TITLE
docs(actions): add inline Doc Detective tests for the checkLink guide

### DIFF
--- a/docs/fern/pages/docs/actions/checkLink.mdx
+++ b/docs/fern/pages/docs/actions/checkLink.mdx
@@ -131,7 +131,7 @@ Here are a few ways you might use the `checkLink` action:
 
 Include non-2xx status codes in `statusCodes` to accept responses that would otherwise fail. This is useful for testing endpoints that return rate limiting (`429`), authentication errors (`403`), or other expected non-success responses.
 
-Doc Detective's retry-with-backoff and HEAD-fallback logic (described above in [Behavior](#behavior)) only runs while the response code isn't yet accepted. As soon as a response matches `statusCodes`—including on the very first `GET`, as in the example below—Doc Detective stops immediately and passes; it doesn't retry or fall back to `HEAD` just because the code happens to be `429` or `403`.
+Doc Detective's retry-with-backoff and HEAD-fallback logic (described above in [Behavior](#behavior)) only runs while the response code isn't yet accepted. As soon as a response matches `statusCodes`—including on the very first `GET`, as in the example below—Doc Detective stops immediately and passes. It doesn't retry or fall back to `HEAD` just because the code happens to be `429` or `403`.
 
 {/* test {"testId":"checklink-non-2xx","detectSteps":false} */}
 

--- a/docs/fern/pages/docs/actions/checkLink.mdx
+++ b/docs/fern/pages/docs/actions/checkLink.mdx
@@ -131,6 +131,8 @@ Here are a few ways you might use the `checkLink` action:
 
 Include non-2xx status codes in `statusCodes` to accept responses that would otherwise fail. This is useful for testing endpoints that return rate limiting (`429`), authentication errors (`403`), or other expected non-success responses.
 
+Doc Detective's retry-with-backoff and HEAD-fallback logic (described above in [Behavior](#behavior)) only runs while the response code isn't yet accepted. As soon as a response matches `statusCodes`—including on the very first `GET`, as in the example below—Doc Detective stops immediately and passes; it doesn't retry or fall back to `HEAD` just because the code happens to be `429` or `403`.
+
 {/* test {"testId":"checklink-non-2xx","detectSteps":false} */}
 
 ```json
@@ -151,7 +153,7 @@ Include non-2xx status codes in `statusCodes` to accept responses that would oth
 }
 ```
 
-{/* step {"stepId":"checklink-429","description":"Check a URL that always returns 429, accepting it explicitly","checkLink":{"url":"http://localhost:8092/status/429","statusCodes":[200,429]}} */}
+{/* step {"stepId":"checklink-429","description":"Check a URL that always returns 429; because 429 is already accepted, this passes on the first GET with no retries or HEAD fallback","checkLink":{"url":"http://localhost:8092/status/429","statusCodes":[200,429]}} */}
 {/* test end */}
 
 ### Check a link with a separate origin and URL path

--- a/docs/fern/pages/docs/actions/checkLink.mdx
+++ b/docs/fern/pages/docs/actions/checkLink.mdx
@@ -33,6 +33,8 @@ Here are a few ways you might use the `checkLink` action:
 
 ### Check if a link is valid (string shorthand)
 
+{/* test {"testId":"checklink-string-shorthand","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -48,7 +50,12 @@ Here are a few ways you might use the `checkLink` action:
 }
 ```
 
+{/* step {"stepId":"checklink-string","description":"Check a URL that returns 200 (string shorthand)","checkLink":"http://localhost:8092/status/200"} */}
+{/* test end */}
+
 ### Check if a link is valid (object format)
+
+{/* test {"testId":"checklink-object-format","detectSteps":false} */}
 
 ```json
 {
@@ -67,7 +74,12 @@ Here are a few ways you might use the `checkLink` action:
 }
 ```
 
+{/* step {"stepId":"checklink-object","description":"Check a URL that returns 200 (object format)","checkLink":{"url":"http://localhost:8092/status/200"}} */}
+{/* test end */}
+
 ### Check for a specific status code response
+
+{/* test {"testId":"checklink-specific-status","detectSteps":false} */}
 
 ```json
 {
@@ -87,7 +99,12 @@ Here are a few ways you might use the `checkLink` action:
 }
 ```
 
+{/* step {"stepId":"checklink-specific","description":"Check a URL expecting only 200","checkLink":{"url":"http://localhost:8092/status/200","statusCodes":200}} */}
+{/* test end */}
+
 ### Check for one of a set of status code responses
+
+{/* test {"testId":"checklink-status-set","detectSteps":false} */}
 
 ```json
 {
@@ -107,9 +124,14 @@ Here are a few ways you might use the `checkLink` action:
 }
 ```
 
+{/* step {"stepId":"checklink-set","description":"Check a URL returning 201 against a set of acceptable codes","checkLink":{"url":"http://localhost:8092/status/201","statusCodes":[200,201,202]}} */}
+{/* test end */}
+
 ### Accept non-2xx status codes
 
 Include non-2xx status codes in `statusCodes` to accept responses that would otherwise fail. This is useful for testing endpoints that return rate limiting (`429`), authentication errors (`403`), or other expected non-success responses.
+
+{/* test {"testId":"checklink-non-2xx","detectSteps":false} */}
 
 ```json
 {
@@ -129,7 +151,12 @@ Include non-2xx status codes in `statusCodes` to accept responses that would oth
 }
 ```
 
+{/* step {"stepId":"checklink-429","description":"Check a URL that always returns 429, accepting it explicitly","checkLink":{"url":"http://localhost:8092/status/429","statusCodes":[200,429]}} */}
+{/* test end */}
+
 ### Check a link with a separate origin and URL path
+
+{/* test {"testId":"checklink-origin-path","detectSteps":false} */}
 
 ```json
 {
@@ -149,9 +176,14 @@ Include non-2xx status codes in `statusCodes` to accept responses that would oth
 }
 ```
 
+{/* step {"stepId":"checklink-origin","description":"Check a path against a specific origin","checkLink":{"url":"/status/200","origin":"http://localhost:8092"}} */}
+{/* test end */}
+
 ### Pass custom headers (allowlist or bypass)
 
 Use the `headers` field to send additional HTTP headers on top of Doc Detective's browser-mimicking defaults. This is useful for sites that allowlist a shared secret or require a bypass token.
+
+{/* test {"testId":"checklink-headers-object","detectSteps":false} */}
 
 ```json
 {
@@ -173,7 +205,12 @@ Use the `headers` field to send additional HTTP headers on top of Doc Detective'
 }
 ```
 
+{/* step {"stepId":"checklink-headers-obj","description":"Check a URL with a custom header (object format)","checkLink":{"url":"http://localhost:8092/status/200","headers":{"X-Doc-Detective-Check":"shared-secret"}}} */}
+{/* test end */}
+
 `headers` also accepts a newline-separated string, which is convenient for multi-header strings loaded from environment variables:
+
+{/* test {"testId":"checklink-headers-string","detectSteps":false} */}
 
 ```json
 {
@@ -183,6 +220,9 @@ Use the `headers` field to send additional HTTP headers on top of Doc Detective'
   }
 }
 ```
+
+{/* step {"stepId":"checklink-headers-str","description":"Check a URL with custom headers as a newline-separated string","checkLink":{"url":"http://localhost:8092/status/200","headers":"X-Api-Key: abc123\nX-Doc-Detective-Check: shared-secret"}} */}
+{/* test end */}
 
 ### Check a relative link using global origin
 
@@ -220,6 +260,8 @@ Values in `params` and `originParams` are embedded directly in request URLs and 
 
 ### Check a link with query parameters
 
+{/* test {"testId":"checklink-query-params","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -240,6 +282,9 @@ Values in `params` and `originParams` are embedded directly in request URLs and 
   ]
 }
 ```
+
+{/* step {"stepId":"checklink-params","description":"Check a URL with query parameters appended","checkLink":{"url":"/status/200","origin":"http://localhost:8092","params":{"token":"test-value"}}} */}
+{/* test end */}
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What changed

Adds inline Doc Detective tests to the [`checkLink` action reference page](docs/fern/pages/docs/actions/checkLink.mdx), continuing the docs-as-tests pattern.

Nine inline tests, exercising `checkLink` against the test server's deterministic **`/status/:code`** fixture ([test/server/index.js](test/server/index.js)) instead of external sites — hermetic, fast, no network dependency:

- string shorthand and object format, both against a `200` response
- `statusCodes` as a single integer, and as an array of acceptable codes
- accepting a non-2xx code explicitly (`429`) against a URL that always returns 429
- `url` + `origin` split
- `headers` as an object, and as a newline-separated string
- query parameters via `params`

## Reviewer notes

- **No per-page setup, no new fixture.** `/status/:code` already exists in the shared test server for exactly this purpose ("Lets integration tests assert checkLink ... behavior against deterministic HTTP responses").
- **Correction (thanks to review feedback):** the 429 test does **not** exercise the retry-with-backoff/HEAD-fallback path. Per `src/core/tests/checkLink.ts`, the retry loop breaks as soon as a response matches `statusCodes`, and the HEAD fallback only runs when it doesn't. Since `429` is already in `statusCodes` here, the check passes on the very first `GET` with no retries — it's fast, not the ~7s I originally claimed. Added a clarifying paragraph to the "Accept non-2xx status codes" section explaining this short-circuit behavior, since the page's own "Behavior" section could otherwise read as implying retries always happen first.
- **Troubleshooting section not wired.** The self-signed-certificate walkthrough needs an external site (`self-signed.badssl.com`) and an env var toggle (`NODE_TLS_REJECT_UNAUTHORIZED`) that would affect the whole test run; left as narrative-only, consistent with how other pages skip permutations that don't fit local/hermetic verification.
- **detectSteps.** All tests set `detectSteps: false`.
- **Verified** with the real docs config: `3 specs / 11 tests / 11 steps, all PASS`.

## Docs impact

This *is* a docs change. No user-facing behavior/API change; no ADR or feature fixture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
