### PR TITLE
docs(actions): add inline Doc Detective tests for the cookie guides

### DIFF
--- a/docs/fern/pages/docs/actions/loadCookie.mdx
+++ b/docs/fern/pages/docs/actions/loadCookie.mdx
@@ -65,6 +65,8 @@ Load a cookie with detailed configuration:
 
 ### Load from default location
 
+{/* test {"testId":"loadcookie-string-shorthand","detectSteps":false} */}
+
 ```json
 {
   "steps": [
@@ -79,6 +81,14 @@ Load a cookie with detailed configuration:
   ]
 }
 ```
+
+{/* step {"stepId":"goto-loadcookie-string-setup","description":"Open the local test server","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"set-cookie-loadstring","description":"Set a cookie to save, then clear it to prove the reload really restores it","runBrowserScript":"document.cookie = 'session_token=reload-me-111; path=/;';"} */}
+{/* step {"stepId":"savecookie-loadstring","description":"Save it to an environment variable","saveCookie":"session_token"} */}
+{/* step {"stepId":"clear-cookie-loadstring","description":"Clear the cookie from the browser","runBrowserScript":"document.cookie = 'session_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;';"} */}
+{/* step {"stepId":"loadcookie-string","description":"Load the saved session cookie back into the browser (string shorthand)","loadCookie":"session_token"} */}
+{/* step {"stepId":"verify-loadcookie-string","description":"Confirm the cookie is present again after loading it","runBrowserScript":{"script":"return document.cookie.includes('session_token=reload-me-111');","output":"true"}} */}
+{/* test end */}
 
 ### Load from specific file
 
@@ -99,6 +109,8 @@ Load a cookie with detailed configuration:
 
 ### Load from environment variable
 
+{/* test {"testId":"loadcookie-object-variable","detectSteps":false} */}
+
 ```json
 {
   "steps": [
@@ -113,7 +125,17 @@ Load a cookie with detailed configuration:
 }
 ```
 
+{/* step {"stepId":"goto-loadcookie-object-setup","description":"Open the local test server","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"set-cookie-loadobject","description":"Set a cookie to save, then clear it","runBrowserScript":"document.cookie = 'session_token=reload-me-222; path=/;';"} */}
+{/* step {"stepId":"savecookie-loadobject","description":"Save it to a named environment variable","saveCookie":{"name":"session_token","variable":"DD_DOCS_LOADCOOKIE_TOKEN"}} */}
+{/* step {"stepId":"clear-cookie-loadobject","description":"Clear the cookie from the browser","runBrowserScript":"document.cookie = 'session_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;';"} */}
+{/* step {"stepId":"loadcookie-object","description":"Load the saved cookie from the named environment variable (object format)","loadCookie":{"name":"session_token","variable":"DD_DOCS_LOADCOOKIE_TOKEN"}} */}
+{/* step {"stepId":"verify-loadcookie-object","description":"Confirm the cookie is present again after loading it","runBrowserScript":{"script":"return document.cookie.includes('session_token=reload-me-222');","output":"true"}} */}
+{/* test end */}
+
 ### Load with domain filtering
+
+{/* test {"testId":"loadcookie-domain-filter","detectSteps":false} */}
 
 ```json
 {
@@ -129,6 +151,14 @@ Load a cookie with detailed configuration:
   ]
 }
 ```
+
+{/* step {"stepId":"goto-loadcookie-domain-setup","description":"Open the local test server","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"set-cookie-loaddomain","description":"Set a cookie to save, then clear it","runBrowserScript":"document.cookie = 'user_session=reload-me-333; path=/;';"} */}
+{/* step {"stepId":"savecookie-loaddomain","description":"Save it, filtering by the local server's domain","saveCookie":{"name":"user_session","variable":"DD_DOCS_USER_SESSION","domain":"localhost"}} */}
+{/* step {"stepId":"clear-cookie-loaddomain","description":"Clear the cookie from the browser","runBrowserScript":"document.cookie = 'user_session=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;';"} */}
+{/* step {"stepId":"loadcookie-domain","description":"Load the domain-filtered cookie back into the browser","loadCookie":{"name":"user_session","variable":"DD_DOCS_USER_SESSION","domain":"localhost"}} */}
+{/* step {"stepId":"verify-loadcookie-domain","description":"Confirm the cookie is present again after loading it","runBrowserScript":{"script":"return document.cookie.includes('user_session=reload-me-333');","output":"true"}} */}
+{/* test end */}
 
 ### Complete workflow example
 

--- a/docs/fern/pages/docs/actions/saveCookie.mdx
+++ b/docs/fern/pages/docs/actions/saveCookie.mdx
@@ -68,6 +68,8 @@ Save a cookie with detailed configuration:
 
 ### Save to default location
 
+{/* test {"testId":"savecookie-string-shorthand","detectSteps":false} */}
+
 ```json
 {
   "steps": [
@@ -90,6 +92,12 @@ Save a cookie with detailed configuration:
 }
 ```
 
+{/* step {"stepId":"goto-savecookie-string","description":"Open the local test server","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"set-cookie-string","description":"Set a cookie in the browser to save","runBrowserScript":"document.cookie = 'session_token=abc123; path=/;';"} */}
+{/* step {"stepId":"savecookie-string","description":"Save the cookie to an environment variable (string shorthand)","saveCookie":"session_token"} */}
+{/* step {"stepId":"verify-savecookie-string","description":"Confirm the cookie value actually landed in the environment variable","runCode":{"language":"javascript","code":"console.log(process.env.session_token);","stdio":"/abc123/"}} */}
+{/* test end */}
+
 ### Save to specific file
 
 ```json
@@ -110,6 +118,8 @@ Save a cookie with detailed configuration:
 
 ### Save to environment variable
 
+{/* test {"testId":"savecookie-object-variable","detectSteps":false} */}
+
 ```json
 {
   "steps": [
@@ -124,7 +134,15 @@ Save a cookie with detailed configuration:
 }
 ```
 
+{/* step {"stepId":"goto-savecookie-object","description":"Open the local test server","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"set-cookie-object","description":"Set a cookie in the browser to save","runBrowserScript":"document.cookie = 'session_token=xyz789; path=/;';"} */}
+{/* step {"stepId":"savecookie-object","description":"Save the cookie to a named environment variable (object format)","saveCookie":{"name":"session_token","variable":"DD_DOCS_SESSION_TOKEN"}} */}
+{/* step {"stepId":"verify-savecookie-object","description":"Confirm the cookie value landed in the named environment variable","runCode":{"language":"javascript","code":"console.log(process.env.DD_DOCS_SESSION_TOKEN);","stdio":"/xyz789/"}} */}
+{/* test end */}
+
 ### Save with domain filtering
+
+{/* test {"testId":"savecookie-domain-filter","detectSteps":false} */}
 
 ```json
 {
@@ -140,6 +158,12 @@ Save a cookie with detailed configuration:
   ]
 }
 ```
+
+{/* step {"stepId":"goto-savecookie-domain","description":"Open the local test server","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"set-cookie-domain","description":"Set a cookie in the browser to save","runBrowserScript":"document.cookie = 'login_token=domain-filtered-456; path=/;';"} */}
+{/* step {"stepId":"savecookie-domain","description":"Save the cookie, filtering by the local server's domain","saveCookie":{"name":"login_token","variable":"DD_DOCS_LOGIN_TOKEN","domain":"localhost"}} */}
+{/* step {"stepId":"verify-savecookie-domain","description":"Confirm the domain-filtered cookie value landed in the environment variable","runCode":{"language":"javascript","code":"console.log(process.env.DD_DOCS_LOGIN_TOKEN);","stdio":"/domain-filtered-456/"}} */}
+{/* test end */}
 
 ## Related actions
 


### PR DESCRIPTION
## What changed

Adds inline Doc Detective tests to the [`saveCookie`](docs/fern/pages/docs/actions/saveCookie.mdx) and [`loadCookie`](docs/fern/pages/docs/actions/loadCookie.mdx) reference pages, continuing the docs-as-tests pattern.

Both pages use `runBrowserScript` to set/read real cookies against the shared static test server, rather than relying on an external login form.

- **`saveCookie.mdx`** (3 tests) — string shorthand, object-format, and domain-filtered saves to an environment variable. Each is verified by a `runCode` step that reads the target env var back and asserts its value via `stdio`.
- **`loadCookie.mdx`** (3 tests) — each does a full round trip: set a cookie → `saveCookie` it → clear it from the browser → `loadCookie` it back → confirm via `runBrowserScript` that the cookie is present again with its original value. This proves `loadCookie` actually restores state, not just that the step ran without error.

## A shell-quoting bug I hit and worked around

My first pass at `saveCookie.mdx`'s verification used `runShell` with `node -e "<js>"`. On Windows, `spawn(..., {shell: true})` routes through `cmd.exe`, which mangled the quoted/parenthesized JS mid-argument and silently truncated the script (confirmed by inspecting the actual `stderr`: a `SyntaxError` from a cut-off script). Switched to `runCode` instead — it writes the code to a file and executes it, so there's no shell-quoting step to go wrong. Worth knowing if this pattern (a `runShell` one-liner with nontrivial JS) comes up in other docs pages.

## Scoping

Both pages skip the file-path-based examples (save/load to a specific file, domain filtering from a file) to avoid writing cookie files into the docs source tree — consistent with the artifact-pollution precedent from `wait.mdx`'s screenshot skip (#566) and `httpRequest.mdx`'s "save response to file" skip (#569). The "Complete workflow example" (a two-test file-based handoff) is left undemonstrated inline for the same reason; the variable-based round trip already covers the same mechanism.

## Reviewer notes

- **No per-page setup, no new fixture.** Reuses the shared static server (#557).
- **detectSteps.** All tests set `detectSteps: false`.
- **Verified** with the real docs config: `4 specs / 8 tests / 32 steps, all PASS`.

## Docs impact

This *is* a docs change. No user-facing behavior/API change; no ADR or feature fixture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
