### PR TITLE
docs(actions): add inline Doc Detective tests for the loadVariables guide

### DIFF
--- a/docs/fern/pages/docs/actions/loadVariables.mdx
+++ b/docs/fern/pages/docs/actions/loadVariables.mdx
@@ -54,6 +54,3 @@ You can load these variables using the `loadVariables` action:
 {/* step {"stepId":"loadvariables-use","description":"Use both loaded variables: BASE_URL in the URL, API_KEY in a header and the request body so the echoed response proves it substituted correctly","httpRequest":{"url":"$BASE_URL/data","method":"POST","request":{"headers":{"Authorization":"Bearer $API_KEY"},"body":{"key":"$API_KEY"}},"response":{"body":{"key":"docs-test-secret-456"}}}} */}
 {/* test end */}
 
-This example uses a `secrets.env` file that lives alongside this page in the repository (`docs/fern/pages/docs/actions/secrets.env`), pointing `BASE_URL` at the local test server rather than a real API. If the `httpRequest` step's URL resolved correctly and its response echoes back the literal `API_KEY` value, both variables loaded and substituted as expected.
-
-

--- a/docs/fern/pages/docs/actions/loadVariables.mdx
+++ b/docs/fern/pages/docs/actions/loadVariables.mdx
@@ -51,6 +51,6 @@ You can load these variables using the `loadVariables` action:
 ```
 
 {/* step {"stepId":"loadvariables-load","description":"Load environment variables from secrets.env","loadVariables":"./secrets.env"} */}
-{/* step {"stepId":"loadvariables-use","description":"Use both loaded variables: BASE_URL in the URL, API_KEY in a header and the request body so the echoed response proves it substituted correctly","httpRequest":{"url":"$BASE_URL/data","method":"POST","request":{"headers":{"Authorization":"Bearer $API_KEY"},"body":{"key":"$API_KEY"}},"response":{"body":{"key":"docs-test-secret-456"}}}} */}
+{/* step {"stepId":"loadvariables-use","description":"Use both loaded variables: BASE_URL in the URL (proven by the request reaching the local server at all) and API_KEY in both a header and the request body -- only the body's substitution is independently verified below, since the echo API reflects the body/query but not request headers","httpRequest":{"url":"$BASE_URL/data","method":"POST","request":{"headers":{"Authorization":"Bearer $API_KEY"},"body":{"key":"$API_KEY"}},"response":{"body":{"key":"docs-test-secret-456"}}}} */}
 {/* test end */}
 

--- a/docs/fern/pages/docs/actions/loadVariables.mdx
+++ b/docs/fern/pages/docs/actions/loadVariables.mdx
@@ -21,6 +21,8 @@ BASE_URL=https://api.example.com
 
 You can load these variables using the `loadVariables` action:
 
+{/* test {"testId":"loadvariables-env-file","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -47,5 +49,11 @@ You can load these variables using the `loadVariables` action:
   ]
 }
 ```
+
+{/* step {"stepId":"loadvariables-load","description":"Load environment variables from secrets.env","loadVariables":"./secrets.env"} */}
+{/* step {"stepId":"loadvariables-use","description":"Use both loaded variables: BASE_URL in the URL, API_KEY in a header and the request body so the echoed response proves it substituted correctly","httpRequest":{"url":"$BASE_URL/data","method":"POST","request":{"headers":{"Authorization":"Bearer $API_KEY"},"body":{"key":"$API_KEY"}},"response":{"body":{"key":"docs-test-secret-456"}}}} */}
+{/* test end */}
+
+This example uses a `secrets.env` file that lives alongside this page in the repository (`docs/fern/pages/docs/actions/secrets.env`), pointing `BASE_URL` at the local test server rather than a real API. If the `httpRequest` step's URL resolved correctly and its response echoes back the literal `API_KEY` value, both variables loaded and substituted as expected.
 
 

--- a/docs/fern/pages/docs/actions/secrets.env
+++ b/docs/fern/pages/docs/actions/secrets.env
@@ -1,0 +1,2 @@
+API_KEY=docs-test-secret-456
+BASE_URL=http://localhost:8092/api


### PR DESCRIPTION
## What changed

Adds an inline Doc Detective test to the [`loadVariables` action reference page](docs/fern/pages/docs/actions/loadVariables.mdx), continuing the docs-as-tests pattern.

Adds **[docs/fern/pages/docs/actions/secrets.env](docs/fern/pages/docs/actions/secrets.env)** alongside the page (matching the doc's own filename/relative-path example), with a fake `API_KEY` placeholder and `BASE_URL` pointed at the local test server instead of a live API.

The inline test:
1. `loadVariables: "./secrets.env"`
2. An `httpRequest` using `$BASE_URL` in the URL and `$API_KEY` in **both** an `Authorization` header and the request body. The echo API reflects the body back, so asserting `response.body.key` equals the literal secret value proves both variables actually loaded and substituted — not just that the request happened to succeed.

Confirmed with a negative-control run that a wrong value in that position fails the assertion, same verification discipline applied after the review feedback on #569's variable-capture test.

## Reviewer notes

- **No per-page setup.** Reuses the shared static server (#557).
- **`secrets.env` contains only a fake placeholder value** (`docs-test-secret-456`), never a real credential — safe to commit.
- **detectSteps.** The test sets `detectSteps: false`.
- **Verified** with the real docs config: `3 specs / 3 tests / 4 steps, all PASS`.

## Docs impact

This *is* a docs change, plus one additive fixture file. No user-facing behavior/API change; no ADR or feature fixture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `loadVariables` example to clearly show environment-variable loading and usage within test and step blocks.
  * Added a sample environment file demonstrating `API_KEY` and `BASE_URL` configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->