### PR TITLE
docs(actions): add inline Doc Detective tests for the runBrowserScript guide

### DIFF
--- a/docs/fern/pages/docs/actions/runBrowserScript.mdx
+++ b/docs/fern/pages/docs/actions/runBrowserScript.mdx
@@ -36,6 +36,8 @@ Here are a few ways you might use the `runBrowserScript` action:
 
 This example navigates to a page and returns its title.
 
+{/* test {"testId":"runbrowserscript-read-value","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -52,9 +54,15 @@ This example navigates to a page and returns its title.
 }
 ```
 
+{/* step {"stepId":"goto-runbrowserscript-read","description":"Open the local test server","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"runbrowserscript-read","description":"Read the page title and assert its exact value","runBrowserScript":{"script":"return document.title;","output":"Basic HTML Elements Demo"}} */}
+{/* test end */}
+
 ### Assert on the return value
 
 This example checks that the current URL uses HTTP(S) via a regular expression.
+
+{/* test {"testId":"runbrowserscript-assert-output","detectSteps":false} */}
 
 ```json
 {
@@ -75,9 +83,15 @@ This example checks that the current URL uses HTTP(S) via a regular expression.
 }
 ```
 
+{/* step {"stepId":"goto-runbrowserscript-assert","description":"Open the local test server","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"runbrowserscript-assert","description":"Validate the page URL","runBrowserScript":{"script":"return window.location.href;","output":"/^https?:\\/\\//"}} */}
+{/* test end */}
+
 ### Pass arguments into the script
 
 The script reads values from `args` through the `arguments` object.
+
+{/* test {"testId":"runbrowserscript-args","detectSteps":false} */}
 
 ```json
 {
@@ -99,9 +113,15 @@ The script reads values from `args` through the `arguments` object.
 }
 ```
 
+{/* step {"stepId":"goto-runbrowserscript-args","description":"Open the local test server","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"runbrowserscript-concat","description":"Concatenate two arguments in the page","runBrowserScript":{"script":"return arguments[0] + arguments[1];","args":["foo","bar"],"output":"foobar"}} */}
+{/* test end */}
+
 ### Capture the return value into a variable
 
 The first step captures the return value into a `TOKEN` variable. The second step substitutes it into `args` and validates it round-trips through the page.
+
+{/* test {"testId":"runbrowserscript-variable-capture","detectSteps":false} */}
 
 ```json
 {
@@ -128,3 +148,9 @@ The first step captures the return value into a `TOKEN` variable. The second ste
   ]
 }
 ```
+
+{/* step {"stepId":"goto-runbrowserscript-var","description":"Open the local test server","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"runbrowserscript-seed","description":"Seed localStorage with a real value, since a fresh page load has none to capture","runBrowserScript":"window.localStorage.setItem('token', 'abc123');"} */}
+{/* step {"stepId":"runbrowserscript-capture","description":"Read the value and store it in a variable","runBrowserScript":"return window.localStorage.getItem('token');","variables":{"TOKEN":"$$result"}} */}
+{/* step {"stepId":"runbrowserscript-reuse","description":"Reuse the captured value and assert it round-tripped correctly","runBrowserScript":{"script":"return arguments[0];","args":["$TOKEN"],"output":"abc123"}} */}
+{/* test end */}


### PR DESCRIPTION
## What changed

Adds inline Doc Detective tests to the [`runBrowserScript` action reference page](docs/fern/pages/docs/actions/runBrowserScript.mdx), continuing the docs-as-tests pattern.

Four inline tests, targeting the shared static test server instead of `example.com`:

- **`runbrowserscript-read-value`** — reads `document.title`, asserted against its exact known value.
- **`runbrowserscript-assert-output`** — asserts on the return value via a regex (URL starts with http/https).
- **`runbrowserscript-args`** — passes positional arguments into the script and asserts the concatenated result.
- **`runbrowserscript-variable-capture`** — captures a return value into a variable and reuses it.

## A test-quality fix along the way

The visible "Capture the return value into a variable" example reads `window.localStorage.getItem('token')` on a page that never set it — on a fresh page load this is always `null`, so a literal inline test would "round-trip" successfully regardless of whether variable capture/substitution actually worked. Added a seed step (`localStorage.setItem('token', 'abc123')`) before the read, so the round-trip assertion is checking a real value, not passing on an empty coincidence — same discipline applied after review feedback on the `httpRequest`/`loadVariables` variable-capture tests earlier in this series.

## Reviewer notes

- **No per-page setup, no new fixture.** Reuses the shared static server (#557).
- **detectSteps.** All tests set `detectSteps: false`.
- **Verified** with the real docs config: `3 specs / 6 tests / 12 steps, all PASS`.

## Docs impact

This *is* a docs change. No user-facing behavior/API change; no ADR or feature fixture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
