### PR TITLE
docs(actions): add inline Doc Detective tests for closeSurface and startSurface

### DIFF
--- a/docs/fern/pages/docs/actions/closeSurface.mdx
+++ b/docs/fern/pages/docs/actions/closeSurface.mdx
@@ -149,7 +149,7 @@ A browser reference with a `tab` selector closes that tab. A `window` selector c
 
 {/* step {"stepId":"closesurface-goto-main","description":"Open the local test server in the default tab","goTo":"http://localhost:8092"} */}
 {/* step {"stepId":"closesurface-open-tab","description":"Open a second, named tab","goTo":{"url":"http://localhost:8092/click-shorthand.html","newTab":"closesurface-cart"}} */}
-{/* step {"stepId":"closesurface-close-tab","description":"Close the cart tab","closeSurface":{"tab":"closesurface-cart"}} */}
+{/* step {"stepId":"closesurface-close-tab","description":"Close the cart tab (the browser field is required on the object form, matching the visible JSON example)","closeSurface":{"browser":"chrome","tab":"closesurface-cart"}} */}
 {/* test end */}
 
 One guardrail applies. Doc Detective refuses to close the **last open tab** of a browser, because closing a tab isn't how you end a session — closing the **whole browser** is.

--- a/docs/fern/pages/docs/actions/closeSurface.mdx
+++ b/docs/fern/pages/docs/actions/closeSurface.mdx
@@ -32,6 +32,8 @@ Here are a few ways you might use the `closeSurface` action:
 
 This example starts a background server and then closes it by name.
 
+{/* test {"testId":"closesurface-process-name","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -59,9 +61,16 @@ This example starts a background server and then closes it by name.
 }
 ```
 
+{/* step {"stepId":"closesurface-start-process","description":"Start a server in the background","runCode":{"language":"javascript","code":"require('http').createServer((req, res) => res.end('ok')).listen(8085);","background":{"name":"closesurface-web","waitUntil":{"port":8085}},"timeout":15000}} */}
+{/* step {"stepId":"closesurface-close-process","description":"Close the server","closeSurface":"closesurface-web","variables":{"CLOSED":"$$closed","CLOSED_COUNT":"$$closedCount"}} */}
+{/* step {"stepId":"verify-closesurface-process","description":"Confirm the surface was reported as actually closed, not merely absent","runCode":{"language":"javascript","code":"console.log(process.env.CLOSED, process.env.CLOSED_COUNT);","stdio":"/closesurface-web/"}} */}
+{/* test end */}
+
 ### Close several surfaces at once
 
 Pass an array of surface identifiers to close more than one surface in a single step.
+
+{/* test {"testId":"closesurface-multiple","detectSteps":false} */}
 
 ```json
 {
@@ -78,9 +87,17 @@ Pass an array of surface identifiers to close more than one surface in a single 
 }
 ```
 
+{/* step {"stepId":"closesurface-start-web","description":"Start the web server in the background","runCode":{"language":"javascript","code":"require('http').createServer((req, res) => res.end('ok')).listen(8085);","background":{"name":"closesurface-web2","waitUntil":{"port":8085}},"timeout":15000}} */}
+{/* step {"stepId":"closesurface-start-api","description":"Start the API server in the background","runCode":{"language":"javascript","code":"require('http').createServer((req, res) => res.end('ok')).listen(8086);","background":{"name":"closesurface-api","waitUntil":{"port":8086}},"timeout":15000}} */}
+{/* step {"stepId":"closesurface-close-multiple","description":"Close the web and API servers","closeSurface":["closesurface-web2",{"process":"closesurface-api"}],"variables":{"CLOSED_COUNT":"$$closedCount"}} */}
+{/* step {"stepId":"verify-closesurface-multiple","description":"Confirm both surfaces were closed in one step","runCode":{"language":"javascript","code":"console.log('closedCount=' + process.env.CLOSED_COUNT);","stdio":"closedCount=2"}} */}
+{/* test end */}
+
 ### Close a process that might not be running
 
 Because closing an absent surface passes, you can call `closeSurface` defensively without checking first whether the process is still running.
+
+{/* test {"testId":"closesurface-absent","detectSteps":false} */}
 
 ```json
 {
@@ -97,9 +114,15 @@ Because closing an absent surface passes, you can call `closeSurface` defensivel
 }
 ```
 
+{/* step {"stepId":"closesurface-close-absent","description":"Close a server that was never started","closeSurface":"closesurface-never-started","variables":{"ABSENT_COUNT":"$$absentCount","CLOSED_COUNT":"$$closedCount"}} */}
+{/* step {"stepId":"verify-closesurface-absent","description":"Confirm the step passed and reported the surface as absent rather than closed","runCode":{"language":"javascript","code":"console.log('absent=' + process.env.ABSENT_COUNT + ' closed=' + process.env.CLOSED_COUNT);","stdio":"absent=1 closed=0"}} */}
+{/* test end */}
+
 ### Close a browser tab or window
 
 A browser reference with a `tab` selector closes that tab. A `window` selector closes the window and its tabs. Selectors accept a name, an index in creation order (`-1` is the newest), or `{ title, url }` criteria. See [Test across multiple tabs, windows, and browsers](/docs/test-docs/multiple-tabs-and-windows).
+
+{/* test {"testId":"closesurface-tab","detectSteps":false} */}
 
 ```json
 {
@@ -124,11 +147,18 @@ A browser reference with a `tab` selector closes that tab. A `window` selector c
 }
 ```
 
+{/* step {"stepId":"closesurface-goto-main","description":"Open the local test server in the default tab","goTo":"http://localhost:8092"} */}
+{/* step {"stepId":"closesurface-open-tab","description":"Open a second, named tab","goTo":{"url":"http://localhost:8092/click-shorthand.html","newTab":"closesurface-cart"}} */}
+{/* step {"stepId":"closesurface-close-tab","description":"Close the cart tab","closeSurface":{"tab":"closesurface-cart"}} */}
+{/* test end */}
+
 One guardrail applies. Doc Detective refuses to close the **last open tab** of a browser, because closing a tab isn't how you end a session — closing the **whole browser** is.
 
 ### Close a whole browser
 
 A browser reference with no `window`/`tab` selector closes that entire browser session: a bare surface name, an engine keyword, or the `{ "browser": …, "name": … }` object form. Closing a browser that isn't open is a PASS no-op, and the active surface falls back to the most recently focused remaining browser. A browser with an active recording refuses to close until you [`stopRecord`](/docs/actions/record). See [Test across multiple tabs, windows, and browsers](/docs/test-docs/multiple-tabs-and-windows).
+
+{/* test {"testId":"closesurface-browser","detectSteps":false} */}
 
 ```json
 {
@@ -152,6 +182,10 @@ A browser reference with no `window`/`tab` selector closes that entire browser s
   ]
 }
 ```
+
+{/* step {"stepId":"closesurface-goto-named","description":"Open a second, named browser session","goTo":{"url":"http://localhost:8092","surface":{"browser":"firefox","name":"closesurface-secondary"}}} */}
+{/* step {"stepId":"closesurface-close-named","description":"Close the named browser session","closeSurface":"closesurface-secondary"} */}
+{/* test end */}
 
 ### Close an app surface
 

--- a/docs/fern/pages/docs/actions/simple-json-server.cjs
+++ b/docs/fern/pages/docs/actions/simple-json-server.cjs
@@ -1,0 +1,6 @@
+require('http')
+  .createServer((req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ status: 'ok' }));
+  })
+  .listen(8087);

--- a/docs/fern/pages/docs/actions/simple-json-server.js
+++ b/docs/fern/pages/docs/actions/simple-json-server.js
@@ -1,0 +1,6 @@
+require('http')
+  .createServer((req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ status: 'ok' }));
+  })
+  .listen(8087);

--- a/docs/fern/pages/docs/actions/simple-json-server.js
+++ b/docs/fern/pages/docs/actions/simple-json-server.js
@@ -1,6 +1,0 @@
-require('http')
-  .createServer((req, res) => {
-    res.setHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify({ status: 'ok' }));
-  })
-  .listen(8087);

--- a/docs/fern/pages/docs/actions/startSurface.mdx
+++ b/docs/fern/pages/docs/actions/startSurface.mdx
@@ -520,7 +520,7 @@ This example targets the `ios` platform, launches the Settings app by its bundle
 }
 ```
 
-{/* step {"stepId":"startsurface-start-process","description":"Start a background server (a small JSON-serving script, to avoid a project-specific npm start)","startSurface":{"process":"node simple-json-server.js","name":"startsurface-web","workingDirectory":".","waitUntil":{"port":8087}}} */}
+{/* step {"stepId":"startsurface-start-process","description":"Start a background server with a self-contained inline command (to avoid a project-specific npm start)","startSurface":{"process":"node -e \"require('http').createServer((req,res)=>{res.setHeader('Content-Type','application/json');res.end(JSON.stringify({status:'ok'}))}).listen(8087)\"","name":"startsurface-web","waitUntil":{"port":8087}}} */}
 {/* step {"stepId":"startsurface-call-process","description":"Call the server to confirm it's actually serving the expected response","httpRequest":{"url":"http://localhost:8087","statusCodes":[200],"response":{"body":{"status":"ok"}}}} */}
 {/* step {"stepId":"startsurface-close-process","description":"Close the server","closeSurface":"startsurface-web"} */}
 {/* test end */}

--- a/docs/fern/pages/docs/actions/startSurface.mdx
+++ b/docs/fern/pages/docs/actions/startSurface.mdx
@@ -457,6 +457,8 @@ This example targets the `ios` platform, launches the Settings app by its bundle
 
 ### Open a named browser session with launch options
 
+{/* test {"testId":"startsurface-browser-session","detectSteps":false} */}
+
 ```json
 {
   "tests": [
@@ -482,7 +484,14 @@ This example targets the `ios` platform, launches the Settings app by its bundle
 }
 ```
 
+{/* step {"stepId":"startsurface-open-browser","description":"Open a second, named Firefox session","startSurface":{"browser":"firefox","name":"startsurface-admin","headless":true,"viewport":{"width":800,"height":600}}} */}
+{/* step {"stepId":"startsurface-goto-browser","description":"Navigate the named session","goTo":{"url":"http://localhost:8092","surface":{"browser":"firefox","name":"startsurface-admin"}}} */}
+{/* step {"stepId":"startsurface-close-browser","description":"Close the named session","closeSurface":"startsurface-admin"} */}
+{/* test end */}
+
 ### Start a background server and call it
+
+{/* test {"testId":"startsurface-process-server","detectSteps":false} */}
 
 ```json
 {
@@ -510,6 +519,11 @@ This example targets the `ios` platform, launches the Settings app by its bundle
   ]
 }
 ```
+
+{/* step {"stepId":"startsurface-start-process","description":"Start a background server (a small JSON-serving script, to avoid a project-specific npm start)","startSurface":{"process":"node simple-json-server.js","name":"startsurface-web","workingDirectory":".","waitUntil":{"port":8087}}} */}
+{/* step {"stepId":"startsurface-call-process","description":"Call the server to confirm it's actually serving the expected response","httpRequest":{"url":"http://localhost:8087","statusCodes":[200],"response":{"body":{"status":"ok"}}}} */}
+{/* step {"stepId":"startsurface-close-process","description":"Close the server","closeSurface":"startsurface-web"} */}
+{/* test end */}
 
 ### Open several surfaces concurrently
 

--- a/docs/fern/pages/docs/actions/startSurface.mdx
+++ b/docs/fern/pages/docs/actions/startSurface.mdx
@@ -520,7 +520,7 @@ This example targets the `ios` platform, launches the Settings app by its bundle
 }
 ```
 
-{/* step {"stepId":"startsurface-start-process","description":"Start a background server with a self-contained inline command (to avoid a project-specific npm start)","startSurface":{"process":"node -e \"require('http').createServer((req,res)=>{res.setHeader('Content-Type','application/json');res.end(JSON.stringify({status:'ok'}))}).listen(8087)\"","name":"startsurface-web","waitUntil":{"port":8087}}} */}
+{/* step {"stepId":"startsurface-start-process","description":"Start a background server (a small JSON-serving script, to avoid a project-specific npm start). A .cjs extension keeps it CommonJS regardless of this repo's package.json \"type\": \"module\"; workingDirectory points at this mdx file's own directory so the script resolves next to it. An inline node -e one-liner was tried first but discarded: startSurface's process field runs with shell:true, and Node only concatenates args unescaped in that mode (confirmed by reproducing the failure locally) -- cmd.exe's parentheses-as-grouping-syntax mangled the script on Windows","startSurface":{"process":"node simple-json-server.cjs","name":"startsurface-web","workingDirectory":".","waitUntil":{"port":8087}}} */}
 {/* step {"stepId":"startsurface-call-process","description":"Call the server to confirm it's actually serving the expected response","httpRequest":{"url":"http://localhost:8087","statusCodes":[200],"response":{"body":{"status":"ok"}}}} */}
 {/* step {"stepId":"startsurface-close-process","description":"Close the server","closeSurface":"startsurface-web"} */}
 {/* test end */}


### PR DESCRIPTION
## What changed

Adds inline Doc Detective tests to the [`closeSurface`](docs/fern/pages/docs/actions/closeSurface.mdx) and [`startSurface`](docs/fern/pages/docs/actions/startSurface.mdx) reference pages, continuing the docs-as-tests pattern.

**`closeSurface.mdx`** (5 tests):
- close a background process by name — verified via the step's own `closed`/`closedCount` outputs, captured into variables and checked with a `runCode` step, not just the step's own PASS
- close several surfaces at once
- close an absent surface defensively — asserts `absentCount`/`closedCount`, proving the no-op path specifically
- close a browser tab by name
- close a whole named browser session

**`startSurface.mdx`** (2 tests): open a named headless Firefox session and navigate it; start a background process, then call it.

## A real bug I found while writing these

The process example originally used `python -m http.server`, which returns an HTML directory listing. That failed unexpectedly: `httpRequest` **unconditionally** defaulted `response.body` to `{}` (`src/core/tests/httpRequest.ts:203-208`) even when a step set no `response` field at all — so *every* `httpRequest` step implicitly asserted an object-shaped body, and a plain-text/HTML response always failed that type check. This wasn't specific to this test; it'd bite anyone hitting a non-JSON endpoint with `httpRequest` and no explicit `response`.

**This is now fixed in #607** (merged) — `httpRequest` no longer implicitly asserts a body shape when `response.body` is unset. Worked around it in the meantime, and kept the fixture afterward for an unrelated, genuinely necessary reason (see below): [docs/fern/pages/docs/actions/simple-json-server.cjs](docs/fern/pages/docs/actions/simple-json-server.cjs), a tiny fixture that serves real JSON, so the verifying step can make a genuine assertion.

**Why a `.cjs` file and not an inline command.** An inline `node -e "..."` one-liner was tried first (to avoid a committed fixture entirely, now that #607 removes the original reason for it), but `startSurface`'s `process` field runs with `shell: true`, and Node only concatenates `process`+`args` unescaped in that mode (its own deprecation warning says as much) — cmd.exe then treats the script's parentheses as command-grouping syntax and mangles it on Windows (reproduced locally). A committed script file sidesteps shell quoting entirely; `.cjs` (not `.js`) keeps it unambiguously CommonJS regardless of this repo's `package.json` `"type": "module"`.

## Scoping

Both pages skip their native-app/mobile examples (Windows/macOS/Android/iOS apps, the two-phone concurrent-array pattern) — all need drivers, emulators, or simulators the hermetic docs test environment doesn't provision. Same class of skip as elsewhere in this series.

## Reviewer notes

- **One committed fixture script**, `simple-json-server.cjs`, for the reason above (not for the httpRequest bug, which #607 already fixes). `workingDirectory` points at this mdx file's own directory. Reuses the shared static server (#557) where applicable.
- **detectSteps.** All tests set `detectSteps: false`.
- **Verified** with the real docs config: `4 specs / 9 tests / 22 steps, all PASS`.

## Docs impact

This *is* a docs change, plus one additive test fixture. No user-facing behavior/API change; no ADR or feature fixture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)