### PR TITLE
fix(ci): stop docker-build.yml app-image jobs from skipping on release chain

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -129,11 +129,13 @@ jobs:
     # workflow_call. A bare `github.event_name != 'push'` guard therefore
     # skips this job on every automated release. `inputs.version` doesn't
     # have that problem: it's only populated (and required) for
-    # workflow_call/workflow_dispatch, so it's empty on a genuine direct
-    # push to this workflow's own `push:` trigger (the windows-base path
-    # filter) and non-empty on a chained workflow_call.
+    # workflow_call/workflow_dispatch, so it's unset (falsy) on a genuine
+    # direct push to this workflow's own `push:` trigger (the windows-base
+    # path filter) and set on a chained workflow_call. Use a falsy check
+    # (`!inputs.version`) rather than `== ''` to avoid depending on the
+    # null-to-string coercion GitHub Actions applies to that comparison.
     if: >-
-      !(github.event_name == 'push' && inputs.version == '') &&
+      !(github.event_name == 'push' && !inputs.version) &&
       !(github.event_name == 'workflow_dispatch' && inputs.build_base)
     timeout-minutes: 60
     env:
@@ -324,9 +326,10 @@ jobs:
     #
     # See the NOTE on build-linux above: `github.event_name` alone can't
     # tell a direct push apart from a workflow_call chain that inherited
-    # 'push' from the root event, so this checks `inputs.version` too.
+    # 'push' from the root event, so this checks `inputs.version` too
+    # (falsy-checked, not `== ''`, to avoid relying on coercion).
     if: >-
-      !(github.event_name == 'push' && inputs.version == '') &&
+      !(github.event_name == 'push' && !inputs.version) &&
       !(github.event_name == 'workflow_dispatch' && inputs.build_base) &&
       !(github.event_name == 'pull_request' && needs.detect-base-change.outputs.base == 'true')
     timeout-minutes: 60
@@ -474,13 +477,13 @@ jobs:
   #     so that base-image breakages are caught pre-merge.
   build-windows-base:
     needs: [detect-base-change]
-    # See the NOTE on build-linux above: without the `inputs.version == ''`
+    # See the NOTE on build-linux above: without the `!inputs.version`
     # check, this job also fires on every automated release (release.yml
     # -> promote.yml -> docker-build.yml via workflow_call), since
     # `github.event_name` inherits 'push' from the root event even though
     # this run never touched the windows-base files.
     if: >-
-      (github.event_name == 'push' && inputs.version == '') ||
+      (github.event_name == 'push' && !inputs.version) ||
       (github.event_name == 'workflow_dispatch' && inputs.build_base) ||
       (github.event_name == 'pull_request' && needs.detect-base-change.outputs.base == 'true')
     timeout-minutes: 90

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -121,8 +121,19 @@ jobs:
     # Skip when this workflow was triggered by a push that only touched
     # the windows-base files, or when the operator explicitly asked for
     # `build_base` via workflow_dispatch.
+    #
+    # NOTE: `github.event_name` is inherited from the *root* triggering
+    # event through nested `workflow_call` chains (release.yml -> push ->
+    # promote.yml -> workflow_call -> docker-build.yml -> workflow_call),
+    # so it still reports 'push' even when this run was reached via
+    # workflow_call. A bare `github.event_name != 'push'` guard therefore
+    # skips this job on every automated release. `inputs.version` doesn't
+    # have that problem: it's only populated (and required) for
+    # workflow_call/workflow_dispatch, so it's empty on a genuine direct
+    # push to this workflow's own `push:` trigger (the windows-base path
+    # filter) and non-empty on a chained workflow_call.
     if: >-
-      github.event_name != 'push' &&
+      !(github.event_name == 'push' && inputs.version == '') &&
       !(github.event_name == 'workflow_dispatch' && inputs.build_base)
     timeout-minutes: 60
     env:
@@ -310,8 +321,12 @@ jobs:
     #     would point at a composite base tag that hasn't been
     #     published yet. build-windows-base (PR build-only) already
     #     proves the base builds.
+    #
+    # See the NOTE on build-linux above: `github.event_name` alone can't
+    # tell a direct push apart from a workflow_call chain that inherited
+    # 'push' from the root event, so this checks `inputs.version` too.
     if: >-
-      github.event_name != 'push' &&
+      !(github.event_name == 'push' && inputs.version == '') &&
       !(github.event_name == 'workflow_dispatch' && inputs.build_base) &&
       !(github.event_name == 'pull_request' && needs.detect-base-change.outputs.base == 'true')
     timeout-minutes: 60
@@ -459,8 +474,13 @@ jobs:
   #     so that base-image breakages are caught pre-merge.
   build-windows-base:
     needs: [detect-base-change]
+    # See the NOTE on build-linux above: without the `inputs.version == ''`
+    # check, this job also fires on every automated release (release.yml
+    # -> promote.yml -> docker-build.yml via workflow_call), since
+    # `github.event_name` inherits 'push' from the root event even though
+    # this run never touched the windows-base files.
     if: >-
-      github.event_name == 'push' ||
+      (github.event_name == 'push' && inputs.version == '') ||
       (github.event_name == 'workflow_dispatch' && inputs.build_base) ||
       (github.event_name == 'pull_request' && needs.detect-base-change.outputs.base == 'true')
     timeout-minutes: 90


### PR DESCRIPTION
## Summary

- The last release (4.26.2) never rebuilt the `docdetective/docdetective` Docker image — only the unrelated `build-windows-base` job ran, and `build-linux`/`build-windows` were skipped.
- Root cause: `github.event_name` is inherited from the *root* triggering event through nested `workflow_call` chains. A push to `main` starts `release.yml`, which calls `promote.yml` (`workflow_call`), which calls `docker-build.yml` (`workflow_call`) — by the time execution reaches `docker-build.yml`, `github.event_name` still reports `'push'`, even though this run was reached via `workflow_call`, not a direct push. The `build-linux`/`build-windows` guard (`github.event_name != 'push'`) skipped on every automated release; `build-windows-base`'s inverse guard (`github.event_name == 'push'`) fired instead.
- Fix: gate on `inputs.version` (only populated/required for `workflow_call`/`workflow_dispatch`) instead of relying on `github.event_name` alone, so a genuine direct push to this workflow's own `push:` trigger (windows-base file changes) can be told apart from a chained `workflow_call` that inherited `'push'` from the root event.

## Test plan

- [ ] Confirm YAML is well-formed (validated locally with `js-yaml`).
- [ ] After merge, verify the next `main` push through the release chain (`release.yml` → `promote.yml` → `docker-build.yml`) actually runs `build-linux`/`build-windows`/`merge-linux` and pushes `docdetective/docdetective:<version>` and `:<version>-linux`/`:<version>-windows` tags, while `build-windows-base` stays skipped.
- [ ] Confirm a direct push touching `src/container/windows-base.Dockerfile` still runs only `build-windows-base`.
- [ ] Confirm manual `workflow_dispatch` with `build_base: true` still runs only `build-windows-base`.
- [ ] Once merged, manually dispatch `docker-build.yml` with `version: 4.26.2, publish_latest_tags: true` to backfill the missing image (or wait for the next release).

No ADR: pure CI pipeline bug fix, no product-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated build workflows so chained executions aren’t incorrectly treated as direct push runs.
  * Prevented unnecessary Linux and Windows builds when a direct push isn’t providing the required version input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->