### PR TITLE
docs(test-code): add inline Doc Detective tests for the HTTP and API guide

### DIFF
--- a/docs/fern/pages/docs/test-code/http-and-api.mdx
+++ b/docs/fern/pages/docs/test-code/http-and-api.mdx
@@ -21,6 +21,8 @@ Start with the simplest case: a `GET` request that passes as long as the endpoin
 
 Create a file named `api.spec.json` and add the following test:
 
+{/* test {"testId":"http-api-basic-get","detectSteps":false} */}
+
 ```json title="api.spec.json"
 {
   "tests": [
@@ -36,7 +38,12 @@ Create a file named `api.spec.json` and add the following test:
 }
 ```
 
+{/* step {"stepId":"http-api-get","description":"Fetch a page of users, against the local echo API instead of a live network call","httpRequest":"http://localhost:8092/api/users?page=2"} */}
+{/* test end */}
+
 To use a method other than `GET`, or to send headers, query parameters, or a body, switch to the object form and set `method` and `request`:
+
+{/* test {"testId":"http-api-post-object","detectSteps":false} */}
 
 ```json
 {
@@ -51,6 +58,9 @@ To use a method other than `GET`, or to send headers, query parameters, or a bod
 }
 ```
 
+{/* step {"stepId":"http-api-post","description":"Create a user, verified via the echoed response body","httpRequest":{"url":"http://localhost:8092/api/users","method":"POST","request":{"body":{"name":"morpheus","job":"leader"}},"response":{"body":{"name":"morpheus","job":"leader"}}}} */}
+{/* test end */}
+
 ## Step 2: Assert on the response
 
 A request that returns a response isn't necessarily a request that returned the *right* response. Tighten the step with response expectations.
@@ -58,6 +68,8 @@ A request that returns a response isn't necessarily a request that returned the 
 - Set `statusCodes` to the codes you accept. The step fails if the response code isn't in the list. The default is `[200]`, so set it explicitly when you expect something else, such as `201` for a created resource.
 - Set `response.body` to assert specific values.
 - Set `response.required` to assert that fields exist without pinning their values—useful for timestamps, IDs, and tokens that change every run.
+
+{/* test {"testId":"http-api-assert-response","detectSteps":false} */}
 
 ```json
 {
@@ -77,11 +89,16 @@ A request that returns a response isn't necessarily a request that returned the 
 }
 ```
 
+{/* step {"stepId":"http-api-assert","description":"Create a user and validate the response (the local echo API returns 200 and echoes exactly what's sent, so id/createdAt are included in the request body here rather than generated server-side)","httpRequest":{"url":"http://localhost:8092/api/users","method":"POST","request":{"body":{"name":"morpheus","job":"leader","id":"usr-101","createdAt":"2026-01-01T00:00:00Z"}},"response":{"body":{"name":"morpheus","job":"leader"},"required":["id","createdAt"]},"statusCodes":[200]}} */}
+{/* test end */}
+
 Fields listed in `response.required` use dot notation for nested fields (`user.profile.name`) and bracket notation for array elements (`orders[0].id`). A field with a `null`, `""`, `0`, or `false` value still counts as present.
 
 ## Step 3: Capture a value and reuse it
 
 To chain calls—create something, then fetch it—capture part of the response with the step-level `variables` object, then reference the variable with `$NAME` in a later step.
+
+{/* test {"testId":"http-api-capture-reuse","detectSteps":false} */}
 
 ```json
 {
@@ -115,11 +132,17 @@ To chain calls—create something, then fetch it—capture part of the response 
 }
 ```
 
+{/* step {"stepId":"http-api-create-capture","description":"Create a user (including an id in the request body) and capture it into a variable","httpRequest":{"url":"http://localhost:8092/api/users","method":"POST","request":{"body":{"name":"neo","job":"the one","id":"neo-101"}}},"variables":{"USER_ID":"$$response.body.id"}} */}
+{/* step {"stepId":"http-api-fetch-with-id","description":"Use the captured ID as a query parameter and assert the echoed response contains it, proving it was actually substituted (the echo API reflects query/body, not path segments)","httpRequest":{"url":"http://localhost:8092/api/users?id=$USER_ID","method":"GET","response":{"body":{"id":"neo-101"}}}} */}
+{/* test end */}
+
 Response expressions such as `$$response.body`, `$$response.headers`, and `$$response.status` support dot notation for nested JSON fields—for example, `$$response.body.user.id`.
 
 ## Step 4: Validate links
 
 To confirm that a URL in your docs is reachable, use `checkLink`. It passes when the URL returns an acceptable status code, so it's a quick way to catch dead links without writing a full request.
+
+{/* test {"testId":"http-api-checklink","detectSteps":false} */}
 
 ```json
 {
@@ -127,6 +150,9 @@ To confirm that a URL in your docs is reachable, use `checkLink`. It passes when
   "checkLink": "https://doc-detective.com"
 }
 ```
+
+{/* step {"stepId":"http-api-checklink-step","description":"Confirm a URL is reachable, against the local test server's deterministic /status/200 fixture instead of a live network call","checkLink":"http://localhost:8092/status/200"} */}
+{/* test end */}
 
 For status-code options, see the [`checkLink`](/docs/actions/checklink) reference.
 


### PR DESCRIPTION
## What changed

Adds inline Doc Detective tests to the [Test HTTP and APIs guide](docs/fern/pages/docs/test-code/http-and-api.mdx), continuing the docs-as-tests series into non-action-reference pages (following #580, #581).

Five inline tests, exercising the guide's full journey against the local echo API and deterministic `/status/:code` fixture instead of `reqres.in`/`doc-detective.com` — hermetic, no network dependency:

- basic GET (string shorthand) and POST (object form), the POST verified via the echoed response body
- asserting `statusCodes`/`response.body`/`response.required` together — `id` and `createdAt` are included in the request body, since the echo API returns 200 and echoes exactly what's sent rather than generating fields server-side the way a real "create" endpoint would
- capturing a value into a variable and reusing it, asserting the substituted value via a query parameter (the echo API reflects query/body, not path segments) — proves the substitution actually happened, the same discipline applied after review feedback on `httpRequest.mdx`'s equivalent test (#569)
- `checkLink` against the local `/status/200` fixture

## Reviewer notes

- **No per-page setup, no new fixture.** Reuses the shared static server (#557) and its `/status/:code` fixture (already used by `checkLink.mdx`, #568).
- **detectSteps.** All tests set `detectSteps: false`.
- **Verified** with the real docs config: `3 specs / 7 tests / 8 steps, all PASS`.

## Docs impact

This *is* a docs change. No user-facing behavior/API change; no ADR or feature fixture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
