### PR TITLE
docs(test-code): add inline Doc Detective tests for the run shell and code guide

### DIFF
--- a/docs/fern/pages/docs/test-code/run-shell-and-code.mdx
+++ b/docs/fern/pages/docs/test-code/run-shell-and-code.mdx
@@ -100,6 +100,10 @@ When your docs embed a code sample instead of a shell command, use `runCode`. Se
 
 To reuse a command's output later in the test, capture it with the step-level `variables` object. Assign a runtime expression such as `$$stdio.stdout`, `$$stdio.stderr`, or `$$exitCode`, then reference the variable in a later step with `$NAME`.
 
+<Note>
+`$$stdio.stdout` includes the command's trailing newline. If you're substituting the captured value into another shell command, extract just the part you need with [`extract`](/reference/expressions#function-operators) (for example, `extract($$stdio.stdout, "[0-9a-f]+")` for a hex commit SHA) so the newline doesn't land in the middle of the next command. Unlike `matches`, `extract`'s pattern is a bare or quoted string, not a `/pattern/` literal.
+</Note>
+
 {/* test {"testId":"runcode-guide-carry-value","detectSteps":false} */}
 
 ```json
@@ -130,8 +134,8 @@ To reuse a command's output later in the test, capture it with the step-level `v
 }
 ```
 
-{/* step {"stepId":"runcode-guide-capture-sha","description":"Capture the current commit SHA (this repo is a git checkout, so this resolves for real)","runShell":{"command":"git rev-parse --short HEAD","stdio":"/.+/"},"variables":{"COMMIT":"$$stdio.stdout"}} */}
-{/* step {"stepId":"runcode-guide-use-sha","description":"Use the captured SHA in a later command","runShell":{"command":"echo Testing against $COMMIT","stdio":"Testing against"}} */}
+{/* step {"stepId":"runcode-guide-capture-sha","description":"Capture the current commit SHA (this repo is a git checkout, so this resolves for real), extracting just the hex characters so the trailing newline in $$stdio.stdout doesn't land inside the next command (the pattern is a bare string, not a /slash/ literal, since extract's second argument goes straight into `new RegExp()`)","runShell":{"command":"git rev-parse --short HEAD","stdio":"/.+/"},"variables":{"COMMIT":"extract($$stdio.stdout, \"[0-9a-f]+\")"}} */}
+{/* step {"stepId":"runcode-guide-use-sha","description":"Use the captured SHA and confirm it was genuinely substituted: a literal, un-substituted '$COMMIT' contains letters outside [0-9a-f] and wouldn't match this pattern","runShell":{"command":"echo Testing against $COMMIT","stdio":"/Testing against [0-9a-f]+/"}} */}
 {/* test end */}
 
 For more on expressions and where variables come from, see [Expressions](/reference/expressions) and the [`runShell`](/docs/actions/runshell) reference.

--- a/docs/fern/pages/docs/test-code/run-shell-and-code.mdx
+++ b/docs/fern/pages/docs/test-code/run-shell-and-code.mdx
@@ -100,10 +100,6 @@ When your docs embed a code sample instead of a shell command, use `runCode`. Se
 
 To reuse a command's output later in the test, capture it with the step-level `variables` object. Assign a runtime expression such as `$$stdio.stdout`, `$$stdio.stderr`, or `$$exitCode`, then reference the variable in a later step with `$NAME`.
 
-<Note>
-`$$stdio.stdout` includes the command's trailing newline. If you're substituting the captured value into another shell command, extract just the part you need with [`extract`](/reference/expressions#function-operators) (for example, `extract($$stdio.stdout, "[0-9a-f]+")` for a hex commit SHA) so the newline doesn't land in the middle of the next command. Unlike `matches`, `extract`'s pattern is a bare or quoted string, not a `/pattern/` literal.
-</Note>
-
 {/* test {"testId":"runcode-guide-carry-value","detectSteps":false} */}
 
 ```json
@@ -134,7 +130,7 @@ To reuse a command's output later in the test, capture it with the step-level `v
 }
 ```
 
-{/* step {"stepId":"runcode-guide-capture-sha","description":"Capture the current commit SHA (this repo is a git checkout, so this resolves for real), extracting just the hex characters so the trailing newline in $$stdio.stdout doesn't land inside the next command (the pattern is a bare string, not a /slash/ literal, since extract's second argument goes straight into `new RegExp()`)","runShell":{"command":"git rev-parse --short HEAD","stdio":"/.+/"},"variables":{"COMMIT":"extract($$stdio.stdout, \"[0-9a-f]+\")"}} */}
+{/* step {"stepId":"runcode-guide-capture-sha","description":"Capture the current commit SHA (this repo is a git checkout, so this resolves for real)","runShell":{"command":"git rev-parse --short HEAD","stdio":"/.+/"},"variables":{"COMMIT":"$$stdio.stdout"}} */}
 {/* step {"stepId":"runcode-guide-use-sha","description":"Use the captured SHA and confirm it was genuinely substituted: a literal, un-substituted '$COMMIT' contains letters outside [0-9a-f] and wouldn't match this pattern","runShell":{"command":"echo Testing against $COMMIT","stdio":"/Testing against [0-9a-f]+/"}} */}
 {/* test end */}
 

--- a/docs/fern/pages/docs/test-code/run-shell-and-code.mdx
+++ b/docs/fern/pages/docs/test-code/run-shell-and-code.mdx
@@ -21,6 +21,8 @@ Start with a command your docs ask the reader to run. Add a `runShell` step that
 
 Create a file named `commands.spec.json` and add the following test:
 
+{/* test {"testId":"runcode-guide-basic-command","detectSteps":false} */}
+
 ```json title="commands.spec.json"
 {
   "tests": [
@@ -35,6 +37,9 @@ Create a file named `commands.spec.json` and add the following test:
   ]
 }
 ```
+
+{/* step {"stepId":"runcode-guide-node-version","description":"Check the installed Node.js version","runShell":"node --version"} */}
+{/* test end */}
 
 By default, `runShell` passes only when the command exits with code `0`. If your docs intentionally show a command that should fail, list the codes you expect with `exitCodes`:
 
@@ -52,6 +57,8 @@ By default, `runShell` passes only when the command exits with code `0`. If your
 
 A command that exits cleanly can still print the wrong thing. Use `stdio` to check the command's combined stdout and stderr against a string or a regular expression. To match a regular expression, wrap the pattern in forward slashes.
 
+{/* test {"testId":"runcode-guide-stdio-assert","detectSteps":false} */}
+
 ```json
 {
   "description": "Confirm the CLI reports a version string.",
@@ -64,9 +71,14 @@ A command that exits cleanly can still print the wrong thing. Use `stdio` to che
 
 If the output doesn't contain the expected text, the step fails. This is what turns a copy-paste command in your docs into a real assertion.
 
+{/* step {"stepId":"runcode-guide-stdio","description":"Confirm the CLI reports a version string","runShell":{"command":"node --version","stdio":"/^v\\d+\\./"}} */}
+{/* test end */}
+
 ## Step 3: Test a documented code snippet
 
 When your docs embed a code sample instead of a shell command, use `runCode`. Set the `language` and pass the snippet as a string in `code`. The same `exitCodes` and `stdio` assertions apply.
+
+{/* test {"testId":"runcode-guide-python-snippet","detectSteps":false} */}
 
 ```json
 {
@@ -81,9 +93,14 @@ When your docs embed a code sample instead of a shell command, use `runCode`. Se
 
 `runCode` supports `javascript`, `python`, and `bash`, each run with the interpreter installed on the machine.
 
+{/* step {"stepId":"runcode-guide-python","description":"Run the documented Python snippet and check its output","runCode":{"language":"python","code":"print('hello from the docs')","stdio":"hello from the docs"}} */}
+{/* test end */}
+
 ## Step 4: Carry a value into the next step
 
 To reuse a command's output later in the test, capture it with the step-level `variables` object. Assign a runtime expression such as `$$stdio.stdout`, `$$stdio.stderr`, or `$$exitCode`, then reference the variable in a later step with `$NAME`.
+
+{/* test {"testId":"runcode-guide-carry-value","detectSteps":false} */}
 
 ```json
 {
@@ -112,6 +129,10 @@ To reuse a command's output later in the test, capture it with the step-level `v
   ]
 }
 ```
+
+{/* step {"stepId":"runcode-guide-capture-sha","description":"Capture the current commit SHA (this repo is a git checkout, so this resolves for real)","runShell":{"command":"git rev-parse --short HEAD","stdio":"/.+/"},"variables":{"COMMIT":"$$stdio.stdout"}} */}
+{/* step {"stepId":"runcode-guide-use-sha","description":"Use the captured SHA in a later command","runShell":{"command":"echo Testing against $COMMIT","stdio":"Testing against"}} */}
+{/* test end */}
 
 For more on expressions and where variables come from, see [Expressions](/reference/expressions) and the [`runShell`](/docs/actions/runshell) reference.
 

--- a/docs/fern/pages/reference/expressions.mdx
+++ b/docs/fern/pages/reference/expressions.mdx
@@ -96,7 +96,7 @@ Write word operators between the operands, with a space on each side.
 Two function operators are always available, including in a plain variable assignment:
 
 - **`jq(value, query)`**: Apply a [jq](https://jqlang.github.io/jq/) query to a value.
-- **`extract(value, pattern)`**: Return the first capture group of a regular expression match against a string, or the full match when the pattern has no capture group.
+- **`extract(value, pattern)`**: Return the first capture group of a regular expression match against a string, or the full match when the pattern has no capture group. Unlike `matches`, write `pattern` as a bare or quoted string (`"[0-9a-f]+"`), not a `/pattern/` literal—`pattern` is passed directly to `new RegExp()`, so wrapping it in slashes makes the slashes part of the literal text to match, which won't find what you expect.
 
 ## Regular expressions in `matches`
 

--- a/docs/fern/pages/reference/expressions.mdx
+++ b/docs/fern/pages/reference/expressions.mdx
@@ -96,7 +96,7 @@ Write word operators between the operands, with a space on each side.
 Two function operators are always available, including in a plain variable assignment:
 
 - **`jq(value, query)`**: Apply a [jq](https://jqlang.github.io/jq/) query to a value.
-- **`extract(value, pattern)`**: Return the first capture group of a regular expression match against a string, or the full match when the pattern has no capture group. Unlike `matches`, write `pattern` as a bare or quoted string (`"[0-9a-f]+"`), not a `/pattern/` literal—`pattern` is passed directly to `new RegExp()`, so wrapping it in slashes makes the slashes part of the literal text to match, which won't find what you expect.
+- **`extract(value, pattern)`**: Return the first capture group of a regular expression match against a string, or the full match when the pattern has no capture group. Returns `null` if the pattern doesn't match. Unlike `matches`, write `pattern` as a bare or quoted string (`"[0-9a-f]+"`), not a `/pattern/` literal—`pattern` is passed directly to `new RegExp()`, so wrapping it in slashes makes the slashes part of the literal text to match, which won't find what you expect.
 
 ## Regular expressions in `matches`
 

--- a/docs/fern/pages/reference/expressions.mdx
+++ b/docs/fern/pages/reference/expressions.mdx
@@ -96,7 +96,7 @@ Write word operators between the operands, with a space on each side.
 Two function operators are always available, including in a plain variable assignment:
 
 - **`jq(value, query)`**: Apply a [jq](https://jqlang.github.io/jq/) query to a value.
-- **`extract(value, pattern)`**: Return the first capture group of a regular expression match against a string, or the full match when the pattern has no capture group. Returns `null` if the pattern doesn't match. Unlike `matches`, write `pattern` as a bare or quoted string (`"[0-9a-f]+"`), not a `/pattern/` literal—`pattern` is passed directly to `new RegExp()`, so wrapping it in slashes makes the slashes part of the literal text to match, which won't find what you expect.
+- **`extract(value, pattern)`**: Return the first capture group of a regular expression match against a string, or the full match when the pattern has no capture group. Returns `null` if the pattern doesn't match. Unlike `matches`, write `pattern` as a bare or quoted string (`"[0-9a-f]+"`), not a `/pattern/` literal—`extract` passes `pattern` straight to `new RegExp()`, so wrapping it in slashes makes the slashes part of the literal text to match, which won't find what you expect.
 
 ## Regular expressions in `matches`
 


### PR DESCRIPTION
## What changed

Adds inline Doc Detective tests to the [Run shell and code steps guide](docs/fern/pages/docs/test-code/run-shell-and-code.mdx), completing this round of non-action-reference pages (alongside #580, #581, #582).

Four inline tests, exercising the guide's full journey with commands that are either already cross-platform-safe or genuinely available in this repo:

- `node --version` (basic command, then the same command with a `stdio` regex assertion — matching the doc's own two-step progression)
- a documented Python snippet via `runCode`, with a `stdio` assertion
- capturing the current commit SHA via `git rev-parse --short HEAD` (this repo *is* a real git checkout, so the command resolves for real) and reusing it in a later command via variable substitution

## Scoping

Skips the "missing file exit code" example (`cat does-not-exist.txt`) — POSIX-only, and already covered in spirit by the exit-code tests added to `runShell.mdx`/`runCode.mdx` earlier in this series (#573).

## Reviewer notes

- **No per-page setup, no new fixture.** Reuses the shared static server's `beforeAny`/`afterAll` wiring (#557) for consistency, though this page's tests don't touch the browser.
- **detectSteps.** All tests set `detectSteps: false`.
- **Verified** with the real docs config: `3 specs / 6 tests / 7 steps, all PASS`.

## Docs impact

This *is* a docs change. No user-facing behavior/API change; no ADR or feature fixture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added explicit testing metadata to shell and code execution examples.
  * Updated examples for capturing and reusing command output, including commit SHA extraction and validation.
  * Clarified `extract` expression syntax, including capture-group vs full-match behavior, and differences from `matches`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->