### PR TITLE
fix(detect): stop dropping legacy v2 inline steps

### DIFF
--- a/src/common/src/detectTests.ts
+++ b/src/common/src/detectTests.ts
@@ -693,17 +693,28 @@ export async function parseContent({
 
         let step = parsedStep;
 
-        // Attach sourceIntegration for Heretto on screenshot steps. This runs
-        // before validation because the helper also normalizes an array-shaped
-        // `screenshot` into a valid object. It keys off the v3 `screenshot`
-        // property, which a v2 step never has, so it can't interfere with the
-        // v2 -> v3 upgrade below.
-        if (step.screenshot && config._herettoPathMapping) {
+        // Attach Heretto sourceIntegration to a v3-shaped screenshot step.
+        // Called both before and after validation below:
+        //  - Before: so the helper's string/array/null normalization runs
+        //    ahead of the schema check — an array-shaped `screenshot` isn't
+        //    valid v3 on its own, and existing behavior relies on this call
+        //    resetting it to `{}` first so the step still validates.
+        //  - After: a legacy v2 `saveScreenshot` step (action-keyed, no
+        //    `screenshot` property yet) only becomes screenshot-shaped once
+        //    validate() upgrades it below, so it's invisible to the "before"
+        //    call and needs this second pass to get its sourceIntegration.
+        // The sourceIntegration guard makes the second call a no-op for a
+        // step the first call already handled.
+        const maybeAttachHeretto = (s: Record<string, any>) => {
+          if (!s.screenshot || s.screenshot.sourceIntegration || !config._herettoPathMapping) {
+            return;
+          }
           const herettoIntegration = findHerettoIntegration(config, filePath);
           if (herettoIntegration) {
-            attachHerettoScreenshotSourceIntegration(step, herettoIntegration, filePath);
+            attachHerettoScreenshotSourceIntegration(s, herettoIntegration, filePath);
           }
-        }
+        };
+        maybeAttachHeretto(step);
 
         // Validate before attaching `location`. A legacy v2 step (one that
         // names its action in an `action` property) is upgraded to the v3
@@ -722,6 +733,7 @@ export async function parseContent({
           return;
         }
         step = validation.object;
+        maybeAttachHeretto(step);
 
         // Attach source location to the validated (v3) step.
         if (typeof statement._startIndex === 'number') {

--- a/src/common/src/detectTests.ts
+++ b/src/common/src/detectTests.ts
@@ -693,7 +693,37 @@ export async function parseContent({
 
         let step = parsedStep;
 
-        // Attach source location
+        // Attach sourceIntegration for Heretto on screenshot steps. This runs
+        // before validation because the helper also normalizes an array-shaped
+        // `screenshot` into a valid object. It keys off the v3 `screenshot`
+        // property, which a v2 step never has, so it can't interfere with the
+        // v2 -> v3 upgrade below.
+        if (step.screenshot && config._herettoPathMapping) {
+          const herettoIntegration = findHerettoIntegration(config, filePath);
+          if (herettoIntegration) {
+            attachHerettoScreenshotSourceIntegration(step, herettoIntegration, filePath);
+          }
+        }
+
+        // Validate before attaching `location`. A legacy v2 step (one that
+        // names its action in an `action` property) is upgraded to the v3
+        // action-as-key form here, via validate()'s compatibleSchemas fallback.
+        // Attaching `location` up front would add a property the v2 action
+        // schemas reject (they set `additionalProperties: false`), so the
+        // fallback would never match and every v2 inline step would be dropped.
+        const validation = validate({
+          schemaKey: "step_v3" as SchemaKey,
+          object: step,
+          addDefaults: false,
+        });
+        /* c8 ignore next 3 - V8 phantom branch on if-else/switch-case */
+        if (!validation.valid) {
+          log(config, "warn", `Step ${JSON.stringify(step)} isn't a valid step. Skipping.`);
+          return;
+        }
+        step = validation.object;
+
+        // Attach source location to the validated (v3) step.
         if (typeof statement._startIndex === 'number') {
           step.location = {
             line: statement._line,
@@ -702,28 +732,8 @@ export async function parseContent({
           };
         }
 
-        // Attach sourceIntegration for Heretto on screenshot steps
-        if (step.screenshot && config._herettoPathMapping) {
-          const herettoIntegration = findHerettoIntegration(config, filePath);
-          if (herettoIntegration) {
-            attachHerettoScreenshotSourceIntegration(step, herettoIntegration, filePath);
-          }
-        }
-
-        const validation = validate({
-          schemaKey: "step_v3" as SchemaKey,
-          object: step,
-          addDefaults: false,
-        });
-        /* c8 ignore start - V8 phantom branch on if-else/switch-case */
-        if (!validation.valid) {
-          log(config, "warn", `Step ${JSON.stringify(step)} isn't a valid step. Skipping.`);
-          return;
-        }
-        step = validation.object;
         test.steps.push(step);
         break;
-        /* c8 ignore stop */
       }
 
       /* c8 ignore next 2 - all statement types are handled above */

--- a/src/common/test/detectTests.test.js
+++ b/src/common/test/detectTests.test.js
@@ -694,6 +694,47 @@ function readFixture(filename) {
         expect(result[0].steps).to.have.lengthOf(1);
       });
 
+      it("should upgrade a legacy v2 step inline statement to v3", async function () {
+        // Regression: `location` used to be attached to the parsed step BEFORE
+        // validation. The v2 action schemas are `additionalProperties: false`,
+        // so the extra property defeated validate()'s v2 -> v3 fallback and the
+        // step was silently dropped ("isn't a valid step. Skipping.").
+        const content =
+          '<!-- test {"steps": []} -->\n' +
+          '<!-- step {"action": "checkLink", "url": "https://example.com"} -->';
+        const result = await parseContent({
+          config: {},
+          content,
+          filePath: "test.md",
+          fileType: markdownFileType,
+        });
+        expect(result).to.have.lengthOf(1);
+        expect(result[0].steps).to.have.lengthOf(1);
+        const step = result[0].steps[0];
+        // Transformed into the v3 action-as-key shape...
+        expect(step.checkLink.url).to.equal("https://example.com");
+        expect(step).to.not.have.property("action");
+        // ...and the source location still rides along.
+        expect(step.location).to.include({ line: 2 });
+      });
+
+      it("should upgrade a legacy v2 find step inline statement to v3", async function () {
+        const content =
+          '<!-- test {"steps": []} -->\n' +
+          '<!-- step {"action": "find", "selector": "h2#fields", "matchText": "Fields"} -->';
+        const result = await parseContent({
+          config: {},
+          content,
+          filePath: "test.md",
+          fileType: markdownFileType,
+        });
+        expect(result[0].steps).to.have.lengthOf(1);
+        const step = result[0].steps[0];
+        expect(step.find.selector).to.equal("h2#fields");
+        expect(step.find.elementText).to.equal("Fields");
+        expect(step).to.not.have.property("action");
+      });
+
       it("should skip invalid step statements", async function () {
         const content =
           '<!-- test {"steps": [{"goTo": {"url": "https://example.com"}}]} -->\n' +

--- a/src/common/test/detectTests.test.js
+++ b/src/common/test/detectTests.test.js
@@ -733,6 +733,35 @@ function readFixture(filename) {
         expect(step.find.selector).to.equal("h2#fields");
         expect(step.find.elementText).to.equal("Fields");
         expect(step).to.not.have.property("action");
+        // Location preservation is the actual regression being guarded here
+        // (see the checkLink test above); assert it symmetrically.
+        expect(step.location).to.include({ line: 2 });
+      });
+
+      it("should attach Heretto sourceIntegration to a legacy v2 saveScreenshot inline step", async function () {
+        // Regression: the Heretto sourceIntegration check ran only BEFORE
+        // validation, keyed off the v3 `screenshot` property. A v2
+        // `saveScreenshot` step (action-keyed) doesn't have that property
+        // until validate() upgrades it, so it silently never got Heretto
+        // integration attached.
+        const content =
+          '<!-- test {"steps": []} -->\n' +
+          '<!-- step {"action": "saveScreenshot", "path": "shot.png"} -->';
+        const result = await parseContent({
+          config: { _herettoPathMapping: { "docs/": "my-integration" } },
+          content,
+          filePath: "docs/test.md",
+          fileType: markdownFileType,
+        });
+        expect(result[0].steps).to.have.lengthOf(1);
+        const step = result[0].steps[0];
+        expect(step.screenshot.path).to.equal("shot.png");
+        expect(step.screenshot.sourceIntegration).to.deep.equal({
+          type: "heretto",
+          integrationName: "my-integration",
+          filePath: "shot.png",
+          contentPath: "docs/test.md",
+        });
       });
 
       it("should skip invalid step statements", async function () {


### PR DESCRIPTION
## What

Legacy v2 inline test steps — a step object that names its action in an `action` property, e.g. an object with `action: "checkLink"` plus a `url` — written inline in Markdown/AsciiDoc/etc. (the explicit `step` statement, not the markup auto-detect path) were being silently dropped during test detection, logged only as `Step {...} isn't a valid step. Skipping.`. When every step in a spec was written this way, the whole spec failed to resolve into any tests.

## Why

`validate()` (`src/common/src/validate.ts`) still supports v2 steps via a `compatibleSchemas` fallback (`step_v3` → `checkLink_v2`, `find_v2`, …) that upgrades a v2-shaped step to its v3 action-as-key form. That fallback was silently defeated: `src/common/src/detectTests.ts`'s `"step"` case attached a `location` property (source line/index metadata) to the parsed step **before** calling `validate()`. The per-action v2 schemas are `additionalProperties: false` and have no `location` field, so the extra property made the object fail every v2 schema too — not just `step_v3` — and `validate()`'s fallback never matched. The step was rejected outright and dropped.

Traced this while investigating why an unrelated GitHub Action's `Fail tests` CI job (doc-detective/github-action#76) was resolving zero tests: its fixture used exactly this v2 `action`-keyed syntax, and every step in it was silently skipped, so `runTests` returned `null` instead of running (and failing) the tests as intended.

## Fix

Reorder validation in the `"step"` case of `src/common/src/detectTests.ts`: call `validate()` on the freshly-parsed step first (letting the v2→v3 upgrade happen), then attach `location` to the validated/upgraded (v3) step afterward. The sibling `"detectedStep"` case (markup auto-detection) is unaffected — it always constructs v3-native step shapes procedurally (e.g. `step[action] = url` where `action` is already a v3 key name like `checkLink`), so it never encounters a v2-shaped object and doesn't need the reorder.

## Testing

- Added two regression tests in `src/common/test/detectTests.test.js` asserting a v2 `action`-keyed `checkLink` step and a v2 `action`-keyed `find` step both upgrade to their v3 shape and retain their `location`.
- `cd src/common && npm test`: **926 passing, 0 failing** (includes the new tests and the existing `kitten-search-inline.md` fixture test covering the same `[comment]: # (step {...})` v2 syntax).
- Root `npm test` (`test/*.test.js`): 3260 passing, 12 failing. All 12 failures are in `test/debug-remaining-coverage.test.js`, exercising `runtime/cacheDir.js` / `runtime/loader.js` / `debug/appium.ts` — none of which this PR touches (diff is limited to `src/common/src/detectTests.ts` and its test file). Confirmed pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conversion of legacy inline steps to the current format without losing location details.
  * Improved screenshot step handling so Heretto source integration is attached correctly, including legacy screenshot steps.
  * Prevented validation issues caused by metadata being applied in the wrong order.
* **Tests**
  * Added regression coverage for legacy link, find, and screenshot steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->