### PR TITLE
fix(runtime): return null instead of throwing on an unusable cacheDir

### DIFF
--- a/adrs/01046-cache-resolver-returns-null-on-unusable-cache-dir.md
+++ b/adrs/01046-cache-resolver-returns-null-on-unusable-cache-dir.md
@@ -1,0 +1,110 @@
+---
+status: accepted
+date: 2026-07-10
+decision-makers: doc-detective maintainers
+---
+
+# Cache-side heavy-dep resolver returns null (not throws) on an unusable cacheDir
+
+## Context and Problem Statement
+
+`resolveHeavyDepPath(name, ctx)` locates a heavy dependency's entry file without importing it,
+preferring the shim's `node_modules` and falling back to `<cacheDir>/runtime` via
+`tryResolveFromCache`. Its documented contract is: *"Returns null if neither location resolves the
+name."* But `tryResolveFromCache` reaches the cache through `getRuntimeDir → getCacheDir`, and
+`getCacheDir` runs `assertSafeRuntimePath` (which throws on a shell-metacharacter in
+`DOC_DETECTIVE_CACHE_DIR` / `config.cacheDir`) and `fs.mkdirSync`. So when the shim copy is absent
+**and** the cache dir is unusable, the "resolver" threw instead of returning null.
+
+Callers that are pure locators — the `doc-detective debug` probes (`probeAppium`, the Appium and
+Browsers collectors) — expect null so they can degrade (`<not installed>`, `detectionFailed`) and
+keep producing a report. Instead an invalid cacheDir crashed the whole `debug` dump. This was
+masked whenever the heavy deps were installed in the shim `node_modules` (shim resolution
+short-circuits before the cache), so it only surfaced in degraded installs — notably Windows
+checkouts where the appium optionalDependencies were pruned — and showed up as a block of
+uncaught-throw failures in `test/debug-remaining-coverage.test.js`.
+
+How should a read-only resolver behave when the cache dir cannot even be constructed?
+
+## Decision Drivers
+
+* A locator must honor its documented "returns null when unresolvable" contract.
+* Diagnostics (`doc-detective debug`) must never crash on bad user input — surfacing the problem is
+  the whole point of the command.
+* The security gate on `cacheDir` (reject shell metacharacters before any `shell:true` spawn) must
+  not be weakened.
+* The fix must behave identically whether or not the shim copy happens to be installed.
+
+## Considered Options
+
+* **A. Swallow the throw in `tryResolveFromCache` and return null** (chosen).
+* **B. Wrap each debug probe (`probeAppium`, Appium/Browsers collectors) in its own try/catch.**
+* **C. Relax `assertSafeRuntimePath` so `getCacheDir` no longer throws on a bad path.**
+
+## Decision Outcome
+
+Chosen option: **A**. `tryResolveFromCache` now wraps its body in try/catch and returns null on any
+failure to construct/probe the runtime dir. This restores the resolver's documented contract at the
+single point where the cache lookup happens, so every caller (`resolveHeavyDepPath`,
+`resolveHeavyDepPathInCache`, `resolveHeavyDepSource`, `loadHeavyDep`'s resolution phase, and the
+`ensureRuntimeInstalled` skip-filter) inherits graceful "not in cache" behavior without repeating a
+guard.
+
+This does **not** weaken security. The only path that actually shells out —
+`ensureRuntimeInstalled` — independently re-runs `assertSafeRuntimePath(runtimeDir, …)` immediately
+before spawning `npm`, so an unsafe cacheDir still fails loudly at install time. Swallowing in the
+read-only locator only stops a bad cacheDir from crashing code that was never going to spawn
+anything. B was rejected as N scattered guards that would drift; the resolver is the correct chokepoint.
+C was rejected outright — it removes the metacharacter defense the spawn depends on.
+
+### Consequences
+
+* Good: `doc-detective debug` degrades gracefully on an invalid `cacheDir` (reports the error in the
+  Install/Cache sections, marks browser detection `detectionFailed`) instead of aborting the dump.
+* Good: locators uniformly honor "null means unresolvable"; no per-caller guards.
+* Neutral: `collectCacheStatus` / `collectInstallStatus` still surface the `shell-metacharacter`
+  message via their own `.error` field — they call `getCacheDir`/`getInstalledRecordPath` directly,
+  not through `tryResolveFromCache`, so their fail-with-error behavior is unchanged.
+* Bad: a genuinely unreadable cache (permissions) is now reported as "dep not in cache" rather than
+  raising — acceptable, since the install path re-attempts and reports the real error.
+* Guard: `loadHeavyDep`'s `autoInstall: false` branch re-derives the runtime dir before it reports
+  "not installed". Without that, a swallowed unusable-cacheDir error would surface as
+  "…is not installed. Run `doc-detective install runtime`" — misdirecting, since that command fails
+  the same way. The precise cause (`shell-metacharacter`, `EACCES`, …) is reported instead.
+
+### Confirmation
+
+Red→green unit tests in `test/runtime-loader.test.js` (`an unusable cacheDir`): the `resolveHeavyDep*`
+family returns null for both a `ctx.cacheDir` and a `DOC_DETECTIVE_CACHE_DIR` override; a
+shim-resolvable dep still resolves without consulting the bad cache; `loadHeavyDep`'s
+`autoInstall: false` path reports the real cause; and a **security regression guard** asserts
+`ensureRuntimeInstalled` still throws on an unsafe cacheDir and **never spawns npm**.
+
+`test/debug-remaining-coverage.test.js` passes end-to-end (74/74). The regression is only observable
+when the heavy deps are absent from the shim `node_modules`, since shim resolution otherwise
+short-circuits before the cache. Controlled before/after, with `appium`, `appium-chromium-driver`,
+and `appium-geckodriver` temporarily removed from `node_modules` to force the cache fallback:
+without the change, 12 tests fail with uncaught `shell-metacharacter` / stubbed-`fs` throws; with
+it, all 74 pass. The `runtime-loader`, `runtime-cache-dir`, `runtime-installer`, `runtime-heavy-deps`,
+`postinstall-runtime`, and `debug` suites remain green.
+
+## Pros and Cons of the Options
+
+### A. Return null in `tryResolveFromCache`
+* Good: one chokepoint; restores documented contract; security gate intact at the spawn site.
+* Bad: hides a permissions-level cache error from pure locators (surfaced later at install time).
+
+### B. Guard each debug probe
+* Good: keeps the resolver strict.
+* Bad: duplicated guards across `probeAppium` and two collectors; easy to miss the next caller.
+
+### C. Relax `assertSafeRuntimePath`
+* Good: trivially stops the throw.
+* Bad: removes the shell-metacharacter defense that the Windows `shell:true` npm spawn relies on.
+
+## More Information
+
+The resolver lives in `src/runtime/loader.ts` (`tryResolveFromCache`); the security gate and cache
+construction in `src/runtime/cacheDir.ts` (`assertSafeRuntimePath`, `getCacheDir`); the spawn-site
+re-validation in `ensureRuntimeInstalled`. Debug consumers: `src/debug/tools.ts` (`probeAppium`),
+`src/debug/appium.ts`, and `collectBrowsers` in `src/debug/index.ts`.

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
+import { inspect } from "node:util";
 import {
   getDeclaredVersion,
   managedDepNames,
@@ -143,9 +144,13 @@ function tryResolveFromCache(
   } catch (err) {
     // Keep the cause reachable for whoever is debugging the installer itself.
     // defaultLogger drops "debug" unless DOC_DETECTIVE_RUNTIME_DEBUG=1, so this
-    // stays silent on the normal path.
+    // stays silent on the normal path. Format defensively: a bare `${err}`
+    // renders a non-Error throwable as "[object Object]" and drops an Error's
+    // stack — both useless in the log this line exists to produce.
+    const detail =
+      err instanceof Error ? err.stack ?? `${err.name}: ${err.message}` : inspect(err);
     defaultLogger(
-      `tryResolveFromCache(${JSON.stringify(name)}) treated as a cache miss: ${err}`,
+      `tryResolveFromCache(${JSON.stringify(name)}) treated as a cache miss: ${detail}`,
       "debug"
     );
     return null;

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -117,14 +117,32 @@ function tryResolveFromCache(
   name: string,
   ctx: CacheDirContext = {}
 ): string | null {
-  const runtimeDir = getRuntimeDir(ctx);
-  // Probe directly with require.resolve anchored at the runtime dir; this
-  // honors package "exports" maps that a naive existsSync(node_modules/<name>)
-  // check would miss for scoped or sub-path entry points.
-  const pkgJsonAnchor = path.join(runtimeDir, "package.json");
-  if (!fs.existsSync(pkgJsonAnchor)) return null;
-  const requireFromCache = createRequire(pathToFileURL(pkgJsonAnchor).href);
-  return resolveEntry(requireFromCache, name);
+  // This is a READ-ONLY locator — it never spawns. Any failure to even
+  // construct the runtime dir means the cache cannot resolve the dep, so
+  // return null ("not in cache") instead of throwing. Two real triggers:
+  //   1. getRuntimeDir → getCacheDir → assertSafeRuntimePath rejects an
+  //      unsafe cacheDir (a shell-metacharacter in DOC_DETECTIVE_CACHE_DIR
+  //      / config.cacheDir), or getCacheDir's own mkdirSync fails.
+  //   2. The fs.existsSync probe below throws (permissions, a stubbed fs).
+  // Swallowing here does NOT weaken the security gate: the only path that
+  // actually shells out (ensureRuntimeInstalled) re-runs
+  // assertSafeRuntimePath on the runtime dir and throws before spawning, so
+  // an unsafe cacheDir still fails loudly at install time. What this
+  // prevents is a bad cacheDir crashing pure resolvers — the `doc-detective
+  // debug` probes (probeAppium, the Appium/Browsers collectors) that only
+  // want to LOCATE a dep and degrade gracefully when they can't.
+  try {
+    const runtimeDir = getRuntimeDir(ctx);
+    // Probe directly with require.resolve anchored at the runtime dir; this
+    // honors package "exports" maps that a naive existsSync(node_modules/<name>)
+    // check would miss for scoped or sub-path entry points.
+    const pkgJsonAnchor = path.join(runtimeDir, "package.json");
+    if (!fs.existsSync(pkgJsonAnchor)) return null;
+    const requireFromCache = createRequire(pathToFileURL(pkgJsonAnchor).href);
+    return resolveEntry(requireFromCache, name);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -226,6 +244,13 @@ export async function loadHeavyDep<T = unknown>(
 
   if (!resolved) {
     if (!autoInstall) {
+      // tryResolveFromCache deliberately swallows an unusable cacheDir so pure
+      // locators can answer null (see it). Here we're about to tell the caller
+      // the dep "is not installed" and point them at `install runtime` — which
+      // would be actively misdirecting when the real fault is the cache dir
+      // itself (that command fails the same way). Re-derive it so an unsafe or
+      // unwritable cacheDir surfaces with its own diagnostic instead.
+      getRuntimeDir(ctx);
       throw new Error(
         `Heavy dep '${name}' is not installed in either the shim's node_modules or <cacheDir>/runtime. Run \`doc-detective install runtime\` to install it, or call loadHeavyDep with { autoInstall: true }.`
       );

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -140,7 +140,14 @@ function tryResolveFromCache(
     if (!fs.existsSync(pkgJsonAnchor)) return null;
     const requireFromCache = createRequire(pathToFileURL(pkgJsonAnchor).href);
     return resolveEntry(requireFromCache, name);
-  } catch {
+  } catch (err) {
+    // Keep the cause reachable for whoever is debugging the installer itself.
+    // defaultLogger drops "debug" unless DOC_DETECTIVE_RUNTIME_DEBUG=1, so this
+    // stays silent on the normal path.
+    defaultLogger(
+      `tryResolveFromCache(${JSON.stringify(name)}) treated as a cache miss: ${err}`,
+      "debug"
+    );
     return null;
   }
 }
@@ -250,6 +257,11 @@ export async function loadHeavyDep<T = unknown>(
       // would be actively misdirecting when the real fault is the cache dir
       // itself (that command fails the same way). Re-derive it so an unsafe or
       // unwritable cacheDir surfaces with its own diagnostic instead.
+      //
+      // Discards the result on purpose: this call is for its throw, not its
+      // value. It re-runs getCacheDir's mkdirSync, which tryResolveFromCache
+      // already attempted — idempotent under `{recursive: true}`, so the repeat
+      // is free when the cacheDir is valid and the dep is simply absent.
       getRuntimeDir(ctx);
       throw new Error(
         `Heavy dep '${name}' is not installed in either the shim's node_modules or <cacheDir>/runtime. Run \`doc-detective install runtime\` to install it, or call loadHeavyDep with { autoInstall: true }.`

--- a/test/runtime-loader.test.js
+++ b/test/runtime-loader.test.js
@@ -249,6 +249,31 @@ describe("runtime/loader", function () {
       }
     });
 
+    it("autoInstall:true fails loudly and never spawns npm with an unsafe cacheDir", async function () {
+      // The default path delegates to ensureRuntimeInstalled. Note it does NOT
+      // surface the shell-metacharacter error for an *undeclared* name:
+      // `specs = toInstall.map(getDeclaredVersion)` runs before
+      // `getRuntimeDir(ctx)`, so getDeclaredVersion throws first. For a
+      // *declared* dep missing from the shim (the published-package layout),
+      // getRuntimeDir throws the cacheDir error instead — that ordering is
+      // pinned by the ensureRuntimeInstalled test below. Either way the
+      // invariant that matters holds: it throws, and npm is never spawned.
+      let spawnCalled = false;
+      const spawner = makeFakeSpawner({ onSpawn: () => { spawnCalled = true; } });
+      let caught;
+      try {
+        await loadHeavyDep(BOGUS, {
+          autoInstall: true,
+          ctx: { cacheDir: BAD_CACHE_DIR },
+          deps: { spawn: spawner, logger: () => {} },
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught, "expected loadHeavyDep to throw").to.exist;
+      expect(spawnCalled, "npm must never be spawned with an unsafe cacheDir").to.equal(false);
+    });
+
     it("ensureRuntimeInstalled still refuses to spawn npm with an unsafe cacheDir", async function () {
       // Security regression guard: swallowing the throw in the read-only
       // resolver must never let an unsafe path reach the `shell: true` npm

--- a/test/runtime-loader.test.js
+++ b/test/runtime-loader.test.js
@@ -249,15 +249,20 @@ describe("runtime/loader", function () {
       }
     });
 
-    it("autoInstall:true fails loudly and never spawns npm with an unsafe cacheDir", async function () {
-      // The default path delegates to ensureRuntimeInstalled. Note it does NOT
-      // surface the shell-metacharacter error for an *undeclared* name:
-      // `specs = toInstall.map(getDeclaredVersion)` runs before
-      // `getRuntimeDir(ctx)`, so getDeclaredVersion throws first. For a
-      // *declared* dep missing from the shim (the published-package layout),
-      // getRuntimeDir throws the cacheDir error instead — that ordering is
-      // pinned by the ensureRuntimeInstalled test below. Either way the
-      // invariant that matters holds: it throws, and npm is never spawned.
+    it("autoInstall:true with an undeclared dep throws and never spawns npm", async function () {
+      // Deliberately narrow: this asserts ONLY throws-and-never-spawns, which is
+      // all it can. With an *undeclared* name the throw comes from
+      // getDeclaredVersion, not from cacheDir validation — `specs =
+      // toInstall.map(getDeclaredVersion)` runs before `getRuntimeDir(ctx)` in
+      // ensureRuntimeInstalled. So this is NOT a guard on the unsafe-cacheDir
+      // path and must not be read as one: it would still pass if that
+      // protection regressed. The real cacheDir guard (declared dep →
+      // getRuntimeDir throws before any spawn) is the ensureRuntimeInstalled
+      // test below, which reaches validation via force:true.
+      //
+      // Forcing a declared dep to miss shim resolution isn't possible here:
+      // tryResolveFromShim binds `require` at module scope and every declared
+      // heavy dep is really installed in this checkout.
       let spawnCalled = false;
       const spawner = makeFakeSpawner({ onSpawn: () => { spawnCalled = true; } });
       let caught;

--- a/test/runtime-loader.test.js
+++ b/test/runtime-loader.test.js
@@ -2,6 +2,7 @@ import {
   loadHeavyDep,
   ensureRuntimeInstalled,
   resolveHeavyDepPath,
+  resolveHeavyDepPathInCache,
   resolveHeavyDepSource,
   resolveHeavyDepVersion,
 } from "../dist/runtime/loader.js";
@@ -194,6 +195,80 @@ describe("runtime/loader", function () {
       } catch (err) {
         expect(String(err.message)).to.match(/not installed/i);
       }
+    });
+  });
+
+  // An unusable cacheDir must not crash the read-only resolvers: they only
+  // LOCATE a dep, so "the cache can't be constructed" means "not in cache"
+  // (null), never a throw. `bad;chars` trips assertSafeRuntimePath, which is
+  // the security gate that still fires at the one place that shells out.
+  describe("an unusable cacheDir", function () {
+    const BAD_CACHE_DIR = "bad;chars";
+    const BOGUS = "definitely-not-a-real-heavy-dep-xyz";
+
+    beforeEach(function () {
+      // getCacheDir prefers DOC_DETECTIVE_CACHE_DIR over ctx.cacheDir, and the
+      // outer beforeEach points it at a real tmpdir — clear it so the `ctx`
+      // values under test are the ones that actually take effect.
+      delete process.env.DOC_DETECTIVE_CACHE_DIR;
+    });
+
+    it("resolveHeavyDep* return null rather than throwing when the cacheDir is unsafe", function () {
+      const ctx = { cacheDir: BAD_CACHE_DIR };
+      expect(resolveHeavyDepPath(BOGUS, ctx)).to.equal(null);
+      expect(resolveHeavyDepPathInCache(BOGUS, ctx)).to.equal(null);
+      expect(resolveHeavyDepSource(BOGUS, ctx)).to.equal(null);
+      expect(resolveHeavyDepVersion(BOGUS, ctx)).to.equal(null);
+    });
+
+    it("an unsafe cacheDir set via DOC_DETECTIVE_CACHE_DIR also degrades to null", function () {
+      process.env.DOC_DETECTIVE_CACHE_DIR = BAD_CACHE_DIR;
+      expect(resolveHeavyDepPath(BOGUS)).to.equal(null);
+      expect(resolveHeavyDepPathInCache(BOGUS)).to.equal(null);
+    });
+
+    it("a shim-resolvable dep still resolves — the bad cache is never consulted", function () {
+      if (!resolveHeavyDepPath("pngjs")) this.skip();
+      expect(resolveHeavyDepPath("pngjs", { cacheDir: BAD_CACHE_DIR })).to.be.a("string");
+      expect(resolveHeavyDepSource("pngjs", { cacheDir: BAD_CACHE_DIR })).to.equal("shim");
+    });
+
+    it("autoInstall:false surfaces the unsafe-cacheDir cause, not a generic 'not installed'", async function () {
+      // Telling the user to run `doc-detective install runtime` would be
+      // actively misdirecting: that command fails the same way. Report the
+      // real reason the cache was unusable instead.
+      try {
+        await loadHeavyDep(BOGUS, {
+          autoInstall: false,
+          ctx: { cacheDir: BAD_CACHE_DIR },
+          deps: { logger: () => {} },
+        });
+        throw new Error("expected loadHeavyDep to throw");
+      } catch (err) {
+        expect(String(err.message)).to.match(/shell-metacharacter/);
+      }
+    });
+
+    it("ensureRuntimeInstalled still refuses to spawn npm with an unsafe cacheDir", async function () {
+      // Security regression guard: swallowing the throw in the read-only
+      // resolver must never let an unsafe path reach the `shell: true` npm
+      // spawn on Windows. force:true bypasses the already-installed fast path
+      // so we reach the spawn site's own assertSafeRuntimePath check.
+      let spawnCalled = false;
+      const spawner = makeFakeSpawner({ onSpawn: () => { spawnCalled = true; } });
+      let caught;
+      try {
+        await ensureRuntimeInstalled(["pngjs"], {
+          ctx: { cacheDir: BAD_CACHE_DIR },
+          force: true,
+          deps: { spawn: spawner, logger: () => {} },
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught, "expected ensureRuntimeInstalled to throw").to.exist;
+      expect(String(caught.message)).to.match(/shell-metacharacter/);
+      expect(spawnCalled, "npm must never be spawned with an unsafe cacheDir").to.equal(false);
     });
   });
 


### PR DESCRIPTION
## Summary

`tryResolveFromCache` (`src/runtime/loader.ts`) is a **read-only locator**, but it reached the cache through `getRuntimeDir → getCacheDir`, which runs `assertSafeRuntimePath` (throws on a shell metacharacter) and `fs.mkdirSync`. When a heavy dep was absent from the shim `node_modules` **and** the cache dir was unusable, it **threw** instead of returning `null` — violating its own documented contract:

> Returns `null` if neither location resolves the name.

That crashed the pure locators in the `doc-detective debug` probes (`probeAppium`, the Appium and Browsers collectors), which rely on `null` to degrade to `<not installed>` / `detectionFailed` and still emit a report. Instead, an invalid `cacheDir` aborted the whole dump.

The bug was **masked** whenever the appium `optionalDependencies` were installed, because shim resolution short-circuits before the cache. It only surfaced in degraded installs — notably Windows checkouts where those deps get pruned — as 12 uncaught-throw failures in `test/debug-remaining-coverage.test.js`.

## Changes

- **`tryResolveFromCache`**: wrap the cache lookup in `try/catch`, return `null` on any failure. One chokepoint, so every caller (`resolveHeavyDepPath`, `resolveHeavyDepPathInCache`, `resolveHeavyDepSource`, `resolveHeavyDepVersion`, `loadHeavyDep`, the `ensureRuntimeInstalled` skip-filter) inherits graceful "not in cache" behavior.
- **`loadHeavyDep` (`autoInstall: false`)**: re-derive the runtime dir before reporting "not installed". Otherwise a swallowed unusable-cacheDir error resurfaced as *"…is not installed. Run `doc-detective install runtime`"* — actively misdirecting, since that command fails the same way. The precise cause is now reported.
- **ADR 01046** documenting the decision and the rejected alternatives.
- **Tests** in `test/runtime-loader.test.js`.

## Security: the gate is *not* weakened

`assertSafeRuntimePath` is unchanged. The only path that actually shells out — `ensureRuntimeInstalled` — independently re-runs `assertSafeRuntimePath(runtimeDir, …)` immediately before spawning `npm.cmd` with `shell: true`, so an unsafe `cacheDir` still fails loudly at install time. Swallowing in the read-only locator only stops a bad `cacheDir` from crashing code that was never going to spawn anything.

Traced every consumer: all Appium spawns use `spawn(process.execPath, [entry, …])` with **no shell**; `debug/tools.ts`'s `shell: true` probes run only hardcoded literal commands. No resolver-derived path reaches a shell without re-validation.

A regression test locks this in: `ensureRuntimeInstalled` **must throw and must never spawn npm** with an unsafe `cacheDir`.

## Verification

Controlled before/after, with `appium`, `appium-chromium-driver`, and `appium-geckodriver` temporarily removed from `node_modules` to force the cache fallback:

| | `debug-remaining-coverage.test.js` |
|---|---|
| before | **62 passing / 12 failing** (uncaught `shell-metacharacter` throws) |
| after | **74 / 74** |

New red→green unit tests in `test/runtime-loader.test.js` (`an unusable cacheDir`) cover the `null` contract via both `ctx.cacheDir` and `DOC_DETECTIVE_CACHE_DIR`, shim-preference (bad cache never consulted), the corrected `autoInstall: false` error, and the npm-never-spawned security guard.

Full sweep green: `debug-remaining-coverage`, `runtime-loader`, `runtime-cache-dir`, `runtime-installer`, `runtime-heavy-deps`, `runtime-browsers`, `runtime-helpers-coverage`, `debug`, `debug-findstrategies-coverage`, `postinstall-runtime` — **353 passing, 0 failing**.

## Docs impact

No new user-facing surface. This restores an already-documented contract and stops `doc-detective debug` from crashing on an invalid `cacheDir`. No new feature fixtures required (no new step type, action option, config/CLI flag, engine, or output format).

`fix:` → patch release, the correct semantic-release bump for a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cache-only heavy-dependency lookups now fail gracefully, returning no result instead of crashing when the cache directory can’t be created or accessed.
  - Invalid/unwritable cache-directory settings produce clearer diagnostics.
  - Unsafe cache paths are rejected early, preventing any installation attempts or external command spawning; alternate/shim-resolvable dependencies still load normally.

- **Tests**
  - Added security/robustness coverage for unusable and unsafe cache paths, including behavior when auto-install is disabled/enabled.

- **Documentation**
  - Updated the design note describing the new cache-resolver behavior and safety guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->