### PR TITLE
fix(core): process-surface teardown is best-effort and always deregisters

### DIFF
--- a/adrs/01048-process-surface-teardown-is-best-effort.md
+++ b/adrs/01048-process-surface-teardown-is-best-effort.md
@@ -1,0 +1,109 @@
+---
+status: accepted
+date: 2026-07-10
+decision-makers: doc-detective maintainers
+---
+
+# Process-surface teardown is best-effort and always deregisters
+
+## Context and Problem Statement
+
+[ADR 01046](01046-retry-process-surface-init-crash-under-concurrency.md) added a bounded retry around
+`startBackgroundProcessSurface` (`src/core/tests/processSurface.ts`). When `waitForReady` fails, the
+catch block kills the crashed child and drops it from the registry before deciding whether to retry:
+
+```ts
+await teardown(bg);
+processRegistry.delete(name);
+```
+
+`teardown` calls the handle's `kill()`. For a PTY-backed handle that is *already dead* — the common
+case here, since an early exit is precisely why readiness failed — `kill()` can **reject**. Nothing
+catches it, so a rejection:
+
+1. **escapes the catch block and the whole function**, turning a clean `FAIL` step result into a
+   thrown step;
+2. **masks the real readiness error** (the caller sees `kill failed: …`, not
+   `Process exited before becoming ready (exit code …)`);
+3. **strands the registry entry**, because `processRegistry.delete(name)` never runs — and the next
+   retry attempt's `processRegistry.set(name, entry)` then silently overwrites the tracked handle, so
+   the run-end sweep can never reach it.
+
+A best-effort cleanup of an already-dead process must not be able to fail the step it is cleaning up
+after.
+
+## Decision Drivers
+
+* Teardown is *cleanup*, not the operation under test — it must never change the step's verdict.
+* The readiness error is the diagnostically useful one and must survive.
+* The registry must be left consistent on every path, so the run-end sweep and the retry's
+  `register()` both see the truth.
+* No behavior change on the happy path or for a `kill()` that succeeds.
+
+## Considered Options
+
+* **A. `try { await teardown(bg) } catch { /* ignore */ } finally { processRegistry.delete(name) }`** (chosen).
+* **B. `try { await teardown(bg) } finally { processRegistry.delete(name) }`** — deregisters, but the
+  rejection still propagates, so (1) and (2) above remain.
+* **C. Leave the entry registered on a failed kill** so the run-end sweep retries the kill.
+* **D. Status quo** — let the rejection escape.
+
+## Decision Outcome
+
+Chosen option: **A**. Swallowing the rejection and deregistering in `finally` fixes all three defects
+with the smallest change: the step still returns its `FAIL` (or proceeds to the next retry), the
+readiness error is preserved verbatim, and the registry is clean on every exit path.
+
+**B** was the reviewer's original suggestion and is a strict improvement over **D**, but it only
+addresses (3); the escaping rejection still corrupts the step result and hides the real error. **C**
+sounds attractive but is unsound here: the retry immediately re-registers the same `name`, overwriting
+the entry, so the sweep gains nothing while the stale handle leaks anyway. **D** is the bug.
+
+Accepted trade-off: if `kill()` genuinely fails on a *live* process, that process is now deregistered
+and the run-end sweep will not reap it. This is acceptable because this path is reached only when
+readiness failed — i.e. the child already exited or never initialized — so there is, in practice,
+nothing left alive to reap. Making the step throw in order to chase that hypothetical is a strictly
+worse trade.
+
+## Consequences
+
+* **Good** — a `kill()` rejection can no longer turn a `FAIL` step into a thrown step, nor mask the
+  readiness error that explains the failure.
+* **Good** — the registry is consistent on every path; a failed kill can't strand an entry for the
+  next attempt's `register()` to overwrite.
+* **Neutral** — a genuinely-live process whose `kill()` fails is no longer swept. Unreachable in
+  practice (see trade-off above).
+* **Neutral** — happy path and successful-`kill()` path are byte-identical.
+
+## Confirmation
+
+* Unit: `test/background-process.test.js` — "a teardown kill() rejection neither escapes, masks the
+  readiness error, nor strands the registry entry" drives a handle whose `kill()` rejects and asserts
+  the call **returns** `FAIL`, that the description still carries the readiness error (`exit code 1`)
+  and *not* `kill failed`, and that `processRegistry` has no leftover entry. It fails on the
+  pre-fix build with the raw `kill failed: process already gone` escaping the function.
+* The existing retry/bound/classifier tests from ADR 01046 remain green (61 passing).
+
+## Pros and Cons of the Options
+
+### A. catch + finally (chosen)
+
+* Good: fixes all three defects; step verdict and readiness error preserved; registry always clean.
+* Good: smallest diff; happy path unchanged.
+* Neutral: a live process with a failing `kill()` goes unswept — unreachable on this path.
+
+### B. finally only
+
+* Good: registry always cleaned.
+* Bad: the rejection still escapes, so the step throws and the readiness error is masked.
+
+### C. Keep the entry registered on failed kill
+
+* Good: in theory the run-end sweep retries the kill.
+* Bad: the retry re-registers the same `name` and overwrites the entry — the sweep never sees the old
+  handle, so it leaks regardless.
+
+### D. Status quo
+
+* Good: no change.
+* Bad: a best-effort cleanup failure crashes the step, hides the real error, and leaks a registry entry.

--- a/src/core/tests/processSurface.ts
+++ b/src/core/tests/processSurface.ts
@@ -184,8 +184,19 @@ async function startBackgroundProcessSurface({
     } catch (error: any) {
       lastReadyError = error;
       // Kill + deregister the crashed handle before deciding whether to retry.
-      await teardown(bg);
-      processRegistry.delete(name);
+      // teardown is BEST-EFFORT: the child has typically already exited (that's
+      // why readiness failed), so a kill() rejection here is meaningless noise.
+      // Swallow it so it can't (a) escape and turn this clean FAIL into a thrown
+      // step, or (b) mask the real readiness error below. Deregister in
+      // `finally` so a failed kill can't strand a stale registry entry that the
+      // next attempt's register() would silently overwrite (ADR 01048).
+      try {
+        await teardown(bg);
+      } catch {
+        // Ignore: best-effort cleanup of an already-dead handle.
+      } finally {
+        processRegistry.delete(name);
+      }
       // Retry only a transient win32 init crash, and only within the bound; a
       // fresh spawn on the next attempt clears the contention in practice.
       if (

--- a/test/background-process.test.js
+++ b/test/background-process.test.js
@@ -932,6 +932,50 @@ describe("startBackgroundProcessSurface: transient init retry (Phase 6)", functi
       `expected 3 spawns (1 initial + 2 retries), got ${spawns.length}`
     );
   });
+
+  // teardown() is best-effort cleanup of an ALREADY-crashed child (that's why
+  // readiness failed). A kill() rejection must never (a) escape and turn a
+  // clean FAIL into a thrown step, (b) mask the real readiness error, or
+  // (c) strand a stale processRegistry entry that the next attempt's register
+  // would silently overwrite.
+  it("a teardown kill() rejection neither escapes, masks the readiness error, nor strands the registry entry", async function () {
+    const { startBackgroundProcessSurface } = await import(
+      "../dist/core/tests/processSurface.js"
+    );
+    const registry = new Map();
+    const result = await startBackgroundProcessSurface({
+      config: {},
+      descriptor: { command: "kill-explodes", name: "kill-rejects" },
+      processRegistry: registry,
+      deps: {
+        platform: "linux",
+        sleep: () => Promise.resolve(),
+        spawnBackgroundCommand: () => ({
+          pid: 4321,
+          // The crashed handle's kill() rejects (e.g. node-pty on a dead pid).
+          kill: async () => {
+            throw new Error("kill failed: process already gone");
+          },
+          getStdout: () => "",
+          getStderr: () => "",
+          getCombined: () => "",
+          write: () => true,
+          onChunk: () => () => {},
+          exited: Promise.resolve(1),
+        }),
+        waitForReady: async () => {
+          throw new Error(`Process exited before becoming ready (exit code 1).`);
+        },
+      },
+    });
+    // (a) it returned rather than threw, and (b) the readiness error survived.
+    assert.equal(result.status, "FAIL");
+    assert.match(result.description, /failed to become ready/);
+    assert.match(result.description, /exit code 1/);
+    assert.doesNotMatch(result.description, /kill failed/);
+    // (c) no stale entry left behind.
+    assert.equal(registry.has("kill-rejects"), false);
+  });
 });
 
 describe("runShell/runCode background (integration)", function () {


### PR DESCRIPTION
## What

Make `startBackgroundProcessSurface`'s teardown best-effort, and always deregister:

```ts
try { await teardown(bg); }
catch { /* best-effort cleanup of an already-dead handle */ }
finally { processRegistry.delete(name); }
```

## Why

Follow-up to the review nit on #547. `teardown` calls the handle's `kill()`. For a PTY-backed handle that is **already dead** — the common case on this path, since an early exit is precisely why `waitForReady` failed — `kill()` can **reject**. Nothing caught it, so the rejection:

1. **escaped the catch and the whole function**, turning a clean `FAIL` step result into a *thrown step*;
2. **masked the real readiness error** (caller saw `kill failed: …` instead of `Process exited before becoming ready (exit code …)`);
3. **stranded the registry entry**, since `processRegistry.delete(name)` never ran — and the next retry's `register()` then silently overwrote the tracked handle, so the run-end sweep could never reach it.

The review flagged (3); the failing test showed (1) and (2) as well. A best-effort cleanup of an already-dead process must not be able to fail the step it's cleaning up after.

> Note: the reviewer's suggested `try { await teardown } finally { delete }` fixes only (3) — the rejection still propagates, so the step still throws and the real error is still masked. Hence catch **and** finally.

## Red → green

New test: **"a teardown kill() rejection neither escapes, masks the readiness error, nor strands the registry entry"**.

- **Red** on the pre-fix build: `Error: kill failed: process already gone` escapes `startBackgroundProcessSurface` and the `await` throws.
- **Green** after: returns `FAIL`, description still carries `exit code 1` (and *not* `kill failed`), and `processRegistry` has no leftover entry.
- Full suite: **61 passing**, no regressions (the ADR 01046 retry/bound/classifier tests stay green).

## Scope

- **No schema change.** Internal reliability only.
- **Docs impact: none user-facing.**
- Happy path and successful-`kill()` path are byte-identical.

## ADR

`adrs/01048-process-surface-teardown-is-best-effort.md` — documents why `catch` + `finally` (option A) over `finally`-only (B) or keeping the entry registered (C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
