### PR TITLE
test(goTo): de-flake device-web settle-budget test via pure ceiling helper

### DIFF
--- a/src/core/tests/goTo.ts
+++ b/src/core/tests/goTo.ts
@@ -3,6 +3,7 @@ import {
   isRelativeUrl,
   appendQueryParams,
   isDeviceWebContext,
+  computeSettleCeiling,
 } from "../utils.js";
 import { findElement } from "./findElement.js";
 import { waitForNetworkIdle, waitForDOMStable } from "./browserWait.js";
@@ -364,8 +365,10 @@ async function goTo({ config, step, driver }: { config: any; step: any; driver: 
       // own wait.
       if (isDeviceWebContext(driver)) {
         try {
-          const remaining = waitTimeout - (Date.now() - waitStartTime);
-          const settleCeiling = Math.max(0, Math.min(3000, remaining));
+          const settleCeiling = computeSettleCeiling(
+            waitTimeout,
+            Date.now() - waitStartTime
+          );
           if (settleCeiling > 0) {
             await driver.waitUntil(
               async () => {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -893,6 +893,9 @@ function isDeviceWebContext(driver: any): boolean {
 // at 0. A non-positive result means "no budget left" — goTo's `> 0` guard then
 // skips the settle entirely. Pure so the guard's arithmetic is tested directly,
 // without racing wall-clock timing through the runner.
+//
+// @internal — an implementation detail of goTo's settle, exported only so the
+// unit tests can exercise it. Not a public API; do not rely on it externally.
 const SETTLE_CEILING_MAX_MS = 3000;
 function computeSettleCeiling(waitTimeout: number, elapsedMs: number): number {
   return Math.max(0, Math.min(SETTLE_CEILING_MAX_MS, waitTimeout - elapsedMs));

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -893,10 +893,11 @@ function isDeviceWebContext(driver: any): boolean {
 // at 0. A non-positive result means "no budget left" — goTo's `> 0` guard then
 // skips the settle entirely. Pure so the guard's arithmetic is tested directly,
 // without racing wall-clock timing through the runner.
-//
-// @internal — an implementation detail of goTo's settle, exported only so the
-// unit tests can exercise it. Not a public API; do not rely on it externally.
 const SETTLE_CEILING_MAX_MS = 3000;
+/**
+ * @internal Implementation detail of goTo's device-web settle, exported only so
+ * the unit tests can exercise it. Not a public API; do not rely on it externally.
+ */
 function computeSettleCeiling(waitTimeout: number, elapsedMs: number): number {
   return Math.max(0, Math.min(SETTLE_CEILING_MAX_MS, waitTimeout - elapsedMs));
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -42,6 +42,7 @@ export {
   isRelativeUrl,
   appendQueryParams,
   isDeviceWebContext,
+  computeSettleCeiling,
   redactUrlForOutput,
   assertUrlHostIsPublic,
   sanitizeFilesystemName,
@@ -885,6 +886,16 @@ function isDeviceWebContext(driver: any): boolean {
   const isMobile = driver.isMobile === true;
   const browserName = driver.capabilities?.browserName;
   return isMobile && typeof browserName === "string" && browserName.length > 0;
+}
+
+// Ceiling (ms) for the device-web post-navigation settle in goTo: whatever of
+// the goTo timeout remains after the readiness gate, capped at 3s and floored
+// at 0. A non-positive result means "no budget left" — goTo's `> 0` guard then
+// skips the settle entirely. Pure so the guard's arithmetic is tested directly,
+// without racing wall-clock timing through the runner.
+const SETTLE_CEILING_MAX_MS = 3000;
+function computeSettleCeiling(waitTimeout: number, elapsedMs: number): number {
+  return Math.max(0, Math.min(SETTLE_CEILING_MAX_MS, waitTimeout - elapsedMs));
 }
 
 function appendQueryParams(

--- a/test/core-utils-coverage.test.js
+++ b/test/core-utils-coverage.test.js
@@ -22,6 +22,7 @@ import {
   matchesExpectedOutput,
   isRelativeUrl,
   appendQueryParams,
+  computeSettleCeiling,
   redactUrlForOutput,
   assertUrlHostIsPublic,
   sanitizeFilesystemName,
@@ -869,6 +870,28 @@ describe("core/utils coverage", function () {
     it("is safe on empty / undefined messages", function () {
       assert.equal(isTransientProcessInitError("", "win32"), false);
       assert.equal(isTransientProcessInitError(undefined, "win32"), false);
+    });
+  });
+
+  // The device-web post-navigation settle's budget arithmetic (goTo). Pure, so
+  // the `settleCeiling > 0` guard is proven here deterministically instead of
+  // racing wall-clock timing through the runner.
+  describe("computeSettleCeiling", function () {
+    it("returns the remaining budget when under the 3s cap", function () {
+      assert.equal(computeSettleCeiling(4000, 1000), 3000); // capped
+      assert.equal(computeSettleCeiling(2500, 1000), 1500);
+      assert.equal(computeSettleCeiling(500, 100), 400);
+    });
+
+    it("caps at 3000ms no matter how much budget remains", function () {
+      assert.equal(computeSettleCeiling(30000, 0), 3000);
+      assert.equal(computeSettleCeiling(10000, 5000), 3000);
+    });
+
+    it("floors at 0 when the budget is spent (the guard then skips the settle)", function () {
+      assert.equal(computeSettleCeiling(50, 50), 0); // exactly spent
+      assert.equal(computeSettleCeiling(50, 120), 0); // overspent -> not negative
+      assert.equal(computeSettleCeiling(1, 1_000_000), 0);
     });
   });
 });

--- a/test/core-utils-coverage.test.js
+++ b/test/core-utils-coverage.test.js
@@ -878,14 +878,15 @@ describe("core/utils coverage", function () {
   // racing wall-clock timing through the runner.
   describe("computeSettleCeiling", function () {
     it("returns the remaining budget when under the 3s cap", function () {
-      assert.equal(computeSettleCeiling(4000, 1000), 3000); // capped
       assert.equal(computeSettleCeiling(2500, 1000), 1500);
       assert.equal(computeSettleCeiling(500, 100), 400);
+      assert.equal(computeSettleCeiling(3000, 100), 2900);
     });
 
     it("caps at 3000ms no matter how much budget remains", function () {
       assert.equal(computeSettleCeiling(30000, 0), 3000);
       assert.equal(computeSettleCeiling(10000, 5000), 3000);
+      assert.equal(computeSettleCeiling(4000, 1000), 3000); // 3000 remaining == cap boundary
     });
 
     it("floors at 0 when the budget is spent (the guard then skips the settle)", function () {

--- a/test/goTo-device-settle.test.js
+++ b/test/goTo-device-settle.test.js
@@ -218,36 +218,14 @@ describe("goTo post-navigation settle (device web only)", function () {
     );
   });
 
-  it("iOS web context with no settle budget left (remaining <= 0) skips the settle and PASSes", async function () {
-    installBrowserStub({ ready: "complete" });
-    const { driver, record } = makeSettleDriver({
-      mobile: true,
-      ios: true,
-      browserName: "Safari",
-    });
-    // timeout: 1 (ms): the pre-settle readiness phases run before the settle
-    // and spend the 1ms budget — in this harness the time comes from the
-    // schema-coerced network/DOM idle waits (the mock's pause() is a no-op) —
-    // so by the time the settle computes its ceiling, remaining <= 0 →
-    // settleCeiling = 0 → the `settleCeiling > 0` guard skips the settle with
-    // no tree poll. NOTE: `timeout: 0` does NOT work — the step is validated
-    // with schema defaults inbound and a 0 timeout is replaced by the goTo
-    // default (30000), leaving a full budget.
-    const step = {
-      goTo: {
-        url: "https://example.com",
-        timeout: 1,
-        waitUntil: { networkIdleTime: null, domIdleTime: null },
-      },
-    };
-    const result = await goTo({ config: {}, step, driver });
-    assert.equal(result.status, "PASS");
-    assert.equal(
-      record.dollarDollarCalls,
-      0,
-      "settle must not poll the tree when no time budget remains"
-    );
-  });
+  // The "no settle budget → skip" path (settleCeiling === 0) is covered
+  // deterministically by the computeSettleCeiling unit tests in
+  // test/core-utils-coverage.test.js. It is NOT asserted here: at the goTo
+  // integration level the settle shares one budget with goTo's own readiness
+  // waits, so the only way to force elapsed > timeout in the mock also trips
+  // goTo's timeout handling — which made a prior wall-clock-timing version of
+  // this test flake on slow CI. The extracted pure helper is the honest,
+  // race-free home for that assertion.
 
   it("iOS web context whose tree stays empty past the ceiling still PROCEEDS to PASS (settle never fails goTo)", async function () {
     installBrowserStub({ ready: "complete" });


### PR DESCRIPTION
## What

De-flake the device-web `goTo` settle "no budget" test by extracting its budget arithmetic into a pure, unit-tested helper.

## Why

On the most recent `main` CI, `test / Test (macos-latest, node 22)` failed on:

> `goTo post-navigation settle (device web only) › iOS web context with no settle budget left … skips the settle and PASSes` — `AssertionError: 0 !== 1`

That test forced `settleCeiling === 0` by giving `goTo` a **1 ms** timeout and relying on incidental elapsed time exceeding it. On a slow runner the elapsed was `< 1 ms`, so `settleCeiling > 0`, the settle ran, polled the tree once, and the strict `dollarDollarCalls === 0` assertion failed. (Flagged as fragile during the #545 review; it has now actually flaked.)

The zero-budget branch **cannot be isolated at the goTo integration level** — the settle shares one budget with goTo's own readiness waits, so any mock trick that forces `elapsed > timeout` also trips goTo's own timeout handling (verified: a jumping `Date.now()` and a real `pause` both make goTo return FAIL instead of reaching the skip).

## Fix

- Extract `computeSettleCeiling(waitTimeout, elapsedMs)` into `src/core/utils.ts` — **byte-identical** to the previous inline `Math.max(0, Math.min(3000, waitTimeout - elapsed))`.
- `goTo` calls the helper; runtime behavior is unchanged.
- Unit-test the helper deterministically (remaining-budget, 3 s cap, floor-at-0 / overspent) in `test/core-utils-coverage.test.js`.
- Remove the timing-fragile integration assertion; the deterministic device-web settle tests (settle runs; settle times out but still PASSes) stay.

## Verification

- `computeSettleCeiling` unit tests + `goTo-device-settle` suite: **119 passing**, and device-settle is stable across repeated local runs (the removed test no longer exists to flake).
- No behavior change → **no ADR** (pure refactor + test reliability). **No schema change. Docs impact: none.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-navigation settling behavior by consistently calculating the remaining wait time and preventing unnecessary waits when the timeout has expired.

* **Tests**
  * Added coverage for settling-time limits, including maximum and zero-budget scenarios.
  * Simplified device navigation integration coverage to reduce flaky timeout-dependent assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->