### PR TITLE
test(server): support multi-segment paths on the echo API fixture

### DIFF
--- a/docs/fern/pages/docs/test-code/http-and-api.mdx
+++ b/docs/fern/pages/docs/test-code/http-and-api.mdx
@@ -133,7 +133,7 @@ To chain calls—create something, then fetch it—capture part of the response 
 ```
 
 {/* step {"stepId":"http-api-create-capture","description":"Create a user (including an id in the request body) and capture it into a variable","httpRequest":{"url":"http://localhost:8092/api/users","method":"POST","request":{"body":{"name":"neo","job":"the one","id":"neo-101"}}},"variables":{"USER_ID":"$$response.body.id"}} */}
-{/* step {"stepId":"http-api-fetch-with-id","description":"Use the captured ID as a query parameter and assert the echoed response contains it, proving it was actually substituted (the echo API reflects query/body, not path segments)","httpRequest":{"url":"http://localhost:8092/api/users?id=$USER_ID","method":"GET","response":{"body":{"id":"neo-101"}}}} */}
+{/* step {"stepId":"http-api-fetch-with-id","description":"Use the captured ID as a path segment, matching the doc's own URL shape exactly. The echo server reflects the resolved request path in an x-echo-path response header (not the body, so it can't be confused with real response data), proving $USER_ID was genuinely substituted rather than left as a literal string","httpRequest":{"url":"http://localhost:8092/api/users/$USER_ID","method":"GET","response":{"headers":{"x-echo-path":"/api/users/neo-101"}}}} */}
 {/* test end */}
 
 Response expressions such as `$$response.body`, `$$response.headers`, and `$$response.status` support dot notation for nested JSON fields—for example, `$$response.body.user.id`.

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -92,8 +92,12 @@ function createServer(options = {}) {
     }
   });
 
-  // Echo API endpoint that returns the request body (catch-all)
-  app.all("/api/:path", (req, res) => {
+  // Echo API endpoint that returns the request body (catch-all). Matches any
+  // number of path segments after /api/ (e.g. /api/users, /api/users/2,
+  // /api/users/2/orders/5) so docs examples that mirror a real multi-segment
+  // REST API (reqres.in-style /api/users/:id) can point straight at this
+  // fixture instead of being adapted to a single hyphenated segment.
+  app.all("/api/{*splat}", (req, res) => {
     try {
       const requestBody = req.method === "GET" ? req.query : req.body;
       const modifiedResponse = modifyResponse(req, requestBody);
@@ -106,6 +110,12 @@ function createServer(options = {}) {
       });
 
       res.set("x-server", "doc-detective-echo-server");
+      // Reflects the resolved request path (post-substitution, e.g. after a
+      // captured $VARIABLE lands in the URL) as a header rather than a body
+      // field, so tests can assert real path-segment substitution happened
+      // without adding a field that would trip an allowAdditionalFields:false
+      // check on the echoed body.
+      res.set("x-echo-path", req.path);
 
       console.log("Response:", { Body: modifiedResponse });
 


### PR DESCRIPTION
## What changed

Improves the shared echo API test fixture (`test/server/index.js`) so docs pages that mirror a real multi-segment REST API can point straight at it, instead of adapting to a single-segment workaround.

**The problem:** the echo server's catch-all route was `app.all("/api/:path", ...)` — Express matches `:path` as exactly one segment. Every doc example that showed a path like `https://reqres.in/api/users/2` had to be adapted for its executed inline test to a single hyphenated segment (`/api/user-2`) or a query parameter, instead of using the same URL shape the visible JSON teaches. This showed up in both `httpRequest.mdx` (#569) and the merged `http-and-api.mdx` (#582).

**The fix:**
- Switched the route to Express 5's named-wildcard syntax, `/api/{*splat}`, which matches any number of path segments (`/api/users`, `/api/users/2`, `/api/users/2/orders/5`, ...).
- Added an `x-echo-path` response header reflecting the resolved request path — deliberately a header, not a body field, so it doesn't collide with `httpRequest.mdx`'s existing `allowAdditionalFields: false` strict-body test (verified unaffected).
- Updated the two examples that previously worked around the single-segment limit (`httpRequest.mdx`'s PUT and variable-capture examples, and `http-and-api.mdx`'s capture-and-reuse example) to use the exact documented multi-segment path, proving real variable substitution via the new header instead of a query-string side channel.

## Verification

- `docs/fern/pages/docs/actions/httpRequest.mdx`: 15 tests / 17 steps, all PASS (on the `#569` branch, not part of this PR).
- `docs/fern/pages/docs/test-code/http-and-api.mdx`: 7 tests / 8 steps, all PASS.
- `test/resolvedTests.test.js` (exercises the DOC_DETECTIVE_API flow against this same server, including a multi-segment `/api/contexts` POST): 4 passing.
- `test/httprequest-coverage.test.js`: 65 passing.

## Docs impact

This is a test-infrastructure change plus a docs update to an already-merged page (`http-and-api.mdx`) to take advantage of it. No user-facing product behavior changes; no ADR or feature fixture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the value-reuse example to substitute captured values directly into API path segments.
  * Revised assertions to verify the resolved request path.

* **Tests**
  * Enhanced test responses to expose the requested path for validating multi-segment REST paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->