### PR TITLE
fix(files): resolve string-shorthand screenshot/record paths via relativePathBase

### DIFF
--- a/adrs/01050-string-shorthand-paths-respect-relative-path-base.md
+++ b/adrs/01050-string-shorthand-paths-respect-relative-path-base.md
@@ -1,0 +1,112 @@
+---
+status: accepted
+date: 2026-07-11
+decision-makers: doc-detective maintainers
+---
+
+# String-shorthand `screenshot`/`record` paths must respect `relativePathBase`
+
+## Context and Problem Statement
+
+`config.relativePathBase` (default `"file"`) controls whether a relative path in a spec resolves
+against the current working directory or against the file that declared it. `resolvePaths()` in
+`src/core/files.ts` implements this by walking a resolved spec and rewriting known path-bearing
+properties (`path`, `directory`, `file`, ...) to absolute paths before any step runs.
+
+That walk keys off property **names** — `path`, `directory`, and so on. It has no notion of the
+action-name properties (`screenshot`, `record`) whose *string* value is itself a path, e.g.
+`"screenshot": "shot.png"`. When the value is an *object* (`"screenshot": { "path": "shot.png" }`),
+the walk recurses into it and finds the `path` key, so the object form is resolved correctly. When
+the value is a bare string, no property name matches, so `resolvePaths()` leaves it untouched.
+
+The string is later boxed into `{ path: <string> }` inside `saveScreenshot.ts` / `startRecording.ts`
+at step-execution time — well after `resolvePaths()` has already run — and is never re-resolved.
+Node's `fs` calls then resolve it against `process.cwd()` by default. Net effect: the string-shorthand
+form always behaves as `relativePathBase: "cwd"`, regardless of the configured (or default `"file"`)
+setting, while the object form correctly honors it. Confirmed empirically: running a spec from a
+different directory than the spec file, `"screenshot": "shot.png"` lands next to the invoking
+process's cwd, while `"screenshot": { "path": "shot.png" }` lands next to the spec file.
+
+## Decision Drivers
+
+* String shorthand and object shorthand must resolve paths identically — an author shouldn't have
+  to know an implementation-internal reason to prefer one form.
+* No change to the *default* observable behavior of the object form, or of any other action.
+* No corruption of user-authored data that happens to reuse the words `screenshot`/`record` as a
+  field name inside unrelated data (e.g. an `httpRequest` request body).
+* Minimal, centralized fix — the same bug pattern (a string shorthand action value is a bare path)
+  should not require a bespoke patch inside every affected action file.
+
+## Considered Options
+
+* **A. Teach `resolvePaths()` to resolve the string form for known step-level actions** (chosen).
+* **B. Fix it inside each action file** (`saveScreenshot.ts`, `startRecording.ts`) at the point
+  where the string gets boxed into `{ path }`.
+* **C. Change the default of `relativePathBase` to `"cwd"`** so the (buggy) string behavior becomes
+  the documented default.
+
+## Decision Outcome
+
+Chosen option: **A**. `resolvePaths()` already owns every other case of this exact problem (config
+paths, spec paths, array-of-path items); teaching it about the two action names extends the existing
+single source of truth instead of duplicating `relativePathBase`-aware resolution logic in each
+action module. Option B works but means the next action with a path-bearing string shorthand
+reintroduces the same bug until someone remembers the fix lives in N different files. Option C
+throws out `relativePathBase: "file"`'s value for every *other* path in a spec, and contradicts the
+documented default.
+
+Implementation: `resolvePaths()` gains a `stepShorthandPathProperties = ["screenshot", "record"]`
+list and an `isStep` flag threaded through the recursive walk. The flag is set `true` only when
+recursing into the `steps` array specifically (`property === "steps"`), so it's `true` exactly when
+`object` is a genuine step, and `false` for every other nested object — including a `record` or
+`screenshot` field that happens to appear inside `request`/`response` body data. When a plain-string
+property value is one of `stepShorthandPathProperties` **and** `isStep` is true, it goes through the
+same `relativePathBase`-aware `resolve()` helper the object form's `path`/`directory` keys already
+use. A URL-shaped string (`https://`, `http://`, `heretto:`) is still left untouched, matching the
+existing behavior for every other path property.
+
+### Consequences
+
+* Good: `"screenshot": "shot.png"` and `"screenshot": { "path": "shot.png" }` now resolve
+  identically, honoring `relativePathBase`.
+* Good: no change to any other action's path resolution, and no change to the object form's
+  existing (already-correct) behavior.
+* Good: a `record`/`screenshot` field nested in unrelated user data (e.g. request/response bodies)
+  is provably left alone — covered by a dedicated regression test.
+* Neutral / breaking for existing users: a spec that authored a string-shorthand `screenshot`/
+  `record` path and *relied on* the old cwd-relative behavior (e.g. an absolute-looking relative
+  path built assuming invocation-directory resolution) now resolves relative to the spec file
+  instead. This matches the documented, already-default `relativePathBase: "file"` contract, so it's
+  a bug fix, not a new default; a project that explicitly sets `relativePathBase: "cwd"` is
+  unaffected (both forms already resolved against cwd there, and continue to).
+
+### Confirmation
+
+Red→green unit tests in `test/misc-edge-branches-coverage.test.js`
+(`resolvePaths — screenshot/record string shorthand`): a step-level string shorthand resolves next
+to the spec file under `relativePathBase: "file"`; a URL-shaped shorthand is left untouched; a
+`record` field nested inside unrelated request-body data is left untouched. Also verified end to end
+against the real CLI: invoking `doc-detective` from a different cwd than the spec file, with a
+string-shorthand `screenshot` step, now writes the file next to the spec file instead of the cwd —
+matching the object form's existing behavior. Existing `resolvePaths` / `detectTests` suites
+(`test/misc-edge-branches-coverage.test.js`, `test/detecttests-coverage.test.js`,
+`test/detecttests-heretto-loader-coverage.test.js`, `test/exports.test.js`,
+`test/cli-index-adapters-coverage.test.js`) pass unchanged.
+
+## Pros and Cons of the Options
+
+### A. Extend `resolvePaths()`
+* Good: single source of truth; matches how every other path property is already handled.
+* Good: naturally scoped via the existing `objectType`/recursion structure, no separate schema walk.
+* Bad: `resolvePaths()` now needs to know two action names instead of being purely generic over
+  property names — a small increase in its surface, though not its complexity.
+
+### B. Fix per-action
+* Good: localized to the file that has the bug today.
+* Bad: duplicates `relativePathBase`-aware resolution logic; the next action with this shape
+  (a string shorthand that's secretly a path) has to remember to opt in.
+
+### C. Change the default
+* Good: no code change.
+* Bad: silently changes behavior for every other spec path; contradicts the documented default and
+  the object form's already-correct, already-shipped behavior.

--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -97,12 +97,14 @@ async function resolvePaths({
   filePath,
   nested = false,
   objectType,
+  isStep = false,
 }: {
   config: any;
   object: any;
   filePath: string;
   nested?: boolean;
   objectType?: string;
+  isStep?: boolean;
 }) {
   // Config properties that contain paths
   const configPaths = [
@@ -144,6 +146,13 @@ async function resolvePaths({
     "requestParams",
     "responseParams",
   ];
+  // Step actions whose STRING (not object) shorthand value IS a path itself
+  // (e.g. `"screenshot": "shot.png"`), rather than a wrapper containing a
+  // `path`/`directory` key. The object form already resolves via the generic
+  // `path`/`directory` handling above; only the bare-string form needs this
+  // separate list. Scoped to `isStep` so a coincidentally-named field nested
+  // inside request/response data (not a step) is never mistaken for one.
+  const stepShorthandPathProperties = ["screenshot", "record"];
 
   function resolve(baseType: string, relativePath: string, filePath: string) {
     // If the path is an http:// or https:// URL, or a heretto: URI, return it
@@ -227,6 +236,7 @@ async function resolvePaths({
             filePath: filePath,
             nested: true,
             objectType: objectType,
+            isStep: property === "steps",
           });
         } else if (
           typeof item === "string" &&
@@ -261,7 +271,10 @@ async function resolvePaths({
       ) {
         continue;
       }
-      if (pathProperties!.includes(property)) {
+      if (
+        pathProperties!.includes(property) ||
+        (isStep && stepShorthandPathProperties.includes(property))
+      ) {
         if (property === "path" && object.directory) {
           const directory = path.isAbsolute(object.directory)
             ? object.directory

--- a/test/misc-edge-branches-coverage.test.js
+++ b/test/misc-edge-branches-coverage.test.js
@@ -215,6 +215,88 @@ describe("core/files.ts — readFile / resolvePaths edge branches", function () 
     assert.equal(out.path[1], path.resolve(absDir, "p2.md"));
   });
 
+  it("resolvePaths resolves a step-level screenshot/record string shorthand relative to the spec file, not cwd", async function () {
+    const dir = mkTmp("dd-edge-files-");
+    const spec = {
+      specId: "s1",
+      tests: [
+        {
+          steps: [
+            { goTo: "https://x" },
+            { stepId: "shot", screenshot: "shot.png" },
+            { stepId: "vid", record: "clip.mp4" },
+          ],
+        },
+      ],
+    };
+    const out = await resolvePaths({
+      config: { relativePathBase: "file" },
+      object: spec,
+      filePath: path.join(dir, "spec.json"),
+    });
+    const steps = out.tests[0].steps;
+    assert.equal(
+      steps[1].screenshot,
+      path.resolve(dir, "shot.png"),
+      "string-shorthand screenshot should resolve relative to the spec file's directory"
+    );
+    assert.equal(
+      steps[2].record,
+      path.resolve(dir, "clip.mp4"),
+      "string-shorthand record should resolve relative to the spec file's directory"
+    );
+  });
+
+  it("resolvePaths leaves a screenshot/record URL shorthand untouched (no path resolution)", async function () {
+    const dir = mkTmp("dd-edge-files-");
+    const spec = {
+      specId: "s1",
+      tests: [
+        {
+          steps: [
+            { stepId: "shot", screenshot: "https://example.com/ref.png" },
+          ],
+        },
+      ],
+    };
+    const out = await resolvePaths({
+      config: { relativePathBase: "file" },
+      object: spec,
+      filePath: path.join(dir, "spec.json"),
+    });
+    assert.equal(out.tests[0].steps[0].screenshot, "https://example.com/ref.png");
+  });
+
+  it("resolvePaths doesn't resolve a non-step-level field that happens to be named screenshot/record", async function () {
+    const dir = mkTmp("dd-edge-files-");
+    const spec = {
+      specId: "s1",
+      tests: [
+        {
+          steps: [
+            {
+              stepId: "req",
+              httpRequest: {
+                url: "https://x",
+                request: { body: { record: "not-a-path" } },
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const out = await resolvePaths({
+      config: { relativePathBase: "file" },
+      object: spec,
+      filePath: path.join(dir, "spec.json"),
+    });
+    assert.equal(
+      out.tests[0].steps[0].httpRequest.request.body.record,
+      "not-a-path",
+      "a `record` field nested inside request body data isn't a recording step and must be left alone"
+    );
+  });
+
   it("readFile returns raw content for a non-json/yaml extension", async function () {
     const dir = mkTmp("dd-edge-files-");
     const p = path.join(dir, "note.txt");


### PR DESCRIPTION
## What changed

Fixes a real bug surfaced while authoring #575's inline tests: string-shorthand `screenshot`/`record` paths (`"screenshot": "shot.png"`) ignore `config.relativePathBase` entirely and always resolve relative to the invoking process's `cwd`, while the equivalent object form (`{"screenshot": {"path": "shot.png"}}`) correctly resolves relative to the spec file (the documented `relativePathBase: "file"` default).

**Root cause:** `resolvePaths()` (`src/core/files.ts`) recognizes path-bearing properties by *name* (`path`, `directory`, `file`, ...). The object form recurses into `{"path": ...}` and matches. The string form's property name is the action itself (`screenshot`/`record`), which was never in that list, so it was left completely untouched by `resolvePaths()`. The string later gets boxed into `{path: string}` inside `saveScreenshot.ts`/`startRecording.ts` at step-execution time — well after `resolvePaths()` already ran — and Node's `fs` calls then resolve it against `process.cwd()`.

**Empirical repro (before the fix):** invoking `doc-detective` from a different directory than the spec file, with `relativePathBase: "file"` (the default): a string-shorthand `screenshot: "shot.png"` landed next to the invocation cwd; an object-form `screenshot: {"path": "object.png"}` correctly landed next to the spec file.

**Fix:** `resolvePaths()` now recognizes `screenshot`/`record` as step-level string-shorthand path properties, gated by a new `isStep` flag that's only `true` when recursing into an actual `steps` array item — so a `record`/`screenshot` field nested inside unrelated request/response body data is never mistaken for a step and is left alone (covered by a dedicated test).

## Docs impact

No documentation changes needed — [`docs/fern/pages/docs/get-started/sample-tests.mdx`](docs/fern/pages/docs/get-started/sample-tests.mdx) already documents the `relativePathBase: "file"` default correctly; this fix makes the code match the already-published behavior rather than changing what's documented.

## Verification

- New red→green unit tests in `test/misc-edge-branches-coverage.test.js`: string shorthand resolves next to the spec file; a URL shorthand is left untouched; a `record` field nested in unrelated request-body data is left untouched.
- `test/misc-edge-branches-coverage.test.js`, `test/detecttests-coverage.test.js`, `test/detecttests-heretto-loader-coverage.test.js`, `test/exports.test.js`, `test/cli-index-adapters-coverage.test.js`: 198 passing, no regressions.
- `test/core-screenshot.test.js`, `test/recording-screenshot-coverage.test.js`, `test/saveScreenshot.test.js`, `test/ffmpeg-recorder.test.js`: 176 passing, no regressions.
- Re-ran the empirical repro after the fix: both string-shorthand and object-form paths now land next to the spec file, matching each other.
- Re-ran the affected docs pages (`screenshot.mdx`, `record.mdx`, `stopRecord.mdx`) against the real docs config: 13 tests / 39 steps, same pass/skip counts as before the fix.

See [`adrs/01050-string-shorthand-paths-respect-relative-path-base.md`](adrs/01050-string-shorthand-paths-respect-relative-path-base.md) for the full decision record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed relative path handling for step-level `screenshot` and `record` string values.
  * These paths now resolve relative to the specification file, consistent with object-form values.
  * URL values remain unchanged.
  * Unrelated nested fields named `screenshot` or `record` are no longer incorrectly modified.

* **Documentation**
  * Added an accepted architectural decision record documenting the path-resolution behavior and compatibility considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->