### PR TITLE
fix(httpRequest): stop implicitly asserting a JSON-object response body

### DIFF
--- a/adrs/01051-httprequest-no-implicit-json-body-assertion.md
+++ b/adrs/01051-httprequest-no-implicit-json-body-assertion.md
@@ -1,0 +1,113 @@
+---
+status: accepted
+date: 2026-07-11
+decision-makers: doc-detective maintainers
+---
+
+# `httpRequest` must not implicitly assert a JSON-object response body
+
+## Context and Problem Statement
+
+`httpRequest`'s response defaults (`src/core/tests/httpRequest.ts`) used to set `response.body` to
+`{}` whenever a step didn't declare one:
+
+```js
+response: {
+  headers: {},
+  body: {},
+  required: [],
+  ...(step.httpRequest.response || {}),
+},
+```
+
+The body-match check that follows only skips when `typeof step.httpRequest.response.body ===
+"undefined"`. Because of the default above, that was never true — `response.body` was always at
+least `{}`. So the check always ran, and it opens with a type comparison: `typeof
+step.httpRequest.response.body !== typeof response.data`. For a JSON API this is harmless (axios
+parses the body into an object, so both sides are `"object"`). For any **non-JSON** response — plain
+text, an HTML directory listing, an empty `204` body — axios leaves `response.data` as a string (or
+empty string), the types mismatch, and the step fails with "Expected response body type didn't match
+actual response body type" — even though the step never asked for a body assertion.
+
+This surfaced while authoring inline docs tests (PR #576): `python -m http.server` (HTML directory
+listing) had to be replaced with a custom JSON-only fixture (`simple-json-server.js`) to avoid
+tripping this check. That's a workaround for a real bug in `httpRequest`, not a docs problem.
+
+## Decision Drivers
+
+* A step that sets no `response.body` must not implicitly require anything about the response body's
+  shape or content type.
+* No regression for steps that DO set `response.body` — every existing assertion behavior there is
+  unchanged.
+* Prefer the smallest fix that removes the false assumption at its source, over teaching the
+  type-match check to special-case "empty" after the fact.
+* Match already-published docs: `$$bodyMatches` is documented as present "when `response.body` is
+  set" — it should not be computed (or defaulted to `true`) when it isn't.
+
+## Considered Options
+
+* **A. Stop defaulting `response.body` to `{}`** (chosen).
+* **B. Keep the `{}` default, but skip the type-match check when the expected body has zero keys**
+  (mirroring the sibling `allowAdditionalFields` check's existing "empty root body imposes no
+  constraint" special-case).
+* **C. Make the type-match Content-Type-aware** — only require a JSON-object body when the actual
+  response's `Content-Type` says JSON.
+
+## Decision Outcome
+
+Chosen option: **A**. The body-match check already has the right guard
+(`typeof ... !== "undefined"`); the bug is that the value was never allowed to BE `undefined`. Not
+defaulting it removes the false assumption at its source instead of adding a second layer of
+special-casing on top of it (Option B), and doesn't require parsing/trusting response headers to
+decide whether an assertion applies (Option C, which also doesn't fully resolve the "was this the
+default or did the user ask for it" ambiguity for a JSON endpoint that returns a top-level string).
+
+Implementation: removed `body: {}` from the `response` defaults spread in `httpRequest.ts`. `headers`
+and `required` keep their defaults (`{}` and `[]` respectively) since the checks that read them
+already treat an empty object/array as "no constraint" by construction, not by an added special case.
+
+A useful side effect: the OpenAPI `mockResponse` branch already had a
+`typeof step.httpRequest.response.body === "undefined"` check to decide whether to fall back to the
+example response body — that check was unreachable dead code because of the `{}` default. It now
+works as originally intended.
+
+### Consequences
+
+* Good: a step with no `response.body` no longer implicitly requires a JSON-object (or array)
+  response — it passes against plain text, HTML, or an empty body, same as if no body check existed.
+* Good: `outputs.bodyMatches` is now genuinely absent (not `true`) when no body assertion applies,
+  matching the documented contract.
+* Good: no change whatsoever to steps that explicitly set `response.body` — same comparisons, same
+  outputs, same failure messages.
+* Neutral / behavior change for anyone who was implicitly relying on the old default to reject a
+  non-object response as a coarse "is this even JSON" check: that was an undocumented side effect
+  of a bug, not a supported way to assert response shape. Use `response.required` (existence) or an
+  explicit `response.body` to assert intentionally.
+
+### Confirmation
+
+Red→green tests added to `test/httprequest-coverage.test.js`
+("no implicit body assertion when response.body is unset"): an HTML response, a plain-text response,
+an empty 204 response, a JSON object response, and a JSON array response ALL now PASS with
+`outputs.bodyMatches` absent when `response.body` is unset, and a control case confirms an explicit
+`response.body` still asserts and can still FAIL. Full existing suites
+(`test/httprequest-coverage.test.js`, `test/httpRequest-assertions.test.js`, `test/httpRequest.test.js`)
+pass unchanged — every pre-existing `bodyMatches`-related test already set `response.body` explicitly,
+so none of them exercised (or depended on) the removed default.
+
+## Pros and Cons of the Options
+
+### A. Remove the default
+* Good: fixes the root cause; the existing guard does the right thing once the value can be
+  genuinely absent; also revives the dead OpenAPI mock-response fallback.
+* Bad: none identified — the default served no purpose the guard didn't already anticipate.
+
+### B. Special-case an empty expected body
+* Good: also fixes the symptom.
+* Bad: duplicates the "empty means no constraint" convention that already exists for
+  `allowAdditionalFields`, instead of just not creating the ambiguous default in the first place.
+
+### C. Content-Type-aware check
+* Good: could, in principle, give a clearer failure message ("expected JSON, got text/html").
+* Bad: more moving parts (header parsing, trusting a possibly-absent/incorrect Content-Type header);
+  doesn't remove the underlying "default vs. user-authored `{}`" ambiguity.

--- a/src/core/tests/httpRequest.ts
+++ b/src/core/tests/httpRequest.ts
@@ -200,9 +200,16 @@ async function httpRequest({ config, step, openApiDefinitions = [] }: { config: 
       headers: {},
       body: {},
     },
+    // NOTE: `body` is deliberately NOT defaulted here (unlike `headers`/
+    // `required`). Defaulting it to `{}` used to make the body-match check
+    // below run unconditionally -- even when the step never asked for a body
+    // assertion -- and silently required the response to be a JSON object,
+    // failing any non-JSON (or empty) response. Leaving `body` genuinely
+    // `undefined` when unset lets the existing `typeof !== "undefined"` guard
+    // skip the check entirely, matching the documented "$$bodyMatches ...
+    // when response.body is set" contract. See ADR on this fix.
     response: {
       headers: {},
-      body: {},
       required: [],
       ...(step.httpRequest.response || {}),
     },

--- a/test/httprequest-coverage.test.js
+++ b/test/httprequest-coverage.test.js
@@ -626,6 +626,133 @@ describe("httpRequest coverage (stubbed axios)", function () {
   });
 
   // ---------------------------------------------------------------------------
+  // No implicit body assertion when response.body is unset (#576 regression):
+  // httpRequest used to default response.body to {} even when the step never
+  // asked for a body assertion, so a non-JSON (or empty) response failed a
+  // type-match check the user never requested. Sanity-check a handful of
+  // realistic response shapes with NO response.body set at all — every one
+  // must PASS with no bodyMatches output at all, regardless of content type.
+  // ---------------------------------------------------------------------------
+  describe("no implicit body assertion when response.body is unset", function () {
+    it("PASSes an HTML response with no response.body set", async function () {
+      stubResponse({
+        status: 200,
+        headers: { "content-type": "text/html" },
+        data: "<html><body>Directory listing</body></html>",
+      });
+      const result = await httpRequest({
+        config,
+        step: {
+          httpRequest: {
+            url: "http://api.example.com/",
+            method: "get",
+            statusCodes: [200],
+          },
+        },
+      });
+      assert.equal(result.status, "PASS", result.description);
+      assert.equal(result.outputs.bodyMatches, undefined);
+    });
+
+    it("PASSes a plain-text response with no response.body set", async function () {
+      stubResponse({
+        status: 200,
+        headers: { "content-type": "text/plain" },
+        data: "ok",
+      });
+      const result = await httpRequest({
+        config,
+        step: {
+          httpRequest: {
+            url: "http://api.example.com/",
+            method: "get",
+            statusCodes: [200],
+          },
+        },
+      });
+      assert.equal(result.status, "PASS", result.description);
+      assert.equal(result.outputs.bodyMatches, undefined);
+    });
+
+    it("PASSes an empty 204-style response (no body at all) with no response.body set", async function () {
+      stubResponse({ status: 204, headers: {}, data: "" });
+      const result = await httpRequest({
+        config,
+        step: {
+          httpRequest: {
+            url: "http://api.example.com/",
+            method: "get",
+            statusCodes: [204],
+          },
+        },
+      });
+      assert.equal(result.status, "PASS", result.description);
+      assert.equal(result.outputs.bodyMatches, undefined);
+    });
+
+    it("PASSes a JSON object response with no response.body set", async function () {
+      stubResponse({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        data: { id: 1, name: "morpheus" },
+      });
+      const result = await httpRequest({
+        config,
+        step: {
+          httpRequest: {
+            url: "http://api.example.com/",
+            method: "get",
+            statusCodes: [200],
+          },
+        },
+      });
+      assert.equal(result.status, "PASS", result.description);
+      assert.equal(result.outputs.bodyMatches, undefined);
+    });
+
+    it("PASSes a JSON array response with no response.body set", async function () {
+      stubResponse({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        data: [1, 2, 3],
+      });
+      const result = await httpRequest({
+        config,
+        step: {
+          httpRequest: {
+            url: "http://api.example.com/",
+            method: "get",
+            statusCodes: [200],
+          },
+        },
+      });
+      assert.equal(result.status, "PASS", result.description);
+      assert.equal(result.outputs.bodyMatches, undefined);
+    });
+
+    it("still asserts the body when response.body IS explicitly set (control case)", async function () {
+      stubResponse({
+        status: 200,
+        headers: { "content-type": "text/plain" },
+        data: "unexpected-text",
+      });
+      const result = await httpRequest({
+        config,
+        step: {
+          httpRequest: {
+            url: "http://api.example.com/",
+            method: "get",
+            statusCodes: [200],
+            response: { body: "expected-text" },
+          },
+        },
+      });
+      assert.equal(result.status, "FAIL");
+      assert.equal(result.outputs.bodyMatches, false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Required-field checks (fieldExistsAtPath)
   // ---------------------------------------------------------------------------
   describe("required response fields (fieldExistsAtPath)", function () {


### PR DESCRIPTION
## What changed

Implements Option 1 from the #576 investigation: `httpRequest` used to default `response.body` to `{}` even when a step never set one, so the body-match check ran unconditionally instead of skipping via its own `typeof !== "undefined"` guard. Against a non-JSON response (plain text, HTML, an empty `204` body), the implicit `{}` expectation type-mismatched `response.data` and failed the step — even though no body assertion was requested. This is what forced the docs workaround in #576 (`python -m http.server`, which returns an HTML directory listing, had to be swapped for a JSON-only fixture).

**Fix:** stop defaulting `response.body`. `headers` and `required` keep their existing defaults, since the checks that read them already treat "empty" as "no constraint" by construction (not via an added special case). Leaving `body` genuinely `undefined` when unset lets the existing guard skip the whole check, matching the already-published docs contract ("`$$bodyMatches`: ...when `response.body` is set"). As a side effect, this also revives previously-dead code in the OpenAPI `mockResponse` fallback that depended on the same `undefined` check.

## Sanity-check tests (response types)

Added to `test/httprequest-coverage.test.js` under "no implicit body assertion when response.body is unset" — each with **no** `response.body` set:

- HTML response (`text/html`, a string body) — now PASSes
- Plain-text response (`text/plain`) — now PASSes
- Empty `204` response (empty string body) — now PASSes
- JSON object response — PASSes, and `outputs.bodyMatches` is now genuinely absent (previously `true` by accident)
- JSON array response — now PASSes
- Control case: an explicit `response.body` still asserts and can still FAIL (proves the fix didn't neuter the real feature)

## Verification

- New tests: red before the fix (5 of 6 failing exactly as predicted), green after.
- `test/httprequest-coverage.test.js` + `test/httpRequest-assertions.test.js`: 84 passing, no regressions — every pre-existing `bodyMatches` test already sets `response.body` explicitly, so none of them exercised the removed default.
- `test/httpRequest.test.js`: 8 passing.
- `test/core-core.test.js` (broad control-flow suite): 70 passing, 3 pending, 0 failing.

See [`adrs/01051-httprequest-no-implicit-json-body-assertion.md`](adrs/01051-httprequest-no-implicit-json-body-assertion.md) for the full decision record, including the options considered.

## Docs impact

No documentation changes needed — the existing docs already describe `$$bodyMatches` as present only "when `response.body` is set"; this fix makes the code match that already-published contract rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `httpRequest` no longer performs an implicit response-body assertion when no expected body is specified.
  - Requests returning HTML, plain text, empty responses, JSON objects, or arrays are evaluated correctly.
  - Explicit response-body expectations continue to be validated as before.

- **Tests**
  - Added regression coverage for responses without configured body expectations and for explicit body matching.

- **Documentation**
  - Documented the decision and behavior in an architectural decision record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->