### PR TITLE
fix(expressions): quote bare words inside a oneOf array literal

### DIFF
--- a/adrs/01052-quote-bare-words-in-oneof-array-literals.md
+++ b/adrs/01052-quote-bare-words-in-oneof-array-literals.md
@@ -13,7 +13,7 @@ The `oneOf` word operator (`src/core/expressions.ts`, `preprocessExpression`) re
 operand is passed through `quoteIfLiteral`, which wraps a bare identifier in quotes unless it's
 already a string/number/boolean/array/object literal. The right operand — the options array — was
 never processed at all; it was spliced into the generated function body verbatim
-(`` `oneOf(${quoteIfLiteral(left)}, ${right.trim()})` ``).
+(`oneOf(${quoteIfLiteral(left)}, ${right.trim()})`).
 
 That's fine when every array element is already quoted (`oneOf ["linux", "mac"]`) or numeric
 (`oneOf [0, 1]`). But a bare-word array like `oneOf [linux, mac, windows]` — the form a `contains`
@@ -65,7 +65,10 @@ aware, so a nested literal item isn't split mid-way) and runs each trimmed item 
 `quoteIfLiteral`, then rejoins. `quoteIfLiteral` already knows to leave numbers, booleans, `null`,
 already-quoted strings, and masked string-literal placeholders (`__DDSTRn__`, from the quote-masking
 pass earlier in `preprocessExpression`) alone, and to quote everything else — so the same rule now
-applies per-element inside the array as it already did for the LHS.
+applies per-element inside the array as it already did for the LHS. Segments that are empty after
+trimming — a trailing comma (`[0, 1,]`) or a hole (`[a,,b]`) — are dropped rather than quoted into a
+spurious `""` element, matching real JS array-literal elision instead of turning an accidental extra
+comma into a silent `""` match.
 
 ### Consequences
 

--- a/adrs/01052-quote-bare-words-in-oneof-array-literals.md
+++ b/adrs/01052-quote-bare-words-in-oneof-array-literals.md
@@ -1,0 +1,112 @@
+---
+status: accepted
+date: 2026-07-12
+decision-makers: doc-detective maintainers
+---
+
+# `oneOf` must quote bare words inside its array-literal operand
+
+## Context and Problem Statement
+
+The `oneOf` word operator (`src/core/expressions.ts`, `preprocessExpression`) rewrites
+`<value> oneOf <options>` into a call to the runtime `oneOf(value, options)` helper. The left
+operand is passed through `quoteIfLiteral`, which wraps a bare identifier in quotes unless it's
+already a string/number/boolean/array/object literal. The right operand — the options array — was
+never processed at all; it was spliced into the generated function body verbatim
+(`` `oneOf(${quoteIfLiteral(left)}, ${right.trim()})` ``).
+
+That's fine when every array element is already quoted (`oneOf ["linux", "mac"]`) or numeric
+(`oneOf [0, 1]`). But a bare-word array like `oneOf [linux, mac, windows]` — the form a `contains`
+user would reasonably expect to work by analogy, and the form used in this repo's own docs guidance
+before PR #585 caught it — compiles each bare word as an unquoted JS identifier inside `new
+Function(...)`. `linux`, `mac`, and `windows` are not declared anywhere in that scope, so evaluating
+the generated function throws a `ReferenceError`. `evaluateExpression`'s try/catch (expressions.ts)
+swallows that error and returns `undefined`, which downstream renders as `false`. The net effect:
+`$$platform oneOf [linux, mac, windows]` silently fails closed on every platform, with no error
+surfaced to the test author — discovered while authoring inline docs tests for the tests-overview
+guide (PR #585), which had to route around it with a quoted array (`oneOf ["linux", "mac",
+"windows"]`) and a note-to-self about a follow-up.
+
+## Decision Drivers
+
+* A test author writing `oneOf [a, b, c]` should get the same "bare word treated as a string
+  literal" behavior `contains` and the comparison operators (`==`, `!=`, etc.) already give them —
+  not a silent, undiagnosable `false`.
+* No regression for already-correct forms: quoted-string arrays, numeric arrays, boolean/null
+  arrays, and a bare `$$meta` variable reference standing in for the whole options list (which is
+  resolved to a JSON array literal by `replaceMetaValues` before `preprocessExpression` ever runs,
+  so it's already valid JS by the time it reaches this code).
+* Keep the fix inside the existing `oneOf` infix rewrite — don't touch `contains`/`matches`, which
+  don't take an array-literal RHS and aren't affected by this defect.
+
+## Considered Options
+
+* **A. Quote bare items inside the `oneOf` array-literal RHS before splicing it into the generated
+  function** (chosen).
+* **B. Throw/log a diagnostic when a `oneOf` RHS array contains an undeclared bare identifier**,
+  instead of silently fixing it up.
+* **C. Require `oneOf` array elements to always be quoted** (docs-only fix; reject bare words as a
+  documented limitation).
+
+## Decision Outcome
+
+Chosen option: **A**. It matches the precedent already set for the LHS of `oneOf` and for
+`contains`'s RHS: a bare word in a word-operator's operand position is treated as an intended string
+literal, not an accidental reference to an undeclared variable. Option B would still leave the
+straightforward, intuitive form broken (test authors would have to learn to always quote). Option C
+just relocates the footgun into documentation that's easy to miss (as #585 demonstrates — the repo's
+own docs guide didn't know about it either).
+
+Implementation: added a `quoteArrayItems` helper in `preprocessExpression` (`src/core/expressions.ts`).
+It matches the RHS against `^\[([\s\S]*)\]$`; if it isn't a `[...]` literal (e.g. a resolved `$$`
+array, or an unresolved `$$token` left bare), it's returned untouched — only an actual array literal
+is rewritten. For a literal, it splits the contents on top-level commas (bracket/brace/paren-depth
+aware, so a nested literal item isn't split mid-way) and runs each trimmed item through the existing
+`quoteIfLiteral`, then rejoins. `quoteIfLiteral` already knows to leave numbers, booleans, `null`,
+already-quoted strings, and masked string-literal placeholders (`__DDSTRn__`, from the quote-masking
+pass earlier in `preprocessExpression`) alone, and to quote everything else — so the same rule now
+applies per-element inside the array as it already did for the LHS.
+
+### Consequences
+
+* Good: `$$platform oneOf [linux, mac, windows]` now evaluates as intended (`true` on all three
+  platforms) instead of silently failing closed.
+* Good: mixed arrays (`["windows", linux]`) work the same as an all-bare or all-quoted array.
+* Good: no change to numeric/boolean/null arrays, already-quoted arrays, or a bare `$$var` RHS —
+  `quoteArrayItems` is a no-op unless the RHS is textually a `[...]` literal.
+* Neutral: a test author who *wanted* `oneOf [someUndeclaredThing]` to fail closed as a signal that
+  they mistyped a `$$` reference will instead get it treated as the literal string
+  `"someUndeclaredThing"`. This matches `contains`'s existing behavior for the same mistake, so it's
+  consistent, not a new risk.
+
+### Confirmation
+
+Red→green unit tests added to `test/expressions-unit.test.js`: a bare-word `oneOf` array evaluating
+`true` and `false` on the matching/non-matching platform, a mixed quoted/bare array, and a numeric
+bare array (regression guard, confirming untouched behavior). Full `test/expressions-unit.test.js`
+and `test/expressions-coverage.test.js` suites pass (123 tests). Broader assertion-touching suites
+(`test/checkLink-assertions.test.js`, `test/custom-assertions.test.js`,
+`test/httpRequest-assertions.test.js`, `test/routing-context.test.js`,
+`test/runCode-assertions.test.js`, `test/runShell.test.js`, `test/core-core.test.js`) pass unchanged.
+A new fixture step in `test/core-artifacts/interactions/custom-assertions.spec.json` exercises
+`$$platform oneOf [linux, mac, windows]` (bare words) end-to-end through the real runner on every OS.
+
+## Pros and Cons of the Options
+
+### A. Quote bare items in the array-literal RHS
+* Good: fixes the root cause where it lives; consistent with existing `quoteIfLiteral` semantics
+  used for `contains` and comparison operators.
+* Good: no new syntax for authors to learn — the form they'd naturally reach for now works.
+* Bad: none identified — a `[...]` literal RHS has no other legitimate bare-word meaning in this
+  grammar.
+
+### B. Diagnostic instead of silent fix-up
+* Good: surfaces the author's mistake explicitly rather than guessing intent.
+* Bad: doesn't fix the common, reasonable case (a test author expecting `contains`-like bare-word
+  ergonomics); adds a new error-reporting path for something that isn't actually ambiguous.
+
+### C. Docs-only, require quoting
+* Good: zero code change.
+* Bad: doesn't fix the footgun, just relocates it into documentation that both users and this repo's
+  own docs authors have already missed once (#585); every future author hits the same silent
+  failure until they read that specific callout.

--- a/docs/fern/pages/reference/expressions.mdx
+++ b/docs/fern/pages/reference/expressions.mdx
@@ -79,10 +79,11 @@ Write word operators between the operands, with a space on each side.
   $$response.body.role contains "admin"
   ```
 
-- **`oneOf`**: True when the left operand equals one of the values in the array on the right.
+- **`oneOf`**: True when the left operand equals one of the values in the array on the right. The array can hold numbers or strings; the same [string literal](#string-literals) quoting rule applies to each value, so bare words work unless they contain spaces or operator characters.
 
   ```text
   $$exitCode oneOf [0, 1]
+  $$platform oneOf [linux, mac, windows]
   ```
 
 - **`matches`**: True when the left operand is a string that matches a regular expression.

--- a/docs/fern/pages/reference/expressions.mdx
+++ b/docs/fern/pages/reference/expressions.mdx
@@ -79,7 +79,7 @@ Write word operators between the operands, with a space on each side.
   $$response.body.role contains "admin"
   ```
 
-- **`oneOf`**: True when the left operand equals one of the values in the array on the right. The array can hold numbers or strings; write string values bare unless one needs to contain a comma (the array's separator) or needs to look like a number, `true`, `false`, or `null`—quote those with the same [string literal](#string-literals) rules used elsewhere.
+- **`oneOf`**: True when the left operand equals one of the values in the array on the right. The array can hold numbers, `true`, `false`, `null`, or strings; write string values bare unless one needs to contain a comma (the array's separator) or needs to look like one of those non-string values—quote those with the same [string literal](#string-literals) rules used elsewhere.
 
   ```text
   $$exitCode oneOf [0, 1]

--- a/docs/fern/pages/reference/expressions.mdx
+++ b/docs/fern/pages/reference/expressions.mdx
@@ -79,7 +79,7 @@ Write word operators between the operands, with a space on each side.
   $$response.body.role contains "admin"
   ```
 
-- **`oneOf`**: True when the left operand equals one of the values in the array on the right. The array can hold numbers or strings; the same [string literal](#string-literals) quoting rule applies to each value, so bare words work unless they contain spaces or operator characters.
+- **`oneOf`**: True when the left operand equals one of the values in the array on the right. The array can hold numbers or strings; write string values bare unless one needs to contain a comma (the array's separator) or needs to look like a number, `true`, `false`, or `null`—quote those with the same [string literal](#string-literals) rules used elsewhere.
 
   ```text
   $$exitCode oneOf [0, 1]

--- a/src/core/expressions.ts
+++ b/src/core/expressions.ts
@@ -575,7 +575,16 @@ function preprocessExpression(expression: string): string {
       }
     }
     items.push(current);
-    return `[${items.map((item) => quoteIfLiteral(item.trim())).join(", ")}]`;
+    // Drop empty segments (a trailing comma, e.g. "[0, 1,]", or a hole, e.g.
+    // "[a,,b]") instead of quoting them into a spurious "" element — real JS
+    // array-literal syntax elides a trailing comma entirely, and quoting a
+    // hole into "" would let an accidental extra comma silently make "" a
+    // valid oneOf match.
+    return `[${items
+      .map((item) => item.trim())
+      .filter((item) => item !== "")
+      .map((item) => quoteIfLiteral(item))
+      .join(", ")}]`;
   };
 
   // ReDoS hardening (CodeQL js/polynomial-redos). The infix-operator rewrites

--- a/src/core/expressions.ts
+++ b/src/core/expressions.ts
@@ -543,6 +543,41 @@ function preprocessExpression(expression: string): string {
     return `"${token}"`;
   };
 
+  // Helper: quote bare words inside a `oneOf` options array literal, e.g.
+  // `[linux, mac, windows]` -> `["linux", "mac", "windows"]`. Unlike
+  // `contains`'s single RHS operand, `oneOf`'s RHS is a whole array literal,
+  // so quoteIfLiteral alone (applied to the full "[...]" string) never fires:
+  // the string starts with "[" and is returned unchanged, leaving bare words
+  // inside as unquoted JS identifiers that throw a ReferenceError in the
+  // generated function — caught by evaluateExpression's try/catch and
+  // surfaced as `undefined`, i.e. the condition fails closed with no
+  // diagnostic (issue #585). Only rewrite an actual "[...]" literal; a bare
+  // variable reference (e.g. an unresolved "$$opts") is left untouched so it
+  // fails the same way it always has.
+  const quoteArrayItems = (arrayLiteral: string): string => {
+    const match = arrayLiteral.match(/^\[([\s\S]*)\]$/);
+    if (!match) return arrayLiteral;
+    const inner = match[1]!;
+    if (inner.trim() === "") return arrayLiteral;
+    // Split on top-level commas only, tracking bracket/brace/paren depth so a
+    // nested literal item (e.g. a nested array) isn't split mid-way.
+    const items: string[] = [];
+    let depth = 0;
+    let current = "";
+    for (const char of inner) {
+      if (char === "[" || char === "{" || char === "(") depth++;
+      if (char === "]" || char === "}" || char === ")") depth--;
+      if (char === "," && depth === 0) {
+        items.push(current);
+        current = "";
+      } else {
+        current += char;
+      }
+    }
+    items.push(current);
+    return `[${items.map((item) => quoteIfLiteral(item.trim())).join(", ")}]`;
+  };
+
   // ReDoS hardening (CodeQL js/polynomial-redos). The infix-operator rewrites
   // below scan the WHOLE expression with a global `replace`. Their left operand
   // pattern (`LEFT`) and the bare RHS used an UNBOUNDED `\S+` (and the unrolled
@@ -586,7 +621,7 @@ function preprocessExpression(expression: string): string {
     expression = expression.replace(
       new RegExp(`${LEFT}\\s+oneOf\\s+(.+)$`),
       (_m: string, left: string, right: string) =>
-        `oneOf(${quoteIfLiteral(left)}, ${right.trim()})`
+        `oneOf(${quoteIfLiteral(left)}, ${quoteArrayItems(right.trim())})`
     );
   }
 

--- a/test/core-artifacts/interactions/custom-assertions.spec.json
+++ b/test/core-artifacts/interactions/custom-assertions.spec.json
@@ -28,6 +28,11 @@
             ]
           },
           "assertions": "$$outputs.exitCode oneOf [0]"
+        },
+        {
+          "description": "oneOf with an unquoted bare-word array (ADR 01052): $$platform is always one of these three, on every OS, so this must PASS everywhere. Regression guard for #585, where bare words in a oneOf array silently evaluated to undefined/false instead of matching.",
+          "runShell": "node -e \"process.exit(0)\"",
+          "assertions": "$$platform oneOf [linux, mac, windows]"
         }
       ]
     },

--- a/test/expressions-unit.test.js
+++ b/test/expressions-unit.test.js
@@ -169,6 +169,32 @@ describe("expressions: evaluateAssertion (condition path, allowOperators)", func
       true
     );
   });
+  it("oneOf with a trailing comma does not create a spurious '' match (Copilot #609)", async function () {
+    assert.equal(
+      await evaluateAssertion("$$outputs.exitCode oneOf [0, 1,]", ctx),
+      true
+    );
+    assert.equal(
+      await evaluateAssertion('$$outputs.exitCode oneOf ["", 1,]', {
+        ...ctx,
+        outputs: { ...ctx.outputs, exitCode: "" },
+      }),
+      true
+    );
+  });
+  it("oneOf with a hole (double comma) drops the empty element instead of matching '' (Copilot #609)", async function () {
+    assert.equal(
+      await evaluateAssertion("$$platform oneOf [windows,,linux]", ctx),
+      true
+    );
+    assert.equal(
+      await evaluateAssertion('$$outputs.exitCode oneOf [0,,1]', {
+        ...ctx,
+        outputs: { ...ctx.outputs, exitCode: "" },
+      }),
+      false
+    );
+  });
 
   // --- matches (regex with a dot) ---
   it("matches /a.c/ -> true", async function () {

--- a/test/expressions-unit.test.js
+++ b/test/expressions-unit.test.js
@@ -145,6 +145,30 @@ describe("expressions: evaluateAssertion (condition path, allowOperators)", func
       false
     );
   });
+  it("oneOf with unquoted bare-word array -> true (#585)", async function () {
+    assert.equal(
+      await evaluateAssertion("$$platform oneOf [windows, linux]", ctx),
+      true
+    );
+  });
+  it("oneOf with unquoted bare-word array -> false (#585)", async function () {
+    assert.equal(
+      await evaluateAssertion("$$platform oneOf [linux, mac]", ctx),
+      false
+    );
+  });
+  it("oneOf with mixed quoted/bare-word array -> true (#585)", async function () {
+    assert.equal(
+      await evaluateAssertion('$$platform oneOf ["windows", linux]', ctx),
+      true
+    );
+  });
+  it("oneOf with unquoted numeric array is unaffected -> true", async function () {
+    assert.equal(
+      await evaluateAssertion("$$outputs.exitCode oneOf [0, 1]", ctx),
+      true
+    );
+  });
 
   // --- matches (regex with a dot) ---
   it("matches /a.c/ -> true", async function () {


### PR DESCRIPTION
## What changed

Fixes the root cause of the `oneOf` quoting gotcha noted in [#585](https://github.com/doc-detective/doc-detective/pull/585): `$$platform oneOf [linux, mac, windows]` (bare, unquoted array elements) silently evaluated to `false`/undefined instead of matching.

## Root cause

`preprocessExpression` (`src/core/expressions.ts`) quotes `oneOf`'s **left** operand via `quoteIfLiteral`, but spliced the right-hand array literal into the generated function body verbatim. `[linux, mac, windows]` compiled to three unquoted JS identifiers with no binding in scope, throwing a `ReferenceError` inside the generated function. That error is caught by `evaluateExpression`'s try/catch and swallowed to `undefined`, so the condition failed closed with no diagnostic — `contains` doesn't have this problem because its single RHS operand already goes through `quoteIfLiteral`.

## Fix

Added a `quoteArrayItems` helper that recognizes an actual `[...]` array literal, splits it on top-level commas (bracket-depth aware, so a nested literal item isn't split mid-way), and runs each element through the existing `quoteIfLiteral` before rejoining — so bare words, numbers, booleans, and already-quoted strings inside the array are handled the same way `contains`'s operand already is. A bare `$$var` RHS (not a literal array) is left untouched, since `replaceMetaValues` already resolves it to valid JSON before this code runs.

## Testing

- 4 new red→green unit tests in `test/expressions-unit.test.js` (bare-word true/false, mixed quoted/bare, numeric-array regression guard) — confirmed failing before the fix, passing after.
- New fixture step in `test/core-artifacts/interactions/custom-assertions.spec.json` exercising `$$platform oneOf [linux, mac, windows]` end-to-end through the real runner; verified PASS via `doc-detective runTests`.
- Full `test/expressions-unit.test.js` + `test/expressions-coverage.test.js` (123 tests) pass.
- Broader assertion/routing suites (`checkLink-assertions`, `custom-assertions`, `httpRequest-assertions`, `routing-context`, `runCode-assertions`, `runShell`, `core-core`) pass unchanged (147 tests, 0 failures).

## Docs impact

This is a bug fix to documented expression syntax, so it carries a docs update: added a bare-word `oneOf` example to `docs/fern/pages/reference/expressions.mdx` and cross-linked the existing string-literal quoting rule, per the follow-up note left in #585.

## ADR

Per repo convention, this behavior change ships with [`adrs/01052-quote-bare-words-in-oneof-array-literals.md`](adrs/01052-quote-bare-words-in-oneof-array-literals.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `oneOf` handling for literal array options written with bare words (e.g., `$$platform oneOf [linux, mac, windows]`) so options are treated as strings and evaluate reliably.
  * Ensured mixed quoted/bare entries work as expected, while preserving existing behavior for numeric/boolean/null and other non-literal RHS forms.
* **Documentation**
  * Updated `oneOf` docs to clarify supported value types and string quoting rules (including values that resemble numbers/booleans/null).
* **Tests**
  * Expanded unit and end-to-end coverage for bare-word, mixed, and numeric arrays, including trailing-comma and “hole” parsing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->