### PR TITLE
fix(runtime): make browser/driver install best-effort like BEST_EFFORT_NPM_DEPS

### DIFF
--- a/adrs/01046-best-effort-browser-asset-install.md
+++ b/adrs/01046-best-effort-browser-asset-install.md
@@ -1,0 +1,124 @@
+---
+status: accepted
+date: 2026-07-10
+decision-makers: doc-detective maintainers
+---
+
+# Make browser/driver install best-effort, matching BEST_EFFORT_NPM_DEPS
+
+## Context and Problem Statement
+
+`installBrowsers` (`src/runtime/installer.ts`, driving `doc-detective install browsers` / `install
+all`) installs each requested browser asset (`chrome`, `firefox`, `chromedriver`, `geckodriver`) in
+a loop and lets any `ensureBrowserInstalled` failure propagate straight out, aborting the whole
+batch. `installRuntime`, right above it, already treats native npm deps with no prebuild guarantee
+across the platform matrix (`BEST_EFFORT_NPM_DEPS`, e.g. the PTY backend) as failure-tolerant: a
+failed asset is recorded `"skipped"` and the rest of the batch still completes.
+
+This asymmetry surfaced as a real build failure: Google's Chrome for Testing publishes no native
+`linux-arm64` build for Chrome or chromedriver. `@puppeteer/browsers` maps
+`BrowserPlatform.LINUX_ARM` to the **x64** (`linux64`) asset for both
+(`node_modules/@puppeteer/browsers/lib/browser-data/{chrome,chromedriver}.js`). On a real arm64
+Linux host with no x86_64 emulation registered (e.g. GitHub's native `ubuntu-24.04-arm` runner, used
+by the `docdetective/docdetective` multi-arch Docker build), the downloaded x64 chromedriver binary
+cannot execute: `execFile` gets `ENOEXEC` from the kernel, Node's child_process falls back to
+re-invoking it via `/bin/sh -c <path>`, and `/bin/sh` fails trying to parse the binary's raw bytes as
+shell syntax (`Syntax error: Unterminated quoted string`). `verifyDriverBinary`
+(`src/runtime/browsers.ts`) correctly detects this as non-functional and throws — and because
+`installBrowsers` has no tolerance, that throw kills the entire `linux.Dockerfile` `RUN
+doc-detective install all --yes` layer, so the arm64 image never builds (see PR #579's follow-up
+investigation: `build-linux (arm64)` failed on every release after the docker-build.yml CI-gating fix
+landed).
+
+This is a platform-availability problem structurally identical to the PTY backend case
+`BEST_EFFORT_NPM_DEPS` already solves — an upstream vendor doesn't ship a binary for one platform,
+and that must degrade a feature rather than abort the batch. How should `installBrowsers` handle a
+per-asset install failure?
+
+## Decision Drivers
+
+* Consistency: browser installs should follow the same failure-tolerance precedent already
+  established for npm heavy deps (`BEST_EFFORT_NPM_DEPS`).
+* The runtime already has a safety net for a missing/broken browser: ADR 01008 validates drivers by
+  execution and falls back across browsers at runtime (`browserFallback` policy). A hard install
+  failure duplicates a guarantee the runtime already provides, at a much higher cost (it kills the
+  whole batch, including unrelated assets).
+* No change to `install all`'s exit-code contract — it has never failed the process on a per-asset
+  problem (npm side already swallows PTY failures); browsers should match.
+* Testability: must be provable without a real emulation gap (inject a fake `browsersModule` whose
+  `install` throws for one asset).
+
+## Considered Options
+
+* **A. Best-effort for every browser asset in `installBrowsers`** (chosen) — catch a per-asset
+  `ensureBrowserInstalled` failure, log a warning, record `"skipped"`, continue the loop.
+* **B. Docker-build-only workaround** — wrap just the Dockerfile's `RUN ... install all` in
+  `|| true` or similar, without touching `installBrowsers`'s general contract.
+* **C. Introduce a `BEST_EFFORT_BROWSER_ASSETS` allowlist** mirroring `BEST_EFFORT_NPM_DEPS`, so only
+  specific assets (e.g. `chromedriver`) are tolerant and the rest still hard-fail.
+
+## Decision Outcome
+
+Chosen option: **A**. B only fixes the Docker build and leaves every other `install all` /
+`install browsers` caller (a user running it directly on unsupported hardware) with a hard crash
+instead of a graceful skip — worse, it would mask a *real* transient failure (corrupt download,
+network error) the same way it masks the platform gap, with no report of what happened. C adds a
+second allowlist to maintain in lockstep with reality (today it's chromedriver on arm64; tomorrow it
+could be a different asset/platform pair) for no behavioral benefit, since every browser asset is
+equally "no reliable prebuild across the full platform matrix" and the runtime-side fallback (ADR
+01008) already treats every browser as potentially missing.
+
+Implementation: `installBrowsers`'s per-asset loop wraps `ensureBrowserInstalled` in try/catch. On
+failure: log a `warn`-level message with the asset name and the original error, push an
+`InstallReport` with `action: "skipped"` and a `notes` entry, and `continue` to the next asset — the
+same shape `installRuntime` already returns for a failed `BEST_EFFORT_NPM_DEPS` entry.
+
+### Consequences
+
+* Good: the arm64 Docker image build (and any user's `install all` on an unsupported platform/arch)
+  completes instead of aborting; the platform gap is visible in the printed report
+  (`[browser] chromedriver — skipped`) instead of a fatal stack trace.
+* Good: no exit-code change — `install all` / `install browsers` have never failed the process on a
+  per-asset problem; this closes the one remaining asymmetry with the npm side.
+* Neutral: a genuinely transient failure (flaky download, disk full) is now also swallowed rather
+  than surfaced as a hard error. Accepted: `install all` already treats `BEST_EFFORT_NPM_DEPS`
+  failures this way, the warning-level log line still surfaces the failure, and `install status` /
+  a re-run remain the way to confirm and retry.
+* Neutral: at runtime, a browser skipped at install time behaves exactly like a broken/missing
+  driver already does — ADR 01008's cross-engine fallback and diagnostic skip reporting apply
+  unchanged.
+
+### Confirmation
+
+Red→green unit test in `test/runtime-installer.test.js` (`installBrowsers` describe block): a fake
+`browsersModule.install` that throws for `chromedriver` but succeeds for `firefox`; asserts the batch
+resolves (not rejects), `chromedriver`'s report is `action: "skipped"`, and `firefox` still installs
+normally.
+
+## Pros and Cons of the Options
+
+### A. Best-effort for every browser asset
+* Good: matches the existing npm-side precedent exactly; smallest change; fixes both the Docker
+  build and direct CLI use.
+* Bad: a real transient failure on an asset that normally works is now silent-ish (warn log only,
+  no process exit code) rather than fatal.
+
+### B. Docker-build-only workaround
+* Good: narrowest possible blast radius.
+* Bad: leaves the general `installBrowsers` contract broken for every non-Docker caller on an
+  unsupported platform/arch; duplicates a fix that belongs in one place.
+
+### C. Allowlist specific best-effort browser assets
+* Good: could in theory keep hard-failing on assets expected to always work.
+* Bad: extra allowlist to keep in sync with upstream platform support that isn't declared anywhere
+  in this codebase; no asset here actually has a "must always work" guarantee across the full
+  platform/arch matrix doc-detective supports.
+
+## More Information
+
+Root-cause chain and cross-arch verification: `@puppeteer/browsers`
+(`node_modules/@puppeteer/browsers/lib/browser-data/chromedriver.js` /`chrome.js`) maps
+`BrowserPlatform.LINUX_ARM` to the `linux64` (x64) download for both Chrome and chromedriver — there
+is no native `linux-arm64` Chrome for Testing build upstream. See [src/runtime/AGENTS.md](../src/runtime/AGENTS.md)
+for the surrounding JIT-install architecture and [ADR 01008](01008-resilient-any-browser-driver-fallback.md)
+for the runtime-side fallback this decision relies on.

--- a/adrs/01046-best-effort-browser-asset-install.md
+++ b/adrs/01046-best-effort-browser-asset-install.md
@@ -8,8 +8,8 @@ decision-makers: doc-detective maintainers
 
 ## Context and Problem Statement
 
-`installBrowsers` (`src/runtime/installer.ts`, driving `doc-detective install browsers` / `install
-all`) installs each requested browser asset (`chrome`, `firefox`, `chromedriver`, `geckodriver`) in
+`installBrowsers` (`src/runtime/installer.ts`, driving `doc-detective install browsers` / `doc-detective install all`)
+installs each requested browser asset (`chrome`, `firefox`, `chromedriver`, `geckodriver`) in
 a loop and lets any `ensureBrowserInstalled` failure propagate straight out, aborting the whole
 batch. `installRuntime`, right above it, already treats native npm deps with no prebuild guarantee
 across the platform matrix (`BEST_EFFORT_NPM_DEPS`, e.g. the PTY backend) as failure-tolerant: a
@@ -25,8 +25,8 @@ cannot execute: `execFile` gets `ENOEXEC` from the kernel, Node's child_process 
 re-invoking it via `/bin/sh -c <path>`, and `/bin/sh` fails trying to parse the binary's raw bytes as
 shell syntax (`Syntax error: Unterminated quoted string`). `verifyDriverBinary`
 (`src/runtime/browsers.ts`) correctly detects this as non-functional and throws — and because
-`installBrowsers` has no tolerance, that throw kills the entire `linux.Dockerfile` `RUN
-doc-detective install all --yes` layer, so the arm64 image never builds (see PR #579's follow-up
+`installBrowsers` has no tolerance, that throw kills the entire `linux.Dockerfile`
+`RUN doc-detective install all --yes` layer, so the arm64 image never builds (see PR #579's follow-up
 investigation: `build-linux (arm64)` failed on every release after the docker-build.yml CI-gating fix
 landed).
 

--- a/adrs/01053-best-effort-browser-asset-install.md
+++ b/adrs/01053-best-effort-browser-asset-install.md
@@ -43,8 +43,9 @@ per-asset install failure?
   execution and falls back across browsers at runtime (`browserFallback` policy). A hard install
   failure duplicates a guarantee the runtime already provides, at a much higher cost (it kills the
   whole batch, including unrelated assets).
-* No change to `install all`'s exit-code contract — it has never failed the process on a per-asset
-  problem (npm side already swallows PTY failures); browsers should match.
+* Parity with the npm side's exit-code contract: `installRuntime` already never fails the process
+  over a `BEST_EFFORT_NPM_DEPS` problem (PTY backend); `installBrowsers` should match instead of
+  being the one asset-install path that still hard-fails the whole command.
 * Testability: must be provable without a real emulation gap (inject a fake `browsersModule` whose
   `install` throws for one asset).
 
@@ -78,12 +79,16 @@ same shape `installRuntime` already returns for a failed `BEST_EFFORT_NPM_DEPS` 
 * Good: the arm64 Docker image build (and any user's `install all` on an unsupported platform/arch)
   completes instead of aborting; the platform gap is visible in the printed report
   (`[browser] chromedriver — skipped`) instead of a fatal stack trace.
-* Good: no exit-code change — `install all` / `install browsers` have never failed the process on a
-  per-asset problem; this closes the one remaining asymmetry with the npm side.
-* Neutral: a genuinely transient failure (flaky download, disk full) is now also swallowed rather
-  than surfaced as a hard error. Accepted: `install all` already treats `BEST_EFFORT_NPM_DEPS`
-  failures this way, the warning-level log line still surfaces the failure, and `install status` /
-  a re-run remain the way to confirm and retry.
+* Bad (accepted): `install all` / `install browsers` previously exited non-zero on ANY browser asset
+  failure (no try/catch existed on this path at all) — that includes genuinely transient failures
+  (flaky download, disk full) on platforms with no availability problem, not just the platform-gap
+  case this ADR targets. Those now also degrade to a warn-level log + `"skipped"` report instead of
+  a hard, exit-1 failure. Accepted for the same reason the npm side already accepts it for
+  `BEST_EFFORT_NPM_DEPS`: `install status` and a re-run remain the way to confirm and retry, and a
+  best-effort install command that fails the whole process for one broken asset is worse than one
+  that finishes and reports what didn't make it.
+* Good: this closes the one remaining asymmetry with the npm side — `installRuntime` already has
+  this best-effort/non-fatal behavior for `BEST_EFFORT_NPM_DEPS`; `installBrowsers` did not.
 * Neutral: at runtime, a browser skipped at install time behaves exactly like a broken/missing
   driver already does — ADR 01008's cross-engine fallback and diagnostic skip reporting apply
   unchanged.

--- a/docs/fern/pages/docs/ci/docker-and-headless.mdx
+++ b/docs/fern/pages/docs/ci/docker-and-headless.mdx
@@ -46,6 +46,10 @@ doc-detective install all --yes
 
 On a fresh `npm install`, Doc Detective also pre-warms these assets automatically. To skip that step—for example, to control exactly when assets download in CI—set `DOC_DETECTIVE_AUTOINSTALL=0`. The official container ships with assets already warmed, so you don't need this step inside it.
 
+<Note>
+`docdetective/docdetective:linux` is a multi-arch image (`linux/amd64` and `linux/arm64`), but Chrome and ChromeDriver have no native `linux/arm64` build upstream—Google's Chrome for Testing only publishes x64 binaries. On the `linux/arm64` variant, Chrome/ChromeDriver pre-warming is skipped rather than failing the image; if you need Chrome-driven tests on arm64 hosts, run the `linux/amd64` variant under emulation, or use Firefox instead.
+</Note>
+
 For a GitHub Actions caching recipe, see [Runtime caching](/docs/ci/github-action#runtime-caching).
 
 ## Step 4: Run headless in CI

--- a/docs/fern/pages/reference/cli/install.mdx
+++ b/docs/fern/pages/reference/cli/install.mdx
@@ -87,6 +87,10 @@ doc-detective install browsers chrome chromedriver
 
 Available names: `chrome`, `firefox`, `chromedriver`, `geckodriver`.
 
+<Note>
+An asset with no installable build for the current platform/architecture (for example, Chrome and ChromeDriver on `linux/arm64`, which Google's Chrome for Testing doesn't publish natively) is skipped rather than failing the whole command—the report shows it as `skipped`. Run `doc-detective install status` to see what actually installed.
+</Note>
+
 ### `install android`
 
 Install the Android SDK toolchain (platform-tools, emulator, a system image) and create Doc Detective's default AVD, so tests that target the `android` platform can run — both native Android app tests (native app phase A3) and mobile web tests in the device's Chrome (phase A5). The system images it installs are the `google_apis` kind, which include Chrome; an emulator created from an image without Chrome skips mobile web tests with a pointer back to this command.

--- a/src/runtime/installer.ts
+++ b/src/runtime/installer.ts
@@ -21,6 +21,7 @@ import {
   ensureBrowserInstalled,
   type BrowserAssetName,
   type BrowserDeps,
+  type EnsureBrowserResult,
 } from "./browsers.js";
 
 export type InstallAction =
@@ -234,7 +235,7 @@ export async function installBrowsers(
 
   for (const name of targets) {
     const before = readInstalledRecord(ctx).browsers[name];
-    let result;
+    let result: EnsureBrowserResult;
     try {
       result = await ensureBrowserInstalled(name, {
         ctx,
@@ -249,15 +250,13 @@ export async function installBrowsers(
       // corresponding feature degrades to a runtime fallback instead (ADR
       // 01008 already validates drivers by execution and falls back
       // across browsers when one is missing or broken).
-      logger(
-        `${name} failed to install and was skipped: ${String((err as Error)?.message ?? err)}`,
-        "warn"
-      );
+      const detail = err instanceof Error ? err.message : String(err);
+      logger(`${name} failed to install and was skipped: ${detail}`, "warn");
       reports.push({
         assetId: name,
         kind: "browser",
         action: "skipped",
-        notes: ["failed to install and was skipped"],
+        notes: [`failed to install and was skipped: ${detail}`],
       });
       continue;
     }

--- a/src/runtime/installer.ts
+++ b/src/runtime/installer.ts
@@ -243,7 +243,7 @@ export async function installBrowsers(
         force,
       });
     } catch (err) {
-      // Best-effort, like BEST_EFFORT_NPM_DEPS on the npm side (ADR 01046):
+      // Best-effort, like BEST_EFFORT_NPM_DEPS on the npm side (ADR 01053):
       // e.g. chromedriver has no native linux-arm64 build upstream, so a
       // platform without an emulation layer can never install it. One
       // asset's unavailability must not abort the rest of the batch — the
@@ -251,12 +251,13 @@ export async function installBrowsers(
       // 01008 already validates drivers by execution and falls back
       // across browsers when one is missing or broken).
       const detail = err instanceof Error ? err.message : String(err);
-      logger(`${name} failed to install and was skipped: ${detail}`, "warn");
+      const message = `failed to install and was skipped: ${detail}`;
+      logger(`${name} ${message}`, "warn");
       reports.push({
         assetId: name,
         kind: "browser",
         action: "skipped",
-        notes: [`failed to install and was skipped: ${detail}`],
+        notes: [message],
       });
       continue;
     }

--- a/src/runtime/installer.ts
+++ b/src/runtime/installer.ts
@@ -234,11 +234,33 @@ export async function installBrowsers(
 
   for (const name of targets) {
     const before = readInstalledRecord(ctx).browsers[name];
-    const result = await ensureBrowserInstalled(name, {
-      ctx,
-      deps: { ...deps.browserDeps, logger },
-      force,
-    });
+    let result;
+    try {
+      result = await ensureBrowserInstalled(name, {
+        ctx,
+        deps: { ...deps.browserDeps, logger },
+        force,
+      });
+    } catch (err) {
+      // Best-effort, like BEST_EFFORT_NPM_DEPS on the npm side (ADR 01046):
+      // e.g. chromedriver has no native linux-arm64 build upstream, so a
+      // platform without an emulation layer can never install it. One
+      // asset's unavailability must not abort the rest of the batch — the
+      // corresponding feature degrades to a runtime fallback instead (ADR
+      // 01008 already validates drivers by execution and falls back
+      // across browsers when one is missing or broken).
+      logger(
+        `${name} failed to install and was skipped: ${String((err as Error)?.message ?? err)}`,
+        "warn"
+      );
+      reports.push({
+        assetId: name,
+        kind: "browser",
+        action: "skipped",
+        notes: ["failed to install and was skipped"],
+      });
+      continue;
+    }
     let action: InstallAction;
     if (force) action = "forced";
     else if (!before) action = "installed";

--- a/test/runtime-installer.test.js
+++ b/test/runtime-installer.test.js
@@ -303,6 +303,33 @@ describe("runtime/installer", function () {
       expect(reports[0].action).to.equal("forced");
       expect(reports[0].installedVersion).to.equal("121.0.0");
     });
+
+    it("a browser asset failing to install does not abort the batch; it's reported skipped", async function () {
+      // Mirrors installRuntime's BEST_EFFORT_NPM_DEPS tolerance (ADR 01046):
+      // e.g. chromedriver has no native linux-arm64 build, so
+      // ensureBrowserInstalled throws there. That must not prevent other
+      // requested assets (e.g. firefox) from installing.
+      const browsersModule = makeFakeBrowsersModule({ latest: "121.0.0" });
+      browsersModule.install = async ({ browser }) => {
+        if (browser === "chromedriver") {
+          throw new Error(
+            "chromedriver 121.0.0 is present but non-functional after a reinstall"
+          );
+        }
+      };
+      const reports = await installBrowsers({
+        names: ["chromedriver", "firefox"],
+        deps: {
+          logger: () => {},
+          browserDeps: { browsersModule },
+        },
+      });
+      const byId = Object.fromEntries(reports.map((r) => [r.assetId, r]));
+      expect(byId.chromedriver.action).to.equal("skipped");
+      expect(byId.chromedriver.notes[0]).to.match(/failed to install and was skipped/);
+      expect(byId.firefox.action).to.equal("installed");
+      expect(byId.firefox.installedVersion).to.equal("121.0.0");
+    });
   });
 
   describe("status", function () {

--- a/test/runtime-installer.test.js
+++ b/test/runtime-installer.test.js
@@ -305,7 +305,7 @@ describe("runtime/installer", function () {
     });
 
     it("a browser asset failing to install does not abort the batch; it's reported skipped", async function () {
-      // Mirrors installRuntime's BEST_EFFORT_NPM_DEPS tolerance (ADR 01046):
+      // Mirrors installRuntime's BEST_EFFORT_NPM_DEPS tolerance (ADR 01053):
       // e.g. chromedriver has no native linux-arm64 build, so
       // ensureBrowserInstalled throws there. That must not prevent other
       // requested assets (e.g. firefox) from installing.


### PR DESCRIPTION
## Summary

Follow-up to [#579](https://github.com/doc-detective/doc-detective/pull/579). Once that CI fix landed, `build-linux (arm64)` started actually running on every release — and immediately started failing, blocking `merge-linux` and leaving no `docdetective/docdetective:<version>`/`:latest` manifest-list ever published (only the `-windows` tag made it out on 4.26.3/4.26.4/4.26.5).

**Root cause:** Chrome and ChromeDriver have no native `linux-arm64` build upstream. `@puppeteer/browsers` maps `BrowserPlatform.LINUX_ARM` to the **x64** asset for both Chrome and ChromeDriver (`node_modules/@puppeteer/browsers/lib/browser-data/{chrome,chromedriver}.js`). On GitHub's native `ubuntu-24.04-arm` runner (real arm64 silicon, no x86_64 emulation registered), the x64 ChromeDriver binary can't execute — the kernel returns `ENOEXEC`, Node's `execFile` falls back to re-invoking it via `/bin/sh -c <path>`, and `/bin/sh` fails trying to parse the binary as a shell script (`Syntax error: Unterminated quoted string`). `verifyDriverBinary` (`src/runtime/browsers.ts`) correctly flags this as non-functional and throws.

The problem: `installBrowsers` (`src/runtime/installer.ts`) has no failure tolerance, so that throw aborted the whole `doc-detective install all` batch — and with it the `linux.Dockerfile RUN doc-detective install all --yes` layer that builds the arm64 image.

**Fix:** `installRuntime` already has this exact tolerance for npm heavy deps without a reliable prebuild across the platform matrix (`BEST_EFFORT_NPM_DEPS`, e.g. the PTY backend) — a failed asset is recorded `"skipped"` and the batch continues. Extend the same per-asset catch-and-skip to `installBrowsers`. At runtime, a skipped/missing browser already degrades gracefully via [ADR 01008](adrs/01008-resilient-any-browser-driver-fallback.md)'s cross-engine driver fallback, so this doesn't remove any safety net — it just stops one unavailable asset from taking down the whole install batch.

See [ADR 01053](adrs/01053-best-effort-browser-asset-install.md) for the full decision record.

## Changes

- `src/runtime/installer.ts`: `installBrowsers` catches a per-asset `ensureBrowserInstalled` failure, logs a warning, and reports `action: "skipped"` instead of throwing.
- `adrs/01053-best-effort-browser-asset-install.md`: new ADR.
- `docs/fern/pages/reference/cli/install.mdx`: note that an unavailable asset is skipped, not fatal.
- `docs/fern/pages/docs/ci/docker-and-headless.mdx`: note the `linux/arm64` Chrome/ChromeDriver limitation on the official image.
- `test/runtime-installer.test.js`: red→green test — a `chromedriver` install failure doesn't prevent `firefox` from installing, and is reported `skipped`.

## Test plan

- [x] New unit test fails before the fix (confirmed: `ensureBrowserInstalled` throw propagates and rejects the batch).
- [x] New unit test passes after the fix; full `test/runtime-installer.test.js` + `test/runtime-helpers-coverage.test.js` suites green (58 passing), no regressions.
- [x] `tsc` compiles clean.
- [ ] After merge, verify the next release's `build-linux (arm64)` job succeeds and `merge-linux` publishes real multi-arch manifest lists (`docker buildx imagetools inspect docdetective/docdetective:<version>` shows both `linux/amd64` and `linux/arm64`).
- [ ] Manually dispatch `docker-build.yml` afterward to backfill the missing `4.26.3`/`4.26.5`/`latest` tags, or wait for the next release.

Docs impact: yes — `install browsers`/`install all` failure semantics changed (documented above); Docker image arm64 Chrome limitation documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser asset installation now continues when an individual asset cannot be installed.
  * Installation reports identify skipped assets and include relevant details.

* **Bug Fixes**
  * Prevented one unavailable browser asset from aborting the entire installation.

* **Documentation**
  * Added guidance for unsupported browser binaries on ARM64 systems.
  * Clarified skipped-asset behavior and how to review installation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->