### PR TITLE
ci: shard the mocha suite into two parallel jobs per matrix cell

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   test:
-    name: Test (${{ matrix.os }}, node ${{ matrix.node }})
+    name: Test (${{ matrix.os }}, node ${{ matrix.node }}, shard ${{ matrix.shard }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:
@@ -50,9 +50,24 @@ jobs:
         # cells' worth of matrix time (Windows/macOS node 22).
         node:
           - 24
+        # Each cell's mocha suite is split into two parallel shard jobs by
+        # scripts/run-test-shard.cjs (deterministic weighted partition of
+        # test/*.test.js). Mocha's root hooks (test/hooks.js) start the 8092/
+        # 8093 test servers per mocha process, so each shard self-provisions;
+        # the coverage-merge job unions the shards' raw-coverage artifacts, and
+        # the union equals the unsharded suite's coverage.
+        shard:
+          - 1
+          - 2
+        # `include` entries only extend existing combinations when every listed
+        # key matches one, so the node-22 cell must spell out both shards.
         include:
           - os: ubuntu-latest
             node: 22
+            shard: 1
+          - os: ubuntu-latest
+            node: 22
+            shard: 2
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -129,14 +144,24 @@ jobs:
       # every node subprocess it spawns) into coverage/tmp — the matrix cells
       # double as cross-platform coverage collectors so no separate full-suite
       # run is needed. An absolute path keeps subprocesses with a different cwd
-      # writing to the same directory.
-      - run: npm test
+      # writing to the same directory. The shard runner replaces `npm test`'s
+      # mocha half: it runs this shard's deterministic slice of test/*.test.js
+      # (the two slices union to exactly the full glob — asserted by
+      # test/run-test-shard.test.js).
+      - run: node scripts/run-test-shard.cjs ${{ matrix.shard }} 2
         env:
           HERETTO_ORG_ID: ${{ secrets.HERETTO_ORG_ID }}
           HERETTO_USERNAME: ${{ secrets.HERETTO_USERNAME }}
           HERETTO_TOKEN: ${{ secrets.HERETTO_TOKEN }}
           DOC_DETECTIVE_SKIP_AUTO_UPDATE: '1'
           NODE_V8_COVERAGE: ${{ github.workspace }}/coverage/tmp
+
+      # The src/common unit suite (the second half of `npm test`) is fast,
+      # server-free, and coverage-neutral for the root union (prune-coverage
+      # drops dist/common/**; the coverage-ratchet job measures it separately),
+      # so one shard per cell is enough to keep it exercised cross-OS/node.
+      - run: npm run test:common
+        if: matrix.shard == 1
 
       # Shrink the raw V8 coverage to the repo's own dist entries and rewrite
       # their paths to be OS-agnostic, so the coverage-merge job can re-root and
@@ -148,7 +173,10 @@ jobs:
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: raw-coverage-${{ matrix.os }}-node${{ matrix.node }}
+          # upload-artifact v4 needs unique names; the shard suffix provides
+          # that, and coverage-merge downloads by the `raw-coverage-*` pattern
+          # so it unions shards with no change.
+          name: raw-coverage-${{ matrix.os }}-node${{ matrix.node }}-shard${{ matrix.shard }}
           path: coverage/tmp
           retention-days: 3
           if-no-files-found: warn

--- a/scripts/run-test-shard.cjs
+++ b/scripts/run-test-shard.cjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// Deterministically partitions the mocha suite (test/*.test.js, matching the
+// non-recursive glob `npm test` uses) into N shards and runs one of them, so
+// CI can split the suite across parallel jobs (see .github/workflows/test.yml).
+//
+// Usage: node scripts/run-test-shard.cjs <shardIndex> <totalShards>
+//   shardIndex is 1-based (matches the workflow matrix values).
+//
+// Coverage: NODE_V8_COVERAGE (and all other env) is inherited by the spawned
+// mocha, so each shard's job uploads its own raw-coverage slice; the
+// coverage-merge job unions the shards, and the union equals the unsharded
+// suite's coverage.
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+// Relative suite weights for greedy bin-packing. Only the known-heavy suites
+// (browser / Appium / recording driven, sized from their `this.timeout(...)`
+// ceilings) need entries; every other file defaults to 1, so new test files
+// are included automatically. A unit test asserts these names still exist —
+// rename the entry when renaming the suite.
+const WEIGHTS = {
+  "core-core.test.js": 20, // "do all the things" smoke incl. recording
+  "appium-port-conflict.test.js": 8, // boots real Appium + driver sessions
+  "core-screenshot.test.js": 8, // browser-driven screenshot permutations
+  "app-surface.test.js": 5,
+  "concurrency.test.js": 5,
+  "browser-fallback-e2e.test.js": 4,
+  "debug.test.js": 4,
+  "app-recording.test.js": 3,
+};
+
+/**
+ * Splits file names into `totalShards` buckets, deterministically: files are
+ * sorted by (weight desc, name asc) and each is assigned to the currently
+ * lightest bucket (ties broken by lowest bucket index). Buckets are disjoint
+ * and their union is exactly the input set.
+ *
+ * @param {string[]} files - base names of the test files
+ * @param {number} totalShards
+ * @returns {string[][]} one array of file names per shard
+ */
+function partition(files, totalShards) {
+  const buckets = Array.from({ length: totalShards }, () => ({
+    files: [],
+    weight: 0,
+  }));
+  const sorted = [...files].sort((a, b) => {
+    const diff = (WEIGHTS[b] ?? 1) - (WEIGHTS[a] ?? 1);
+    return diff !== 0 ? diff : a.localeCompare(b);
+  });
+  for (const file of sorted) {
+    let lightest = buckets[0];
+    for (const bucket of buckets) {
+      if (bucket.weight < lightest.weight) lightest = bucket;
+    }
+    lightest.files.push(file);
+    lightest.weight += WEIGHTS[file] ?? 1;
+  }
+  return buckets.map((b) => [...b.files].sort());
+}
+
+/**
+ * Parses and validates CLI args. Throws on anything out of range so a
+ * mistyped matrix value fails the job loudly instead of running shard 1.
+ *
+ * @param {string[]} argv - [shardIndex, totalShards]
+ * @returns {{ shardIndex: number, totalShards: number }}
+ */
+function resolveShard(argv) {
+  const shardIndex = Number(argv[0]);
+  const totalShards = Number(argv[1]);
+  if (!Number.isInteger(totalShards) || totalShards < 1) {
+    throw new Error(`invalid totalShards: ${argv[1]}`);
+  }
+  if (
+    !Number.isInteger(shardIndex) ||
+    shardIndex < 1 ||
+    shardIndex > totalShards
+  ) {
+    throw new Error(
+      `invalid shardIndex: ${argv[0]} (expected 1..${totalShards})`
+    );
+  }
+  return { shardIndex, totalShards };
+}
+
+function main() {
+  const { shardIndex, totalShards } = resolveShard(process.argv.slice(2));
+  const testDir = path.join(process.cwd(), "test");
+  const files = fs
+    .readdirSync(testDir)
+    .filter((f) => f.endsWith(".test.js"))
+    .sort();
+  const shard = partition(files, totalShards)[shardIndex - 1];
+  if (shard.length === 0) {
+    console.log(`shard ${shardIndex}/${totalShards}: no test files, nothing to run`);
+    return;
+  }
+  console.log(
+    `shard ${shardIndex}/${totalShards}: ${shard.length} of ${files.length} test files`
+  );
+  // Spawn mocha via its resolved JS entry with an args array: cross-platform
+  // (no .cmd shim, no shell globbing) and .mocharc.yml is picked up from cwd.
+  const mochaBin = require.resolve("mocha/bin/mocha.js");
+  const result = spawnSync(
+    process.execPath,
+    [mochaBin, "--exit", ...shard.map((f) => path.join("test", f))],
+    { stdio: "inherit" }
+  );
+  process.exit(result.status ?? 1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { partition, resolveShard, WEIGHTS };

--- a/test/run-test-shard.test.js
+++ b/test/run-test-shard.test.js
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+// CommonJS script (repo is type:module); interop via createRequire.
+const { partition, WEIGHTS } = require("../scripts/run-test-shard.cjs");
+
+// The real file list the CI shards run, matching mocha's non-recursive
+// `test/*.test.js` glob.
+const realFiles = fs
+  .readdirSync(path.join(process.cwd(), "test"))
+  .filter((f) => f.endsWith(".test.js"))
+  .sort();
+
+describe("run-test-shard partition", function () {
+  it("is deterministic for the same inputs", function () {
+    const a = partition(realFiles, 2);
+    const b = partition([...realFiles].reverse(), 2);
+    assert.deepEqual(a, b);
+  });
+
+  it("is complete and disjoint — shards union to exactly the input set", function () {
+    for (const total of [2, 3, 4]) {
+      const shards = partition(realFiles, total);
+      assert.equal(shards.length, total);
+      const combined = shards.flat().sort();
+      assert.deepEqual(combined, [...realFiles].sort());
+      // Disjoint: combined has no duplicates.
+      assert.equal(new Set(combined).size, combined.length);
+    }
+  });
+
+  it("separates the two heaviest suites across shards when N=2", function () {
+    const byWeight = Object.entries(WEIGHTS).sort((a, b) => b[1] - a[1]);
+    const [heaviest, second] = [byWeight[0][0], byWeight[1][0]];
+    const shards = partition(realFiles, 2);
+    const shardOf = (file) => shards.findIndex((s) => s.includes(file));
+    assert.notEqual(shardOf(heaviest), -1);
+    assert.notEqual(shardOf(second), -1);
+    assert.notEqual(shardOf(heaviest), shardOf(second));
+  });
+
+  it("balances shards — totals differ by at most the largest single weight", function () {
+    const weightOf = (f) => WEIGHTS[f] ?? 1;
+    const maxWeight = Math.max(...realFiles.map(weightOf));
+    const shards = partition(realFiles, 2);
+    const totals = shards.map((s) => s.reduce((sum, f) => sum + weightOf(f), 0));
+    assert.ok(
+      Math.abs(totals[0] - totals[1]) <= maxWeight,
+      `shard totals ${totals.join(" vs ")} differ by more than ${maxWeight}`
+    );
+  });
+
+  it("keeps every weighted file pointing at a file that still exists", function () {
+    // Guards against a heavy suite being renamed/removed while its weight
+    // entry silently rots into a no-op.
+    for (const name of Object.keys(WEIGHTS)) {
+      assert.ok(
+        realFiles.includes(name),
+        `WEIGHTS entry ${name} does not match any test/*.test.js file`
+      );
+    }
+  });
+
+  it("rejects out-of-range shard indexes at the CLI boundary", function () {
+    const { resolveShard } = require("../scripts/run-test-shard.cjs");
+    assert.throws(() => resolveShard(["0", "2"]));
+    assert.throws(() => resolveShard(["3", "2"]));
+    assert.throws(() => resolveShard(["x", "2"]));
+    assert.deepEqual(resolveShard(["2", "2"]), { shardIndex: 2, totalShards: 2 });
+  });
+});


### PR DESCRIPTION
> **Stacked on #614** — retarget to `main` after that merges (GitHub retargets automatically if the base branch is deleted on merge).

## What

The mocha half of `npm test` is the PR gate's critical path: 18.4 min serial on the Windows node-24 cell (baseline run 29197151761). This splits it into two parallel shard jobs per matrix cell:

- **`scripts/run-test-shard.cjs`** deterministically partitions `test/*.test.js` (the same non-recursive glob `npm test` uses) into N buckets via greedy bin-packing. Known-heavy browser/Appium/recording suites carry explicit weights; every other file defaults to weight 1, so new test files are auto-included. The CLI runs one bucket through mocha (resolved JS entry + args array — cross-platform, `.mocharc.yml` picked up from cwd, `NODE_V8_COVERAGE` inherited).
- **`test/run-test-shard.test.js`** (written red-first) asserts the partition is deterministic, complete, disjoint, balanced within the largest single weight, that the two heaviest suites land on different shards, that the weight map's file names still exist (rename-rot guard), and that out-of-range shard indexes throw.
- **`test.yml`**: `shard: [1, 2]` matrix dimension (the ubuntu node-22 `include` cell spells out both shards — `include` entries don't expand over unlisted keys). Coverage artifacts get a `-shard<k>` suffix; `coverage-merge` needs no change (it downloads by the `raw-coverage-*` pattern and c8 unions collision-free — shard₁ ∪ shard₂ per cell equals the unsharded cell's coverage, so the ratchet is unaffected). The fast, server-free `src/common` suite runs on shard 1 only; it's coverage-neutral for the root union (`prune-coverage.cjs` drops `dist/common/**`) and the `coverage-ratchet` job measures it independently.

Each shard self-provisions the 8092/8093 test servers: mocha's root hooks (`test/hooks.js`) start them per mocha process. Shards run on separate runners, so port 4723 and the checked-in image baselines stay in-process concerns exactly as today.

`npm test` in package.json is unchanged for local use.

## Docs impact

None — CI internals only.

## Verification

- Locally: `node scripts/run-test-shard.cjs 1 2` reports 59 files, `2 2` reports 62; the unit test asserts their union is exactly the 121-file glob. Smoke-ran a small real shard end-to-end through mocha (91 tests passing, servers up/down cleanly).
- TDD: the test file was run before the script existed (fails `MODULE_NOT_FOUND`), then green after implementation.
- In CI: 8 matrix jobs, `coverage-merge` downloads 8 artifacts, ratchet passes at the pre-shard percentage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test execution by splitting cross-platform test suites into balanced parallel shards.
  * Added validation to ensure test shards are deterministic, complete, non-overlapping, and correctly handle invalid inputs.
  * Enhanced coverage collection so results from all shards are preserved and merged accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->