### PR TITLE
ci: add a weekly dd-cache warmer so cold installs never land on a PR

### DIFF
--- a/.github/actions/dd-cache/action.yml
+++ b/.github/actions/dd-cache/action.yml
@@ -1,0 +1,93 @@
+# Single source of truth for the Doc Detective install-cache mechanics: the
+# junction from the default cache location to a persistent dir, the weekly
+# ISO-week key, and the actions/cache restore/save. test.yml, fixtures.yml,
+# and cache-warmer.yml all call this action, so the key can no longer drift
+# between producers and consumers (a drifted key silently warms nothing).
+# Design rationale and repair recipes: docs/maintenance/ci-cache-warming.md.
+
+name: Doc Detective install cache
+description: >-
+  Junction the default Doc Detective cache location (<os.tmpdir()>/doc-detective)
+  to a persistent per-user dir and restore/save it under the shared weekly key.
+
+inputs:
+  node:
+    description: Node major line for the key's node component (e.g. "24").
+    required: true
+  weekOffsetHours:
+    description: >-
+      Hours added to "now" before computing the key's ISO week. The cache
+      warmer passes a positive offset on its Sunday-night run so it computes
+      and saves NEXT week's entry before the key rolls over at Monday 00:00
+      UTC; consumers leave the default 0.
+    required: false
+    default: '0'
+
+outputs:
+  cache-hit:
+    description: >-
+      "true" when the primary key hit exactly (the entry already exists;
+      actions/cache will not save, and installs would be pure check-and-skip).
+    value: ${{ steps.cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    # Doc Detective's install cache (browsers, drivers, heavy runtime npm
+    # deps, git-bash) lives at <os.tmpdir()>/doc-detective by default, which
+    # hosted runners discard. Junction/symlink that default location to a
+    # stable per-user dir so actions/cache can persist it. Deliberately NOT
+    # via DOC_DETECTIVE_CACHE_DIR: a job-level env var outranks the
+    # config.cacheDir isolation many unit tests rely on, and some suites
+    # delete the var mid-run. node's fs.symlinkSync(..., 'junction') needs no
+    # admin on Windows and degrades to a plain symlink on POSIX.
+    - name: Persist the default Doc Detective cache dir
+      shell: bash
+      run: |
+        node -e "
+          const fs = require('fs'), os = require('os'), path = require('path');
+          const persist = path.join(os.homedir(), '.dd-cache');
+          const link = path.join(os.tmpdir(), 'doc-detective');
+          fs.mkdirSync(persist, { recursive: true });
+          fs.rmSync(link, { recursive: true, force: true });
+          fs.symlinkSync(persist, link, 'junction');
+          console.log(link, '->', persist);
+        "
+
+    # ISO week ("GGGG-WW") in pure node so every OS computes it identically
+    # (BSD date can't offset, and the warmer needs a future-instant week).
+    # The algorithm is validated against GNU `date -u +%G-%V` across year-
+    # boundary and week-53 edge dates in the PR that introduced it (#617).
+    - name: Compute cache week
+      id: week
+      shell: bash
+      run: |
+        node -e "
+          const offset = Number('${{ inputs.weekOffsetHours }}') * 3600e3;
+          const date = new Date(Date.now() + offset);
+          const dayNum = date.getUTCDay() || 7;
+          date.setUTCDate(date.getUTCDate() + 4 - dayNum);
+          const isoYear = date.getUTCFullYear();
+          const week = Math.ceil(((date.getTime() - Date.UTC(isoYear, 0, 1)) / 86400000 + 1) / 7);
+          const out = isoYear + '-' + String(week).padStart(2, '0');
+          require('fs').appendFileSync(process.env.GITHUB_OUTPUT, 'week=' + out + '\n');
+          console.log('cache week:', out);
+        "
+
+    # The whole cache dir is cached as one unit: runtime/node_modules MUST
+    # travel with runtime/package.json and installed.json, or the next JIT
+    # install treats the restored packages as extraneous and npm prunes them
+    # mid-run (see src/runtime/AGENTS.md). The key rotates weekly because
+    # browser channels float and a present-but-outdated browser is warn-only
+    # (never re-downloads) — a cache restored across weeks would pin old
+    # browsers forever. The node component keeps the runtime npm tree isolated
+    # per node line; the second restore-key still accepts any same-week entry
+    # (the installers verify and top up whatever they find).
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      id: cache
+      with:
+        path: ~/.dd-cache
+        key: dd-cache-${{ runner.os }}-${{ steps.week.outputs.week }}-node${{ inputs.node }}-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          dd-cache-${{ runner.os }}-${{ steps.week.outputs.week }}-node${{ inputs.node }}-
+          dd-cache-${{ runner.os }}-${{ steps.week.outputs.week }}-

--- a/.github/workflows/cache-warmer.yml
+++ b/.github/workflows/cache-warmer.yml
@@ -1,25 +1,36 @@
 # Weekly Doc Detective cache warmer. The dd-cache key rotates on ISO week BY
 # DESIGN (browser channels float and a present-but-outdated browser is
 # warn-only — it never re-downloads — so a cache restored across weeks would
-# pin old browsers forever; see test.yml). The cost of that design is that the
-# first run of each week pays the full cold install on every OS — and without
-# this workflow, that run is some human's PR. This cron populates the new
-# week's cache entries early Monday UTC so PR runs restore warm all week.
+# pin old browsers forever; see .github/actions/dd-cache/action.yml). The cost
+# of that design is that the first run of each week pays the full cold install
+# on every OS — and without this workflow, that run is some human's PR.
 #
-# The key/junction/step layout MUST stay in lockstep with test.yml and
-# fixtures.yml — a drifted key silently warms nothing (the run still succeeds,
-# PRs just go back to paying cold installs).
+# This cron runs SUNDAY 23:47 UTC and computes the key for NOW+2h (the
+# dd-cache action's weekOffsetHours input), so it installs into — and saves —
+# NEXT week's entry BEFORE the key rolls over at Monday 00:00 UTC: there is no
+# cold window at all, and the odd minute dodges GitHub's delay-prone
+# top-of-hour scheduling slots. The key/junction mechanics live in the shared
+# .github/actions/dd-cache composite action (same one test.yml and
+# fixtures.yml consume), so producer/consumer key drift is structurally
+# impossible.
 #
-# Failure mode is benign: if this workflow fails or is skipped, the first PR
-# of the week simply pays the cold install, exactly as before this existed.
+# Operational notes (full detail: docs/maintenance/ci-cache-warming.md):
+# - Cache entries are IMMUTABLE. Re-dispatching cannot repair a bad entry —
+#   delete it first (`gh cache delete <key>`), then dispatch.
+# - Dispatch FROM THE DEFAULT BRANCH: cache entries are branch-scoped, and an
+#   entry saved from a feature branch is invisible to other branches' PRs.
+# - `install all` is best-effort for browsers (a flaky download is logged and
+#   skipped, the job stays green), so a saved entry can be missing an asset;
+#   consumers JIT-install what's missing per job. Partial beats absent.
+# - GitHub disables cron schedules after 60 days without repo activity.
+# - Failure mode is benign: a missed warm just means the first PR of the week
+#   pays the cold install, exactly as before this workflow existed.
 
 name: Cache Warmer
 
 on:
   schedule:
-    # Mondays 00:30 UTC — just after the ISO week (and its cache key) rolls
-    # over at Monday 00:00 UTC.
-    - cron: '30 0 * * 1'
+    - cron: '47 23 * * 0'
   workflow_dispatch:
 
 permissions:
@@ -29,7 +40,11 @@ jobs:
   warm:
     name: Warm dd-cache (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # Generous: the cold path is npm ci + build + the runtime bulk npm install
+    # (which alone carries a 9-minute inner budget, see src/runtime) + three
+    # browser downloads; 30 min was tight on a slow Windows runner, and a
+    # timed-out job forfeits the cache save entirely.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -48,53 +63,33 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
-      # Same junction mapping as test.yml/fixtures.yml: the default cache
-      # location (<os.tmpdir()>/doc-detective) points at the persistent dir
-      # that actions/cache saves.
-      - name: Persist the default Doc Detective cache dir
-        shell: bash
-        run: |
-          node -e "
-            const fs = require('fs'), os = require('os'), path = require('path');
-            const persist = path.join(os.homedir(), '.dd-cache');
-            const link = path.join(os.tmpdir(), 'doc-detective');
-            fs.mkdirSync(persist, { recursive: true });
-            fs.rmSync(link, { recursive: true, force: true });
-            fs.symlinkSync(persist, link, 'junction');
-            console.log(link, '->', persist);
-          "
-
-      - name: Compute cache week
-        id: cache-week
-        shell: bash
-        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
-
-      # Key must equal the node-24 key that test.yml and fixtures.yml use, or
-      # the warmed entry is never restored by them.
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # weekOffsetHours 2: 23:47 Sunday + 2h lands in Monday's ISO week, so
+      # the scheduled run claims next week's key. A manual dispatch mid-week
+      # computes the same (current) week either way.
+      - uses: ./.github/actions/dd-cache
+        id: dd-cache
         with:
-          path: ~/.dd-cache
-          key: dd-cache-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-node24-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            dd-cache-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-node24-
+          node: '24'
+          weekOffsetHours: '2'
 
-      - run: npm ci
-      - run: npm run build
+      # On an exact primary-key hit the post-job save is skipped by
+      # actions/cache, so installing would be pure check-and-skip waste
+      # (~10 min × 3 OSes on a redundant dispatch). Skip the work instead.
+      - if: steps.dd-cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - if: steps.dd-cache.outputs.cache-hit != 'true'
+        run: npm run build
 
       # The complete install set — the same pre-warm the test matrix runs.
-      - run: node ./bin/doc-detective.js install all --yes
-        env:
-          DOC_DETECTIVE_SKIP_AUTO_UPDATE: '1'
-
-      # `install all` covers runtime + browsers only; git-bash (runShell's
-      # Windows bash backend) is otherwise JIT-downloaded by the first
-      # process-group job of the week, so warm it here too. No-op off Windows.
-      - if: runner.os == 'Windows'
-        run: node ./bin/doc-detective.js install bash --yes
+      # This includes git-bash on Windows (the `all` subcommand runs the bash
+      # installer on win32 itself; see src/runtime/installCommand.ts).
+      - if: steps.dd-cache.outputs.cache-hit != 'true'
+        run: node ./bin/doc-detective.js install all --yes
         env:
           DOC_DETECTIVE_SKIP_AUTO_UPDATE: '1'
 
       # Show what got installed so a warmer run is auditable from its log.
       - name: Report cache contents
+        if: steps.dd-cache.outputs.cache-hit != 'true'
         shell: bash
         run: node ./bin/doc-detective.js debug || true

--- a/.github/workflows/cache-warmer.yml
+++ b/.github/workflows/cache-warmer.yml
@@ -1,0 +1,100 @@
+# Weekly Doc Detective cache warmer. The dd-cache key rotates on ISO week BY
+# DESIGN (browser channels float and a present-but-outdated browser is
+# warn-only — it never re-downloads — so a cache restored across weeks would
+# pin old browsers forever; see test.yml). The cost of that design is that the
+# first run of each week pays the full cold install on every OS — and without
+# this workflow, that run is some human's PR. This cron populates the new
+# week's cache entries early Monday UTC so PR runs restore warm all week.
+#
+# The key/junction/step layout MUST stay in lockstep with test.yml and
+# fixtures.yml — a drifted key silently warms nothing (the run still succeeds,
+# PRs just go back to paying cold installs).
+#
+# Failure mode is benign: if this workflow fails or is skipped, the first PR
+# of the week simply pays the cold install, exactly as before this existed.
+
+name: Cache Warmer
+
+on:
+  schedule:
+    # Mondays 00:30 UTC — just after the ISO week (and its cache key) rolls
+    # over at Monday 00:00 UTC.
+    - cron: '30 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  warm:
+    name: Warm dd-cache (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      # Same junction mapping as test.yml/fixtures.yml: the default cache
+      # location (<os.tmpdir()>/doc-detective) points at the persistent dir
+      # that actions/cache saves.
+      - name: Persist the default Doc Detective cache dir
+        shell: bash
+        run: |
+          node -e "
+            const fs = require('fs'), os = require('os'), path = require('path');
+            const persist = path.join(os.homedir(), '.dd-cache');
+            const link = path.join(os.tmpdir(), 'doc-detective');
+            fs.mkdirSync(persist, { recursive: true });
+            fs.rmSync(link, { recursive: true, force: true });
+            fs.symlinkSync(persist, link, 'junction');
+            console.log(link, '->', persist);
+          "
+
+      - name: Compute cache week
+        id: cache-week
+        shell: bash
+        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
+      # Key must equal the node-24 key that test.yml and fixtures.yml use, or
+      # the warmed entry is never restored by them.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.dd-cache
+          key: dd-cache-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-node24-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            dd-cache-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-node24-
+
+      - run: npm ci
+      - run: npm run build
+
+      # The complete install set — the same pre-warm the test matrix runs.
+      - run: node ./bin/doc-detective.js install all --yes
+        env:
+          DOC_DETECTIVE_SKIP_AUTO_UPDATE: '1'
+
+      # `install all` covers runtime + browsers only; git-bash (runShell's
+      # Windows bash backend) is otherwise JIT-downloaded by the first
+      # process-group job of the week, so warm it here too. No-op off Windows.
+      - if: runner.os == 'Windows'
+        run: node ./bin/doc-detective.js install bash --yes
+        env:
+          DOC_DETECTIVE_SKIP_AUTO_UPDATE: '1'
+
+      # Show what got installed so a warmer run is auditable from its log.
+      - name: Report cache contents
+        shell: bash
+        run: node ./bin/doc-detective.js debug || true

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -133,45 +133,18 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
-      # Persist Doc Detective's install cache (browsers, drivers, heavy runtime
-      # npm deps, git-bash) across runs so the per-job JIT installs become
-      # check-and-skip. Same design as test.yml: junction/symlink the DEFAULT
-      # cache location (<os.tmpdir()>/doc-detective) to a stable per-user dir —
-      # deliberately not via DOC_DETECTIVE_CACHE_DIR, which would leak into the
-      # runtime under test — rotate the key weekly because browser channels
-      # float and present-but-outdated is warn-only (never re-downloads), and
-      # cache the whole dir as one unit so runtime/node_modules travels with
-      # runtime/package.json + installed.json (npm-prune hazard,
-      # src/runtime/AGENTS.md). Fixture jobs pin node 24, so the key carries
-      # node24 and thereby SHARES entries with test.yml's node-24 cells (whose
-      # `install all` populates the complete set). The android KVM/lazy jobs
-      # below deliberately do NOT get this cache — they exist to prove the cold
-      # install/bootstrap paths.
-      - name: Persist the default Doc Detective cache dir
-        shell: bash
-        run: |
-          node -e "
-            const fs = require('fs'), os = require('os'), path = require('path');
-            const persist = path.join(os.homedir(), '.dd-cache');
-            const link = path.join(os.tmpdir(), 'doc-detective');
-            fs.mkdirSync(persist, { recursive: true });
-            fs.rmSync(link, { recursive: true, force: true });
-            fs.symlinkSync(persist, link, 'junction');
-            console.log(link, '->', persist);
-          "
-
-      - name: Compute cache week
-        id: cache-week
-        shell: bash
-        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore/save the Doc Detective install cache (browsers, drivers, heavy
+      # runtime deps, git-bash) via the shared composite action — the single
+      # home for the junction + weekly-key mechanics, shared with test.yml and
+      # the Sunday cache warmer so the key cannot drift between producers and
+      # consumers (docs/maintenance/ci-cache-warming.md). Fixture jobs pin
+      # node 24, so the key SHARES entries with test.yml's node-24 cells
+      # (whose `install all` populates the complete set). The android KVM/lazy
+      # jobs below deliberately do NOT get this cache — they exist to prove
+      # the cold install/bootstrap paths.
+      - uses: ./.github/actions/dd-cache
         with:
-          path: ~/.dd-cache
-          key: dd-cache-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-node24-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            dd-cache-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-node24-
-            dd-cache-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-
+          node: '24'
 
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,54 +79,15 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
-      # Doc Detective's install cache (browsers, drivers, heavy runtime npm
-      # deps, git-bash) lives at <os.tmpdir()>/doc-detective by default, which
-      # hosted runners discard. Junction/symlink that default location to a
-      # stable per-user dir so actions/cache can persist it across runs.
-      # Deliberately NOT via DOC_DETECTIVE_CACHE_DIR: a job-level env var
-      # outranks the config.cacheDir isolation many unit tests rely on, and
-      # several suites delete the var mid-run (e.g. config-coverage's
-      # afterEach), which broke 17 tests and would silently un-warm the cache
-      # for later files. Mapping the default path keeps runtime and test
-      # resolution untouched.
-      - name: Persist the default Doc Detective cache dir
-        shell: bash
-        run: |
-          node -e "
-            const fs = require('fs'), os = require('os'), path = require('path');
-            const persist = path.join(os.homedir(), '.dd-cache');
-            const link = path.join(os.tmpdir(), 'doc-detective');
-            fs.mkdirSync(persist, { recursive: true });
-            fs.rmSync(link, { recursive: true, force: true });
-            fs.symlinkSync(persist, link, 'junction');
-            console.log(link, '->', persist);
-          "
-
-      # Browser versions float (stable/latest channels, resolved at install
-      # time — see src/runtime/browsers.ts) and a present-but-outdated browser
-      # is warn-only: it never re-downloads. A cache restored across weeks
-      # would therefore pin old browsers forever. The ISO-week key component
-      # forces one cold install per OS per week; restore-keys stay within the
-      # week on purpose.
-      - name: Compute cache week
-        id: cache-week
-        shell: bash
-        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
-
-      # The whole cache dir is cached as one unit: runtime/node_modules MUST
-      # travel with runtime/package.json and installed.json, or the next JIT
-      # install treats the restored packages as extraneous and npm prunes them
-      # mid-run (see src/runtime/AGENTS.md). The node component keeps the
-      # runtime npm tree isolated per node line (native prebuilds could in
-      # principle differ across majors); the second restore-key still accepts
-      # any same-week entry — the installers verify and top up what they find.
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore/save the Doc Detective install cache (browsers, drivers,
+      # heavy runtime deps, git-bash) via the shared composite action — the
+      # single home for the junction + weekly-key mechanics, shared with
+      # fixtures.yml and the Sunday cache warmer so the key cannot drift
+      # between producers and consumers. Design + repair recipes:
+      # docs/maintenance/ci-cache-warming.md.
+      - uses: ./.github/actions/dd-cache
         with:
-          path: ~/.dd-cache
-          key: dd-cache-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-node${{ matrix.node }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            dd-cache-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-node${{ matrix.node }}-
-            dd-cache-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-
+          node: ${{ matrix.node }}
 
       - run: npm ci
       - run: npm run build

--- a/docs/maintenance/ci-cache-warming.md
+++ b/docs/maintenance/ci-cache-warming.md
@@ -1,0 +1,62 @@
+# CI install-cache warming
+
+How the Doc Detective install cache (`~/.dd-cache`: browsers, drivers, heavy
+runtime npm deps, git-bash) is persisted across CI runs, kept warm, and
+repaired when something goes wrong.
+
+## Design
+
+- **Single home for the mechanics.** The junction (default cache location →
+  persistent dir), the ISO-week key computation, and the `actions/cache` call
+  live in one composite action:
+  [.github/actions/dd-cache/action.yml](../../.github/actions/dd-cache/action.yml).
+  `test.yml`, `fixtures.yml`, and `cache-warmer.yml` all call it, so
+  producer/consumer key drift is structurally impossible. **Never hand-copy
+  the key template into a workflow.**
+- **The key rotates on ISO week on purpose.** Browser channels float
+  (`stable`/`latest`) and a present-but-outdated browser is warn-only — it
+  never re-downloads — so an entry restored across weeks would pin old
+  browsers forever. Weekly cold refresh is the mechanism that keeps browsers
+  current.
+- **The warmer removes the weekly cold window.** `Cache Warmer` runs Sunday
+  23:47 UTC and computes the key for now+2h (`weekOffsetHours: '2'`), so next
+  week's entry exists *before* the key rolls over at Monday 00:00 UTC. The odd
+  minute dodges GitHub's delay-prone top-of-hour cron slots.
+
+## Repair recipes
+
+- **A week's entry is bad or incomplete** (e.g. a browser download 503'd
+  during the warm — `install all` is best-effort for browsers, so the job
+  stays green and saves what it got): cache entries are **immutable**;
+  re-dispatching the warmer restores the existing entry as an exact hit and
+  saves nothing. Delete the entry first, then dispatch:
+
+  ```bash
+  gh cache list --key dd-cache- --json id,key,createdAt
+  gh cache delete "<full key>"
+  gh workflow run "Cache Warmer"   # from the default branch
+  ```
+
+- **Dispatch from the default branch only.** Cache entries are branch-scoped:
+  an entry saved by a dispatch from a feature branch is invisible to other
+  branches' PRs — the run goes green while warming nothing anyone uses.
+- **Cron stopped firing?** GitHub disables schedules after 60 days without
+  repo activity, and can delay or drop runs in high-load slots. A missed warm
+  is benign — the first PR of the week just pays the cold install.
+
+## Accepted trade-offs
+
+- **Partial saves beat no saves.** Browser installs are best-effort (#611), so
+  a flaky download yields a green warm with a missing asset; consumer jobs
+  JIT-install what's missing. Do not "harden" the warmer to fail on partial
+  installs — a failed job saves nothing at all.
+- **App-surface Appium drivers are not warmed.** `install all` covers
+  `HEAVY_NPM_DEPS` + browsers (+ git-bash on Windows); the platform app
+  drivers (mac2/novawindows/uiautomator2) are JIT-installed by platform
+  preflights only. That JIT path is deliberately exercised (non-destructive
+  installs, ADR 01025).
+- **Cross-node-line restores are assumed ABI-safe.** The key carries a
+  `node<major>` component with a same-week any-node fallback restore-key; the
+  heavy native deps are Node-API/prebuilt (chosen for exactly this), so a
+  node22 cell topping up from a node24 entry is safe today. Revisit if a
+  heavy dep ever compiles per-ABI at install time.


### PR DESCRIPTION
> Round-2 CI latency work, PR A of 5. **Do not merge yet** — prepped for review; merge serially per maintainer direction.

## What

The dd-cache key rotates on ISO week by design (ADR 01048: browser channels float, and present-but-outdated browsers warn but never re-download). The cost: the first run of each week pays the full cold install (~5 min/OS) — and today that run is some human's PR.

This adds a `Cache Warmer` cron (Mondays 00:30 UTC, right after the key rolls at 00:00, plus `workflow_dispatch`) that per OS: junctions the default cache location, restores/saves the **same node24 key** the test matrix and fixture jobs use, runs `install all`, and additionally warms git-bash on Windows (otherwise JIT-downloaded by the first proc-sessions job of the week). A `debug` step makes each warm auditable from its log.

Key discipline: the key/junction steps must stay in lockstep with test.yml/fixtures.yml — a drifted key warms nothing (noted in the header comment). Failure mode is benign: a missed warm reverts to pay-cold-on-first-PR.

## Docs impact / ADR

None — CI-internal, no gate semantics change (mechanical; no ADR needed).

## Verification

After merge: trigger `workflow_dispatch` once and confirm (a) three green jobs, (b) `actions/cache` reports a save on the node24 key per OS, (c) the next PR run logs a cache **restore hit** on that key and its `install all` step completes in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated weekly cache warming to speed up CI installation and browser setup.
  * Centralized installation-cache handling across test and fixture workflows.
* **Documentation**
  * Added guidance on cache rotation, maintenance, troubleshooting, and recovery procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->