### PR TITLE
ci: auto-rerun Test jobs clipped by lost runners, once

### DIFF
--- a/.github/workflows/rerun-lost-runners.yml
+++ b/.github/workflows/rerun-lost-runners.yml
@@ -1,22 +1,33 @@
 # Auto-rerun for runner-infrastructure losses. Hosted runners occasionally
 # vanish mid-run: GitHub assigns a VM that never reports a step (or reaps a
 # healthy sibling in the same sweep), the affected jobs land as `cancelled`,
-# and the run fails with nothing for a human to fix except clicking
-# "Re-run failed jobs". Observed on the macOS pool (two jobs clipped at the
-# same second, one with an EMPTY step list — the lost-runner signature).
+# and the run fails with nothing for a human to fix except clicking "Re-run
+# failed jobs". Observed on the macOS pool (PR #616 run 29219105593: two jobs
+# clipped in the same sweep — one had executed 18 steps, the other zero).
 #
-# This workflow re-runs the failed jobs of a Test run EXACTLY ONCE when — and
-# only when — the failure looks like lost infrastructure:
-#   - the run concluded `failure` (a manual run-cancel concludes `cancelled`
-#     and never qualifies),
-#   - it was the first attempt (no retry loops),
-#   - every red job is `cancelled` (a single real `failure`/`timed_out` job
-#     disqualifies the run — genuine test failures must stay red), and
-#   - at least one cancelled job executed ZERO steps (a runner that never
-#     reported; manually-cancelled jobs virtually always have steps).
+# Detection rests on GitHub's run-conclusion semantics, which make a small,
+# exact signature possible (see docs/maintenance/ci-rerun-lost-runners.md and
+# ADR 01054):
+#   - A user run-cancel or a concurrency `cancel-in-progress` supersede
+#     concludes the run as `cancelled`, so the job `if:` (conclusion ==
+#     'failure') never fires for those.
+#   - A genuine job failure or timeout concludes the run `failure` but leaves a
+#     `failure`/`timed_out` job, so the `real == 0` guard excludes it — real
+#     reds must stay red.
+#   - With fail-fast:false across the matrices (test.yml, fixtures.yml), a real
+#     failure never cancels siblings, so the ONLY way a run concludes `failure`
+#     with zero failed/timed-out jobs and >=1 `cancelled` job is lost
+#     infrastructure. That is the whole signature — no per-step heuristic
+#     needed (an earlier draft keyed on zero executed steps, which would have
+#     silently missed the 18-step clip above).
 #
-# workflow_run executes this file from the DEFAULT branch with a read/write
-# token scoped by the permissions block below — PR branches can't alter it.
+# Reruns exactly once: `rerun-failed-jobs` bumps run_attempt to 2, and the
+# re-triggered workflow_run event carries run_attempt == 2, which the guard
+# blocks — so a run that stays red after one rerun is left red for a human.
+# `rerun-failed-jobs` re-runs `cancelled` jobs too (verified on the run above).
+#
+# workflow_run executes this file from the DEFAULT branch with the token scoped
+# by the permissions block below; it cannot be exercised from a feature branch.
 
 name: Rerun Lost Runners
 
@@ -41,16 +52,42 @@ jobs:
           RUN_ID: ${{ github.event.workflow_run.id }}
           REPO: ${{ github.repository }}
         run: |
-          jobs=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?filter=latest&per_page=100" --paginate)
-          red=$(echo "$jobs" | jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")]')
-          total=$(echo "$red" | jq 'length')
-          real=$(echo "$red" | jq '[.[] | select(.conclusion != "cancelled")] | length')
-          lost=$(echo "$red" | jq '[.[] | select(.conclusion == "cancelled" and (.steps | length) == 0)] | length')
-          echo "red=$total real-failures=$real lost-runners=$lost"
-          if [ "$total" -gt 0 ] && [ "$real" -eq 0 ] && [ "$lost" -gt 0 ]; then
+          set -euo pipefail
+
+          # `--paginate --jq '.jobs[]'` streams job objects across every page
+          # (gh applies the filter per page), then `jq -s` slurps them into one
+          # array — correct regardless of how far the matrix grows past the
+          # 100/page cap. A plain `--paginate` without `--jq` would concatenate
+          # raw page objects into invalid JSON and only the first page's jobs
+          # would be counted.
+          jobs=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?filter=latest&per_page=100" \
+            --paginate --jq '.jobs[]' | jq -s '.')
+
+          counts=$(jq -r '
+            {
+              red:       [.[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")] | length,
+              real:      [.[] | select(.conclusion == "failure" or .conclusion == "timed_out")] | length,
+              cancelled: [.[] | select(.conclusion == "cancelled")] | length
+            } | "\(.red) \(.real) \(.cancelled)"' <<<"$jobs")
+          read -r red real cancelled <<<"$counts"
+          echo "red=$red real-failures=$real cancelled=$cancelled"
+
+          # Infra-loss signature: the run concluded `failure` (job `if:`), no
+          # job actually failed or timed out, and >=1 job was cancelled.
+          if [ "$real" -eq 0 ] && [ "$cancelled" -gt 0 ]; then
             echo "Lost-runner signature confirmed — re-running failed jobs once."
-            echo "$red" | jq -r '.[] | "  clipped: \(.name)"'
+            clipped=$(jq -r '.[] | select(.conclusion == "cancelled") | "  - \(.name) (\(.steps | length) steps)"' <<<"$jobs")
+            echo "$clipped"
+            # Durable signal so a systemic pool problem (repeated reruns) is
+            # visible in the run summary, not just this ephemeral log line.
+            {
+              echo "### Auto-rerun: lost runners"
+              echo "Re-ran run \`$RUN_ID\` once — $cancelled cancelled job(s), no genuine failures:"
+              echo "$clipped"
+              echo ""
+              echo "_If this recurs on one OS pool, the pool may be degrading — investigate rather than leaning on the rerun._"
+            } >> "$GITHUB_STEP_SUMMARY"
             gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs"
           else
-            echo "Not a lost-runner failure (real failures or no empty-step cancellations) — leaving the run red."
+            echo "Not a lost-runner failure (real failures present, or no cancellations) — leaving the run red."
           fi

--- a/.github/workflows/rerun-lost-runners.yml
+++ b/.github/workflows/rerun-lost-runners.yml
@@ -33,6 +33,9 @@ name: Rerun Lost Runners
 
 on:
   workflow_run:
+    # Matches by the target workflow's `name:` field, NOT its filename — this
+    # must stay equal to npm-test.yaml's `name: Test`. Renaming that workflow
+    # silently breaks this trigger with no error, so rename both together.
     workflows: [Test]
     types: [completed]
 
@@ -65,19 +68,22 @@ jobs:
 
           counts=$(jq -r '
             {
-              red:       [.[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")] | length,
               real:      [.[] | select(.conclusion == "failure" or .conclusion == "timed_out")] | length,
               cancelled: [.[] | select(.conclusion == "cancelled")] | length
-            } | "\(.red) \(.real) \(.cancelled)"' <<<"$jobs")
-          read -r red real cancelled <<<"$counts"
-          echo "red=$red real-failures=$real cancelled=$cancelled"
+            } | "\(.real) \(.cancelled)"' <<<"$jobs")
+          read -r real cancelled <<<"$counts"
+          echo "real-failures=$real cancelled=$cancelled"
 
           # Infra-loss signature: the run concluded `failure` (job `if:`), no
           # job actually failed or timed out, and >=1 job was cancelled.
           if [ "$real" -eq 0 ] && [ "$cancelled" -gt 0 ]; then
             echo "Lost-runner signature confirmed — re-running failed jobs once."
-            clipped=$(jq -r '.[] | select(.conclusion == "cancelled") | "  - \(.name) (\(.steps | length) steps)"' <<<"$jobs")
+            clipped=$(jq -r '.[] | select(.conclusion == "cancelled") | "- \(.name) (\(.steps | length) steps)"' <<<"$jobs")
             echo "$clipped"
+            # Do the rerun first, then record it — so a failed POST (set -e
+            # exits the step) never leaves a summary claiming a rerun that
+            # didn't happen.
+            gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs"
             # Durable signal so a systemic pool problem (repeated reruns) is
             # visible in the run summary, not just this ephemeral log line.
             {
@@ -87,7 +93,6 @@ jobs:
               echo ""
               echo "_If this recurs on one OS pool, the pool may be degrading — investigate rather than leaning on the rerun._"
             } >> "$GITHUB_STEP_SUMMARY"
-            gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs"
           else
             echo "Not a lost-runner failure (real failures present, or no cancellations) — leaving the run red."
           fi

--- a/.github/workflows/rerun-lost-runners.yml
+++ b/.github/workflows/rerun-lost-runners.yml
@@ -1,0 +1,56 @@
+# Auto-rerun for runner-infrastructure losses. Hosted runners occasionally
+# vanish mid-run: GitHub assigns a VM that never reports a step (or reaps a
+# healthy sibling in the same sweep), the affected jobs land as `cancelled`,
+# and the run fails with nothing for a human to fix except clicking
+# "Re-run failed jobs". Observed on the macOS pool (two jobs clipped at the
+# same second, one with an EMPTY step list — the lost-runner signature).
+#
+# This workflow re-runs the failed jobs of a Test run EXACTLY ONCE when — and
+# only when — the failure looks like lost infrastructure:
+#   - the run concluded `failure` (a manual run-cancel concludes `cancelled`
+#     and never qualifies),
+#   - it was the first attempt (no retry loops),
+#   - every red job is `cancelled` (a single real `failure`/`timed_out` job
+#     disqualifies the run — genuine test failures must stay red), and
+#   - at least one cancelled job executed ZERO steps (a runner that never
+#     reported; manually-cancelled jobs virtually always have steps).
+#
+# workflow_run executes this file from the DEFAULT branch with a read/write
+# token scoped by the permissions block below — PR branches can't alter it.
+
+name: Rerun Lost Runners
+
+on:
+  workflow_run:
+    workflows: [Test]
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  rerun:
+    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Rerun failed jobs when the only reds are lost runners
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          jobs=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?filter=latest&per_page=100" --paginate)
+          red=$(echo "$jobs" | jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")]')
+          total=$(echo "$red" | jq 'length')
+          real=$(echo "$red" | jq '[.[] | select(.conclusion != "cancelled")] | length')
+          lost=$(echo "$red" | jq '[.[] | select(.conclusion == "cancelled" and (.steps | length) == 0)] | length')
+          echo "red=$total real-failures=$real lost-runners=$lost"
+          if [ "$total" -gt 0 ] && [ "$real" -eq 0 ] && [ "$lost" -gt 0 ]; then
+            echo "Lost-runner signature confirmed — re-running failed jobs once."
+            echo "$red" | jq -r '.[] | "  clipped: \(.name)"'
+            gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs"
+          else
+            echo "Not a lost-runner failure (real failures or no empty-step cancellations) — leaving the run red."
+          fi

--- a/adrs/01054-auto-rerun-lost-runner-jobs.md
+++ b/adrs/01054-auto-rerun-lost-runner-jobs.md
@@ -1,0 +1,105 @@
+---
+status: accepted
+date: 2026-07-13
+decision-makers: doc-detective maintainers
+---
+
+# Auto-rerun Test runs whose only failures are lost hosted runners
+
+## Context and Problem Statement
+
+GitHub's hosted runner pools occasionally drop a VM mid-run: the runner is
+assigned but never reports (or a healthy sibling is reaped in the same sweep),
+the affected jobs conclude `cancelled`, and the whole `Test` run concludes
+`failure`. There is nothing to fix in the code — the only remedy is a human
+clicking "Re-run failed jobs". This was observed on the macOS pool (PR #616,
+run 29219105593: two jobs clipped in one sweep, one having executed 18 steps,
+the other zero) and cost a manual rerun mid-merge-train. As the PR gate's job
+count grows (sharded mocha + bundled fixtures), the exposure to at least one
+pool hiccup per run rises.
+
+## Decision Drivers
+
+* Remove the manual-rerun toil for infrastructure losses.
+* Never mask a genuine test failure — a real red must stay red.
+* Bounded: rerun at most once, no loops, no runaway runner spend.
+* Don't hide a *systemic* pool problem behind silent reruns.
+
+## Considered Options
+
+* **A — Signature-gated auto-rerun via `workflow_run`** (chosen): detect the
+  infra-loss signature from the completed run and call `rerun-failed-jobs` once.
+* **B — Status quo**: humans click rerun. Reliable but toilsome, and stalls
+  merge trains until someone notices.
+* **C — Larger / self-hosted runners**: fewer losses, but real cost and
+  operational burden, and hosted losses still happen. Orthogonal.
+* **D — Blanket "retry any failed run once"**: trivial, but masks real
+  failures and doubles CI cost on every genuine red. Rejected.
+
+## Decision Outcome
+
+Chosen option: **A**. [.github/workflows/rerun-lost-runners.yml](../.github/workflows/rerun-lost-runners.yml)
+triggers on `workflow_run` completion of `Test` and reruns exactly when the
+infra-loss signature holds. The signature is derived from GitHub's
+run-conclusion semantics rather than a fragile heuristic:
+
+* **Job `if:` `conclusion == 'failure' && run_attempt == 1`.** A user
+  run-cancel or a concurrency `cancel-in-progress` supersede concludes the run
+  `cancelled`, not `failure`, so those never enter. `run_attempt == 1` makes
+  the rerun fire at most once: `rerun-failed-jobs` bumps the attempt to 2, and
+  the re-triggered event carries `run_attempt == 2`, which the guard blocks.
+* **`real == 0`** (no `failure`/`timed_out` job): a genuine failure or timeout
+  leaves such a job, so this guard keeps real reds red.
+* **`cancelled > 0`.** With `fail-fast: false` on every matrix (test.yml,
+  fixtures.yml), a real failure never cancels siblings — so a run that
+  concluded `failure` with zero failed/timed-out jobs and ≥1 cancelled job can
+  *only* be lost infrastructure. **No per-step heuristic is used**: the first
+  draft required a cancelled job with zero executed steps, but run 29219105593
+  shows a lost runner can be reaped after many steps (18), so that condition
+  produced false negatives. The run-level guards above are sufficient and
+  strictly more correct.
+
+`rerun-failed-jobs` re-runs `cancelled` jobs (verified: attempt 2 of the run
+above re-ran both and passed). On a rerun the workflow writes a
+`$GITHUB_STEP_SUMMARY` note naming the clipped jobs, so repeated reruns on one
+pool surface as a visible pattern rather than being silently absorbed.
+
+### Consequences
+
+* Good: infra losses self-heal once, no human in the loop; genuine failures
+  are untouched (`real == 0` guard).
+* Good: bounded and loop-free (`run_attempt` guard); pagination-safe job
+  enumeration (`--paginate --jq '.jobs[]' | jq -s`).
+* Cost/watch: a rerun costs a second execution of the clipped jobs. If a pool
+  degrades systematically, the workflow reruns each occurrence — the step
+  summary is the signal to escalate (pin the image, switch pool, file with
+  GitHub) instead of leaning on the rerun. Recorded in
+  docs/maintenance/ci-rerun-lost-runners.md.
+* Limitation: `workflow_run` runs only from the default branch, so the logic
+  cannot be exercised from its own PR; first live activation is post-merge.
+
+### Confirmation
+
+* Replaying run 29219105593's attempt-1 job set through the signature yields
+  `real == 0, cancelled == 2` → rerun (matches the manual rerun that fixed it).
+* The 17-genuine-failure run (29212878097) yields `real > 0` → no rerun.
+* A concurrency-superseded run concludes `cancelled` → job `if:` never fires.
+
+## Pros and Cons of the Options
+
+### A — Signature-gated auto-rerun (CHOSEN)
+
+* Good: heals the exact infra case, provably excludes genuine failures and
+  user/concurrency cancels, bounded to one attempt.
+* Bad: relies on GitHub run-conclusion semantics (documented + verified here);
+  can't self-test pre-merge.
+
+### B — Manual rerun (status quo)
+
+* Good: zero machinery, full human judgment.
+* Bad: toil; stalls merges until noticed.
+
+### D — Blanket retry-once
+
+* Good: trivial.
+* Bad: masks real failures and doubles CI cost on every genuine red.

--- a/docs/maintenance/ci-rerun-lost-runners.md
+++ b/docs/maintenance/ci-rerun-lost-runners.md
@@ -1,0 +1,42 @@
+# CI auto-rerun for lost runners
+
+The [`Rerun Lost Runners`](../../.github/workflows/rerun-lost-runners.yml)
+workflow re-runs a `Test` run once when its only failures are lost hosted
+runners, so an infrastructure hiccup doesn't need a human to click "Re-run
+failed jobs". Design rationale: [ADR 01054](../../adrs/01054-auto-rerun-lost-runner-jobs.md).
+
+## When it fires
+
+On a completed `Test` run, it reruns exactly when **all** hold:
+
+- the run concluded `failure` on its **first** attempt (`run_attempt == 1`);
+- **no** job concluded `failure` or `timed_out` (a genuine red stays red);
+- **at least one** job concluded `cancelled`.
+
+With `fail-fast: false` on every matrix, that combination can only mean lost
+infrastructure. It does **not** key on step counts — a runner can be reaped
+after running many steps.
+
+## What a maintainer sees
+
+- A second `run_attempt` appears on the Test run with **no human trigger** —
+  this workflow created it. Not a flaky pipeline, not a compromised token.
+- The `Rerun Lost Runners` run's **summary** names the clipped jobs.
+
+## Operational notes
+
+- **Exactly once.** The rerun bumps `run_attempt` to 2; the re-triggered event
+  is blocked by the `run_attempt == 1` guard. A run still red after one rerun
+  is a real problem — investigate, don't re-trigger blindly.
+- **Repeated reruns on one OS pool are a signal, not noise.** If the step
+  summary shows the same pool clipped week over week, the pool is degrading —
+  escalate (pin the runner image, switch pool, file with GitHub Support)
+  rather than leaning on the auto-rerun. The summary note exists precisely so
+  this trend is visible.
+- **Default-branch only.** `workflow_run` workflows execute from the default
+  branch, so changes to this file can't be validated from a PR; the first live
+  exercise is after merge. Validate the shell/jq logic by replaying a known
+  run's job list (see the ADR's Confirmation section) before merging changes.
+- **Genuine failure + lost runner in the same sweep** is left red on purpose
+  (`real > 0`): a human reruns after confirming the real failure was the infra
+  event, not a code bug.


### PR DESCRIPTION
> Round-2 CI latency work, PR B of 5. **Do not merge yet** — prepped for review; merge serially.

## What

When the runner pool drops a VM mid-run, the affected jobs land as `cancelled` and the run fails with nothing to fix except clicking "Re-run failed jobs" (this happened on the first #616 run: two macOS jobs clipped at the same second, one with an **empty step list** — it never executed anything).

This adds a `workflow_run`-triggered job that performs that click exactly once, gated to the infrastructure signature:

- run concluded `failure` on **attempt 1** (manual run-cancels conclude `cancelled` and never trigger; no retry loops),
- **zero** `failure`/`timed_out` jobs — one genuine test failure leaves the run red,
- at least one cancelled job executed **zero steps** (lost-runner fingerprint; manually-cancelled jobs virtually always have steps).

The workflow runs from the default branch with `permissions: actions: write` only.

## Verification

Heuristic replayed against both historical runs via the same jq filters:

| Run | red | real | empty-steps | verdict |
|---|---|---|---|---|
| 29219105593 (lost macOS runner) | 2 | 0 | 1 | WOULD-RERUN ✔ |
| 29212878097 (17 real test failures) | 37 | 4 | 32 | LEAVE-RED ✔ |

The second row also shows why the `real == 0` guard matters: superseded runs strand many never-started cancelled jobs, and only the conjunction of guards separates the cases.

## Docs impact / ADR

None — CI-internal; a rerun still has to pass the unchanged gate (mechanical; no ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic one-time reruns for test jobs cancelled by lost hosted runners.
  * Reruns occur only when no genuine test failures or timeouts are detected.

* **Documentation**
  * Added guidance explaining rerun behavior, job summaries, safeguards, and troubleshooting scenarios.
  * Documented the infrastructure decision and operational limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->