### PR TITLE
ci: pre-boot the iOS simulator to cut the apps-ios critical path

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -138,12 +138,18 @@ jobs:
       # Kick off the iOS simulator boot NOW so it overlaps npm ci/build/link/
       # servers (~4 min): the iOS legs' dominant cost is the first XCUITest
       # session (~14 min observed), which starts with a cold simulator boot.
-      # `simctl boot` returns immediately and boots in the background, and Doc
+      # `simctl boot` returns immediately and boots in the background.
+      #
+      # IMPORTANT — this changes the DEVICE, not just the timing. Doc
       # Detective's default-device plan reuses ANY booted iPhone before booting
-      # its own (src/core/tests/iosSimulator.ts: reuse-booted precedes
-      # boot/create), so the device booted here is picked up directly. An
-      # imperfect pick is harmless — Doc Detective just boots its own device
-      # and the pre-booted one idles.
+      # its own (src/core/tests/iosSimulator.ts: `reuse-booted` precedes
+      # boot/create), so whatever we boot here becomes the device the fixtures
+      # run on. We therefore pick the newest iPhone Doc Detective would itself
+      # pick — newest runtime, then highest model number, Pro/Max ahead of
+      # plain (SE, which has no model number, sorts last). This must track
+      # iosSimulator.ts's newest-device intent, and the iOS fixtures must stay
+      # device-model-robust (stock apps + version-robust selectors). See
+      # docs/maintenance/ci-ios-preboot.md.
       - name: Pre-boot iOS simulator (overlaps setup)
         if: runner.os == 'macOS' && matrix.bundle.prebootIos
         shell: bash
@@ -152,20 +158,31 @@ jobs:
             let s = '';
             process.stdin.on('data', (d) => (s += d)).on('end', () => {
               const { devices } = JSON.parse(s);
+              const modelNum = (name) => { const m = name.match(/iPhone (\d+)/); return m ? Number(m[1]) : 0; };
               const c = [];
               for (const [rt, list] of Object.entries(devices))
                 for (const d of list)
                   if (d.isAvailable && /^iPhone/.test(d.name)) c.push({ rt, udid: d.udid, name: d.name });
-              c.sort((a, b) => b.rt.localeCompare(a.rt, undefined, { numeric: true }) || b.name.localeCompare(a.name, undefined, { numeric: true }));
+              c.sort((a, b) =>
+                b.rt.localeCompare(a.rt, undefined, { numeric: true }) ||  // newest runtime
+                modelNum(b.name) - modelNum(a.name) ||                     // highest model (SE -> 0, last)
+                b.name.length - a.name.length);                           // Pro Max > Pro > plain (proxy)
               if (c[0]) console.log(c[0].udid);
             });
           ")
-          if [ -n "$udid" ]; then
-            echo "pre-booting simulator $udid"
-            xcrun simctl boot "$udid" || true
+          if [ -z "$udid" ]; then
+            echo "no available iPhone simulator found; skipping pre-boot"
+            exit 0
+          fi
+          # Only export PREBOOT_UDID when the boot command actually succeeds, so
+          # a failed boot doesn't make the wait step below block on a device
+          # that never started. `simctl boot` accepting the request (exit 0) is
+          # the signal; the async boot itself is what the wait step confirms.
+          echo "pre-booting simulator $udid"
+          if xcrun simctl boot "$udid"; then
             echo "PREBOOT_UDID=$udid" >> "$GITHUB_ENV"
           else
-            echo "no available iPhone simulator found; skipping pre-boot"
+            echo "simctl boot failed; skipping pre-boot (Doc Detective will boot its own)"
           fi
 
       # Restore/save the Doc Detective install cache (browsers, drivers, heavy
@@ -210,15 +227,18 @@ jobs:
           npm ls -g doc-detective || true
           npx --no-install doc-detective --version || echo "(bare npx --version not supported; non-fatal)"
 
-      # Diagnostic: surface how much simulator boot time setup did NOT hide —
-      # this step's duration in the job log is the residual boot wait. Waiting
-      # here (instead of inside the first startSurface) costs nothing extra and
-      # gives the boot cost a step of its own for timing analysis. Bounded so a
-      # wedged boot can't eat the job budget; Doc Detective copes either way.
-      - name: Wait for simulator boot (diagnostic)
+      # Block on the pre-booted simulator reaching `Booted`. This wait is NOT
+      # additive on the happy path — Doc Detective's first startSurface would
+      # wait for the same boot anyway; doing it here just gives the boot cost
+      # its own step in the timing breakdown AND fails faster than DD's
+      # generous per-session timeout would if a sim wedges in `Booting`. Only
+      # runs when the pre-boot succeeded (PREBOOT_UDID set). Bounded at 5 min
+      # (a healthy simulator boots in ~1-3); on timeout it's non-fatal — DD
+      # still reuses whatever state the sim reached, or boots its own.
+      - name: Wait for pre-booted simulator
         if: runner.os == 'macOS' && matrix.bundle.prebootIos && env.PREBOOT_UDID != ''
         shell: bash
-        run: timeout 600 xcrun simctl bootstatus "$PREBOOT_UDID" || echo "bootstatus did not confirm within 10 min (non-fatal)"
+        run: timeout 300 xcrun simctl bootstatus "$PREBOOT_UDID" || echo "bootstatus did not confirm within 5 min (non-fatal; Doc Detective will cope)"
 
       # Run the group through the Doc Detective GitHub Action, against the linked
       # local build (version: "" → bare `npx doc-detective`, see

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -112,6 +112,7 @@ jobs:
           - name: apps-ios
             input: test/core-artifacts/apps-ios
             timeout: 55
+            prebootIos: true
           # Mobile web (phase A5, Safari on iOS). Safari runs on the managed
           # simulator end-to-end on the macOS leg (gated on ≥1 PASS below);
           # Windows/Linux legs legitimately SKIP, and the SKIP-matrix
@@ -119,6 +120,7 @@ jobs:
           - name: mobile-web-ios
             input: test/core-artifacts/mobile-web-ios
             timeout: 55
+            prebootIos: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -132,6 +134,39 @@ jobs:
           node-version: 24
           cache: 'npm'
           cache-dependency-path: package-lock.json
+
+      # Kick off the iOS simulator boot NOW so it overlaps npm ci/build/link/
+      # servers (~4 min): the iOS legs' dominant cost is the first XCUITest
+      # session (~14 min observed), which starts with a cold simulator boot.
+      # `simctl boot` returns immediately and boots in the background, and Doc
+      # Detective's default-device plan reuses ANY booted iPhone before booting
+      # its own (src/core/tests/iosSimulator.ts: reuse-booted precedes
+      # boot/create), so the device booted here is picked up directly. An
+      # imperfect pick is harmless — Doc Detective just boots its own device
+      # and the pre-booted one idles.
+      - name: Pre-boot iOS simulator (overlaps setup)
+        if: runner.os == 'macOS' && matrix.bundle.prebootIos
+        shell: bash
+        run: |
+          udid=$(xcrun simctl list devices available -j | node -e "
+            let s = '';
+            process.stdin.on('data', (d) => (s += d)).on('end', () => {
+              const { devices } = JSON.parse(s);
+              const c = [];
+              for (const [rt, list] of Object.entries(devices))
+                for (const d of list)
+                  if (d.isAvailable && /^iPhone/.test(d.name)) c.push({ rt, udid: d.udid, name: d.name });
+              c.sort((a, b) => b.rt.localeCompare(a.rt, undefined, { numeric: true }) || b.name.localeCompare(a.name, undefined, { numeric: true }));
+              if (c[0]) console.log(c[0].udid);
+            });
+          ")
+          if [ -n "$udid" ]; then
+            echo "pre-booting simulator $udid"
+            xcrun simctl boot "$udid" || true
+            echo "PREBOOT_UDID=$udid" >> "$GITHUB_ENV"
+          else
+            echo "no available iPhone simulator found; skipping pre-boot"
+          fi
 
       # Restore/save the Doc Detective install cache (browsers, drivers, heavy
       # runtime deps, git-bash) via the shared composite action — the single
@@ -174,6 +209,16 @@ jobs:
           echo "local package version: $(node -p 'require("./package.json").version')"
           npm ls -g doc-detective || true
           npx --no-install doc-detective --version || echo "(bare npx --version not supported; non-fatal)"
+
+      # Diagnostic: surface how much simulator boot time setup did NOT hide —
+      # this step's duration in the job log is the residual boot wait. Waiting
+      # here (instead of inside the first startSurface) costs nothing extra and
+      # gives the boot cost a step of its own for timing analysis. Bounded so a
+      # wedged boot can't eat the job budget; Doc Detective copes either way.
+      - name: Wait for simulator boot (diagnostic)
+        if: runner.os == 'macOS' && matrix.bundle.prebootIos && env.PREBOOT_UDID != ''
+        shell: bash
+        run: timeout 600 xcrun simctl bootstatus "$PREBOOT_UDID" || echo "bootstatus did not confirm within 10 min (non-fatal)"
 
       # Run the group through the Doc Detective GitHub Action, against the linked
       # local build (version: "" → bare `npx doc-detective`, see

--- a/docs/maintenance/ci-ios-preboot.md
+++ b/docs/maintenance/ci-ios-preboot.md
@@ -1,0 +1,45 @@
+# CI iOS simulator pre-boot
+
+The `apps-ios` and `mobile-web-ios` fixture legs pre-boot an iOS simulator
+early in the job (right after `setup-node`, marked by the `prebootIos: true`
+matrix flag) so the cold simulator boot overlaps `npm ci` / build / link /
+server startup instead of being paid serially inside the first XCUITest
+session. On a warm-WDA run that first session was ~14 min, dominated by the
+boot.
+
+## The load-bearing coupling
+
+This changes **which device the fixtures run on**, not just when it boots:
+
+- Doc Detective's default-device plan reuses **any** already-booted iPhone
+  before booting or creating its own — `reuse-booted` precedes boot/create in
+  [`src/core/tests/iosSimulator.ts`](../../src/core/tests/iosSimulator.ts).
+- So whatever the pre-boot step boots becomes the device DD adopts
+  (`bootedByUs=false`, left running; the run-end sweep only shuts down devices
+  DD itself booted).
+
+Two consequences a maintainer must keep true:
+
+1. **The pre-boot must pick the device DD would pick.** The step selects the
+   newest iPhone: newest runtime, then highest model number (Pro/Max ahead of
+   plain via a name-length proxy; `iPhone SE` has no model number and sorts
+   last). If `iosSimulator.ts` changes its newest-device intent, update the
+   step's sort to match — otherwise the pre-boot warms a device DD would
+   itself reject, DD boots its own anyway, and the overlap saving is silently
+   lost (the build still goes green).
+2. **The iOS fixtures must stay device-model-robust.** They target stock apps
+   (Settings) with version-robust selectors precisely so the exact simulator
+   model doesn't matter. A fixture that asserts on a screenshot baseline or a
+   model-specific viewport would become CI-only flaky the moment the runner
+   image's newest iPhone changes. Keep iOS fixtures model-agnostic.
+
+## Operational notes
+
+- A **failed `simctl boot`** does not export `PREBOOT_UDID`, so the wait step
+  is skipped and DD boots its own device — no wasted wait.
+- The **wait step is not additive** on the happy path (DD would wait for the
+  same boot); it exists to surface the boot cost as its own step and to fail
+  faster (5-min bound) than DD's generous per-session timeout if a sim wedges.
+- If iOS legs regress to ~cold-boot timings, first check the pre-boot step's
+  log: "no available iPhone" or a device DD didn't reuse means the selection
+  drifted from `iosSimulator.ts`.


### PR DESCRIPTION
> Round-2 CI latency work, PR C of 5. **Do not merge yet** — prepped for review; merge serially. Touches fixtures.yml, so expect a trivial rebase against PRs D/E depending on merge order.

## Why not the parallel split (the original ask)

I profiled the 24-minute `apps-ios (macos)` job before implementing. The breakdown:

- setup (checkout → servers): ~4 min
- **first XCUITest session: 13.9 min** (`Booting simulator "iPhone 17 Pro"` 02:58:54 → `Opened app surface` 03:12:48) — **with a warm WDA cache** ("build will be incremental")
- spec 2 (interactions): 4.1 min, spec 3 (recording): 1.6 min — both reuse the booted simulator

The first-session cost is per-job, so splitting the 3 specs across parallel jobs re-pays it in every job: a 2-way split produces ~18- and ~20-minute jobs — **no wall-clock improvement, double the macOS runner cost**. Split rejected on the data.

## What this does instead

1. **Pre-boot the simulator concurrently with setup**: right after `setup-node`, pick the newest available iPhone via `simctl list -j` and fire `simctl boot` (returns immediately, boots in background). Doc Detective's default-device plan **reuses any booted iPhone before booting its own** ([iosSimulator.ts](https://github.com/doc-detective/doc-detective/blob/main/src/core/tests/iosSimulator.ts) `reuse-booted` precedes boot/create), so the pre-booted device is picked up directly; a mismatched pick harmlessly degrades to today's behavior. Hides up to ~4 min of boot behind npm ci/build/link/servers.
2. **Instrument the residue**: a bounded `simctl bootstatus` diagnostic step right before the action gives the *remaining* boot wait its own step timing. After one run we'll know exactly how the ~14 min decomposes (boot vs. WDA/session establishment) and whether a deeper attack (e.g. WDA prewarming in the cache-warmer cron) is worth it.

Applied to both `apps-ios` and `mobile-web-ios` via a `prebootIos` matrix flag; all other bundles untouched.

## Docs impact / ADR

None — no gate semantics change (the same specs run the same way; the simulator just starts booting earlier). Topology unchanged, so ADR 01048 stands as-is.

## Verification

On this PR's run, compare `apps-ios (macos)`: the pre-boot step should be ~0s, the diagnostic wait step shows the residual boot time, and the fixtures step should start with a booted/booting simulator (`reuse-booted` in the debug log). Success = total job time drops below the ~24-min baseline by roughly the overlapped amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iOS CI fixture runs now pre-boot an available simulator to improve setup performance and reuse.
  * Simulator startup continues gracefully when booting or readiness checks fail.

* **Documentation**
  * Added maintenance guidance covering simulator selection, reuse behavior, failure handling, and troubleshooting timing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->