### PR TITLE
ci: narrow the PR fixture matrix to affected bundles (ADR 01049)

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -27,7 +27,7 @@ on:
     inputs:
       # Comma-joined bundle names to run, or "all". The PR gate narrows this
       # via scripts/select-fixture-bundles.cjs ONLY for change sets confined
-      # to fixture group directories (ADR 01049); every other change — and
+      # to fixture group directories (ADR 01055); every other change — and
       # every caller that omits the input, like the release gate — runs "all".
       # Skipped bundles surface as skipped jobs in the run, never silently.
       bundles:

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -64,8 +64,10 @@ jobs:
         run: |
           matrix=''
           # Only a PR context can narrow. `if files=$(...)` tolerates a non-zero
-          # gh api (transient 5xx / rate limit) without tripping `set -e`.
-          if [ -n "$PR" ] && files=$(gh api "repos/${{ github.repository }}/pulls/$PR/files?per_page=100" --paginate --jq '.[].filename'); then
+          # gh api (transient 5xx / rate limit) without tripping `set -e`, and
+          # `timeout 120` makes a HANG fail-safe too (exit 124 → the full
+          # matrix) instead of silently eating the job's 5-min budget.
+          if [ -n "$PR" ] && files=$(timeout 120 gh api "repos/${{ github.repository }}/pulls/$PR/files?per_page=100" --paginate --jq '.[].filename'); then
             printf 'changed files:\n%s\n' "$files"
             matrix=$(printf '%s\n' "$files" | node scripts/select-fixture-bundles.cjs --matrix || echo '')
           fi

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -24,27 +24,64 @@ name: Fixture Matrix
 
 on:
   workflow_call:
-    inputs:
-      # Comma-joined bundle names to run, or "all". The PR gate narrows this
-      # via scripts/select-fixture-bundles.cjs ONLY for change sets confined
-      # to fixture group directories (ADR 01055); every other change — and
-      # every caller that omits the input, like the release gate — runs "all".
-      # Skipped bundles surface as skipped jobs in the run, never silently.
-      bundles:
-        type: string
-        required: false
-        default: all
 
 permissions:
   contents: read
+  # The `select` job reads the PR's changed files to narrow the matrix.
+  pull-requests: read
 
 jobs:
+  # Compute the fixture matrix for this run (ADR 01055). scripts/
+  # select-fixture-bundles.cjs is the SINGLE SOURCE OF TRUTH for the bundle
+  # definitions; `--matrix` emits the JSON the matrix below consumes via
+  # fromJSON. Narrowing happens ONLY when a PR's change set is confined to
+  # fixture group directories; product/script/workflow/shared-infra changes,
+  # non-PR triggers (the release gate calls this on push — no PR), and every
+  # error path all fall back to the FULL matrix. Fail-safe by construction: an
+  # empty matrix would run zero fixtures, so the job never emits one.
+  #
+  # Why a dynamic matrix and not a per-job `if:`: the `matrix` context is not
+  # available in a job-level `if:` (only github/needs/vars/inputs are), so a
+  # bundle can't gate itself on its own matrix value. Emitting only the
+  # selected bundles into the matrix sidesteps that entirely — and a deselected
+  # bundle produces no job at all (cleaner than a skipped one).
+  select:
+    name: Select fixture bundles
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.pick.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Pick the matrix for this change set
+        id: pick
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          matrix=''
+          # Only a PR context can narrow. `if files=$(...)` tolerates a non-zero
+          # gh api (transient 5xx / rate limit) without tripping `set -e`.
+          if [ -n "$PR" ] && files=$(gh api "repos/${{ github.repository }}/pulls/$PR/files?per_page=100" --paginate --jq '.[].filename'); then
+            printf 'changed files:\n%s\n' "$files"
+            matrix=$(printf '%s\n' "$files" | node scripts/select-fixture-bundles.cjs --matrix || echo '')
+          fi
+          # Fail-safe: no PR, API/selector failure, or an empty/degenerate value
+          # → the full matrix (never zero fixtures). Empty stdin selects all.
+          if [ -z "$matrix" ] || [ "$matrix" = "[]" ]; then
+            echo "defaulting to the full fixture matrix"
+            matrix=$(printf '' | node scripts/select-fixture-bundles.cjs --matrix)
+          fi
+          echo "selected matrix: $matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   fixtures:
+    needs: select
     name: ${{ matrix.bundle.name }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    # Comma-delimited guards so one bundle name can't substring-match another
-    # (`apps` would otherwise match `apps-ios`).
-    if: inputs.bundles == 'all' || contains(format(',{0},', inputs.bundles), format(',{0},', matrix.bundle.name))
     # Default headroom is 20 min; entries that need more carry their own
     # `timeout` (apps: the first Mac2/XCUITest session on a macOS runner
     # builds WebDriverAgent(Mac) via xcodebuild — minutes on a cold runner;
@@ -60,80 +97,14 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
-        # One job per (bundle x OS). Every fixture GROUP directory must appear
-        # in exactly one bundle's `input` (comma-joined; the action passes the
-        # value verbatim to `--input`, which splits on commas). Not every
-        # test/core-artifacts/ subdirectory is a gate group: `ordering/` and
-        # `output/` hold specs/data consumed by the mocha suite, not this
-        # matrix. Fast groups share a job to cut per-job
-        # setup and runner-queue pressure (ADR 01048, amending ADR 01022's
-        # one-job-per-group shape); groups stay in their own directories and
-        # a heavy or special-cased group keeps a job to itself. Bundles are
-        # sized so the worst (Windows, cold-cache) leg stays well under the
-        # 20-min default timeout — re-check timings before growing one.
-        #
-        # CAUTION: the zero-spec guard in check-fixture-results.cjs only
-        # fails a FULLY empty run. In a multi-directory bundle a typo'd dir
-        # contributes zero specs while the others still produce results, so
-        # a typo can pass silently — double-check paths when editing inputs.
-        #
-        # iOS-flavored groups must stay solo: the action's `ios: auto`
-        # spec-scan resolves the input value as one literal path, and a
-        # comma-joined value resolves to a nonexistent path (scan returns
-        # false — harmless for bundles without ios specs, but it would skip
-        # the WDA cache for a bundle that had them).
-        bundle:
-          - name: nav-capture
-            input: test/core-artifacts/navigation,test/core-artifacts/capture
-          - name: interactions
-            input: test/core-artifacts/interactions
-          - name: web-plumbing
-            input: test/core-artifacts/routing,test/core-artifacts/http,test/core-artifacts/guards
-          - name: proc-sessions
-            input: test/core-artifacts/process,test/core-artifacts/sessions
-          - name: recording
-            input: test/core-artifacts/recording
-          # Native app surfaces (phase A1). Its own job for job-size reasons
-          # (driver install + UIA automation are the slowest fixtures). The
-          # historical freeze that first motivated isolating it — the app
-          # preflight's mid-run driver install pruned node-pty from the runtime
-          # cache and the next ConPTY spawn froze the process (issue #501) — is
-          # fixed at the root (ADR 01025 non-destructive installs, ADR 01024
-          # spawn guards), and the in-process app→tty pairing is exercised ON
-          # PURPOSE by apps/app-then-tty.spec.json in this very group.
-          - name: apps
-            input: test/core-artifacts/apps
-            timeout: 30
-          # Native app surfaces (phase A3b Android) + mobile web on Android
-          # (phase A5, Chrome). On the general matrix (Windows/macOS runners,
-          # and Linux without KVM) every android spec lands SKIPPED via the
-          # emulator-acceleration preflight — asserted gating, skip-tolerant
-          # here, so the two groups share a job. The SKIP-matrix permutations
-          # (firefox/webkit/safari on android, mixed app+web) land SKIPPED on
-          # every host by design; the four-targets spec's windows/mac contexts
-          # run desktop Chrome where the host matches. Real Android PASS
-          # coverage runs in the dedicated KVM jobs below (reuse +
-          # managed-boot). `android: true` routes the
-          # DOC_DETECTIVE_NO_ANDROID_AUTOINSTALL env to this job.
-          - name: android-skip
-            input: test/core-artifacts/apps-android,test/core-artifacts/mobile-web-android
-            android: true
-          # Native app surfaces (phase A4, iOS). iOS app contexts run end-to-end
-          # on a managed simulator via XCUITest; the macOS leg gates on ≥1 PASS
-          # (DD_FIXTURES_REQUIRE_PASS below, ADR 01028), while Windows/Linux legs
-          # legitimately SKIP (iOS simulators are macOS-only).
-          - name: apps-ios
-            input: test/core-artifacts/apps-ios
-            timeout: 55
-            prebootIos: true
-          # Mobile web (phase A5, Safari on iOS). Safari runs on the managed
-          # simulator end-to-end on the macOS leg (gated on ≥1 PASS below);
-          # Windows/Linux legs legitimately SKIP, and the SKIP-matrix
-          # permutations land SKIPPED everywhere by design.
-          - name: mobile-web-ios
-            input: test/core-artifacts/mobile-web-ios
-            timeout: 55
-            prebootIos: true
+        # One (bundle x OS) job. The bundle list comes from select-fixture-
+        # bundles.cjs (`--matrix`) via the `select` job — the single source of
+        # truth for names, `input` (comma-joined group dirs; the action passes
+        # it verbatim to `--input`, which splits on commas), and the per-bundle
+        # timeout / android / prebootIos attributes. Bundle composition, the
+        # zero-spec-typo caution, and the iOS-solo rule are documented in that
+        # script and ADR 01048 / 01055.
+        bundle: ${{ fromJSON(needs.select.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -24,6 +24,16 @@ name: Fixture Matrix
 
 on:
   workflow_call:
+    inputs:
+      # Comma-joined bundle names to run, or "all". The PR gate narrows this
+      # via scripts/select-fixture-bundles.cjs ONLY for change sets confined
+      # to fixture group directories (ADR 01049); every other change — and
+      # every caller that omits the input, like the release gate — runs "all".
+      # Skipped bundles surface as skipped jobs in the run, never silently.
+      bundles:
+        type: string
+        required: false
+        default: all
 
 permissions:
   contents: read
@@ -32,6 +42,9 @@ jobs:
   fixtures:
     name: ${{ matrix.bundle.name }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # Comma-delimited guards so one bundle name can't substring-match another
+    # (`apps` would otherwise match `apps-ios`).
+    if: inputs.bundles == 'all' || contains(format(',{0},', inputs.bundles), format(',{0},', matrix.bundle.name))
     # Default headroom is 20 min; entries that need more carry their own
     # `timeout` (apps: the first Mac2/XCUITest session on a macOS runner
     # builds WebDriverAgent(Mac) via xcodebuild — minutes on a cold runner;

--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -47,7 +47,7 @@ concurrency:
 permissions:
   contents: read
   # The `changes` job lists the PR's changed files to narrow the fixture
-  # matrix (ADR 01049).
+  # matrix (ADR 01055).
   pull-requests: read
 
 jobs:
@@ -55,7 +55,12 @@ jobs:
   # construction (scripts/select-fixture-bundles.cjs): only a change set
   # confined entirely to fixture group directories narrows the matrix; any
   # product/script/workflow/shared-infra change — and any non-PR trigger —
-  # selects "all". A failure here fails the gate loudly (fixtures `needs` it).
+  # selects "all". FAIL-SAFE: every error path (API failure, script error,
+  # empty output) defaults to "all". A narrowed matrix must only ever be the
+  # result of a confidently fixture-confined change set — never of a failure —
+  # because an empty/mismatched `bundles` value would make every fixture leg's
+  # `if:` evaluate false, and a skipped required check counts as passing under
+  # branch protection (i.e. would merge a PR with zero fixtures run).
   changes:
     name: Select fixture bundles
     runs-on: ubuntu-latest
@@ -75,14 +80,24 @@ jobs:
         run: |
           if [ -z "$PR" ]; then
             echo "no PR context (manual dispatch) — running all bundles"
-            echo "bundles=all" >> "$GITHUB_OUTPUT"
-          else
-            files=$(gh api "repos/${{ github.repository }}/pulls/$PR/files?per_page=100" --paginate --jq '.[].filename')
+            bundles=all
+          # `if files=$(...)` tolerates a non-zero gh api (transient 5xx / rate
+          # limit) without tripping `set -e`; a failed list falls back to all.
+          elif files=$(gh api "repos/${{ github.repository }}/pulls/$PR/files?per_page=100" --paginate --jq '.[].filename'); then
             printf 'changed files:\n%s\n' "$files"
-            bundles=$(printf '%s\n' "$files" | node scripts/select-fixture-bundles.cjs)
-            echo "selected bundles: $bundles"
-            echo "bundles=$bundles" >> "$GITHUB_OUTPUT"
+            # `|| echo all` keeps a selector crash fail-safe too.
+            bundles=$(printf '%s\n' "$files" | node scripts/select-fixture-bundles.cjs || echo all)
+          else
+            echo "could not list PR files — defaulting to all bundles"
+            bundles=all
           fi
+          # Defense in depth: never emit an empty value (would skip every leg).
+          if [ -z "$bundles" ]; then
+            echo "empty selection — defaulting to all bundles"
+            bundles=all
+          fi
+          echo "selected bundles: $bundles"
+          echo "bundles=$bundles" >> "$GITHUB_OUTPUT"
 
   # Smoke + unit/integration matrix (mocha) and the coverage ratchets. The bulk
   # of the *.spec.json fixtures no longer run here — see the `fixtures` job.
@@ -98,7 +113,7 @@ jobs:
 
   # Per-feature Doc Detective fixtures, fanned out one small job per (bundle x
   # OS) so no single job is a 90-minute monolith. Runs the PR's own build,
-  # narrowed to the bundles the change set can affect (ADR 01049).
+  # narrowed to the bundles the change set can affect (ADR 01055).
   fixtures:
     needs: changes
     uses: ./.github/workflows/fixtures.yml

--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -46,59 +46,12 @@ concurrency:
 
 permissions:
   contents: read
-  # The `changes` job lists the PR's changed files to narrow the fixture
-  # matrix (ADR 01055).
+  # Granted so the reusable fixtures workflow's `select` job can read the PR's
+  # changed files to narrow its matrix (ADR 01055). A reusable workflow can't
+  # hold a permission the caller doesn't grant, so it lives here.
   pull-requests: read
 
 jobs:
-  # Select which fixture bundles this change set needs. Conservative by
-  # construction (scripts/select-fixture-bundles.cjs): only a change set
-  # confined entirely to fixture group directories narrows the matrix; any
-  # product/script/workflow/shared-infra change — and any non-PR trigger —
-  # selects "all". FAIL-SAFE: every error path (API failure, script error,
-  # empty output) defaults to "all". A narrowed matrix must only ever be the
-  # result of a confidently fixture-confined change set — never of a failure —
-  # because an empty/mismatched `bundles` value would make every fixture leg's
-  # `if:` evaluate false, and a skipped required check counts as passing under
-  # branch protection (i.e. would merge a PR with zero fixtures run).
-  changes:
-    name: Select fixture bundles
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      bundles: ${{ steps.select.outputs.bundles }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Select bundles for this change set
-        id: select
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          if [ -z "$PR" ]; then
-            echo "no PR context (manual dispatch) — running all bundles"
-            bundles=all
-          # `if files=$(...)` tolerates a non-zero gh api (transient 5xx / rate
-          # limit) without tripping `set -e`; a failed list falls back to all.
-          elif files=$(gh api "repos/${{ github.repository }}/pulls/$PR/files?per_page=100" --paginate --jq '.[].filename'); then
-            printf 'changed files:\n%s\n' "$files"
-            # `|| echo all` keeps a selector crash fail-safe too.
-            bundles=$(printf '%s\n' "$files" | node scripts/select-fixture-bundles.cjs || echo all)
-          else
-            echo "could not list PR files — defaulting to all bundles"
-            bundles=all
-          fi
-          # Defense in depth: never emit an empty value (would skip every leg).
-          if [ -z "$bundles" ]; then
-            echo "empty selection — defaulting to all bundles"
-            bundles=all
-          fi
-          echo "selected bundles: $bundles"
-          echo "bundles=$bundles" >> "$GITHUB_OUTPUT"
-
   # Smoke + unit/integration matrix (mocha) and the coverage ratchets. The bulk
   # of the *.spec.json fixtures no longer run here — see the `fixtures` job.
   test:
@@ -112,10 +65,8 @@ jobs:
       HERETTO_TOKEN: ${{ github.event_name == 'workflow_dispatch' && secrets.HERETTO_TOKEN || '' }}
 
   # Per-feature Doc Detective fixtures, fanned out one small job per (bundle x
-  # OS) so no single job is a 90-minute monolith. Runs the PR's own build,
-  # narrowed to the bundles the change set can affect (ADR 01055).
+  # OS) so no single job is a 90-minute monolith. Runs the PR's own build. The
+  # reusable workflow computes its own matrix (its `select` job), narrowed to
+  # the bundles the PR's change set can affect (ADR 01055).
   fixtures:
-    needs: changes
     uses: ./.github/workflows/fixtures.yml
-    with:
-      bundles: ${{ needs.changes.outputs.bundles }}

--- a/.github/workflows/npm-test.yaml
+++ b/.github/workflows/npm-test.yaml
@@ -46,8 +46,44 @@ concurrency:
 
 permissions:
   contents: read
+  # The `changes` job lists the PR's changed files to narrow the fixture
+  # matrix (ADR 01049).
+  pull-requests: read
 
 jobs:
+  # Select which fixture bundles this change set needs. Conservative by
+  # construction (scripts/select-fixture-bundles.cjs): only a change set
+  # confined entirely to fixture group directories narrows the matrix; any
+  # product/script/workflow/shared-infra change — and any non-PR trigger —
+  # selects "all". A failure here fails the gate loudly (fixtures `needs` it).
+  changes:
+    name: Select fixture bundles
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      bundles: ${{ steps.select.outputs.bundles }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Select bundles for this change set
+        id: select
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -z "$PR" ]; then
+            echo "no PR context (manual dispatch) — running all bundles"
+            echo "bundles=all" >> "$GITHUB_OUTPUT"
+          else
+            files=$(gh api "repos/${{ github.repository }}/pulls/$PR/files?per_page=100" --paginate --jq '.[].filename')
+            printf 'changed files:\n%s\n' "$files"
+            bundles=$(printf '%s\n' "$files" | node scripts/select-fixture-bundles.cjs)
+            echo "selected bundles: $bundles"
+            echo "bundles=$bundles" >> "$GITHUB_OUTPUT"
+          fi
+
   # Smoke + unit/integration matrix (mocha) and the coverage ratchets. The bulk
   # of the *.spec.json fixtures no longer run here — see the `fixtures` job.
   test:
@@ -60,7 +96,11 @@ jobs:
       HERETTO_USERNAME: ${{ github.event_name == 'workflow_dispatch' && secrets.HERETTO_USERNAME || '' }}
       HERETTO_TOKEN: ${{ github.event_name == 'workflow_dispatch' && secrets.HERETTO_TOKEN || '' }}
 
-  # Per-feature Doc Detective fixtures, fanned out one small job per (group x OS)
-  # so no single job is a 90-minute monolith. Runs the PR's own build.
+  # Per-feature Doc Detective fixtures, fanned out one small job per (bundle x
+  # OS) so no single job is a 90-minute monolith. Runs the PR's own build,
+  # narrowed to the bundles the change set can affect (ADR 01049).
   fixtures:
+    needs: changes
     uses: ./.github/workflows/fixtures.yml
+    with:
+      bundles: ${{ needs.changes.outputs.bundles }}

--- a/adrs/01049-path-filtered-fixture-bundles.md
+++ b/adrs/01049-path-filtered-fixture-bundles.md
@@ -1,0 +1,94 @@
+---
+status: accepted
+date: 2026-07-13
+decision-makers: doc-detective maintainers
+---
+
+# Narrow the PR fixture matrix to the bundles a change set can affect
+
+## Context and Problem Statement
+
+Every PR-gate run executes all 27 general fixture jobs (9 bundles × 3 OSes, ADR 01048) plus the
+android legs, regardless of what changed. For a PR that only edits fixture specs in one group —
+a common shape when authoring feature fixtures per the CLAUDE.md policy — the other bundles burn
+~25 jobs of runner time and queue pressure to re-verify code the PR cannot have touched. ADR 01048
+deliberately deferred this lever ("option C") because a wrong path→bundle mapping fails silent: the
+gate a change needed simply doesn't run, and green means nothing.
+
+## Decision Drivers
+
+* Cut wasted runner time and queue pressure for narrow PRs without weakening the gate.
+* A mapping gap must fail LOUD or fail SAFE (run everything) — never silently skip coverage.
+* The release gate must keep running everything, always.
+* Skipped work must be visible in the run UI, not invisible.
+
+## Considered Options
+
+* **A — Conservative selector, fallback-to-all** (chosen): the only narrowing case is a change set
+  confined entirely to fixture group directories; anything else selects "all".
+* **B — Full path map (source files → bundles)**: map product source areas to affected bundles
+  (e.g. `src/core/tests/httpRequest.ts` → web-plumbing). Maximum savings, but the map is a living
+  artifact whose staleness silently unguards exactly the code being changed.
+* **C — Status quo**: run everything, always.
+
+## Decision Outcome
+
+Chosen option: **A**.
+
+* [`scripts/select-fixture-bundles.cjs`](../scripts/select-fixture-bundles.cjs) (zero-dependency)
+  returns `all` unless every changed file lives under `test/core-artifacts/<group>/` for a known
+  bundle group; then it returns exactly the owning bundles. Shared fixture infrastructure inside
+  `core-artifacts` (`env`, `config.groups.json`, the mocha-owned `ordering/` and `output/` dirs)
+  and empty change sets also return `all`.
+* The PR gate ([`npm-test.yaml`](../.github/workflows/npm-test.yaml)) runs a `changes` job that
+  lists the PR's files (GitHub API; non-PR triggers select `all`) and feeds the selector; the
+  `fixtures` call passes the result as the new `bundles` input of
+  [`fixtures.yml`](../.github/workflows/fixtures.yml). Each bundle job carries a comma-guarded
+  `if:` (bundle names are not substring-safe: `apps` vs `apps-ios`), so deselected bundles appear
+  as **skipped jobs** — visible, auditable, never silent.
+* [`release.yml`](../.github/workflows/release.yml) omits the input and gets the default `all`:
+  the release gate is unchanged and re-verifies everything before publish.
+* Drift guards: a mocha test (`test/select-fixture-bundles.test.js`) asserts the script's bundle
+  map deep-equals the fixtures.yml matrix, so editing one without the other fails the unit suite;
+  a `changes`-job failure fails the whole gate (`fixtures` `needs` it).
+
+### Consequences
+
+* Good: fixture-authoring PRs run only their own bundles (e.g. one group → 3 jobs instead of 27),
+  with the mocha matrix unchanged as a cross-cutting backstop.
+* Good: the failure directions are safe — selector bug returns `all` (waste, not risk); drift
+  between map and matrix breaks the unit suite; `changes` job failure fails the gate.
+* Neutral: most PRs touch product code and still select `all` — by design. This ADR buys the
+  narrow case cheaply; option B's larger savings remain available later if wanted, with this
+  selector as its fallback layer.
+* Cost: one more always-on job (`changes`, seconds). Skipped bundle jobs still appear in the
+  checks list (as skipped), which reviewers must read as "not applicable", not "passed".
+
+### Confirmation
+
+* A PR touching only `test/core-artifacts/http/**` runs exactly the `web-plumbing` bundle jobs
+  (3) plus the mocha matrix; the other bundle jobs show as skipped.
+* A PR touching any `src/**` file runs all bundle jobs.
+* Renaming a bundle in fixtures.yml without updating the selector fails
+  `test/select-fixture-bundles.test.js`.
+* A release-branch push runs the full matrix (no `bundles` input in release.yml).
+
+## Pros and Cons of the Options
+
+### A — Conservative selector, fallback-to-all (CHOSEN)
+
+* Good: silent-skip-proof by construction; trivial to reason about; zero-dependency selector.
+* Good: unit-tested pure function; drift guard ties it to the matrix definition.
+* Bad: no savings for product-code PRs (deliberate).
+
+### B — Full source→bundle path map
+
+* Good: biggest savings (most PRs would run a small subset).
+* Bad: the map ages with the codebase, and a stale entry silently skips exactly the coverage the
+  change needed; requires discipline no gate enforces. Rejected for now; can layer on top of A.
+
+### C — Status quo
+
+* Good: nothing to maintain.
+* Bad: ~25 wasted jobs per fixture-authoring PR, and continued queue pressure on the shared
+  Windows/macOS pools.

--- a/adrs/01055-path-filtered-fixture-bundles.md
+++ b/adrs/01055-path-filtered-fixture-bundles.md
@@ -33,51 +33,60 @@ gate a change needed simply doesn't run, and green means nothing.
 
 ## Decision Outcome
 
-Chosen option: **A**.
+Chosen option: **A**, implemented as a **dynamic matrix** so only the selected bundles ever
+materialize as jobs.
 
 * [`scripts/select-fixture-bundles.cjs`](../scripts/select-fixture-bundles.cjs) (zero-dependency)
-  returns `all` unless every changed file lives under `test/core-artifacts/<group>/` for a known
-  bundle group; then it returns exactly the owning bundles. Shared fixture infrastructure inside
-  `core-artifacts` (`env`, `config.groups.json`, the mocha-owned `ordering/` and `output/` dirs)
-  and empty change sets also return `all`.
-* The PR gate ([`npm-test.yaml`](../.github/workflows/npm-test.yaml)) runs a `changes` job that
-  lists the PR's files (GitHub API; non-PR triggers select `all`) and feeds the selector; the
-  `fixtures` call passes the result as the new `bundles` input of
-  [`fixtures.yml`](../.github/workflows/fixtures.yml). Each bundle job carries a comma-guarded
-  `if:` (bundle names are not substring-safe: `apps` vs `apps-ios`), so deselected bundles appear
-  as **skipped jobs** — visible, auditable, never silent.
-* [`release.yml`](../.github/workflows/release.yml) omits the input and gets the default `all`:
-  the release gate is unchanged and re-verifies everything before publish.
-* Drift guards: a mocha test (`test/select-fixture-bundles.test.js`) asserts the script's bundle
-  map deep-equals the fixtures.yml matrix, so editing one without the other fails the unit suite;
-  a `changes`-job failure fails the whole gate (`fixtures` `needs` it).
+  is the **single source of truth** for the bundle definitions (name, group dirs, and the
+  per-bundle `timeout`/`android`/`prebootIos` CI attributes). Its `--matrix` mode emits the JSON
+  array of bundle objects to run: every bundle unless the change set is confined entirely to
+  fixture group directories, in which case only the owning bundles. Shared fixture infrastructure
+  inside `core-artifacts` (`env`, `config.groups.json`, the mocha-owned `ordering/`/`output/`
+  dirs) and empty change sets yield the full matrix.
+* [`fixtures.yml`](../.github/workflows/fixtures.yml) computes its own matrix: a `select` job
+  reads the PR's changed files (GitHub API; non-PR triggers and every error path fall back to the
+  full matrix) and runs the script's `--matrix`; the `fixtures` job's
+  `matrix.bundle: ${{ fromJSON(needs.select.outputs.matrix) }}` expands to exactly the selected
+  bundles. A **deselected bundle produces no job at all** — cleaner than a skipped one.
+* **Why a dynamic matrix, not a per-job `if:`.** The `matrix` context is not available in a
+  job-level `if:` (only `github`/`needs`/`vars`/`inputs` are), so a bundle can't gate itself on
+  its own matrix value — an `if:` referencing `matrix.bundle.name` is a workflow-compile
+  (startup) failure. Emitting only the selected bundles into the matrix sidesteps that entirely.
+* Self-contained in the reusable workflow, so both callers benefit with no plumbing:
+  [`npm-test.yaml`](../.github/workflows/npm-test.yaml) just calls `fixtures.yml` (and grants
+  `pull-requests: read`, which a reusable workflow can't hold unless the caller does), and
+  [`release.yml`](../.github/workflows/release.yml) is unchanged — its push context has no PR, so
+  the `select` job falls back to the full matrix and the release gate re-verifies everything.
+* Drift guards (`test/select-fixture-bundles.test.js`): the script's bundle dirs must match the
+  on-disk `test/core-artifacts/` group directories **exactly, one bundle each** (ties the source
+  of truth to the filesystem, not to a second copy), and fixtures.yml must consume
+  `fromJSON(needs.select.outputs.matrix)` from a `select` job that runs `--matrix`.
 
 ### Consequences
 
 * Good: fixture-authoring PRs run only their own bundles (e.g. one group → 3 jobs instead of 27),
   with the mocha matrix unchanged as a cross-cutting backstop.
-* Good: every failure direction is safe — selector bug, API failure, or empty output all default
-  to `all` (waste, not lost coverage); drift between map and matrix breaks the unit suite. An
-  empty `bundles` value is the one dangerous state (it would skip every leg, and a skipped
-  required check counts as passing), so the `changes` job guards against emitting it.
-* Neutral: most PRs touch product code and still select `all` — by design. This ADR buys the
-  narrow case cheaply; option B's larger savings remain available later if wanted, with this
-  selector as its fallback layer.
-* Cost: one more always-on job (`changes`, seconds). Skipped bundle jobs still appear in the
-  checks list (as skipped), which reviewers must read as "not applicable", not "passed".
-* Scope: the `bundles` input gates only the general `fixtures` matrix. The three heavy Android
-  KVM jobs (`fixtures-android-reuse`/`-managed`/`-action`) are NOT gated here and run on every
-  PR — the safe direction (Android coverage is never skipped), but they remain a cost this ADR
-  does not address. Gating those legs by Android relevance is a separate decision (ADR 01056).
+* Good: every failure direction is safe — selector bug, API failure, empty/degenerate output all
+  fall back to the **full** matrix (waste, not lost coverage). The one dangerous state, an empty
+  matrix (which would run zero fixtures), is impossible: the `select` job never emits `[]`.
+* Good: no second copy of the bundle list to drift — the workflow's matrix is generated from the
+  script, and the coverage guard is against the actual filesystem.
+* Neutral: most PRs touch product code and still run `all` — by design. This ADR buys the narrow
+  case cheaply; option B's larger savings remain available later, with this selector as the base.
+* Cost: one more always-on job (`select`, seconds).
+* Scope: the matrix narrowing gates only the general `fixtures` jobs. The three heavy Android KVM
+  jobs (`fixtures-android-reuse`/`-managed`/`-action`) are NOT gated here and run on every PR —
+  the safe direction (Android coverage is never skipped), but a cost this ADR does not address.
+  Gating those legs by Android relevance is a separate decision (ADR 01056).
 
 ### Confirmation
 
-* A PR touching only `test/core-artifacts/http/**` runs the `web-plumbing` bundle jobs (3) plus
-  the mocha matrix and the three always-on Android KVM jobs; every other bundle job shows as
-  skipped.
+* A PR touching only `test/core-artifacts/http/**` materializes only the `web-plumbing` bundle
+  jobs (3) — the other bundles produce no jobs — plus the mocha matrix and the three always-on
+  Android KVM jobs.
 * A PR touching any `src/**` file runs all bundle jobs.
-* Renaming a bundle in fixtures.yml without updating the selector fails
-  `test/select-fixture-bundles.test.js`.
+* Adding/renaming a `test/core-artifacts/<group>/` dir without updating the script, or unwiring
+  the fixtures matrix from the `select` job, fails `test/select-fixture-bundles.test.js`.
 * A release-branch push runs the full matrix (no `bundles` input in release.yml).
 
 ## Pros and Cons of the Options

--- a/adrs/01055-path-filtered-fixture-bundles.md
+++ b/adrs/01055-path-filtered-fixture-bundles.md
@@ -56,18 +56,25 @@ Chosen option: **A**.
 
 * Good: fixture-authoring PRs run only their own bundles (e.g. one group → 3 jobs instead of 27),
   with the mocha matrix unchanged as a cross-cutting backstop.
-* Good: the failure directions are safe — selector bug returns `all` (waste, not risk); drift
-  between map and matrix breaks the unit suite; `changes` job failure fails the gate.
+* Good: every failure direction is safe — selector bug, API failure, or empty output all default
+  to `all` (waste, not lost coverage); drift between map and matrix breaks the unit suite. An
+  empty `bundles` value is the one dangerous state (it would skip every leg, and a skipped
+  required check counts as passing), so the `changes` job guards against emitting it.
 * Neutral: most PRs touch product code and still select `all` — by design. This ADR buys the
   narrow case cheaply; option B's larger savings remain available later if wanted, with this
   selector as its fallback layer.
 * Cost: one more always-on job (`changes`, seconds). Skipped bundle jobs still appear in the
   checks list (as skipped), which reviewers must read as "not applicable", not "passed".
+* Scope: the `bundles` input gates only the general `fixtures` matrix. The three heavy Android
+  KVM jobs (`fixtures-android-reuse`/`-managed`/`-action`) are NOT gated here and run on every
+  PR — the safe direction (Android coverage is never skipped), but they remain a cost this ADR
+  does not address. Gating those legs by Android relevance is a separate decision (ADR 01056).
 
 ### Confirmation
 
-* A PR touching only `test/core-artifacts/http/**` runs exactly the `web-plumbing` bundle jobs
-  (3) plus the mocha matrix; the other bundle jobs show as skipped.
+* A PR touching only `test/core-artifacts/http/**` runs the `web-plumbing` bundle jobs (3) plus
+  the mocha matrix and the three always-on Android KVM jobs; every other bundle job shows as
+  skipped.
 * A PR touching any `src/**` file runs all bundle jobs.
 * Renaming a bundle in fixtures.yml without updating the selector fails
   `test/select-fixture-bundles.test.js`.

--- a/scripts/select-fixture-bundles.cjs
+++ b/scripts/select-fixture-bundles.cjs
@@ -1,55 +1,93 @@
 #!/usr/bin/env node
-// Selects which fixture bundles the PR gate must run for a change set (see
-// .github/workflows/npm-test.yaml and ADR 01055). Deliberately conservative:
-// the ONLY narrowing case is a change set confined entirely to fixture GROUP
-// directories — then only the bundles owning the touched groups run. Anything
-// else (product code, scripts, workflows, shared fixture infra like env /
-// config.groups.json / the mocha-owned ordering+output dirs, or an empty
-// list) returns "all", so a mapping gap can never silently skip coverage.
+// Computes the fixture matrix the PR gate should run for a change set (see
+// .github/workflows/fixtures.yml and ADR 01055). This is the SINGLE SOURCE OF
+// TRUTH for the bundle definitions — fixtures.yml builds its matrix from this
+// script's `--matrix` output via fromJSON, so there is no second copy to drift.
 //
-// Zero runtime dependencies on purpose: the CI `changes` job runs this
-// straight from a checkout, before any npm install. The bundle map below is
-// kept in lockstep with .github/workflows/fixtures.yml by a drift-guard
-// assertion in test/select-fixture-bundles.test.js — edit them together.
+// Deliberately conservative: the ONLY narrowing case is a change set confined
+// entirely to fixture GROUP directories — then only the bundles owning the
+// touched groups run. Anything else (product code, scripts, workflows, shared
+// fixture infra like env / config.groups.json / the mocha-owned ordering+output
+// dirs, or an empty list) selects ALL bundles, so a mapping gap can never
+// silently skip coverage.
+//
+// Zero runtime dependencies on purpose: the CI `select` job runs this straight
+// from a checkout, before any npm install.
 
-// One entry per fixtures.yml matrix bundle, in matrix order.
+// One entry per fixture bundle, in matrix order. `dirs` are the fixture group
+// directories under test/core-artifacts/; the CI-only attributes (timeout,
+// android, prebootIos) travel with each bundle into the matrix.
 const BUNDLES = [
   { name: "nav-capture", dirs: ["navigation", "capture"] },
   { name: "interactions", dirs: ["interactions"] },
   { name: "web-plumbing", dirs: ["routing", "http", "guards"] },
   { name: "proc-sessions", dirs: ["process", "sessions"] },
   { name: "recording", dirs: ["recording"] },
-  { name: "apps", dirs: ["apps"] },
-  { name: "android-skip", dirs: ["apps-android", "mobile-web-android"] },
-  { name: "apps-ios", dirs: ["apps-ios"] },
-  { name: "mobile-web-ios", dirs: ["mobile-web-ios"] },
+  { name: "apps", dirs: ["apps"], timeout: 30 },
+  { name: "android-skip", dirs: ["apps-android", "mobile-web-android"], android: true },
+  { name: "apps-ios", dirs: ["apps-ios"], timeout: 55, prebootIos: true },
+  { name: "mobile-web-ios", dirs: ["mobile-web-ios"], timeout: 55, prebootIos: true },
 ];
 
 const GROUP_TO_BUNDLE = new Map();
 for (const bundle of BUNDLES)
   for (const dir of bundle.dirs) GROUP_TO_BUNDLE.set(dir, bundle.name);
 
+// The matrix object fixtures.yml consumes: `input` is the comma-joined
+// --input value (the action passes it verbatim to `--input`, which splits on
+// commas); the optional CI attributes are included only when set.
+function toMatrixEntry(b) {
+  const entry = {
+    name: b.name,
+    input: b.dirs.map((d) => `test/core-artifacts/${d}`).join(","),
+  };
+  if (b.timeout) entry.timeout = b.timeout;
+  if (b.android) entry.android = true;
+  if (b.prebootIos) entry.prebootIos = true;
+  return entry;
+}
+
 /**
- * @param {string[]} changedFiles - repo-relative paths (either separator)
- * @returns {string} "all", or a comma-joined subset of bundle names in
- *   fixtures.yml matrix order
+ * Bundle NAMES to run for a change set: "all", or a comma-joined subset in
+ * matrix order. (Kept for readability/tests; selectMatrix drives CI.)
+ * @param {string[]} changedFiles
+ * @returns {string}
  */
 function selectBundles(changedFiles) {
-  if (!Array.isArray(changedFiles) || changedFiles.length === 0) return "all";
+  const names = selectedNames(changedFiles);
+  return names === null ? "all" : names.join(",");
+}
+
+/**
+ * The matrix (array of bundle objects) to run for a change set. Not narrowable
+ * → every bundle. Never empty.
+ * @param {string[]} changedFiles
+ * @returns {object[]}
+ */
+function selectMatrix(changedFiles) {
+  const names = selectedNames(changedFiles);
+  const keep = names === null ? null : new Set(names);
+  return BUNDLES.filter((b) => keep === null || keep.has(b.name)).map(toMatrixEntry);
+}
+
+// Returns the selected bundle names in matrix order, or null meaning "not
+// narrowable → all bundles". Null (not an empty array) is the all-signal so an
+// empty change set and a fully-confined-but-unmatched set stay distinct.
+function selectedNames(changedFiles) {
+  if (!Array.isArray(changedFiles) || changedFiles.length === 0) return null;
   const touched = new Set();
   for (const raw of changedFiles) {
     const file = String(raw).replace(/\\/g, "/");
     const match = file.match(/^test\/core-artifacts\/([^/]+)\//);
     const bundle = match && GROUP_TO_BUNDLE.get(match[1]);
-    if (!bundle) return "all"; // outside a known group dir → run everything
+    if (!bundle) return null; // outside a known group dir → run everything
     touched.add(bundle);
   }
-  return BUNDLES.filter((b) => touched.has(b.name))
-    .map((b) => b.name)
-    .join(",");
+  return BUNDLES.filter((b) => touched.has(b.name)).map((b) => b.name);
 }
 
 function main() {
+  const matrixMode = process.argv.includes("--matrix");
   let input = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", (d) => (input += d));
@@ -58,7 +96,11 @@ function main() {
       .split(/\r?\n/)
       .map((line) => line.trim())
       .filter((line) => line.length > 0);
-    process.stdout.write(selectBundles(files) + "\n");
+    // --matrix: single-line JSON array for a workflow matrix. Default: comma
+    // names, for humans and any name-only consumer.
+    process.stdout.write(
+      (matrixMode ? JSON.stringify(selectMatrix(files)) : selectBundles(files)) + "\n"
+    );
   });
 }
 
@@ -66,4 +108,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { selectBundles, BUNDLES };
+module.exports = { selectBundles, selectMatrix, toMatrixEntry, BUNDLES };

--- a/scripts/select-fixture-bundles.cjs
+++ b/scripts/select-fixture-bundles.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Selects which fixture bundles the PR gate must run for a change set (see
-// .github/workflows/npm-test.yaml and ADR 01049). Deliberately conservative:
+// .github/workflows/npm-test.yaml and ADR 01055). Deliberately conservative:
 // the ONLY narrowing case is a change set confined entirely to fixture GROUP
 // directories — then only the bundles owning the touched groups run. Anything
 // else (product code, scripts, workflows, shared fixture infra like env /

--- a/scripts/select-fixture-bundles.cjs
+++ b/scripts/select-fixture-bundles.cjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Selects which fixture bundles the PR gate must run for a change set (see
+// .github/workflows/npm-test.yaml and ADR 01049). Deliberately conservative:
+// the ONLY narrowing case is a change set confined entirely to fixture GROUP
+// directories — then only the bundles owning the touched groups run. Anything
+// else (product code, scripts, workflows, shared fixture infra like env /
+// config.groups.json / the mocha-owned ordering+output dirs, or an empty
+// list) returns "all", so a mapping gap can never silently skip coverage.
+//
+// Zero runtime dependencies on purpose: the CI `changes` job runs this
+// straight from a checkout, before any npm install. The bundle map below is
+// kept in lockstep with .github/workflows/fixtures.yml by a drift-guard
+// assertion in test/select-fixture-bundles.test.js — edit them together.
+
+// One entry per fixtures.yml matrix bundle, in matrix order.
+const BUNDLES = [
+  { name: "nav-capture", dirs: ["navigation", "capture"] },
+  { name: "interactions", dirs: ["interactions"] },
+  { name: "web-plumbing", dirs: ["routing", "http", "guards"] },
+  { name: "proc-sessions", dirs: ["process", "sessions"] },
+  { name: "recording", dirs: ["recording"] },
+  { name: "apps", dirs: ["apps"] },
+  { name: "android-skip", dirs: ["apps-android", "mobile-web-android"] },
+  { name: "apps-ios", dirs: ["apps-ios"] },
+  { name: "mobile-web-ios", dirs: ["mobile-web-ios"] },
+];
+
+const GROUP_TO_BUNDLE = new Map();
+for (const bundle of BUNDLES)
+  for (const dir of bundle.dirs) GROUP_TO_BUNDLE.set(dir, bundle.name);
+
+/**
+ * @param {string[]} changedFiles - repo-relative paths (either separator)
+ * @returns {string} "all", or a comma-joined subset of bundle names in
+ *   fixtures.yml matrix order
+ */
+function selectBundles(changedFiles) {
+  if (!Array.isArray(changedFiles) || changedFiles.length === 0) return "all";
+  const touched = new Set();
+  for (const raw of changedFiles) {
+    const file = String(raw).replace(/\\/g, "/");
+    const match = file.match(/^test\/core-artifacts\/([^/]+)\//);
+    const bundle = match && GROUP_TO_BUNDLE.get(match[1]);
+    if (!bundle) return "all"; // outside a known group dir → run everything
+    touched.add(bundle);
+  }
+  return BUNDLES.filter((b) => touched.has(b.name))
+    .map((b) => b.name)
+    .join(",");
+}
+
+function main() {
+  let input = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (d) => (input += d));
+  process.stdin.on("end", () => {
+    const files = input
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    process.stdout.write(selectBundles(files) + "\n");
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { selectBundles, BUNDLES };

--- a/test/select-fixture-bundles.test.js
+++ b/test/select-fixture-bundles.test.js
@@ -5,75 +5,140 @@ import { createRequire } from "node:module";
 import { parse as parseYaml } from "yaml";
 
 const require = createRequire(import.meta.url);
-const { selectBundles, BUNDLES } = require("../scripts/select-fixture-bundles.cjs");
+const {
+  selectBundles,
+  selectMatrix,
+  BUNDLES,
+} = require("../scripts/select-fixture-bundles.cjs");
+
+// Directories under test/core-artifacts/ that are NOT fixture-gate groups:
+// they hold specs/data consumed by the mocha suite, not this matrix.
+const NON_GROUP_DIRS = new Set(["ordering", "output"]);
 
 describe("select-fixture-bundles", function () {
-  it("returns 'all' when any changed file is outside the fixture group dirs", function () {
-    assert.equal(selectBundles(["src/core/utils.ts"]), "all");
-    assert.equal(
-      selectBundles(["test/core-artifacts/http/x.spec.json", "src/core/utils.ts"]),
-      "all"
-    );
-    assert.equal(selectBundles(["package-lock.json"]), "all");
-    assert.equal(selectBundles([".github/workflows/fixtures.yml"]), "all");
-    assert.equal(selectBundles(["test/run-test-shard.test.js"]), "all");
+  describe("selectBundles (names)", function () {
+    it("returns 'all' when any changed file is outside the fixture group dirs", function () {
+      assert.equal(selectBundles(["src/core/utils.ts"]), "all");
+      assert.equal(
+        selectBundles(["test/core-artifacts/http/x.spec.json", "src/core/utils.ts"]),
+        "all"
+      );
+      assert.equal(selectBundles(["package-lock.json"]), "all");
+      assert.equal(selectBundles([".github/workflows/fixtures.yml"]), "all");
+      assert.equal(selectBundles(["test/run-test-shard.test.js"]), "all");
+    });
+
+    it("returns 'all' for shared fixture infrastructure inside core-artifacts", function () {
+      // env vars, the shared group config, and the mocha-owned dirs feed every
+      // bundle (or none) — narrowing on them would silently skip real coverage.
+      assert.equal(selectBundles(["test/core-artifacts/env"]), "all");
+      assert.equal(selectBundles(["test/core-artifacts/config.groups.json"]), "all");
+      assert.equal(selectBundles(["test/core-artifacts/ordering/_setup.spec.json"]), "all");
+      assert.equal(selectBundles(["test/core-artifacts/output/docker-output.txt"]), "all");
+    });
+
+    it("returns 'all' for an empty change set", function () {
+      assert.equal(selectBundles([]), "all");
+    });
+
+    it("maps group-confined changes to their bundles", function () {
+      assert.equal(selectBundles(["test/core-artifacts/http/checkLink.spec.json"]), "web-plumbing");
+      assert.equal(
+        selectBundles([
+          "test/core-artifacts/http/checkLink.spec.json",
+          "test/core-artifacts/guards/requires.spec.json",
+        ]),
+        "web-plumbing"
+      );
+      assert.equal(
+        selectBundles([
+          "test/core-artifacts/navigation/goTo.spec.json",
+          "test/core-artifacts/sessions/s.spec.json",
+        ]),
+        "nav-capture,proc-sessions"
+      );
+      assert.equal(
+        selectBundles(["test/core-artifacts/apps-android/a.spec.json"]),
+        "android-skip"
+      );
+    });
+
+    it("normalizes Windows-style separators", function () {
+      assert.equal(
+        selectBundles(["test\\core-artifacts\\recording\\recording.spec.json"]),
+        "recording"
+      );
+    });
   });
 
-  it("returns 'all' for shared fixture infrastructure inside core-artifacts", function () {
-    // env vars, the shared group config, and the mocha-owned dirs feed every
-    // bundle (or none) — narrowing on them would silently skip real coverage.
-    assert.equal(selectBundles(["test/core-artifacts/env"]), "all");
-    assert.equal(selectBundles(["test/core-artifacts/config.groups.json"]), "all");
-    assert.equal(selectBundles(["test/core-artifacts/ordering/_setup.spec.json"]), "all");
-    assert.equal(selectBundles(["test/core-artifacts/output/docker-output.txt"]), "all");
+  describe("selectMatrix (CI matrix objects)", function () {
+    it("returns the full matrix for a non-narrowable change set", function () {
+      const all = selectMatrix(["src/core/utils.ts"]);
+      assert.equal(all.length, BUNDLES.length);
+      // Every entry carries a name and a non-empty comma-joined input.
+      for (const b of all) {
+        assert.ok(b.name && typeof b.name === "string");
+        assert.ok(b.input && /^test\/core-artifacts\//.test(b.input));
+      }
+    });
+
+    it("returns the full matrix for an empty change set (never empty)", function () {
+      assert.equal(selectMatrix([]).length, BUNDLES.length);
+    });
+
+    it("narrows to only the touched bundles, preserving CI attributes", function () {
+      const m = selectMatrix(["test/core-artifacts/apps-ios/a.spec.json"]);
+      assert.deepEqual(m, [
+        {
+          name: "apps-ios",
+          input: "test/core-artifacts/apps-ios",
+          timeout: 55,
+          prebootIos: true,
+        },
+      ]);
+    });
+
+    it("emits the android attribute for the android bundle", function () {
+      const m = selectMatrix(["test/core-artifacts/mobile-web-android/m.spec.json"]);
+      assert.equal(m.length, 1);
+      assert.equal(m[0].name, "android-skip");
+      assert.equal(m[0].android, true);
+    });
   });
 
-  it("returns 'all' for an empty change set", function () {
-    assert.equal(selectBundles([]), "all");
+  it("covers every fixture group directory on disk exactly once", function () {
+    // Stronger than comparing to the workflow (which no longer holds the list):
+    // tie the script to the actual filesystem. Every real group dir under
+    // test/core-artifacts/ (minus the mocha-owned ones) must map to exactly one
+    // bundle, and every bundle dir must exist.
+    const root = path.join(process.cwd(), "test", "core-artifacts");
+    const groupDirs = fs
+      .readdirSync(root, { withFileTypes: true })
+      .filter((d) => d.isDirectory() && !NON_GROUP_DIRS.has(d.name))
+      .map((d) => d.name)
+      .sort();
+    const covered = BUNDLES.flatMap((b) => b.dirs).sort();
+    assert.deepEqual(covered, groupDirs, "bundle dirs must match on-disk group dirs exactly");
+    assert.equal(new Set(covered).size, covered.length, "no directory in two bundles");
   });
 
-  it("maps group-confined changes to their bundles", function () {
-    assert.equal(selectBundles(["test/core-artifacts/http/checkLink.spec.json"]), "web-plumbing");
-    assert.equal(
-      selectBundles([
-        "test/core-artifacts/http/checkLink.spec.json",
-        "test/core-artifacts/guards/requires.spec.json",
-      ]),
-      "web-plumbing"
-    );
-    assert.equal(
-      selectBundles([
-        "test/core-artifacts/navigation/goTo.spec.json",
-        "test/core-artifacts/sessions/s.spec.json",
-      ]),
-      "nav-capture,proc-sessions"
-    );
-    assert.equal(
-      selectBundles(["test/core-artifacts/apps-android/a.spec.json"]),
-      "android-skip"
-    );
-  });
-
-  it("normalizes Windows-style separators", function () {
-    assert.equal(
-      selectBundles(["test\\core-artifacts\\recording\\recording.spec.json"]),
-      "recording"
-    );
-  });
-
-  it("keeps its bundle map in lockstep with fixtures.yml (drift guard)", function () {
+  it("keeps fixtures.yml wired to the script's --matrix output (drift guard)", function () {
     const wf = parseYaml(
       fs.readFileSync(
         path.join(process.cwd(), ".github", "workflows", "fixtures.yml"),
         "utf8"
       )
     );
-    const fromWorkflow = wf.jobs.fixtures.strategy.matrix.bundle.map((b) => ({
-      name: b.name,
-      dirs: b.input
-        .split(",")
-        .map((p) => p.trim().replace("test/core-artifacts/", "")),
-    }));
-    assert.deepEqual(BUNDLES, fromWorkflow);
+    // The matrix is dynamic (built from the select job), not a static list.
+    assert.equal(
+      wf.jobs.fixtures.strategy.matrix.bundle,
+      "${{ fromJSON(needs.select.outputs.matrix) }}"
+    );
+    assert.equal(wf.jobs.fixtures.needs, "select");
+    // The select job runs THIS script with --matrix.
+    const selectRun = wf.jobs.select.steps
+      .map((s) => s.run || "")
+      .join("\n");
+    assert.match(selectRun, /select-fixture-bundles\.cjs --matrix/);
   });
 });

--- a/test/select-fixture-bundles.test.js
+++ b/test/select-fixture-bundles.test.js
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { parse as parseYaml } from "yaml";
+
+const require = createRequire(import.meta.url);
+const { selectBundles, BUNDLES } = require("../scripts/select-fixture-bundles.cjs");
+
+describe("select-fixture-bundles", function () {
+  it("returns 'all' when any changed file is outside the fixture group dirs", function () {
+    assert.equal(selectBundles(["src/core/utils.ts"]), "all");
+    assert.equal(
+      selectBundles(["test/core-artifacts/http/x.spec.json", "src/core/utils.ts"]),
+      "all"
+    );
+    assert.equal(selectBundles(["package-lock.json"]), "all");
+    assert.equal(selectBundles([".github/workflows/fixtures.yml"]), "all");
+    assert.equal(selectBundles(["test/run-test-shard.test.js"]), "all");
+  });
+
+  it("returns 'all' for shared fixture infrastructure inside core-artifacts", function () {
+    // env vars, the shared group config, and the mocha-owned dirs feed every
+    // bundle (or none) — narrowing on them would silently skip real coverage.
+    assert.equal(selectBundles(["test/core-artifacts/env"]), "all");
+    assert.equal(selectBundles(["test/core-artifacts/config.groups.json"]), "all");
+    assert.equal(selectBundles(["test/core-artifacts/ordering/_setup.spec.json"]), "all");
+    assert.equal(selectBundles(["test/core-artifacts/output/docker-output.txt"]), "all");
+  });
+
+  it("returns 'all' for an empty change set", function () {
+    assert.equal(selectBundles([]), "all");
+  });
+
+  it("maps group-confined changes to their bundles", function () {
+    assert.equal(selectBundles(["test/core-artifacts/http/checkLink.spec.json"]), "web-plumbing");
+    assert.equal(
+      selectBundles([
+        "test/core-artifacts/http/checkLink.spec.json",
+        "test/core-artifacts/guards/requires.spec.json",
+      ]),
+      "web-plumbing"
+    );
+    assert.equal(
+      selectBundles([
+        "test/core-artifacts/navigation/goTo.spec.json",
+        "test/core-artifacts/sessions/s.spec.json",
+      ]),
+      "nav-capture,proc-sessions"
+    );
+    assert.equal(
+      selectBundles(["test/core-artifacts/apps-android/a.spec.json"]),
+      "android-skip"
+    );
+  });
+
+  it("normalizes Windows-style separators", function () {
+    assert.equal(
+      selectBundles(["test\\core-artifacts\\recording\\recording.spec.json"]),
+      "recording"
+    );
+  });
+
+  it("keeps its bundle map in lockstep with fixtures.yml (drift guard)", function () {
+    const wf = parseYaml(
+      fs.readFileSync(
+        path.join(process.cwd(), ".github", "workflows", "fixtures.yml"),
+        "utf8"
+      )
+    );
+    const fromWorkflow = wf.jobs.fixtures.strategy.matrix.bundle.map((b) => ({
+      name: b.name,
+      dirs: b.input
+        .split(",")
+        .map((p) => p.trim().replace("test/core-artifacts/", "")),
+    }));
+    assert.deepEqual(BUNDLES, fromWorkflow);
+  });
+});


### PR DESCRIPTION
> Round-2 CI latency work, PR E of 5. **Do not merge yet** — prepped for review; merge serially. Touches fixtures.yml/npm-test.yaml; PR D stacks on this.

## What

Lands ADR 01048's deferred "option C" in its silent-skip-proof form (ADR 01049, included):

- **Selector** ([scripts/select-fixture-bundles.cjs](../blob/ci/path-filtered-fixtures/scripts/select-fixture-bundles.cjs), zero-dependency): returns `all` unless the change set is confined entirely to fixture group dirs — then exactly the owning bundles. Shared infra inside core-artifacts (`env`, `config.groups.json`, mocha-owned `ordering/`+`output/`), empty sets, and non-PR triggers → `all`.
- **PR gate**: new `changes` job lists PR files via the API and feeds the selector; `fixtures` receives the result through a new `bundles` input. Deselected bundles appear as **skipped jobs** — visible, auditable.
- **Release gate unchanged**: release.yml omits the input → default `all`.
- **Comma-guarded `if:`** because bundle names aren't substring-safe (`apps` vs `apps-ios`).

Failure directions are all safe: selector bug → `all` (waste, not risk); bundle-map drift → `test/select-fixture-bundles.test.js` fails (it deep-equals the map against the fixtures.yml matrix); `changes` job failure → gate fails (`needs`).

TDD: test written and run red (`MODULE_NOT_FOUND`) before the script existed; 6 passing after.

## Effect

Fixture-authoring PRs (a common shape under the repo's every-permutation fixture policy) drop from 27 general fixture jobs to only their own bundles (e.g. 3). Product-code PRs still run everything — deliberately; the ADR documents the full source→bundle map as possible future work layered on this fallback.

## Note for this PR's own CI

This PR touches workflows + scripts + test files → the selector itself picks `all`, so its own run exercises the full matrix through the new input plumbing. A follow-up fixture-only PR is the natural place to observe the narrowed path (or dispatch one synthetically).

## Docs impact

None user-facing; agent-facing docs are the ADR + workflow comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull requests now auto-select the relevant fixture bundles based on the changed file paths.
  * When changes can’t be safely mapped, CI falls back to running the full fixture matrix (never an empty matrix).
* **Documentation**
  * Added an ADR documenting the conservative narrowing rules and the fallback behavior.
* **Tests**
  * Added/expanded tests for bundle selection, matrix generation, path normalization, Android-specific behavior, and workflow wiring consistency.
* **Chores**
  * Updated CI workflows to compute the fixture bundle matrix dynamically at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->