### PR TITLE
ci: skip the android KVM legs when a change set is android-inert (ADR 01050)

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -51,6 +51,8 @@ jobs:
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.pick.outputs.matrix }}
+      # "true"/"false": whether the heavy Android KVM legs run (ADR 01056).
+      androidLegs: ${{ steps.pick.outputs.androidLegs }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -63,13 +65,15 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
         run: |
           matrix=''
+          androidLegs=true
           # Only a PR context can narrow. `if files=$(...)` tolerates a non-zero
           # gh api (transient 5xx / rate limit) without tripping `set -e`, and
           # `timeout 120` makes a HANG fail-safe too (exit 124 → the full
-          # matrix) instead of silently eating the job's 5-min budget.
+          # matrix + legs on) instead of silently eating the job's 5-min budget.
           if [ -n "$PR" ] && files=$(timeout 120 gh api "repos/${{ github.repository }}/pulls/$PR/files?per_page=100" --paginate --jq '.[].filename'); then
             printf 'changed files:\n%s\n' "$files"
             matrix=$(printf '%s\n' "$files" | node scripts/select-fixture-bundles.cjs --matrix || echo '')
+            androidLegs=$(printf '%s\n' "$files" | node scripts/select-fixture-bundles.cjs --android-legs || echo true)
           fi
           # Fail-safe: no PR, API/selector failure, or an empty/degenerate value
           # → the full matrix (never zero fixtures). Empty stdin selects all.
@@ -77,8 +81,13 @@ jobs:
             echo "defaulting to the full fixture matrix"
             matrix=$(printf '' | node scripts/select-fixture-bundles.cjs --matrix)
           fi
+          # androidLegs must be exactly false to skip the legs; anything else
+          # (crash, empty, unexpected) coerces to true so the legs stay on.
+          [ "$androidLegs" = "false" ] || androidLegs=true
           echo "selected matrix: $matrix"
+          echo "android KVM legs: $androidLegs"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "androidLegs=$androidLegs" >> "$GITHUB_OUTPUT"
 
   fixtures:
     needs: select
@@ -294,11 +303,18 @@ jobs:
   #
   # reactivecircus/android-emulator-runner is pinned to a commit SHA (v2.37.0)
   # to match this repo's action-pinning policy.
+  #
+  # All three KVM legs (reuse, managed-boot, action) are gated on the `select`
+  # job's `androidLegs` output (ADR 01056): they run unless every changed file
+  # is provably android-inert. Fail-safe — any uncertainty keeps them on — and
+  # non-PR triggers (the release gate) always run them.
 
   # Reuse leg: the emulator-runner boots an emulator, and Doc Detective detects
   # and REUSES it (bootedByUs=false, left running) — the default-device path.
   fixtures-android-reuse:
     name: apps-android + mobile-web (ubuntu KVM, reuse)
+    needs: select
+    if: needs.select.outputs.androidLegs != 'false'
     runs-on: ubuntu-latest
     # Headroom for the second (mobile-web, phase A5) gated run on the same
     # emulator — chromedriver download + Chrome session.
@@ -431,6 +447,8 @@ jobs:
   # creations + serial boots — too heavy for the other legs).
   fixtures-android-managed:
     name: apps-android + mobile-web (ubuntu KVM, managed-boot)
+    needs: select
+    if: needs.select.outputs.androidLegs != 'false'
     runs-on: ubuntu-latest
     # Headroom for the second (mobile-web, phase A5) gated run, which boots the
     # managed AVD again after the first run's sweep, plus the two serial
@@ -523,6 +541,8 @@ jobs:
   # `reactivecircus`-free, install-free counterpart to the two jobs above.)
   fixtures-android-action:
     name: apps-android (action auto-KVM, lazy)
+    needs: select
+    if: needs.select.outputs.androidLegs != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:

--- a/adrs/01056-gate-android-kvm-legs-by-relevance.md
+++ b/adrs/01056-gate-android-kvm-legs-by-relevance.md
@@ -1,0 +1,97 @@
+---
+status: accepted
+date: 2026-07-13
+decision-makers: doc-detective maintainers
+---
+
+# Skip the android KVM legs on PRs that cannot affect android behavior
+
+## Context and Problem Statement
+
+Three dedicated ubuntu jobs prove the android bootstrap paths on every PR: the emulator-runner
+**reuse** leg (~8 min), the **managed-boot** leg (~15 min, `install android` + two boot cycles +
+the A6 two-device spec), and the **action-lazy** leg (~7 min, cold SDK bootstrap through the
+GitHub Action). That is ~30 runner-minutes per PR — on scarce Linux-KVM runners — verifying flows
+that a documentation-fixture or mocha-test-only change cannot alter. ADR 01055's `select` job
+already analyzes the change set to build the fixture matrix; the same analysis can gate these legs
+under the same silent-skip-proof discipline.
+
+## Decision Drivers
+
+* ~30 runner-minutes per PR is the largest remaining always-on cost after ADR 01048/01055.
+* The legs exist to catch regressions in android-adjacent product code — which most PRs don't touch.
+* Same non-negotiable as ADR 01055: skipping must fail safe (run the legs) on any uncertainty.
+* The release gate must always run all three legs.
+
+## Considered Options
+
+* **A — Safe-list relevance predicate** (chosen): the legs run UNLESS every changed file is
+  provably android-inert.
+* **B — Trigger-list predicate**: run the legs only when a curated list of android-ish paths
+  changes. Inverts the failure direction — a missing entry silently skips the gate. Rejected.
+* **C — Status quo**: all three legs on every PR.
+
+## Decision Outcome
+
+Chosen option: **A**.
+
+* `androidLegsRelevant(changedFiles)` in
+  [`scripts/select-fixture-bundles.cjs`](../scripts/select-fixture-bundles.cjs) returns `false`
+  (skip the legs) only when **every** changed file is android-safe:
+  * a fixture spec in a **non-android** bundle group directory,
+  * a mocha-suite-only file (`test/<name>.test.js` — never loaded by fixture jobs), or
+  * prose (`docs/`, `adrs/`, any `*.md`).
+  Everything else is relevant — product code, `scripts/`, workflows, package manifests, shared
+  fixture infra (`env`, `config.groups.json`), and **the test servers** (`test/server/**`), which
+  the mobile-web legs reach from inside the emulator via 10.0.2.2. Empty change sets are relevant.
+* Reusing ADR 01055's self-contained `select` job: it emits an `androidLegs` output (computed by
+  the same `--android-legs` run of the script over the PR's changed files), and each of the three
+  KVM jobs carries `needs: select` + `if: needs.select.outputs.androidLegs != 'false'`. Job-level
+  `if:` **can** read the `needs` context (unlike `matrix`), so this gates cleanly. No input
+  plumbing through the callers — the same reason the matrix moved into the reusable workflow
+  ([ADR 01055](01055-path-filtered-fixture-bundles.md)).
+* Fail-safe by construction: the `select` job coerces anything other than an explicit `false` to
+  `true`, and a non-PR trigger (the release gate's push) never narrows — so the legs always run
+  there and on any error.
+* The general-matrix `android-skip` bundle is NOT gated by this: it asserts the SKIP paths on
+  non-KVM hosts and is governed by the ADR 01055 matrix selector like any other bundle.
+* Unit tests (`test/select-fixture-bundles.test.js`) pin the predicate — including the test-server
+  and shared-infra relevance cases — and assert all three KVM jobs carry the gate.
+
+### Consequences
+
+* Good: fixture-authoring and mocha-test-only PRs shed ~30 runner-minutes and one of the two
+  slowest remaining jobs (managed-boot).
+* Good: failure direction is safe — any unrecognized file keeps the legs on; the safe-list is
+  small, explicit, and unit-pinned.
+* Neutral: product-code PRs (the majority) still run all three legs. Deliberate — those changes can
+  plausibly reach runtime/installer/driver behavior the legs guard.
+* Cost/watch: `test/<name>.test.js` files are classified android-inert on the premise that fixture
+  jobs never execute mocha files. If a future fixture leg starts consuming files from `test/`
+  outside `core-artifacts/` and `server/`, revisit the predicate.
+
+### Confirmation
+
+* A PR touching only `test/core-artifacts/http/**` shows all three KVM legs as skipped; a PR
+  touching any `src/**` file shows them running.
+* A push to a release branch runs all three legs (the `select` job's push path never narrows).
+* `npx mocha test/select-fixture-bundles.test.js` covers the relevant/inert classifications and
+  asserts each KVM job gates on `needs.select.outputs.androidLegs`.
+
+## Pros and Cons of the Options
+
+### A — Safe-list relevance predicate (CHOSEN)
+
+* Good: fail-safe direction; tiny reviewable safe-list; reuses ADR 01055's `select` job end-to-end.
+* Bad: conservative — src-touching PRs get no savings (accepted).
+
+### B — Trigger-list of android-ish paths
+
+* Good: bigger savings on src PRs that don't match the list.
+* Bad: a stale list silently un-guards exactly the code being changed; the failure mode ADR 01055
+  exists to avoid. Rejected.
+
+### C — Status quo
+
+* Good: zero risk.
+* Bad: ~30 runner-minutes per PR spent proving flows most PRs cannot break.

--- a/scripts/select-fixture-bundles.cjs
+++ b/scripts/select-fixture-bundles.cjs
@@ -86,8 +86,46 @@ function selectedNames(changedFiles) {
   return BUNDLES.filter((b) => touched.has(b.name)).map((b) => b.name);
 }
 
+// Groups whose fixtures exercise android surfaces; changes there always keep
+// the heavy KVM legs on.
+const ANDROID_GROUPS = new Set(["apps-android", "mobile-web-android"]);
+
+// A file is "android-safe" when it demonstrably cannot change what the KVM
+// legs (fixtures-android-reuse/-managed/-action) execute: fixture specs of
+// NON-android groups, files consumed only by the mocha suite (test/<name>.
+// test.js — the fixture jobs never load them), and prose (docs/, adrs/, *.md).
+// Everything else — product code, scripts, workflows, package manifests, the
+// test servers (hit from INSIDE the emulator via 10.0.2.2), shared fixture
+// infra — is android-relevant.
+function isAndroidSafe(file) {
+  const groupMatch = file.match(/^test\/core-artifacts\/([^/]+)\//);
+  if (groupMatch)
+    return GROUP_TO_BUNDLE.has(groupMatch[1]) && !ANDROID_GROUPS.has(groupMatch[1]);
+  if (/^test\/[^/]+\.test\.js$/.test(file)) return true;
+  if (/^(docs|adrs)\//.test(file)) return true;
+  if (/\.md$/i.test(file)) return true;
+  return false;
+}
+
+/**
+ * Whether the heavy android KVM legs must run for this change set. Fail-safe:
+ * empty/unknown sets are relevant (the legs run).
+ * @param {string[]} changedFiles
+ * @returns {boolean}
+ */
+function androidLegsRelevant(changedFiles) {
+  if (!Array.isArray(changedFiles) || changedFiles.length === 0) return true;
+  return !changedFiles.every((raw) =>
+    isAndroidSafe(String(raw).replace(/\\/g, "/"))
+  );
+}
+
 function main() {
-  const matrixMode = process.argv.includes("--matrix");
+  const mode = process.argv.includes("--matrix")
+    ? "matrix"
+    : process.argv.includes("--android-legs")
+    ? "android"
+    : "names";
   let input = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", (d) => (input += d));
@@ -96,11 +134,16 @@ function main() {
       .split(/\r?\n/)
       .map((line) => line.trim())
       .filter((line) => line.length > 0);
-    // --matrix: single-line JSON array for a workflow matrix. Default: comma
-    // names, for humans and any name-only consumer.
-    process.stdout.write(
-      (matrixMode ? JSON.stringify(selectMatrix(files)) : selectBundles(files)) + "\n"
-    );
+    // --matrix: single-line JSON array for a workflow matrix.
+    // --android-legs: "true"/"false" for the KVM-leg `if:` guards.
+    // Default: comma names, for humans and any name-only consumer.
+    const out =
+      mode === "matrix"
+        ? JSON.stringify(selectMatrix(files))
+        : mode === "android"
+        ? String(androidLegsRelevant(files))
+        : selectBundles(files);
+    process.stdout.write(out + "\n");
   });
 }
 
@@ -108,4 +151,10 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { selectBundles, selectMatrix, toMatrixEntry, BUNDLES };
+module.exports = {
+  selectBundles,
+  selectMatrix,
+  androidLegsRelevant,
+  toMatrixEntry,
+  BUNDLES,
+};

--- a/test/select-fixture-bundles.test.js
+++ b/test/select-fixture-bundles.test.js
@@ -8,6 +8,7 @@ const require = createRequire(import.meta.url);
 const {
   selectBundles,
   selectMatrix,
+  androidLegsRelevant,
   BUNDLES,
 } = require("../scripts/select-fixture-bundles.cjs");
 
@@ -106,6 +107,56 @@ describe("select-fixture-bundles", function () {
     });
   });
 
+  describe("androidLegsRelevant", function () {
+    it("keeps the KVM legs on for product, script, workflow, and infra changes", function () {
+      assert.equal(androidLegsRelevant(["src/core/utils.ts"]), true);
+      assert.equal(androidLegsRelevant(["scripts/check-fixture-results.cjs"]), true);
+      assert.equal(androidLegsRelevant([".github/workflows/fixtures.yml"]), true);
+      assert.equal(androidLegsRelevant(["package-lock.json"]), true);
+      // The fixture jobs' test servers are reached from inside the emulator.
+      assert.equal(androidLegsRelevant(["test/server/start.js"]), true);
+      assert.equal(androidLegsRelevant(["test/core-artifacts/env"]), true);
+      assert.equal(androidLegsRelevant(["test/core-artifacts/config.groups.json"]), true);
+    });
+
+    it("keeps the KVM legs on when android fixtures change", function () {
+      assert.equal(androidLegsRelevant(["test/core-artifacts/apps-android/a.spec.json"]), true);
+      assert.equal(
+        androidLegsRelevant(["test/core-artifacts/mobile-web-android/m.spec.json"]),
+        true
+      );
+    });
+
+    it("keeps the KVM legs on for an empty change set", function () {
+      assert.equal(androidLegsRelevant([]), true);
+    });
+
+    it("skips the KVM legs when changes cannot reach android behavior", function () {
+      assert.equal(androidLegsRelevant(["test/core-artifacts/http/checkLink.spec.json"]), false);
+      assert.equal(androidLegsRelevant(["test/run-test-shard.test.js"]), false);
+      assert.equal(androidLegsRelevant(["docs/pages/get-started.mdx"]), false);
+      assert.equal(androidLegsRelevant(["adrs/01055-path-filtered-fixture-bundles.md"]), false);
+      assert.equal(androidLegsRelevant(["test/AGENTS.md"]), false);
+      assert.equal(
+        androidLegsRelevant([
+          "test/core-artifacts/recording/recording.spec.json",
+          "test/hints.test.js",
+        ]),
+        false
+      );
+    });
+
+    it("one relevant file flips the whole set to relevant", function () {
+      assert.equal(
+        androidLegsRelevant([
+          "test/core-artifacts/http/checkLink.spec.json",
+          "src/core/appium.ts",
+        ]),
+        true
+      );
+    });
+  });
+
   it("covers every fixture group directory on disk exactly once", function () {
     // Stronger than comparing to the workflow (which no longer holds the list):
     // tie the script to the actual filesystem. Every real group dir under
@@ -135,10 +186,32 @@ describe("select-fixture-bundles", function () {
       "${{ fromJSON(needs.select.outputs.matrix) }}"
     );
     assert.equal(wf.jobs.fixtures.needs, "select");
-    // The select job runs THIS script with --matrix.
+    // The select job runs THIS script with --matrix and --android-legs.
     const selectRun = wf.jobs.select.steps
       .map((s) => s.run || "")
       .join("\n");
     assert.match(selectRun, /select-fixture-bundles\.cjs --matrix/);
+    assert.match(selectRun, /select-fixture-bundles\.cjs --android-legs/);
+  });
+
+  it("gates all three android KVM legs on the select job's androidLegs output", function () {
+    const wf = parseYaml(
+      fs.readFileSync(
+        path.join(process.cwd(), ".github", "workflows", "fixtures.yml"),
+        "utf8"
+      )
+    );
+    for (const job of [
+      "fixtures-android-reuse",
+      "fixtures-android-managed",
+      "fixtures-android-action",
+    ]) {
+      assert.equal(wf.jobs[job].needs, "select", `${job} must need select`);
+      assert.equal(
+        wf.jobs[job].if,
+        "needs.select.outputs.androidLegs != 'false'",
+        `${job} must gate on androidLegs`
+      );
+    }
   });
 });


### PR DESCRIPTION
> Round-2 CI latency work, PR D of 5 — **stacked on #620** (retarget to main after it merges). **Do not merge yet.**

## What

The three android KVM legs (reuse ~8 min, managed-boot ~15 min, action-lazy ~7 min) run on every PR — ~30 runner-minutes proving bootstrap flows most PRs can't break. This gates them on change-set relevance, reusing #620's plumbing end-to-end:

- `androidLegsRelevant()` (in the same selector script) uses a **safe-list** predicate — the legs skip only when *every* changed file is provably android-inert: a non-android fixture group spec, a mocha-only `test/<name>.test.js`, or prose (`docs/`, `adrs/`, `*.md`). Anything else — product code, scripts, workflows, manifests, shared fixture infra, and notably `test/server/**` (the mobile-web legs hit those servers from inside the emulator via 10.0.2.2) — keeps them on. Empty sets and non-PR triggers keep them on.
- The `changes` job emits `androidLegs`; `fixtures.yml` gains an `androidLegs` input (default `'true'` → release gate always runs the legs); each leg gets `if: inputs.androidLegs != 'false'`. Skips are visible as skipped jobs.
- The trigger-list alternative (run legs only when android-ish paths change) was rejected in ADR 01050: it inverts the failure direction — a stale list silently un-guards the code being changed.

TDD: predicate tests red first (`androidLegsRelevant is not a function`), 11 passing after; the safe-list edge cases (test servers relevant, android fixture dirs relevant, mixed sets) are unit-pinned.

## Docs impact

None user-facing; gate-scope decision documented in ADR 01050.

## Verification

- On a fixture-only follow-up PR: all three KVM legs show as skipped, everything else per #620.
- On this PR itself (touches workflows + scripts): legs run — the predicate classifies it relevant.
- Release-branch pushes: legs always run (input omitted → default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Android emulator-based test runs now execute only when changed files may affect Android behavior.
  * Runs remain enabled for uncertain, invalid, or non-pull-request changes to preserve coverage.

* **Documentation**
  * Added documentation describing the Android test-run gating strategy and its safety rules.

* **Tests**
  * Added coverage for Android relevance detection and workflow gating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->