### PR TITLE
ci: decouple doc-detective-common test run from its build (ADR 01057)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,9 +165,13 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - run: npm ci
-      # build:common compiles dist and runs `c8 mocha`, writing
-      # src/common/coverage/coverage-summary.json that the ratchet reads.
       - run: npm run build:common
+      # build:common no longer runs the suite (it builds artifacts only, so the
+      # ~40 fixture/shard jobs that just need dist do not pay for — or flake on —
+      # the src/common tests; see ADR 01057). This job runs them explicitly to
+      # produce src/common/coverage/coverage-summary.json for the ratchet.
+      - run: npm run test:coverage
+        working-directory: src/common
       - run: npm run test:coverage:ratchet
         working-directory: src/common
 

--- a/adrs/01057-decouple-common-tests-from-build.md
+++ b/adrs/01057-decouple-common-tests-from-build.md
@@ -1,0 +1,102 @@
+---
+status: accepted
+date: 2026-07-13
+decision-makers: doc-detective maintainers
+---
+
+# Decouple the doc-detective-common test run from its build
+
+## Context and Problem Statement
+
+`src/common`'s `build` script ended with `&& npm run test:coverage`, so building
+the package also ran its full `c8 mocha` suite. Because the root `build`
+(`build:common && compile && copy:schemas`) is invoked by **every** CI job that
+needs the compiled artifacts — all ~40 fixture jobs, both mocha shards, and the
+coverage jobs — every one of those jobs ran the src/common test suite purely as
+a side effect of building. Two costs followed:
+
+* **Flakiness.** `src/common/test/integration.test.js` does real module-load /
+  fs work under a 10s timeout; on loaded macOS runners it intermittently
+  exceeded it, failing the **build** step of otherwise-unrelated jobs (observed
+  reruns on PRs #619, #620, #621). A flake in one small suite could red any of
+  ~40 jobs.
+* **Wasted wall-clock.** Those jobs need the built `dist/`, not a test run. The
+  suite added ~1 minute to the build step of every macOS fixture job (where the
+  build step is already ~3 min), on the scarce macOS pool.
+
+The src/common suite is already run where it belongs: the dedicated
+`coverage-ratchet` job and the cross-OS/node mocha matrix.
+
+## Decision Drivers
+
+* A build should produce artifacts; running tests as a build side effect couples
+  unrelated jobs to an unrelated suite's flakiness and runtime.
+* Don't lose the src/common coverage ratchet or the integration coverage.
+* Minimal blast radius — exactly one CI job relied on the build running tests.
+
+## Considered Options
+
+* **A — Decouple** (chosen): `build` builds only; the one job that needs the
+  coverage runs `test:coverage` explicitly.
+* **B — Bump only the integration test's timeout** to 60s. Removes the flake but
+  keeps every job paying to run the suite during build.
+* **C — Status quo.**
+
+## Decision Outcome
+
+Chosen option: **A** (with B folded in as defense-in-depth).
+
+* `src/common`'s `build` is now `dereferenceSchemas && generate:types &&
+  compile` — no `test:coverage`. Every `npm run build` / `build:common`
+  consumer builds artifacts without running the suite.
+* The only consumer that relied on the side effect — the `Coverage ratchet
+  (src/common)` job in [`test.yml`](../.github/workflows/test.yml) — now runs
+  `npm run test:coverage` (in `src/common`) explicitly before the ratchet
+  check, producing the `coverage-summary.json` the ratchet reads.
+* Defense-in-depth: `integration.test.js`'s suite timeout is raised 10s → 60s,
+  so the jobs that still run it (the ratchet + the mocha matrix) don't trip on a
+  loaded runner.
+* A regression guard (`test/common-build-contract.test.js`) asserts the build
+  builds artifacts without invoking the suite (no `test:coverage`/`mocha`/`c8`),
+  still runs `compile`, and keeps a separate `test:coverage` entry — red against
+  the prior build script, green against the decoupled one.
+
+### Consequences
+
+* Good: the src/common suite no longer runs in ~40 fixture/shard jobs — one
+  flaky suite can no longer red an unrelated build step, and each macOS fixture
+  job's build step drops ~1 min.
+* Good: coverage and the ratchet are unchanged — the suite still runs in the
+  ratchet job (now explicitly) and the mocha matrix.
+* Neutral: one extra `run:` step in the ratchet job (the explicit test run),
+  replacing the implicit one — same total work there.
+* Watch: anyone adding a new CI job that assumed `build:common` also runs the
+  tests must run them explicitly. Documented in `src/common/AGENTS.md`.
+
+### Confirmation
+
+* `npm run build:common` produces `src/common/dist/` with **no** mocha output.
+* The `Coverage ratchet (src/common)` job stays green (runs `test:coverage`
+  then the ratchet).
+* Fixture/shard build steps no longer show src/common test output, and the
+  `integration.test.js` timeout flake stops recurring.
+* `test/common-build-contract.test.js` fails against the prior build script and
+  passes against the decoupled one.
+
+## Pros and Cons of the Options
+
+### A — Decouple (CHOSEN)
+
+* Good: removes both the cross-job flake surface and the per-job waste at the
+  root; tiny, contained change.
+* Bad: one CI job needs an explicit test step added (done).
+
+### B — Timeout bump only
+
+* Good: one-line flake fix.
+* Bad: leaves ~40 jobs running the suite during build — the waste and the
+  coupling remain.
+
+### C — Status quo
+
+* Bad: recurring reruns and wasted macOS minutes.

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -92,7 +92,7 @@ When `validate()` is called:
 1. Edit source schema in `src/schemas/src_schemas/`
 2. Add/update `examples` array (required for tests)
 3. If adding new file, add to `files` array in `dereferenceSchemas.js`
-4. Run `npm run build` (runs `dereferenceSchemas` + tests)
+4. Run `npm run build` (`dereferenceSchemas` + `generate:types` + `compile`; it does NOT run tests — run `npm run test:coverage` separately, per ADR 01057)
 5. If creating v3 schema, add to published list in `dereferenceSchemas.js` (line ~130)
 
 ### Dual-build requirement (schema edits aren't live until BOTH builds run)

--- a/src/common/package.json
+++ b/src/common/package.json
@@ -22,7 +22,7 @@
     "dereferenceSchemas": "node ./src/schemas/dereferenceSchemas.cjs",
     "clean": "node -e \"require('fs').rmSync('dist', {recursive: true, force: true})\"",
     "compile": "npm run clean && tsc && node scripts/createCjsWrapper.js",
-    "build": "npm run dereferenceSchemas && npm run generate:types && npm run compile && npm run test:coverage",
+    "build": "npm run dereferenceSchemas && npm run generate:types && npm run compile",
     "test": "mocha",
     "test:coverage": "c8 mocha",
     "test:coverage:html": "c8 --reporter=html mocha",

--- a/src/common/test/integration.test.js
+++ b/src/common/test/integration.test.js
@@ -15,7 +15,10 @@ const require = createRequire(import.meta.url);
 
   describe("Module Integration Tests", function () {
     // Increase timeout for spawning node processes
-    this.timeout(10000);
+    // Module-load + build-artifact assertions do real fs/require work; on a
+    // loaded CI runner the default 10s tripped intermittently (this suite runs
+    // in every job that builds). 60s is ample headroom, still catches a hang.
+    this.timeout(60000);
 
     describe("CommonJS (require)", function () {
       it("should export validate function via require", function () {

--- a/src/common/test/integration.test.js
+++ b/src/common/test/integration.test.js
@@ -14,10 +14,11 @@ const __dirname = path.dirname(__filename);
 const require = createRequire(import.meta.url);
 
   describe("Module Integration Tests", function () {
-    // Increase timeout for spawning node processes
     // Module-load + build-artifact assertions do real fs/require work; on a
-    // loaded CI runner the default 10s tripped intermittently (this suite runs
-    // in every job that builds). 60s is ample headroom, still catches a hang.
+    // loaded CI runner the default 10s tripped intermittently. 60s is ample
+    // headroom and still catches a genuine hang. (Since ADR 01057 this suite
+    // runs only in the coverage-ratchet job and the mocha matrix, not in every
+    // job that builds — but the wider bound is cheap insurance either way.)
     this.timeout(60000);
 
     describe("CommonJS (require)", function () {

--- a/test/common-build-contract.test.js
+++ b/test/common-build-contract.test.js
@@ -11,13 +11,17 @@ import path from "node:path";
 // npm run test:coverage`) the "does not run the suite" assertion fails;
 // against the decoupled script it passes.
 describe("doc-detective-common build contract (ADR 01057)", function () {
-  const pkg = JSON.parse(
-    fs.readFileSync(
-      path.join(process.cwd(), "src", "common", "package.json"),
-      "utf8"
-    )
-  );
-  const build = pkg.scripts.build;
+  let pkg, build;
+
+  before(function () {
+    pkg = JSON.parse(
+      fs.readFileSync(
+        path.join(process.cwd(), "src", "common", "package.json"),
+        "utf8"
+      )
+    );
+    build = pkg.scripts.build;
+  });
 
   it("builds artifacts without running the test suite", function () {
     assert.doesNotMatch(

--- a/test/common-build-contract.test.js
+++ b/test/common-build-contract.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+// Guards the build/test decoupling from ADR 01057: `build:common` (and thus
+// the root `npm run build` that every fixture/shard job runs) must build
+// artifacts WITHOUT running the src/common test suite. Re-adding a test run to
+// the build regresses the flake surface and per-job waste this ADR removed.
+//
+// Red→green anchor: against the prior build script (`… && npm run compile &&
+// npm run test:coverage`) the "does not run the suite" assertion fails;
+// against the decoupled script it passes.
+describe("doc-detective-common build contract (ADR 01057)", function () {
+  const pkg = JSON.parse(
+    fs.readFileSync(
+      path.join(process.cwd(), "src", "common", "package.json"),
+      "utf8"
+    )
+  );
+  const build = pkg.scripts.build;
+
+  it("builds artifacts without running the test suite", function () {
+    assert.doesNotMatch(
+      build,
+      /\btest(:coverage)?\b|\bmocha\b|\bc8\b/,
+      `src/common build must not invoke tests (ADR 01057); got: ${build}`
+    );
+  });
+
+  it("still compiles the package", function () {
+    assert.match(build, /\bcompile\b/, "src/common build must still run compile");
+  });
+
+  it("keeps a separate coverage entry for the ratchet job to call", function () {
+    assert.equal(pkg.scripts["test:coverage"], "c8 mocha");
+  });
+});


### PR DESCRIPTION
## Why (from the round-2 wall-clock analysis)

Profiling the macOS `apps-ios` leg showed the build step at ~3 min, and `build:common` was running `&& npm run test:coverage` — so **every** job that builds artifacts (all ~40 fixture jobs, both mocha shards, the coverage jobs) ran the src/common test suite purely as a build side effect. Two costs:

- **Flakiness:** `src/common/test/integration.test.js` (10s timeout, real module-load work) intermittently timed out on loaded macOS runners, failing the **build** step of unrelated jobs — the recurring flake that forced reruns on #619, #620, and #621.
- **Wasted macOS minutes:** those jobs need `dist/`, not a test run — ~1 min/job on the scarce macOS pool.

## What

- `src/common` `build` → `dereferenceSchemas && generate:types && compile` (no `test:coverage`). Verified locally: emits no mocha output, still produces `dist/`.
- The only consumer of the side effect — the **Coverage ratchet (src/common)** job — now runs `npm run test:coverage` explicitly before the ratchet (same coverage, unchanged ratchet).
- Defense-in-depth: `integration.test.js` suite timeout 10s → 60s for the jobs that still run it.
- Corrected the stale "build runs tests" note in `src/common/AGENTS.md`.

Coverage is unchanged — the suite still runs in the ratchet job and the mocha matrix; it just stops running in the ~40 jobs that only need artifacts. ADR 01057 has the full rationale.

## Verification

- `npm run build:common` → 0 mocha lines, `dist/index.js` present (checked).
- This PR's own gate: the `Coverage ratchet (src/common)` job stays green; fixture build steps no longer show src/common test output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI coverage reporting by decoupling artifact builds from coverage tests, ensuring the coverage summary is generated deterministically.
  * Increased integration-test timeout to reduce intermittent CI failures in slower environments.
* **Tests**
  * Added a build-contract check to ensure the common build no longer runs coverage/test commands.
* **Documentation**
  * Clarified what the common package build does, and documented the build/coverage separation rationale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->