### PR TITLE
fix(container): align smoke-test fixture with runShell's bash default

### DIFF
--- a/src/container/test/artifacts/runShell_pipes.spec.json
+++ b/src/container/test/artifacts/runShell_pipes.spec.json
@@ -3,33 +3,24 @@
     {
       "contexts": [
         {
-          "app": { "name": "firefox" },
-          "platforms": ["windows"]
+          "app": {
+            "name": "firefox"
+          },
+          "platforms": [
+            "windows",
+            "mac",
+            "linux"
+          ]
         }
       ],
       "steps": [
         {
-          "action": "runShell",
-          "command": "echo dev | find \"dev\"",
-          "output": "dev"
+          "runShell": {
+            "command": "echo dev | grep dev",
+            "stdio": "dev"
+          }
         }
       ]
-    },
-    {
-      "contexts": [
-        {
-          "app": { "name": "firefox" },
-          "platforms": ["mac", "linux"]
-        }
-      ],
-      "steps": [
-        {
-          "action": "runShell",
-          "command": "echo dev | grep dev",
-          "output": "dev"
-        }
-      ]
-
     }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up investigation from [#611](https://github.com/doc-detective/doc-detective/pull/611): after that fix shipped, release 4.27.0's `build-windows` Docker job failed on an unrelated regression.

**Root cause:** [#610](https://github.com/doc-detective/doc-detective/pull/610) changed `runShell`'s default shell on Windows from `cmd.exe` to bash (Git Bash/MinGit) and updated `test/core-artifacts/process/runShell_pipes.spec.json` to match — but missed a second, separate copy used only by the container's own smoke test: `src/container/test/artifacts/runShell_pipes.spec.json`. Its Windows context still used cmd.exe's `find "dev"` for a substring match. Under the bash default, `find "dev"` resolves to POSIX `find` (search for a path literally named `dev`), which fails with `find: 'dev': No such file or directory` — failing `src/container/test/runTests.test.cjs`'s "All specs pass" assertion and taking down `build-windows` on every release since.

## Changes

- `src/container/test/artifacts/runShell_pipes.spec.json`: collapsed the two platform-forked contexts (windows-only `find`, mac/linux `grep`) into one `["windows", "mac", "linux"]` context using `grep`, mirroring the already-fixed `core-artifacts` copy. Also switched the step to current `v3` syntax (`{"runShell": {...}}`) and renamed the legacy `output` field to `stdio`.

## Test plan

- [x] Verified for real against the actual CLI (not just schema validation): `node ./bin/doc-detective.js --input src/container/test/artifacts/runShell_pipes.spec.json` — 1/1 specs, 1/1 tests, 1/1 steps passed.
- [ ] After merge, confirm the next release's `build-windows` Docker job passes this step (currently failing since 4.27.0).

No ADR: this restores a fixture to the behavior already decided and documented in ADR 01053 (`configurable-runshell-shell-with-bash-default`) — not a new decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the `runShell` test artifact to reflect the latest step format.
  * Expanded test context coverage across Windows, macOS, and Linux.
  * Preserved validation of piped shell command output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->