### PR TITLE
docs(design): plan managed WDA prebuild and inline warm phase

### DIFF
--- a/adrs/01057-keep-google-apis-emulator-images.md
+++ b/adrs/01057-keep-google-apis-emulator-images.md
@@ -1,0 +1,82 @@
+---
+status: accepted
+date: 2026-07-13
+decision-makers: doc-detective maintainers
+---
+
+# Keep google_apis Android emulator images; reject ATD images
+
+## Context and Problem Statement
+
+The Android CI legs' costs are dominated by multi-GB `sdkmanager` system-image downloads and cold
+emulator boots. Google's Automated Test Device (ATD) images (`aosp_atd`, `google_atd`) are
+purpose-built for headless CI — smaller downloads and faster boots — and were evaluated during the
+2026-07 CI wall-clock investigation as a replacement for the `google_apis` images used by
+[`doc-detective install android`](../src/runtime/androidInstaller.ts), the lazy bootstrap, and the
+[fixtures.yml](../.github/workflows/fixtures.yml) KVM legs. Should Doc Detective's managed Android
+installs switch to (or offer) ATD images?
+
+## Decision Drivers
+
+* CI wall-clock time (download size, boot time) and download-flake exposure.
+* Fixture coverage integrity: `mobile-web-android` drives **device Chrome** through the shared
+  UiAutomator2 session; `apps-android` installs its own APK.
+* Production representativeness: Doc Detective's premise is verifying what a user's reader
+  actually sees; stripped images weaken that fidelity claim.
+* API-level availability of image variants.
+
+## Considered Options
+
+* **Keep `google_apis` (full image) everywhere.**
+* **Switch managed installs to ATD images.**
+* **Split by requirement:** ATD for pure-app specs, `google_apis` where device Chrome is needed.
+
+## Decision Outcome
+
+Chosen option: **keep `google_apis` everywhere**, because ATD images strip preinstalled apps —
+putting the `mobile-web-android` Chrome dependency at direct risk (`aosp_atd` lacks Chrome;
+`google_atd`'s Chrome presence is unverified) — carry no Play Store and (on `aosp_atd`) no Google
+Play services, disable services/animations that make them less production-representative, and
+exist for a narrower API-level range than `google_apis`. The wall-clock problem is instead
+attacked by the [warm phase](../docs/design/warm-phase.md) (overlapped boots) and the installer's
+existing transient-download retry/verification, which don't trade away image fidelity.
+
+### Consequences
+
+* Good: `mobile-web-android` fixtures keep a guaranteed device Chrome; future GMS-dependent app
+  fixtures stay possible; emulator behavior stays closest to real devices.
+* Bad: managed installs keep paying the full `google_apis` download size and boot time; the
+  truncated-download flake surface stays proportionally larger.
+* Neutral: the split-by-requirement option remains available later without a breaking change (an
+  installer image option is additive) if new evidence — e.g. a verified Chrome-bearing
+  `google_atd` — changes the trade-off.
+
+### Confirmation
+
+The managed Android paths ([androidInstaller.ts](../src/runtime/androidInstaller.ts), the fixtures
+KVM legs) continue to specify `google_apis` targets; the `mobile-web-android` required-PASS gate
+on the KVM legs keeps proving device Chrome is present.
+
+## Pros and Cons of the Options
+
+### Keep `google_apis` (CHOSEN)
+
+* Good: full stock-app surface (Chrome, Settings), GMS, Play-adjacent behavior; maximal fidelity.
+* Good: broadest API-level availability.
+* Bad: largest download and slowest boot of the options.
+
+### Switch to ATD images
+
+* Good: smaller downloads (less flake exposure), meaningfully faster boots, purpose-built for
+  headless CI.
+* Bad: preinstalled apps are stripped — breaks `mobile-web-android`'s device-Chrome dependency
+  outright on `aosp_atd`, unverified on `google_atd`.
+* Bad: no Play Store; `aosp_atd` has no GMS at all; disabled services reduce representativeness.
+* Bad: narrower API-level availability.
+
+### Split by requirement
+
+* Good: captures ATD's speed for pure-app specs while keeping Chrome where needed.
+* Bad: two image variants to install, cache, and debug; per-spec image selection logic; the KVM
+  legs share one emulator across app and mobile-web groups, so a split forfeits the shared-boot
+  savings that motivated it.

--- a/docs/design/ios-wda-prebuild.md
+++ b/docs/design/ios-wda-prebuild.md
@@ -44,10 +44,11 @@ Every Doc Detective user running iOS tests in CI pays the cold compile or hand-r
 
 ## Cache layout and key
 
-```
+```text
 <cacheDir>/ios/wda/<key>/           # e.g. ios/wda/xcode-16.4-16F6-driver-7.28.3/
   DerivedData/                      # xcodebuild -derivedDataPath target
   products.json                     # completeness marker — written LAST, after validation
+  last-used                         # sidecar stamp touched by the session-time locator
 <cacheDir>/ios/wda/.lock/           # advisory lock dir (writer only)
 ```
 
@@ -58,24 +59,39 @@ Every Doc Detective user running iOS tests in CI pays the cold compile or hand-r
   Xcode can build WDA).
 - **`products.json` marker.** Records key inputs, the validated
   `Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app` path, and a timestamp.
-  Readers require the marker; a crashed half-built dir has no marker and is invisible. This is the
-  lock-free correctness story for readers.
-- **Pruning.** On a successful build, delete sibling key dirs not touched within 30 days (mtime).
-  Not "keep current only": CI macOS runner pools mix Xcode images
-  ([test/AGENTS.md:86](../../test/AGENTS.md)), and a shared weekly cache legitimately accumulates
-  one entry per image. Keyed subdirs make mixed images coexist instead of thrash.
+  **Published atomically** — written to a temp file in the same dir, then renamed (the
+  `writeInstalledRecord` pattern, [cacheDir.ts:238-271](../../src/runtime/cacheDir.ts)) — so a
+  lock-free reader never observes partial JSON. Readers require the marker; a crashed half-built
+  dir has no marker and is invisible. This is the lock-free correctness story for readers.
+- **Pruning.** Keyed by the `last-used` sidecar stamp, **not** directory mtime (reads inside a
+  subtree don't bump a dir's mtime on APFS, so an actively-used key would look untouched). The
+  session-time locator touches `last-used` on every valid hit; the installer, under the lock,
+  deletes sibling key dirs whose stamp is >30 days old and updates the `installed.json` `ios` slot
+  in the same pass so it never references a deleted key. Active-use safety follows: any key a live
+  session consumes was stamped at that session's start, so a pruned key is provably 30 days unused
+  (the residual cross-process race — a session that resolved a path and then idled 30 days before
+  reading it — is not a real execution shape). Not "keep current only": CI macOS runner pools mix
+  Xcode images ([test/AGENTS.md:86](../../test/AGENTS.md)), and a shared weekly cache legitimately
+  accumulates one entry per image. Keyed subdirs make mixed images coexist instead of thrashing.
 - **installed.json.** Add an optional `ios?` slot mirroring the `android?` pattern
   ([cacheDir.ts:39-46, 220-222](../../src/runtime/cacheDir.ts)) recording the built key(s).
 
 ## Phase 1 — advisory lock primitive (`src/runtime/lock.ts`)
 
 A small cross-process lock: `mkdir`-as-lock with a metadata file (`pid`, `hostname`, ISO
-timestamp), bounded wait with polling, and staleness takeover (metadata older than a TTL, or a
-dead same-host pid). Injected fs/clock/sleep effects so it's hermetically unit-testable per the
-installer-test house pattern (no real spawns/fs in unit tests).
+timestamp), bounded wait with polling. **Staleness is a heartbeat lease, not age-since-acquire** —
+lock age alone must never permit takeover, because a legitimate xcodebuild can hold the lock for
+~20 minutes and a TTL long enough to cover it would make a crashed holder block the next build for
+that whole window. Instead: the holder refreshes the metadata timestamp on a short interval
+(~30 s); a contender may take over only when the **heartbeat** is stale (e.g. >5 min — many missed
+refreshes) or, on the same host, the recorded pid is dead. A live slow build heartbeats and is
+never stolen; a crashed holder is recovered within minutes. Injected fs/clock/sleep effects so
+it's hermetically unit-testable per the installer-test house pattern (no real spawns/fs in unit
+tests).
 
-TDD sequence: acquire-when-free → contend-and-wait → stale-takeover → release-on-throw. Pure unit
-tests only; no ADR needed alone (it ships with Phase 2's ADR as an implementation detail).
+TDD sequence: acquire-when-free → contend-and-wait → heartbeat-keeps-lease (old lock, fresh
+heartbeat, no takeover) → stale-heartbeat takeover → dead-pid takeover → release-on-throw. Pure
+unit tests only; no ADR needed alone (it ships with Phase 2's ADR as an implementation detail).
 
 ## Phase 2 — the prebuild in `install ios`
 
@@ -86,33 +102,44 @@ what it was reserved for. Pipeline, each step a report-visible outcome:
 1. Existing probes unchanged (darwin, `--yes`, `xcode-select -p`, `simctl`). Dry-run gains a note
    that a WDA build would be verified/performed.
 2. **New probe:** `xcodebuild -version` via the injected `run` dep. Failure ⇒ CLT-only host ⇒
-   `skipped` row with "full Xcode required to prebuild WebDriverAgent" guidance. **Best-effort:
-   never a non-zero exit.**
+   `skipped` row with "full Xcode required to prebuild WebDriverAgent" guidance. The probe also
+   enforces a **minimum Xcode version floor**: `build-for-testing` against the generic
+   `platform=iOS Simulator` destination requires a modern Xcode (pin the exact floor during
+   red→green — verify empirically, likely 14+); below it, `skipped` with upgrade guidance rather
+   than a doomed build. **Best-effort: never a non-zero exit.**
 3. **Ensure the driver** via `ensureRuntimeInstalled(["appium-xcuitest-driver"])` — routed through
    the loader, never a raw `npm install`, so the npm-prune defenses stay engaged
    ([src/runtime/AGENTS.md](../../src/runtime/AGENTS.md), issue #501). This makes `install ios`
    heavier than today (driver download on a bare host) — acceptable and reportable.
 4. **Resolve WDA source** from `resolveHeavyDepPathInCache("appium-xcuitest-driver", ctx)` →
    bundled `appium-webdriveragent/` package root (walk, don't hardcode nesting — hoisting varies).
-5. **Check-and-skip:** valid `products.json` for the current key ⇒ `already-up-to-date`.
-6. **Build under lock:** acquire `ios/wda/.lock` (bounded wait; on timeout report `skipped`,
-   "another install is building"), then
+5. **Check-and-skip (pre-lock fast path):** valid `products.json` for the current key ⇒
+   `already-up-to-date`, no lock overhead.
+6. **Acquire the lock** (`ios/wda/.lock`, bounded wait; on timeout report `skipped`, "another
+   install is building"), then **re-check the marker before building**: a contender that waited
+   out a concurrent build finds the now-valid `products.json`, releases, and reports
+   `already-up-to-date` — closing the TOCTOU window between steps 5 and 6 that would otherwise
+   double-build on a cold host with parallel CI jobs.
+7. **Build:**
    `xcodebuild build-for-testing -project WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner
    -destination "generic/platform=iOS Simulator" -derivedDataPath <keyed>/DerivedData`
    with a generous timeout (~20 min; the android installer's transient-retry shape,
    [androidInstaller.ts:454-479](../../src/runtime/androidInstaller.ts), applies with
    xcodebuild-specific transient signatures). No `-destination` device dependency: no simulator
    needs to exist or be booted.
-7. **Validate** the Runner .app exists → write `products.json` → record in `installed.json` →
-   prune stale siblings → release lock. Report `installed` (or `updated` when replacing a
-   different key).
+8. **Validate** the Runner .app exists → write `products.json` (atomic temp+rename) → record in
+   `installed.json` → prune stale siblings → release lock. Report `installed` when no key existed
+   before, `updated` when a **new** key was built while a different key was previously recorded —
+   keys are additive subdirs, never replaced in place, so "updated" means "the current toolchain
+   moved", not "rebuilt in place".
 
 Structure it as the android installer does: a **pure plan builder** (inputs: probe results,
 existing marker, key) driving both `--dry-run` and execution, with the full effect surface
 injected (`run`, `fs`, lock, `ensureRuntimeInstalled`, clock). Every branch above gets a red→green
 unit test in `test/ios-installer.test.js` (stub `resolvePathInCache`/`ensureInstalled` per
-[src/runtime/AGENTS.md](../../src/runtime/AGENTS.md) testing note); `test/cli-install.test.js`
-covers the dry-run wiring cross-platform.
+[src/runtime/AGENTS.md](../../src/runtime/AGENTS.md) testing note), including the
+**contend-and-lose** case (second contender acquires the lock, finds the completed marker, skips
+the build); `test/cli-install.test.js` covers the dry-run wiring cross-platform.
 
 Expect the new `xcodebuild` spawn from a cache-derived path to trip CodeQL's
 `js/command-line-injection` false-positive class ([test/AGENTS.md:108-124](../../test/AGENTS.md));
@@ -128,16 +155,21 @@ apps) and [mobileBrowser.ts:173-197](../../src/core/tests/mobileBrowser.ts) (mob
    exactly as today (`derivedDataPath` only, caller owns semantics). Existing users see zero change.
 2. Otherwise, **pure managed-products locator**: compute the current key (driver version via
    `resolveHeavyDepVersion`, Xcode version via a shared probe helper extracted from Phase 2), read
-   `products.json`, and on a valid hit set **both** `appium:derivedDataPath` (the keyed
-   DerivedData) **and** `appium:usePrebuiltWDA: true`. On any miss/unusable-cache condition return
-   null and change nothing — ADR 01049 degradation semantics. A keyed miss after a driver or Xcode
-   bump is exactly today's behavior (session builds WDA itself), never an error.
-3. `usePrebuiltWDA` makes sessions **read-only** consumers — the concurrency answer. If a
-   prebuilt-WDA session creation fails, the existing ADR 01033 retry
-   ([tests.ts:4868-4915](../../src/core/tests.ts)) applies; a persistent failure surfaces normally.
-   (Implementation checkpoint: verify on a real macOS CI session that the resolved driver version
-   honors `usePrebuiltWDA` + `derivedDataPath` as expected; newer drivers also offer
-   `appium:prebuiltWDAPath` as an alternative — pick during red→green against the live leg.)
+   `products.json`, and on a valid hit touch the `last-used` stamp and set **both**
+   `appium:derivedDataPath` (the keyed DerivedData) **and** `appium:usePrebuiltWDA: true`. On any
+   miss/unusable-cache condition — including a driver version outside the locator's **supported
+   floor** (see below) — return null and change nothing: ADR 01049 degradation semantics. A keyed
+   miss after a driver or Xcode bump is exactly today's behavior (session builds WDA itself),
+   never an error.
+3. `usePrebuiltWDA` makes sessions **read-only** consumers (except the sidecar stamp) — the
+   concurrency answer. If a prebuilt-WDA session creation fails, the existing ADR 01033 retry
+   ([tests.ts:4868-4915](../../src/core/tests.ts)) applies; a persistent failure surfaces
+   normally. **Compatibility gate (implementation checkpoint):** prebuilt-WDA handling is
+   driver-version-sensitive (`usePrebuiltWDA`+`derivedDataPath` vs the newer
+   `appium:prebuiltWDAPath` / `useXctestrunFile` paths, and `.xctestrun` handling differs across
+   versions). Pin a minimum supported `appium-xcuitest-driver` version during red→green against
+   the live macOS leg, record it as the locator's floor, and pick the capability pair there —
+   unsupported combinations get null (plain fallback), never a guess.
 4. The Xcode-version probe result is memoized per run (one `xcodebuild -version` spawn max).
 
 Unit tests: locator hit/miss/stale-key/marker-absent; env-override precedence; capability-shape

--- a/docs/design/ios-wda-prebuild.md
+++ b/docs/design/ios-wda-prebuild.md
@@ -1,0 +1,178 @@
+# Design: managed WebDriverAgent prebuild
+
+Status: **planned — no phase started.** This document is the implementation plan for building
+WebDriverAgent (WDA) as part of `doc-detective install ios` and auto-consuming the build products in
+iOS sessions. It was produced from the CI wall-clock investigation (2026-07-13); the companion plan
+is [warm-phase.md](warm-phase.md), which front-loads provisioning (including this feature's
+products check) into an inline warm phase.
+
+## Problem
+
+The first XCUITest session on a cold host compiles WebDriverAgent via `xcodebuild` — ~10 minutes of
+the ~14-minute first-session cost that dominates the `apps-ios` / `mobile-web-ios` CI legs. The
+mitigations that exist today are partial and live in the wrong places:
+
+- The capability mapping already exists but is **opt-in via env var**:
+  `DOC_DETECTIVE_IOS_WDA_DERIVED_DATA_PATH` → `appium:derivedDataPath`
+  ([appSurface.ts:622-632](../../src/core/tests/appSurface.ts),
+  [mobileBrowser.ts:193-196](../../src/core/tests/mobileBrowser.ts)), with the comment "e.g. a CI
+  cache keyed by driver + Xcode version" — i.e. the caller owns correctness.
+- The actual build cache lives in the **external** `doc-detective/github-action` (`ios: auto`, "ios
+  WDA cache key v2"), whose key carries only OS + Xcode version. It cannot see the JIT-installed
+  `appium-xcuitest-driver` version, and ADR 01033 documents the resulting failure: a stale restored
+  cache produced a 15-minute session timeout plus a ceiling-length retry (~30 min worst case).
+- `doc-detective install ios` ([iosInstaller.ts](../../src/runtime/iosInstaller.ts)) is
+  guidance-only: it probes `xcode-select -p` and `simctl list devices`, downloads and builds
+  nothing — despite its describe text promising WebDriverAgent/XCUITest preparation.
+
+Every Doc Detective user running iOS tests in CI pays the cold compile or hand-rolls caching.
+
+## Decisions (settled, 2026-07-13)
+
+1. **Prebuild is part of `install ios`, default-on, no flag.** Check-and-skip on **build
+   products** (not devices): WDA builds once per (Xcode version × driver version) against a generic
+   simulator destination; device availability is neither necessary nor sufficient.
+2. **No off-switch; best-effort instead.** The build is attempted and any failure (no full Xcode,
+   signing issues, transient xcodebuild failure) degrades to a `skipped` report row with guidance —
+   the command stays green, matching the ADR 01053 best-effort pattern
+   ([installer.ts:240-264](../../src/runtime/installer.ts)).
+3. **Concurrency by read-only consumption + a single locked writer.** Sessions consume the
+   products via `appium:usePrebuiltWDA` (readers never mutate the derived data), so N concurrent
+   runners share one path safely. Only the installer writes, behind a new advisory lock — **no
+   cross-process lock primitive exists in the codebase today** (confirmed by sweep); one must be
+   added.
+
+## Cache layout and key
+
+```
+<cacheDir>/ios/wda/<key>/           # e.g. ios/wda/xcode-16.4-16F6-driver-7.28.3/
+  DerivedData/                      # xcodebuild -derivedDataPath target
+  products.json                     # completeness marker — written LAST, after validation
+<cacheDir>/ios/wda/.lock/           # advisory lock dir (writer only)
+```
+
+- **Key inputs.** Driver version: `resolveHeavyDepVersion("appium-xcuitest-driver", ctx)`
+  ([loader.ts:216-240](../../src/runtime/loader.ts)) — already exists. Xcode version + build: a
+  **new** `xcodebuild -version` probe in iosInstaller (nothing in `src/` reads the Xcode version
+  today; `xcode-select -p` can't distinguish full Xcode from bare Command Line Tools, and only full
+  Xcode can build WDA).
+- **`products.json` marker.** Records key inputs, the validated
+  `Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app` path, and a timestamp.
+  Readers require the marker; a crashed half-built dir has no marker and is invisible. This is the
+  lock-free correctness story for readers.
+- **Pruning.** On a successful build, delete sibling key dirs not touched within 30 days (mtime).
+  Not "keep current only": CI macOS runner pools mix Xcode images
+  ([test/AGENTS.md:86](../../test/AGENTS.md)), and a shared weekly cache legitimately accumulates
+  one entry per image. Keyed subdirs make mixed images coexist instead of thrash.
+- **installed.json.** Add an optional `ios?` slot mirroring the `android?` pattern
+  ([cacheDir.ts:39-46, 220-222](../../src/runtime/cacheDir.ts)) recording the built key(s).
+
+## Phase 1 — advisory lock primitive (`src/runtime/lock.ts`)
+
+A small cross-process lock: `mkdir`-as-lock with a metadata file (`pid`, `hostname`, ISO
+timestamp), bounded wait with polling, and staleness takeover (metadata older than a TTL, or a
+dead same-host pid). Injected fs/clock/sleep effects so it's hermetically unit-testable per the
+installer-test house pattern (no real spawns/fs in unit tests).
+
+TDD sequence: acquire-when-free → contend-and-wait → stale-takeover → release-on-throw. Pure unit
+tests only; no ADR needed alone (it ships with Phase 2's ADR as an implementation detail).
+
+## Phase 2 — the prebuild in `install ios`
+
+Extend [iosInstaller.ts](../../src/runtime/iosInstaller.ts) after its existing probes. The
+installer's `ctx: CacheDirContext` hook is already accepted-but-unused (`:44-45`) — this phase is
+what it was reserved for. Pipeline, each step a report-visible outcome:
+
+1. Existing probes unchanged (darwin, `--yes`, `xcode-select -p`, `simctl`). Dry-run gains a note
+   that a WDA build would be verified/performed.
+2. **New probe:** `xcodebuild -version` via the injected `run` dep. Failure ⇒ CLT-only host ⇒
+   `skipped` row with "full Xcode required to prebuild WebDriverAgent" guidance. **Best-effort:
+   never a non-zero exit.**
+3. **Ensure the driver** via `ensureRuntimeInstalled(["appium-xcuitest-driver"])` — routed through
+   the loader, never a raw `npm install`, so the npm-prune defenses stay engaged
+   ([src/runtime/AGENTS.md](../../src/runtime/AGENTS.md), issue #501). This makes `install ios`
+   heavier than today (driver download on a bare host) — acceptable and reportable.
+4. **Resolve WDA source** from `resolveHeavyDepPathInCache("appium-xcuitest-driver", ctx)` →
+   bundled `appium-webdriveragent/` package root (walk, don't hardcode nesting — hoisting varies).
+5. **Check-and-skip:** valid `products.json` for the current key ⇒ `already-up-to-date`.
+6. **Build under lock:** acquire `ios/wda/.lock` (bounded wait; on timeout report `skipped`,
+   "another install is building"), then
+   `xcodebuild build-for-testing -project WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner
+   -destination "generic/platform=iOS Simulator" -derivedDataPath <keyed>/DerivedData`
+   with a generous timeout (~20 min; the android installer's transient-retry shape,
+   [androidInstaller.ts:454-479](../../src/runtime/androidInstaller.ts), applies with
+   xcodebuild-specific transient signatures). No `-destination` device dependency: no simulator
+   needs to exist or be booted.
+7. **Validate** the Runner .app exists → write `products.json` → record in `installed.json` →
+   prune stale siblings → release lock. Report `installed` (or `updated` when replacing a
+   different key).
+
+Structure it as the android installer does: a **pure plan builder** (inputs: probe results,
+existing marker, key) driving both `--dry-run` and execution, with the full effect surface
+injected (`run`, `fs`, lock, `ensureRuntimeInstalled`, clock). Every branch above gets a red→green
+unit test in `test/ios-installer.test.js` (stub `resolvePathInCache`/`ensureInstalled` per
+[src/runtime/AGENTS.md](../../src/runtime/AGENTS.md) testing note); `test/cli-install.test.js`
+covers the dry-run wiring cross-platform.
+
+Expect the new `xcodebuild` spawn from a cache-derived path to trip CodeQL's
+`js/command-line-injection` false-positive class ([test/AGENTS.md:108-124](../../test/AGENTS.md));
+the resolution is alert dismissal with justification, not code contortions. The cache path is
+already shell-meta-guarded by `assertSafeRuntimePath` ([cacheDir.ts:122-131](../../src/runtime/cacheDir.ts)).
+
+## Phase 3 — runtime consumption in iOS sessions
+
+In the two capability builders — [appSurface.ts:602-633](../../src/core/tests/appSurface.ts) (iOS
+apps) and [mobileBrowser.ts:173-197](../../src/core/tests/mobileBrowser.ts) (mobile web):
+
+1. **Env override wins, unchanged.** If `DOC_DETECTIVE_IOS_WDA_DERIVED_DATA_PATH` is set, behave
+   exactly as today (`derivedDataPath` only, caller owns semantics). Existing users see zero change.
+2. Otherwise, **pure managed-products locator**: compute the current key (driver version via
+   `resolveHeavyDepVersion`, Xcode version via a shared probe helper extracted from Phase 2), read
+   `products.json`, and on a valid hit set **both** `appium:derivedDataPath` (the keyed
+   DerivedData) **and** `appium:usePrebuiltWDA: true`. On any miss/unusable-cache condition return
+   null and change nothing — ADR 01049 degradation semantics. A keyed miss after a driver or Xcode
+   bump is exactly today's behavior (session builds WDA itself), never an error.
+3. `usePrebuiltWDA` makes sessions **read-only** consumers — the concurrency answer. If a
+   prebuilt-WDA session creation fails, the existing ADR 01033 retry
+   ([tests.ts:4868-4915](../../src/core/tests.ts)) applies; a persistent failure surfaces normally.
+   (Implementation checkpoint: verify on a real macOS CI session that the resolved driver version
+   honors `usePrebuiltWDA` + `derivedDataPath` as expected; newer drivers also offer
+   `appium:prebuiltWDAPath` as an alternative — pick during red→green against the live leg.)
+4. The Xcode-version probe result is memoized per run (one `xcodebuild -version` spawn max).
+
+Unit tests: locator hit/miss/stale-key/marker-absent; env-override precedence; capability-shape
+assertions for both builders.
+
+## Phase 4 — CI adoption
+
+- **cache-warmer.yml (macOS leg):** add `node ./bin/doc-detective.js install ios --yes` after
+  `install all`. The dd-cache action already persists the whole cache dir, so `ios/wda/**` rides
+  the existing weekly key; keyed subdirs absorb the mixed-Xcode-image runner pool.
+- **fixtures.yml:** the `apps-ios` / `mobile-web-ios` legs run `install ios --yes` after cache
+  restore (seconds on a warm week; one build on a cold one). Once proven, the action's `ios: auto`
+  WDA cache and its stale-key failure mode become redundant for these legs — retire via a
+  follow-up in `doc-detective/github-action` (tracked, not part of this repo's change).
+- Expected effect: first-iOS-session cost drops from ~14 min to simulator-boot-plus-launch on every
+  warm-cache run, and the ADR 01033 stale-cache 30-minute worst case disappears (the key now sees
+  the driver version).
+
+## Companions (repo policy)
+
+- **ADR** (one, with the Phase 2+3 PR): `install ios` performs a best-effort WDA prebuild;
+  sessions auto-consume managed products read-only; env var remains the override. Number picked at
+  merge time per the collision rule.
+- **Fixtures:** no new fixture *files* — the `apps-ios`/`mobile-web-ios` legs already exercise the
+  full session path end-to-end and now do so through the prebuilt products (the required-PASS gate
+  on macOS is the assertion). The install-side permutations are hermetic unit tests by design
+  (fixtures can't assert installer internals cross-platform).
+- **Docs impact: yes.** The `install ios` CLI reference (behavior change from guidance-only to
+  building), plus a CI-caching section (persona Priya, CUJ P-series). Land with the code.
+
+## Non-goals
+
+- Shipping prebuilt WDA binaries (per-Xcode artifacts hosted by us) — maintenance-heavy, signing
+  questions; the keyed local build achieves the win.
+- Building WebDriverAgentMac (the macOS `apps` leg's cold cost) — same pattern could follow later;
+  out of scope here.
+- An opt-out flag — deliberately omitted (decision 2); an escape hatch can be added later
+  additively if a real need appears.

--- a/docs/design/warm-phase.md
+++ b/docs/design/warm-phase.md
@@ -1,0 +1,159 @@
+# Design: inline warm phase (resolve → warm → run → sweep)
+
+Status: **planned — no phase started; inline-first.** This document is the implementation plan for
+an always-on provisioning phase that runs between test resolution and test execution: it
+concurrently resolves, repairs, and warms everything the run will need — driver installs, browser
+installs, device boots, WDA availability, chromedriver prefetch — and only then runs tests. The
+standalone `doc-detective warm` CLI (CI overlap with build steps) is **deferred** to a later phase.
+Produced from the CI wall-clock investigation (2026-07-13); companion plan:
+[ios-wda-prebuild.md](ios-wda-prebuild.md).
+
+## Problem
+
+Provisioning costs are paid serially at first use, buried inside per-context execution:
+
+- Native app drivers JIT-install inside `appSurfacePreflight`, invoked per-context in `runContext`
+  ([appSurface.ts:922-991](../../src/core/tests/appSurface.ts), [tests.ts:3354](../../src/core/tests.ts)).
+- Simulators/emulators boot at first `startSurface`; a boot (1–5+ min) serializes ahead of the
+  first test instead of overlapping other setup.
+- Chromedriver for mobile-web-android downloads at session time
+  ([mobileBrowser.ts:150-172](../../src/core/tests/mobileBrowser.ts)).
+- The existing warm-up, `warmUpContexts` ([tests.ts:2514-2640](../../src/core/tests.ts)), probes
+  driver/browser combinations — but only when `concurrentRunners > 1`
+  ([tests.ts:1848](../../src/core/tests.ts)), and it doesn't touch devices or mobile toolchains.
+- CI hand-rolls what this phase should own: the iOS simulator pre-boot step in
+  [fixtures.yml:148-181](../../.github/workflows/fixtures.yml) duplicates iosSimulator.ts's
+  newest-device selection logic and carries an explicit must-track-the-product hazard comment
+  ([docs/maintenance/ci-ios-preboot.md](../maintenance/ci-ios-preboot.md)).
+
+The insight: warm-phase parallelism is **independent of runner concurrency**. Even a fully serial
+test run benefits, because boot ∥ npm install ∥ browser download overlap *each other* during warm.
+
+## Decisions (settled, 2026-07-13)
+
+1. **Always-on, inline, no flag.** The phase derives strictly from resolved needs, so a pure-web
+   run warms only what it already JIT-installs today — baseline latency is unchanged by
+   construction.
+2. **Warm is an accelerator, never a new failure mode.** Every warm task is best-effort: a failure
+   logs a warning and the run proceeds; the per-context paths retry/fail with exactly today's
+   semantics. (Warm *pre-pays* work; it never *gates* work.)
+3. **Teardown reuses the ownership ledger.** Anything warm boots is recorded in the same run
+   registries with `bootedByUs: true`, so the existing run-end sweep tears it down whether or not
+   any test used it. No new lifecycle concept for the inline phase.
+
+## Where it lives
+
+`runSpecs` already has the exact seams:
+
+- After Phase 1, `sizingJobs` ([tests.ts:1597](../../src/core/tests.ts)) enumerates **every**
+  context/surface the run needs — the first point the full provisioning set is known.
+- Registries (`deviceRegistry`, `simulatorRegistry`, `processRegistry`) and the appium pool are
+  created at [tests.ts:1695-1778](../../src/core/tests.ts); `warmUpContexts` runs at `:1848`.
+- The warm phase replaces/generalizes the `:1848` call: **always** run (drop the `limit > 1`
+  gate), over a broader task set, executed concurrently.
+- Run-end teardown is already centralized in the `finally` block
+  ([tests.ts:2008-2057](../../src/core/tests.ts)): `teardownDeviceRegistry`,
+  `teardownSimulatorRegistry`, appium/Xvfb/process sweeps. Warm-booted devices land in those
+  registries and are swept for free — including the warmed-but-unused case, because ownership is
+  established at provision time, not first use.
+
+The `runTests`-level JIT block ([core/index.ts:96-241](../../src/core/index.ts) —
+`inferRuntimeNeeds` → `ensureRuntimeInstalled`/`ensureBrowserInstalled`) stays where it is; it is
+effectively warm step zero and already runs before `runSpecs`.
+
+## Phase B1 — warm planner + executor
+
+**Planner (pure).** `planWarmTasks(sizingJobs, runnerDetails, config) → WarmTask[]`, a pure
+derivation unit-testable without drivers. Task kinds, deduplicated across jobs:
+
+| kind | derived from | pre-pays |
+|---|---|---|
+| `driver-install` | app/mobile contexts per platform | `ensureRuntimeInstalled([driverPackage])` — the body of `appSurfacePreflight`'s install half |
+| `browser-install` | browser contexts | `ensureContextBrowserInstalled` (already memoized via `installAttempts`, [tests.ts:5036-5101](../../src/core/tests.ts)) |
+| `device-boot` | ios/android contexts + explicit `device` descriptors | `acquireSimulator` / `acquireDevice` into the run registries |
+| `wda-check` | ios contexts | managed-products locator from [ios-wda-prebuild.md](ios-wda-prebuild.md) Phase 3 (memoized probe; never builds — building stays with `install ios`) |
+| `chromedriver-prefetch` | mobile-web-android contexts | the autodownload the first session pays today |
+| `session-probe` | what `selectWarmUpTargets` picks today ([tests.ts:2460](../../src/core/tests.ts)) | folded-in existing `warmUpContexts` probes — **kept `limit > 1`-gated**: a throwaway probe session is only worth paying when it prevents concurrent first-session races |
+
+**Executor.** Run tasks through the existing primitives — `runResourceAware` with the run's
+`ResourceRegistry` ([utils.ts:121-212](../../src/core/utils.ts)) and the same exclusivity tags
+jobs use (`jobDisplayResources`, [tests.ts:466-568](../../src/core/tests.ts)): device boots for the
+same device serialize, `native-app-driver`-bound tasks respect ADR 01038, independent tasks
+overlap. Warm concurrency limit: a small constant (e.g. 4) independent of `concurrentRunners`,
+since tasks are I/O-heavy, not display-heavy.
+
+**Failure semantics.** Each task resolves to `{name, kind, outcome: warmed|skipped|failed,
+durationMs, note?}`. `failed` → `logger warn` + proceed. The planner and executor share the run's
+`installAttempts`/`warmUpResults` memo maps ([tests.ts:1373-1377](../../src/core/tests.ts)) so
+per-context paths never redo warm's work — and warm's failures don't poison them (a failed warm
+install records nothing, letting the per-context retry happen exactly as today).
+
+**Device-boot ownership detail.** `acquireSimulator`/`acquireDevice` already return registry
+entries with correct `bootedByUs` (`reuse-booted` → `false`, boot/create → `true`,
+[iosSimulator.ts:438-521](../../src/core/tests/iosSimulator.ts),
+[androidEmulator.ts:313-428](../../src/core/tests/androidEmulator.ts)) and an in-flight `ready`
+promise — warm kicks off the boot and does **not** await readiness; the first consuming context
+awaits `ready` as it does now. Warm's job is to start the clock early, not to block on it.
+
+TDD sequence (each red→green): planner derivation per task kind (including dedup and the empty
+web-only plan) → executor failure-isolation (one failed task, run proceeds) → ownership test
+(warm-booted, unused device is swept — assert via injected shutdown effect) → memo-sharing test
+(warm install attempt visible to `ensureContextBrowserInstalled`) → integration: `runSpecs` on a
+spec mix asserts warm ran before Phase 2 and the report carries warm results.
+
+## Phase B2 — report timing
+
+Attach `report.warm = { durationMs, tasks: [...] }` alongside the skeleton built at
+[tests.ts:1394-1424](../../src/core/tests.ts). This is the first structured provisioning-timing
+surface — it also serves the broader "per-phase timing" telemetry goal from the CI investigation,
+and it's how CI legs verify the phase is actually overlapping (fixture-output artifacts include
+it).
+
+Schema note: `report_v3` gains an optional `warm` block — schema-first in
+`src/common/src/schemas/src_schemas/`, positive+negative validation tests, `npm run build:common`,
+per the CLAUDE.md schema workflow.
+
+## Phase B3 (deferred) — standalone `doc-detective warm` + ownership handoff
+
+Sketch only; own ADR when picked up. `doc-detective warm --input <specs>` runs resolve + B1's
+planner/executor and **exits with devices left up**, writing an ownership handoff manifest
+(`<cacheDir>/warm-manifest.json`: UDIDs, AVD names, PIDs, timestamp). The next `runTests`
+atomically claims it (rename — exactly one of N concurrent runners adopts), merges the resources
+into its registries as `bootedByUs: true`, and sweeps them at run end as if it booted them.
+Staleness guard: manifest older than TTL or with dead PIDs/UDIDs is cleaned, not adopted.
+`doc-detective warm --down` for manual teardown. This is what finally deletes the
+[fixtures.yml](../../.github/workflows/fixtures.yml) pre-boot step and its device-selection
+coupling. Hosted-runner VM disposal remains the backstop; the manifest matters most on self-hosted
+runners and dev machines.
+
+## Companions (repo policy)
+
+- **ADR** (one, with the B1+B2 PR): the always-on warm phase, its best-effort/never-gates
+  semantics, and the provision-time ownership rule. Number picked at merge time per the collision
+  rule.
+- **Fixtures:** PASS/SKIPPED semantics of every existing fixture are unchanged (warm never fails a
+  run) — the existing matrix is the regression net. The observable new surface is `report.warm`,
+  asserted via a focused `it(...)` in [test/core-core.test.js](../../test/core-core.test.js) per
+  the precise-assertion rule; no new fixture files.
+- **Docs impact: yes, modest.** The run-lifecycle/report reference gains the `warm` block; CI
+  guidance (persona Priya) gains "what warm pre-pays and how to read its timings". Land with the
+  code.
+
+## Interplay and sequencing
+
+- **After** [ios-wda-prebuild.md](ios-wda-prebuild.md) Phases 1–3 land: warm's `wda-check` task
+  consumes that locator. (B1 can land first with `wda-check` absent — the plans are independent
+  except for that one task.)
+- The Android image question from the same investigation was settled as **keep `google_apis`**
+  (full image; device Chrome required for mobile-web) — recorded here so the ATD option isn't
+  re-litigated without new evidence: ATD images strip preinstalled apps, putting the
+  `mobile-web-android` Chrome dependency at risk.
+
+## Non-goals
+
+- A `warm: false` config key — deliberately omitted (decision 1); additive later if a real need
+  appears.
+- Warming across runs / a device-pool daemon — B3's manifest is the bounded version of this;
+  anything longer-lived is out of scope.
+- Blocking the run on warm completion — warm starts work; consumers await readiness exactly where
+  they do today.

--- a/docs/design/warm-phase.md
+++ b/docs/design/warm-phase.md
@@ -70,23 +70,51 @@ derivation unit-testable without drivers. Task kinds, deduplicated across jobs:
 |---|---|---|
 | `driver-install` | app/mobile contexts per platform | `ensureRuntimeInstalled([driverPackage])` — the body of `appSurfacePreflight`'s install half |
 | `browser-install` | browser contexts | `ensureContextBrowserInstalled` (already memoized via `installAttempts`, [tests.ts:5036-5101](../../src/core/tests.ts)) |
-| `device-boot` | ios/android contexts + explicit `device` descriptors | `acquireSimulator` / `acquireDevice` into the run registries |
+| `device-boot` | ios/android contexts + explicit `device` descriptors, normalized via the same `normalizeDeviceDescriptor` path `runContext` uses ([tests.ts:3567](../../src/core/tests.ts)) | `acquireSimulator` / `acquireDevice` into the run registries |
 | `wda-check` | ios contexts | managed-products locator from [ios-wda-prebuild.md](ios-wda-prebuild.md) Phase 3 (memoized probe; never builds — building stays with `install ios`) |
 | `chromedriver-prefetch` | mobile-web-android contexts | the autodownload the first session pays today |
 | `session-probe` | what `selectWarmUpTargets` picks today ([tests.ts:2460](../../src/core/tests.ts)) | folded-in existing `warmUpContexts` probes — **kept `limit > 1`-gated**: a throwaway probe session is only worth paying when it prevents concurrent first-session races |
+
+**Device selection is not the planner's job.** `planWarmTasks` normalizes descriptors exactly as
+`runContext` would and hands them to `acquireSimulator`/`acquireDevice`; the selection heuristics
+(newest-iPhone plan, default AVD) stay solely in
+[iosSimulator.ts](../../src/core/tests/iosSimulator.ts) /
+[androidEmulator.ts](../../src/core/tests/androidEmulator.ts) — the single source of truth whose
+duplication in the fixtures.yml pre-boot step is precisely the hazard this phase exists to retire.
+Deduplication is the registries' existing behavior: entries are keyed by device name, so N
+contexts needing the same device produce one boot and N `ready` awaiters, and warm's acquire and a
+context's later acquire meet on the same entry.
 
 **Executor.** Run tasks through the existing primitives — `runResourceAware` with the run's
 `ResourceRegistry` ([utils.ts:121-212](../../src/core/utils.ts)) and the same exclusivity tags
 jobs use (`jobDisplayResources`, [tests.ts:466-568](../../src/core/tests.ts)): device boots for the
 same device serialize, `native-app-driver`-bound tasks respect ADR 01038, independent tasks
-overlap. Warm concurrency limit: a small constant (e.g. 4) independent of `concurrentRunners`,
-since tasks are I/O-heavy, not display-heavy.
+overlap. **Cache-mutating tasks get a dedicated `runtime-install` exclusivity tag** —
+`driver-install`, `browser-install`, and `chromedriver-prefetch` all write the shared runtime/app
+cache, which is exactly why today's `warmUpContexts` runs its combinations serially
+([tests.ts:2505-2512](../../src/core/tests.ts)) and why the npm-prune hazard exists
+([src/runtime/AGENTS.md](../../src/runtime/AGENTS.md)); they serialize among themselves while
+overlapping device boots. Warm concurrency limit: a small constant (e.g. 4) independent of
+`concurrentRunners`, since tasks are I/O-heavy, not display-heavy. The two constraints compose:
+the pool is the **outer ceiling**, and tag exclusivity further serializes within it (two tasks
+sharing a tag queue even when fewer than 4 tasks are running — the pool never bypasses the
+registry).
 
 **Failure semantics.** Each task resolves to `{name, kind, outcome: warmed|skipped|failed,
-durationMs, note?}`. `failed` → `logger warn` + proceed. The planner and executor share the run's
-`installAttempts`/`warmUpResults` memo maps ([tests.ts:1373-1377](../../src/core/tests.ts)) so
-per-context paths never redo warm's work — and warm's failures don't poison them (a failed warm
-install records nothing, letting the per-context retry happen exactly as today).
+durationMs, note?}`. `failed` → `logger warn` + proceed. Memo-map effects follow
+`warmUpContexts`' existing **mirror contract** ([tests.ts:2510-2512](../../src/core/tests.ts)):
+warm leaves `installAttempts`/`warmUpResults` in *exactly the state a serial first-consuming
+context would have produced* — no more, no less. Concretely: install tasks record their outcome in
+`installAttempts` just as the first context's on-demand install would (so N contexts don't retry
+a failed install in parallel — that recorded-once semantics is today's behavior, not a new
+suppression), and the folded-in `session-probe` keeps its existing recorded-skip semantics
+([tests.ts:2621, 3753](../../src/core/tests.ts) — a combination that can't start a driver is
+skipped by later contexts; that's the established fast-fail, which would have happened per-context
+anyway, just slower). The **"never gates"** contract is therefore precise: the *new* task kinds
+(`device-boot`, `wda-check`, `chromedriver-prefetch`) record nothing any gate reads — their
+failures are warm-report entries only — and warm introduces **no gating that doesn't already
+exist** for installs/probes. Keeping `session-probe` behind `limit > 1` also preserves the
+documented byte-identical serial-run behavior ([tests.ts:1845-1847](../../src/core/tests.ts)).
 
 **Device-boot ownership detail.** `acquireSimulator`/`acquireDevice` already return registry
 entries with correct `bootedByUs` (`reuse-booted` → `false`, boot/create → `true`,
@@ -118,9 +146,14 @@ per the CLAUDE.md schema workflow.
 Sketch only; own ADR when picked up. `doc-detective warm --input <specs>` runs resolve + B1's
 planner/executor and **exits with devices left up**, writing an ownership handoff manifest
 (`<cacheDir>/warm-manifest.json`: UDIDs, AVD names, PIDs, timestamp). The next `runTests`
-atomically claims it (rename — exactly one of N concurrent runners adopts), merges the resources
-into its registries as `bootedByUs: true`, and sweeps them at run end as if it booted them.
-Staleness guard: manifest older than TTL or with dead PIDs/UDIDs is cleaned, not adopted.
+atomically claims it — rename to `warm-manifest.claimed-<runId>.json` **in the same directory**,
+so exactly one of N concurrent runners adopts *and* the claimed state stays durable and
+discoverable (a rename-to-nowhere would leave a crash window: adopter dies post-claim,
+pre-adoption, and the devices are up with no record). The adopter merges the resources into its
+registries as `bootedByUs: true`, deletes the claimed file only after its run-end sweep, and
+cleanup (`--down`, or the next warm/run) scans for `claimed-*` files whose owning run is dead and
+sweeps their resources. Staleness guard: any manifest older than TTL or with dead PIDs/UDIDs is
+cleaned, not adopted.
 `doc-detective warm --down` for manual teardown. This is what finally deletes the
 [fixtures.yml](../../.github/workflows/fixtures.yml) pre-boot step and its device-selection
 coupling. Hosted-runner VM disposal remains the backstop; the manifest matters most on self-hosted
@@ -144,10 +177,10 @@ runners and dev machines.
 - **After** [ios-wda-prebuild.md](ios-wda-prebuild.md) Phases 1–3 land: warm's `wda-check` task
   consumes that locator. (B1 can land first with `wda-check` absent — the plans are independent
   except for that one task.)
-- The Android image question from the same investigation was settled as **keep `google_apis`**
-  (full image; device Chrome required for mobile-web) — recorded here so the ATD option isn't
-  re-litigated without new evidence: ATD images strip preinstalled apps, putting the
-  `mobile-web-android` Chrome dependency at risk.
+- The Android image question from the same investigation was settled as **keep `google_apis`** —
+  now recorded as its own decision in
+  [ADR 01057](../../adrs/01057-keep-google-apis-emulator-images.md) (device Chrome required for
+  mobile-web; ATD images strip preinstalled apps).
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

Two implementation plans from the CI wall-clock investigation (the iOS/Android legs are the long poles). Design docs only — no code changes.

- **[docs/design/ios-wda-prebuild.md](https://github.com/doc-detective/doc-detective/blob/claude/ci-wall-clock-optimization-0a1632/docs/design/ios-wda-prebuild.md)** — build WebDriverAgent as part of `doc-detective install ios`: default-on, check-and-skip on build products keyed by (Xcode version × `appium-xcuitest-driver` version), best-effort with no off-switch (Xcode-less hosts degrade to guidance). Sessions auto-consume the products **read-only** via `appium:usePrebuiltWDA` + `appium:derivedDataPath` (concurrent-runner safe); the single writer sits behind a new advisory lock (none exists in the codebase today). Kills the ~10-min cold WDA compile on warm caches and the ADR 01033 stale-cache 30-min worst case (the key finally sees the driver version).
- **[docs/design/warm-phase.md](https://github.com/doc-detective/doc-detective/blob/claude/ci-wall-clock-optimization-0a1632/docs/design/warm-phase.md)** — an always-on **resolve → warm → run → sweep** phase in `runSpecs`: once `sizingJobs` enumerates every surface the run needs, concurrently pre-provision driver installs, browser installs, device boots, WDA availability, and chromedriver — overlapping each other even when test execution is serial. Best-effort by contract (warm never gates a run); teardown reuses the existing `bootedByUs` ownership ledger, so warmed-but-unused devices are swept for free. Standalone `doc-detective warm` CLI + ownership-handoff manifest is sketched as a deferred phase.

Also records the settled **keep `google_apis` / no ATD images** decision (device Chrome is required for `mobile-web-android`).

## Docs-impact assessment

Design docs only — no behavior change in this PR, so no ADR or fixtures here. Each plan specifies its own required companions (ADR numbered at merge, fixture/docs assessments) for the implementing PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design plan for prebuilding and reusing iOS WebDriverAgent artifacts with best-effort behavior, caching, and concurrency safeguards.
  * Documented an always-on “warm phase” that overlaps provisioning steps and reports warm timing without blocking test execution.
  * Added an ADR confirming Doc Detective CI will keep `google_apis` Android emulator images, citing coverage and consistency needs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->