### PR TITLE
feat(core): inline always-on warm phase (resolve → warm → run → sweep)

### DIFF
--- a/adrs/01060-inline-warm-phase.md
+++ b/adrs/01060-inline-warm-phase.md
@@ -1,0 +1,145 @@
+---
+status: accepted
+date: 2026-07-14
+decision-makers: [hawkeyexl]
+---
+
+# Inline always-on warm phase in `runSpecs`
+
+## Context and Problem Statement
+
+Provisioning costs were paid serially at first use, buried inside per-context execution: native app
+drivers JIT-install inside `appSurfacePreflight` (per context), simulators/emulators boot at first
+`startSurface` (1–5+ minutes serialized ahead of the first test), the android mobile-web
+chromedriver downloads at session time, and the existing `warmUpContexts` pre-pass ran only when
+`concurrentRunners > 1` and touched neither devices nor mobile toolchains. CI hand-rolled what the
+runner should own (the fixtures.yml iOS pre-boot step duplicating iosSimulator.ts's selection
+logic). The key insight from the CI wall-clock investigation (2026-07-13): warm-phase parallelism
+is independent of runner concurrency — even a fully serial test run benefits, because boot ∥ npm
+install ∥ browser download overlap *each other* during warm.
+
+The full implementation plan this ADR records the decisions of is
+[docs/design/warm-phase.md](../docs/design/warm-phase.md) (phases B1 + B2).
+
+## Decision Drivers
+
+- Provisioning should overlap, not serialize ahead of the first test — for every run shape,
+  including `concurrentRunners: 1`.
+- Warm must be an accelerator, never a new failure mode: a pure-web run's baseline latency and a
+  serial run's memoization semantics must be unchanged by construction.
+- No new lifecycle concepts: teardown must reuse the existing launch-ownership ledger and run-end
+  sweeps.
+- The npm-prune hazard (issue #501) forbids concurrent installs into the shared runtime cache.
+- Structured provisioning timing (the CI investigation's telemetry goal) needs a home in the report.
+
+## Considered Options
+
+1. **Always-on inline warm phase in `runSpecs`** — a pure planner derives tasks from the resolved
+   sizing jobs; a resource-aware executor overlaps them between resolution and Phase 2 dispatch;
+   results land in `report.warm`.
+2. **Extend the existing `limit > 1` pre-pass** — add device/toolchain work to `warmUpContexts`,
+   keeping the concurrency gate.
+3. **Standalone `doc-detective warm` CLI only** — provision in a separate CI step overlapping the
+   build, leave `runSpecs` untouched.
+
+## Decision Outcome
+
+Chosen option: **option 1**, because the phase derives strictly from resolved needs (a run warms
+only what it already JIT-provisions today, so baseline latency is unchanged by construction),
+serial runs benefit too (option 2 helps only concurrent runs), and it requires no workflow change
+from users (option 3 — the design doc's phase B3 — remains deferred and complementary, not
+competing).
+
+Specifics settled here:
+
+- **Always-on, inline, no flag.** `planWarmTasks` (pure, `src/core/warmPhase.ts`) derives the task
+  set from `sizingJobs` (flat + routed contexts); `executeWarmTasks` runs it before Phase 2
+  dispatch under the run's resource registry, bounded by a small fixed pool (4) independent of
+  `concurrentRunners`. A run with nothing to warm reports `warm: { durationMs: 0, tasks: [] }`
+  without executing anything.
+- **Best-effort, never gates.** Every task resolves `warmed | skipped | failed`; `failed` logs a
+  warning and the run proceeds — the per-context paths retry or skip with exactly their existing
+  semantics. The new task kinds (`device-boot`, `wda-check`, `chromedriver-prefetch`) record
+  nothing any gate reads; the install/probe kinds follow the established mirror contract:
+  `warmBrowserInstall` (the install + first-attempt re-detect half of `warmUpContexts`, extracted
+  and shared) leaves `installAttempts` / `runnerDetails.availableApps` exactly as the first
+  same-browser consuming context would have serially.
+- **Exclusivity via the run's one resource registry.** Every npm-cache-mutating task
+  (`driver-install`, `browser-install`, `session-probe`, `chromedriver-prefetch`) serializes on a
+  shared `runtime-install` tag — the npm-prune hazard structurally cannot recur — while device
+  boots serialize per device (plus the shared `android-emulator` bound) and everything else
+  overlaps. Tags never span phases: warm is awaited and `runResourceAware` releases in a
+  `finally`, so Phase 2 starts with an empty registry (extends ADR 01038's tag vocabulary).
+- **Ownership at provision time.** Device boots acquire into the existing run registries; the
+  placeholder carries `bootedByUs: true` and the in-flight `ready` promise, so the existing
+  run-end sweeps reclaim a warm-booted device **whether or not any test used it**. Boot tasks
+  resolve at boot *initiation* (`raceBootInitiation`, with the failure path routed to a warning,
+  never an unhandled rejection); consumers await `ready` exactly where they do today.
+- **The session probe keeps its gate.** The folded-in `warmUpContexts` probe still runs only at
+  `limit > 1` with a browser Appium pool — a throwaway driver session is only worth paying when it
+  prevents concurrent first-session races — preserving the documented byte-identical serial-run
+  behavior. The outer `limit > 1` gate on the *phase* is gone.
+- **`chromedriver-prefetch` awaits readiness (the one exception).** On-device chromedriver is only
+  downloadable through a live UiAutomator2 session, so the task chains idempotent steps
+  (preflight → acquire → throwaway session on a dedicated short-lived server) instead of an
+  executor dependency graph. Trade-off, stated plainly: the warm barrier now waits for a device
+  boot plus one throwaway session — but **only** for runs containing android mobile-web contexts,
+  which would pay exactly that cost at their first mobile context anyway; warm overlaps it with
+  the other tasks. Because the phase is awaited before Phase 2, the throwaway session can never
+  overlap the first real session on the device.
+- **Warm never lazy-installs the android toolchain.** The light env probe skips instead — the loud
+  multi-GB lazy install (and its report-visible warning) stays with the consuming context.
+- **`wda-check` probes, never builds.** It consults the managed WDA locator (ADR 01059) for
+  visibility and to pre-pay the memoized Xcode probe; building stays with `install ios`.
+- **Report timing (B2).** `report.warm = { durationMs, tasks[] }` is the first structured
+  provisioning-timing surface, added schema-first to `report_v3` as an optional `readOnly` block;
+  the emitted report remains runtime-unvalidated (the `recordingSerialized` precedent).
+
+### Consequences
+
+- Good: provisioning overlaps itself and no longer serializes ahead of the first test; serial runs
+  benefit; CI legs can read `report.warm` from fixture artifacts to verify the overlap.
+- Good: warm-booted devices are swept for free (ownership at provision time), including the
+  warmed-but-unused case.
+- Bad: runs with android mobile-web contexts block on boot + one throwaway session before Phase 2
+  (cost moved earlier, overlapped, and scoped to runs that already pay it).
+- Bad: at `concurrentRunners: 1`, install log lines now appear during warm rather than inside the
+  first consuming context — the memo end-state is identical.
+- Neutral: `doc-detective warm` (standalone CLI + cross-run ownership handoff, design phase B3)
+  stays deferred; the fixtures.yml iOS pre-boot step is only fully retired by B3.
+
+### Confirmation
+
+Hermetic unit suites: planner derivation per kind incl. dedup, host gating, and purity
+(`test/warm-phase-plan.test.js` — real predicates via `buildWarmPlanDeps`), executor failure
+isolation / tag exclusivity / pool ceiling (`test/warm-phase-executor.test.js`), boot-initiation +
+unhandled-rejection guard + ownership sweep (`test/warm-phase-device-boot.test.js`), the
+warmBrowserInstall mirror contract (`test/warm-phase-memo.test.js`), and the prefetch chain +
+teardown-in-finally (`test/warm-phase-prefetch.test.js`). Integration: `test/core-core.test.js`
+asserts `report.warm` on the browser smoke (browser-install/session-probe present) and the exact
+empty block on a shell-only run. The existing fixture matrix is the regression net — warm never
+fails a run, so every fixture's PASS/SKIPPED is unchanged.
+
+## Pros and Cons of the Options
+
+### Option 1 — always-on inline warm phase
+
+- Good: benefits every run shape; derives from resolved needs so no-op by construction when
+  there's nothing to warm; ownership and teardown reuse existing machinery.
+- Good: one place (the planner) knows the full provisioning set the moment it's knowable.
+- Bad: a new module + task vocabulary to maintain; the prefetch's await-readiness exception needs
+  its trade-off documented (above).
+
+### Option 2 — extend the `limit > 1` pre-pass
+
+- Good: smallest diff.
+- Bad: serial runs — the common local case — keep paying serialized provisioning; the pre-pass's
+  serial loop would either stay serial (no overlap win) or need exactly the executor this option
+  avoids building.
+
+### Option 3 — standalone `doc-detective warm` only
+
+- Good: overlaps provisioning with CI build steps (the biggest possible win in CI).
+- Bad: requires every user to restructure their pipeline to benefit; needs a cross-run ownership
+  handoff (manifest, staleness, adoption) before it's safe — deferred as design phase B3, to build
+  on this phase's planner/executor.

--- a/adrs/01060-inline-warm-phase.md
+++ b/adrs/01060-inline-warm-phase.md
@@ -122,10 +122,12 @@ Specifics settled here:
   memo-hit wording (not the first-consumer "on-demand install failed" wording), and a browserless
   context ordered before a pinned-browser context can now resolve the warm-installed engine as its
   default and run where it previously skipped.
-- Bad: the `android-emulator` exclusivity bound no longer spans a warm boot's background window —
-  warm releases the tag at initiation, so one background warm boot can overlap one Phase-2 boot of
-  a *different* device (same-device work still converges on the registry entry). Accepted: the
-  overlap is capped at one background boot, and multi-device android runs are rare.
+- Neutral: warm boots at most **one device per mobile platform** (the first), and the android boot
+  holds a manual `android-emulator` lease from initiation until the boot settles (released in the
+  background, past the task's resolution), so the one-emulator-at-a-time bound holds across warm
+  and Phase 2. Additional devices boot inside their consuming contexts exactly as before — the
+  first CI run of this branch proved that overlapping emulator boots starve a small KVM runner
+  (four concurrent boots timed out the very sessions the tests needed).
 - Neutral: `doc-detective warm` (standalone CLI + cross-run ownership handoff, design phase B3)
   stays deferred; the fixtures.yml iOS pre-boot step is only fully retired by B3.
 

--- a/adrs/01060-inline-warm-phase.md
+++ b/adrs/01060-inline-warm-phase.md
@@ -74,7 +74,17 @@ Specifics settled here:
   placeholder carries `bootedByUs: true` and the in-flight `ready` promise, so the existing
   run-end sweeps reclaim a warm-booted device **whether or not any test used it**. Boot tasks
   resolve at boot *initiation* (`raceBootInitiation`, with the failure path routed to a warning,
-  never an unhandled rejection); consumers await `ready` exactly where they do today.
+  never an unhandled rejection); consumers await `ready` exactly where they do today. Because a
+  boot can now still be in flight at run end, the teardown sweeps await an owned entry's `ready`
+  before shutting it down (a mid-boot placeholder has no process/udid to kill yet — sweeping it
+  blind would orphan the device).
+- **Warm plans only what the run's own gates would provision.** The planner applies the
+  per-context `requires` capability gate (an unmet gate provisions nothing, exactly like
+  runContext), and the mobile driver-install bodies re-check the host-capability probes
+  (android SDK/acceleration, iOS toolchain) before installing — warm never installs a driver the
+  per-context preflight would have refused to install. Desktop driver installs don't re-run the
+  macOS TCC probe (an inconclusive probe never blocks installs in the preflight either); the
+  worst case is a one-time cached install on a host whose contexts later skip.
 - **The session probe keeps its gate.** The folded-in `warmUpContexts` probe still runs only at
   `limit > 1` with a browser Appium pool — a throwaway driver session is only worth paying when it
   prevents concurrent first-session races — preserving the documented byte-identical serial-run
@@ -85,8 +95,11 @@ Specifics settled here:
   executor dependency graph. Trade-off, stated plainly: the warm barrier now waits for a device
   boot plus one throwaway session — but **only** for runs containing android mobile-web contexts,
   which would pay exactly that cost at their first mobile context anyway; warm overlaps it with
-  the other tasks. Because the phase is awaited before Phase 2, the throwaway session can never
-  overlap the first real session on the device.
+  the other tasks. The task holds only its device tag: its cache-mutating half (the android
+  preflight, one per run) executes under a manually-acquired `runtime-install` lease inside the
+  body, so the minutes-long device-ready await never blocks the install tasks queued on that
+  mutex. Because the phase is awaited before Phase 2, the throwaway session can never overlap the
+  first real session on the device.
 - **Warm never lazy-installs the android toolchain.** The light env probe skips instead — the loud
   multi-GB lazy install (and its report-visible warning) stays with the consuming context.
 - **`wda-check` probes, never builds.** It consults the managed WDA locator (ADR 01059) for
@@ -104,7 +117,15 @@ Specifics settled here:
 - Bad: runs with android mobile-web contexts block on boot + one throwaway session before Phase 2
   (cost moved earlier, overlapped, and scoped to runs that already pay it).
 - Bad: at `concurrentRunners: 1`, install log lines now appear during warm rather than inside the
-  first consuming context — the memo end-state is identical.
+  first consuming context — the memo end-state is identical, but two serial-run edges shift to
+  match today's concurrent-run behavior: a failed install's skip description uses the generic
+  memo-hit wording (not the first-consumer "on-demand install failed" wording), and a browserless
+  context ordered before a pinned-browser context can now resolve the warm-installed engine as its
+  default and run where it previously skipped.
+- Bad: the `android-emulator` exclusivity bound no longer spans a warm boot's background window —
+  warm releases the tag at initiation, so one background warm boot can overlap one Phase-2 boot of
+  a *different* device (same-device work still converges on the registry entry). Accepted: the
+  overlap is capped at one background boot, and multi-device android runs are rare.
 - Neutral: `doc-detective warm` (standalone CLI + cross-run ownership handoff, design phase B3)
   stays deferred; the fixtures.yml iOS pre-boot step is only fully retired by B3.
 

--- a/docs/design/warm-phase.md
+++ b/docs/design/warm-phase.md
@@ -1,11 +1,16 @@
 # Design: inline warm phase (resolve → warm → run → sweep)
 
-Status: **planned — no phase started; inline-first.** This document is the implementation plan for
-an always-on provisioning phase that runs between test resolution and test execution: it
-concurrently resolves, repairs, and warms everything the run will need — driver installs, browser
-installs, device boots, WDA availability, chromedriver prefetch — and only then runs tests. The
-standalone `doc-detective warm` CLI (CI overlap with build steps) is **deferred** to a later phase.
-Produced from the CI wall-clock investigation (2026-07-13); companion plan:
+Status: **B1 + B2 shipped** ([ADR 01060](../../adrs/01060-inline-warm-phase.md)) — the always-on
+inline phase (planner + executor, `src/core/warmPhase.ts`) and the `report.warm` timing block are
+live, including `wda-check` (enabled by the ADR 01059 managed WDA prebuild landing first) and
+`chromedriver-prefetch` (implemented as a chained throwaway session — the one task that awaits
+device readiness, scoped to runs with android mobile-web contexts). The standalone
+`doc-detective warm` CLI (**B3**, CI overlap with build steps + ownership handoff) remains
+**deferred**; until it lands, the fixtures.yml iOS pre-boot step stays. This document is the
+implementation plan for an always-on provisioning phase that runs between test resolution and test
+execution: it concurrently resolves, repairs, and warms everything the run will need — driver
+installs, browser installs, device boots, WDA availability, chromedriver prefetch — and only then
+runs tests. Produced from the CI wall-clock investigation (2026-07-13); companion plan:
 [ios-wda-prebuild.md](ios-wda-prebuild.md).
 
 ## Problem

--- a/docs/fern/pages/docs/ci/docker-and-headless.mdx
+++ b/docs/fern/pages/docs/ci/docker-and-headless.mdx
@@ -46,7 +46,7 @@ doc-detective install all --yes
 
 On a fresh `npm install`, Doc Detective also pre-warms these assets automatically. To skip that step—for example, to control exactly when assets download in CI—set `DOC_DETECTIVE_AUTOINSTALL=0`. The official container ships with assets already warmed, so you don't need this step inside it.
 
-Whatever the cache is missing, each run front-loads for itself: before executing tests, Doc Detective plans the installs, device boots, and downloads its tests need and runs them concurrently as a warm phase. With a persisted cache the phase completes in milliseconds; on a cold cache it overlaps the downloads instead of paying them one test at a time. The per-task timings land in the JSON results—see [Read the warm-phase timings](/docs/ci/reporters-and-artifacts#read-the-warm-phase-timings).
+Whatever the cache is missing, each run front-loads for itself: before executing tests, Doc Detective plans the installs, device boots, and downloads its tests need and runs them concurrently as a warm phase. With a persisted cache the phase completes in milliseconds. On a cold cache it overlaps the downloads instead of paying them one test at a time. The per-task timings land in the JSON results—see [Read the warm-phase timings](/docs/ci/reporters-and-artifacts#read-the-warm-phase-timings).
 
 <Note>
 `docdetective/docdetective:linux` is a multi-arch image (`linux/amd64` and `linux/arm64`), but Chrome and ChromeDriver have no native `linux/arm64` build upstream—Google's Chrome for Testing only publishes x64 binaries. On the `linux/arm64` variant, Chrome/ChromeDriver pre-warming is skipped rather than failing the image; if you need Chrome-driven tests on arm64 hosts, run the `linux/amd64` variant under emulation, or use Firefox instead.

--- a/docs/fern/pages/docs/ci/docker-and-headless.mdx
+++ b/docs/fern/pages/docs/ci/docker-and-headless.mdx
@@ -46,6 +46,8 @@ doc-detective install all --yes
 
 On a fresh `npm install`, Doc Detective also pre-warms these assets automatically. To skip that step—for example, to control exactly when assets download in CI—set `DOC_DETECTIVE_AUTOINSTALL=0`. The official container ships with assets already warmed, so you don't need this step inside it.
 
+Whatever the cache is missing, each run front-loads for itself: before executing tests, Doc Detective plans the installs, device boots, and downloads its tests need and runs them concurrently as a warm phase. With a persisted cache the phase completes in milliseconds; on a cold cache it overlaps the downloads instead of paying them one test at a time. The per-task timings land in the JSON results—see [Read the warm-phase timings](/docs/ci/reporters-and-artifacts#read-the-warm-phase-timings).
+
 <Note>
 `docdetective/docdetective:linux` is a multi-arch image (`linux/amd64` and `linux/arm64`), but Chrome and ChromeDriver have no native `linux/arm64` build upstream—Google's Chrome for Testing only publishes x64 binaries. On the `linux/arm64` variant, Chrome/ChromeDriver pre-warming is skipped rather than failing the image; if you need Chrome-driven tests on arm64 hosts, run the `linux/amd64` variant under emulation, or use Firefox instead.
 </Note>

--- a/docs/fern/pages/docs/ci/reporters-and-artifacts.mdx
+++ b/docs/fern/pages/docs/ci/reporters-and-artifacts.mdx
@@ -50,6 +50,22 @@ The `json` reporter writes the full results to a file:
 
 The results file carries a `summary` object with the pass, fail, warning, and skipped counts, followed by the per-spec, per-test, per-context, and per-step detail. For an example of the results structure, see [Create your first test](/docs/get-started/create-your-first-test#outcome). To act on results programmatically, parse this file (see [Fail CI when tests fail](#step-6-fail-ci-when-tests-fail)).
 
+### Read the warm-phase timings
+
+The results also carry a `warm` object that records what the run provisioned before executing tests. At the start of every run, Doc Detective front-loads the setup its tests would otherwise pay one at a time—browser and driver installs, simulator and emulator boots, and related downloads—and runs those tasks concurrently. Each entry lists the task, its outcome, and how long it took:
+
+```json
+"warm": {
+  "durationMs": 4211,
+  "tasks": [
+    { "name": "browser-install:chrome", "kind": "browser-install", "outcome": "skipped", "durationMs": 2, "note": "'chrome' is already available" },
+    { "name": "session-probe", "kind": "session-probe", "outcome": "warmed", "durationMs": 4205, "note": "1 combination ok" }
+  ]
+}
+```
+
+Outcomes are `warmed` (Doc Detective performed the work), `skipped` (nothing to do, or the environment handles it later), and `failed`. The warm phase is best-effort: a `failed` task logs a warning and never fails the run—the affected test context retries or skips with its normal behavior and reason. Use the timings to spot provisioning costs in slow CI runs: a long `warmed` task on every run usually means the [runtime cache](/docs/ci/docker-and-headless#step-3-warm-runtime-assets) isn't persisted between runs.
+
 ## Step 4: Find the HTML report
 
 The `html` reporter writes a self-contained HTML report you can open in a browser:

--- a/src/common/src/schemas/src_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/report_v3.schema.json
@@ -123,7 +123,7 @@
             "kind": "session-probe",
             "outcome": "warmed",
             "durationMs": 4205,
-            "note": "1 combination(s) ok"
+            "note": "1 combination ok"
           }
         ]
       }

--- a/src/common/src/schemas/src_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/report_v3.schema.json
@@ -31,6 +31,71 @@
           }
         ]
       }
+    },
+    "warm": {
+      "type": "object",
+      "description": "Results of the run's inline warm phase — the always-on, best-effort provisioning pass (dependency installs, device boots, session probes) performed between test resolution and test execution. A failed task never gates the run; the per-context paths retry or skip with their normal semantics. Absent when the run ended before the phase (for example, when no specs matched). System-populated.",
+      "readOnly": true,
+      "additionalProperties": false,
+      "required": [
+        "durationMs",
+        "tasks"
+      ],
+      "properties": {
+        "durationMs": {
+          "type": "number",
+          "description": "Wall-clock duration of the warm phase in milliseconds. Tasks overlap, so this is less than the sum of the per-task durations."
+        },
+        "tasks": {
+          "type": "array",
+          "description": "One entry per executed warm task.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "kind",
+              "outcome",
+              "durationMs"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Task identity, e.g. `browser-install:chrome` or `device-boot:android:<default>:<latest>`."
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "driver-install",
+                  "browser-install",
+                  "device-boot",
+                  "wda-check",
+                  "session-probe",
+                  "chromedriver-prefetch"
+                ],
+                "description": "What the task pre-pays: a native app driver install, a browser install, a simulator/emulator boot, the managed WebDriverAgent availability check, the concurrent-run driver session probe, or the android mobile-web chromedriver download."
+              },
+              "outcome": {
+                "type": "string",
+                "enum": [
+                  "warmed",
+                  "skipped",
+                  "failed"
+                ],
+                "description": "`warmed` — the work was performed (for device boots, the boot was initiated); `skipped` — nothing to do or the environment isn't ready (the consuming context handles it as usual); `failed` — the attempt failed (logged as a warning; never fails the run)."
+              },
+              "durationMs": {
+                "type": "number",
+                "description": "Wall-clock duration of this task in milliseconds."
+              },
+              "note": {
+                "type": "string",
+                "description": "Human-readable detail about the outcome."
+              }
+            }
+          }
+        }
+      }
     }
   },
   "required": [
@@ -42,7 +107,26 @@
         {
           "$ref": "spec_v3.schema.json#/examples/0"
         }
-      ]
+      ],
+      "warm": {
+        "durationMs": 4211,
+        "tasks": [
+          {
+            "name": "browser-install:chrome",
+            "kind": "browser-install",
+            "outcome": "skipped",
+            "durationMs": 2,
+            "note": "'chrome' is already available"
+          },
+          {
+            "name": "session-probe",
+            "kind": "session-probe",
+            "outcome": "warmed",
+            "durationMs": 4205,
+            "note": "1 combination(s) ok"
+          }
+        ]
+      }
     },
     {
       "specs": [

--- a/src/common/src/types/generated/report_v3.ts
+++ b/src/common/src/types/generated/report_v3.ts
@@ -49,6 +49,46 @@ export interface Report {
    * @minItems 1
    */
   specs: [Specification, ...Specification[]];
+  /**
+   * Results of the run's inline warm phase — the always-on, best-effort provisioning pass (dependency installs, device boots, session probes) performed between test resolution and test execution. A failed task never gates the run; the per-context paths retry or skip with their normal semantics. Absent when the run ended before the phase (for example, when no specs matched). System-populated.
+   */
+  warm?: {
+    /**
+     * Wall-clock duration of the warm phase in milliseconds. Tasks overlap, so this is less than the sum of the per-task durations.
+     */
+    durationMs: number;
+    /**
+     * One entry per executed warm task.
+     */
+    tasks: {
+      /**
+       * Task identity, e.g. `browser-install:chrome` or `device-boot:android:<default>:<latest>`.
+       */
+      name: string;
+      /**
+       * What the task pre-pays: a native app driver install, a browser install, a simulator/emulator boot, the managed WebDriverAgent availability check, the concurrent-run driver session probe, or the android mobile-web chromedriver download.
+       */
+      kind:
+        | "driver-install"
+        | "browser-install"
+        | "device-boot"
+        | "wda-check"
+        | "session-probe"
+        | "chromedriver-prefetch";
+      /**
+       * `warmed` — the work was performed (for device boots, the boot was initiated); `skipped` — nothing to do or the environment isn't ready (the consuming context handles it as usual); `failed` — the attempt failed (logged as a warning; never fails the run).
+       */
+      outcome: "warmed" | "skipped" | "failed";
+      /**
+       * Wall-clock duration of this task in milliseconds.
+       */
+      durationMs: number;
+      /**
+       * Human-readable detail about the outcome.
+       */
+      note?: string;
+    }[];
+  };
   [k: string]: unknown;
 }
 export interface Specification {

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -1176,6 +1176,110 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(original).to.deep.equal(originalCopy);
       });
     });
+
+    describe("report_v3 warm block", function () {
+      const minimalSpecs = [
+        { tests: [{ steps: [{ goTo: { url: "https://example.com" } }] }] },
+      ];
+      const warmTask = {
+        name: "browser-install:chrome",
+        kind: "browser-install",
+        outcome: "warmed",
+        durationMs: 900,
+      };
+
+      it("should validate a report_v3 object with a warm block", function () {
+        const result = validate({
+          schemaKey: "report_v3",
+          object: {
+            specs: minimalSpecs,
+            warm: {
+              durationMs: 1234,
+              tasks: [
+                warmTask,
+                {
+                  name: "wda-check",
+                  kind: "wda-check",
+                  outcome: "skipped",
+                  durationMs: 3,
+                  note: "no prebuilt WebDriverAgent",
+                },
+              ],
+            },
+          },
+        });
+        expect(result.valid, result.errors).to.be.true;
+        expect(result.errors).to.equal("");
+        expect(result.object.warm.tasks[0].kind).to.equal("browser-install");
+      });
+
+      it("should validate a report_v3 object without a warm block (back-compat)", function () {
+        const result = validate({
+          schemaKey: "report_v3",
+          object: { specs: minimalSpecs },
+        });
+        expect(result.valid, result.errors).to.be.true;
+        expect(result.object.warm).to.equal(undefined);
+      });
+
+      it("should reject a warm task with an unknown outcome", function () {
+        const result = validate({
+          schemaKey: "report_v3",
+          object: {
+            specs: minimalSpecs,
+            warm: {
+              durationMs: 1,
+              tasks: [{ ...warmTask, outcome: "exploded" }],
+            },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+        expect(result.errors).to.include("outcome");
+      });
+
+      it("should reject a warm task with an unknown kind", function () {
+        const result = validate({
+          schemaKey: "report_v3",
+          object: {
+            specs: minimalSpecs,
+            warm: {
+              durationMs: 1,
+              tasks: [{ ...warmTask, kind: "coffee" }],
+            },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.include("kind");
+      });
+
+      it("should reject a warm task missing required fields", function () {
+        const result = validate({
+          schemaKey: "report_v3",
+          object: {
+            specs: minimalSpecs,
+            warm: {
+              durationMs: 1,
+              tasks: [{ name: "x", outcome: "warmed", durationMs: 1 }],
+            },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.include("kind");
+      });
+
+      it("should reject unknown properties inside the warm block", function () {
+        const result = validate({
+          schemaKey: "report_v3",
+          object: {
+            specs: minimalSpecs,
+            warm: { durationMs: 1, tasks: [], extra: true },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+      });
+    });
   });
 
   describe("transformToSchemaKey", function () {

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -2857,18 +2857,28 @@ function buildWarmTaskRunner({
   // share a single result instead of each blocking the executor on it.
   let iosToolchain: ReturnType<typeof probeIosToolchain> | undefined;
   const getIosToolchain = () => (iosToolchain ??= probeIosToolchain());
-  // Manual lease on the shared install mutex, for work that must serialize
-  // with the runtime-install-tagged tasks but runs inside a task that
-  // deliberately does NOT hold that tag for its whole duration (the
-  // chromedriver prefetch, whose device-ready await must not block installs).
-  const withRuntimeInstallLock = async <T>(fn: () => Promise<T>): Promise<T> => {
-    while (!resourceRegistry.tryAcquire([RUNTIME_INSTALL_RESOURCE])) {
+  // Manual leases on the run's resource registry, for work that must
+  // serialize on a named mutex but can't express its hold window as a task
+  // tag (runResourceAware releases tags at task RESOLUTION, and warm tasks
+  // deliberately resolve before their background work finishes). The
+  // returned release is idempotent.
+  const acquireLease = async (names: string[]): Promise<() => void> => {
+    while (!resourceRegistry.tryAcquire(names)) {
       await resourceRegistry.waitForFree();
     }
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      resourceRegistry.release(names);
+    };
+  };
+  const withRuntimeInstallLock = async <T>(fn: () => Promise<T>): Promise<T> => {
+    const release = await acquireLease([RUNTIME_INSTALL_RESOURCE]);
     try {
       return await fn();
     } finally {
-      resourceRegistry.release([RUNTIME_INSTALL_RESOURCE]);
+      release();
     }
   };
   // One android app preflight (driver install + Appium co-homing) per run,
@@ -2942,10 +2952,21 @@ function buildWarmTaskRunner({
               note: "Android toolchain not ready; device setup stays with the consuming context",
             };
           }
+          // Hold the run's "android-emulator" mutex from before initiation
+          // until the boot settles — in the BACKGROUND, past this task's
+          // resolution — so warm's boot and any Phase-2 job's boot (which
+          // tag the same name) can never run two emulators at once: on a
+          // small CI runner concurrent boots starve each other and the
+          // sessions that follow. Released via the acquire promise's settle
+          // chain (both branches handled — no unhandled rejection), not a
+          // finally, precisely because the task resolves first.
+          const releaseEmulatorLease = await acquireLease([
+            "android-emulator",
+          ]);
           return raceBootInitiation({
             onError,
-            startAcquire: (signalInitiated) =>
-              acquireDevice({
+            startAcquire: (signalInitiated) => {
+              const acquiring = acquireDevice({
                 desc,
                 registry: deviceRegistry,
                 sdkRoot: env.sdkRoot,
@@ -2954,7 +2975,13 @@ function buildWarmTaskRunner({
                   ["createAvd", "boot"],
                   signalInitiated
                 ),
-              }),
+              });
+              acquiring.then(
+                () => releaseEmulatorLease(),
+                () => releaseEmulatorLease()
+              );
+              return acquiring;
+            },
           });
         }
         const toolchain = getIosToolchain();
@@ -3031,6 +3058,7 @@ function buildWarmTaskRunner({
             // the prefetch task itself only holds its device tag while it
             // awaits readiness and runs the throwaway session.
             appSurfacePreflight: () => getAndroidPreflight(),
+            acquireEmulatorLease: () => acquireLease(["android-emulator"]),
           },
         });
     }
@@ -3068,6 +3096,9 @@ async function prefetchMobileChromedriver({
     startAppiumServer?: typeof startAppiumServer;
     driverStart?: typeof driverStart;
     killTree?: typeof killTree;
+    // Serializes any boot this task's acquire performs with every other
+    // emulator boot in the run (warm's and Phase 2's).
+    acquireEmulatorLease?: () => Promise<() => void>;
   };
 }): Promise<{ outcome: WarmOutcome; note?: string }> {
   const preflight = deps.appSurfacePreflight ?? appSurfacePreflight;
@@ -3091,13 +3122,23 @@ async function prefetchMobileChromedriver({
   if (!pre.ok) return { outcome: "skipped", note: pre.reason };
   // Await the device. If the device-boot task already initiated this boot,
   // this acquire converges on the same registry entry and awaits its
-  // in-flight `ready`; otherwise it performs the full acquire itself.
-  const acquired = await acquire({
-    desc,
-    registry: deviceRegistry,
-    sdkRoot: env.sdkRoot,
-    deps: env.deviceDeps,
-  });
+  // in-flight `ready`; otherwise it performs the full acquire itself —
+  // under the shared emulator lease, so a boot this task performs never
+  // overlaps another emulator boot in the run.
+  const releaseLease = deps.acquireEmulatorLease
+    ? await deps.acquireEmulatorLease()
+    : undefined;
+  let acquired;
+  try {
+    acquired = await acquire({
+      desc,
+      registry: deviceRegistry,
+      sdkRoot: env.sdkRoot,
+      deps: env.deviceDeps,
+    });
+  } finally {
+    releaseLease?.();
+  }
   if ("skip" in acquired) return { outcome: "skipped", note: acquired.skip };
 
   let server: any;

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -91,6 +91,8 @@ import {
   buildMobileBrowserCapabilities,
 } from "./tests/mobileBrowser.js";
 import {
+  planWarmTasks,
+  executeWarmTasks,
   raceBootInitiation,
   type WarmPlanDeps,
   type WarmTask,
@@ -1812,6 +1814,16 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   // shut down (launch-ownership).
   const simulatorRegistry: SimulatorRegistry = createSimulatorRegistry();
 
+  // One resource registry per run, shared by the warm phase, every phase's
+  // flat pool, AND the routed sequencer — so warm's cache-mutating tasks,
+  // flat-pool recordings, and routed-spec recordings all contend on the same
+  // named mutexes. Warm is awaited before Phase 2 dispatch and
+  // runResourceAware releases every tag in a `finally`, so the pools always
+  // start with an empty registry. Only consulted where items carry tags
+  // (warm tasks always do; jobs only at limit>1 — at limit===1 the pools
+  // stay on the byte-identical runConcurrent path).
+  const resourceRegistry = createResourceRegistry();
+
   // Kill every still-registered background process (and its child tree) and
   // remove any deferred temp scripts. Awaits the kills so the process tree is
   // actually gone before the run returns. Idempotent: closeSurface already
@@ -1870,25 +1882,50 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   // warmUpContexts (e.g. getAvailableApps failing during the re-detect) would
   // leak the started servers, leaving orphaned processes bound to their ports.
   try {
-    // For concurrent runs, resolve missing browser dependencies and warm up
-    // each unique driver combination serially *before* the pool. Two contexts
-    // can't then race on an on-demand install (which mutates the shared app
-    // cache), and a combination that can't start a driver is recorded once here
-    // so every parallel context sharing it skips instantly instead of re-paying
-    // driverStart's backoff. This pre-populates installAttempts /
-    // warmUpResults / runnerDetails.availableApps, so runContext's own gates
-    // below collapse to fast cache hits. Sequential runs (limit 1) keep #338's
-    // natural first-context-warms-up behavior in runContext — no pre-pass, no
-    // extra driver start, byte-identical to before.
-    if (limit > 1 && appiumPool) {
-      await warmUpContexts({
-        jobs: sizingJobs,
-        config,
-        runnerDetails,
-        appiumPool,
-        installAttempts,
-        warmUpResults,
+    // Inline warm phase (docs/design/warm-phase.md): always-on, best-effort
+    // provisioning between resolution and execution. The planner derives
+    // every task the run's contexts would JIT-provision anyway (browser and
+    // app-driver installs, device boots, the WDA availability check, the
+    // mobile chromedriver prefetch, the folded-in session probe) and the
+    // executor overlaps them under the run's resource registry — so boot ∥
+    // npm install ∥ browser download overlap each other even for a serial
+    // test run. A failed task is a warning; the per-context paths retry or
+    // skip with exactly the semantics they have today. The historical
+    // `limit > 1 && appiumPool` gate now guards only the session-probe TASK
+    // (inside planWarmTasks), preserving #338's natural
+    // first-context-warms-up behavior for serial runs, whose memo state is
+    // byte-identical by the warmBrowserInstall mirror contract. Device
+    // boots resolve at initiation; only the chromedriver prefetch awaits
+    // readiness (and only runs with android mobile-web contexts pay it —
+    // they'd pay the same boot + session at their first mobile context).
+    const warmTasks = planWarmTasks({
+      sizingJobs,
+      runnerDetails,
+      config,
+      limit,
+      hasAppiumPool: !!appiumPool,
+      hostPlatform: platform,
+      deps: buildWarmPlanDeps(),
+    });
+    if (warmTasks.length > 0) {
+      log(config, "debug", `Warm phase: ${warmTasks.length} task(s).`);
+      report.warm = await executeWarmTasks({
+        tasks: warmTasks,
+        registry: resourceRegistry,
+        runTask: buildWarmTaskRunner({
+          config,
+          runnerDetails,
+          sizingJobs,
+          appiumPool,
+          installAttempts,
+          warmUpResults,
+          deviceRegistry,
+          simulatorRegistry,
+        }),
+        log: (level, message) => log(config, level, message),
       });
+    } else {
+      report.warm = { durationMs: 0, tasks: [] };
     }
 
     // Phase 2: run context jobs through the worker pool, gated into three
@@ -1979,12 +2016,6 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
         : "main";
       routedByPhase[phase].push(entry);
     }
-    // One resource registry per run, shared by every phase's flat pool AND the
-    // routed sequencer, so a flat-pool recording and a routed-spec recording
-    // never hold the shared "display" at the same time. Only consulted at
-    // limit>1 (where jobs were tagged); at limit===1 the pools stay on the
-    // byte-identical runConcurrent path.
-    const resourceRegistry = createResourceRegistry();
     for (const phase of PHASES) {
       if (limit > 1) {
         await runResourceAware(

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -190,6 +190,7 @@ export {
   jobDisplayResources,
   buildWarmPlanDeps,
   warmBrowserInstall,
+  prefetchMobileChromedriver,
 };
 // exports.appiumStart = appiumStart;
 // exports.appiumIsReady = appiumIsReady;
@@ -2932,14 +2933,120 @@ function buildWarmTaskRunner({
       }
 
       case "chromedriver-prefetch":
-        return {
-          outcome: "skipped",
-          note: "chromedriver prefetch not implemented yet",
-        };
+        return prefetchMobileChromedriver({
+          config,
+          desc: task.payload.desc,
+          deviceRegistry,
+          getAndroidEnv,
+        });
     }
   };
 }
 /* c8 ignore stop */
+
+/**
+ * Pre-pay the on-device chromedriver download for android mobile-web: the
+ * UiAutomator2 server only fetches a chromedriver matching the device's
+ * Chrome at SESSION creation, so this task awaits the device (the one warm
+ * task that blocks on readiness), opens a disposable mobile-web session on a
+ * dedicated short-lived Appium server with the scoped autodownload feature —
+ * the exact shape runContext's mobile-web branch uses — and tears both down.
+ * The downloaded chromedriver lands in the shared cache, so the first real
+ * session skips the download. Because the warm phase is awaited before
+ * Phase 2 dispatch, this throwaway session can never overlap the first real
+ * session on the same device. A throw is the executor's problem (recorded
+ * as failed, run proceeds). Effects are injected for hermetic tests.
+ */
+async function prefetchMobileChromedriver({
+  config,
+  desc,
+  deviceRegistry,
+  getAndroidEnv,
+  deps = {},
+}: {
+  config: any;
+  desc: any;
+  deviceRegistry: DeviceRegistry;
+  getAndroidEnv: () => Promise<{ sdkRoot: string; deviceDeps: any } | null>;
+  deps?: {
+    appSurfacePreflight?: typeof appSurfacePreflight;
+    acquireDevice?: typeof acquireDevice;
+    startAppiumServer?: typeof startAppiumServer;
+    driverStart?: typeof driverStart;
+    killTree?: typeof killTree;
+  };
+}): Promise<{ outcome: WarmOutcome; note?: string }> {
+  const preflight = deps.appSurfacePreflight ?? appSurfacePreflight;
+  const acquire = deps.acquireDevice ?? acquireDevice;
+  const startServer = deps.startAppiumServer ?? startAppiumServer;
+  const startDriver = deps.driverStart ?? driverStart;
+  const kill = deps.killTree ?? killTree;
+
+  const env = await getAndroidEnv();
+  if (!env) {
+    return {
+      outcome: "skipped",
+      note: "Android toolchain not ready; the first mobile-web session downloads chromedriver as needed",
+    };
+  }
+  // Driver install + Appium co-homing, idempotent: usually a no-op after
+  // the driver-install task (the shared runtime-install exclusivity tag
+  // keeps the two from ever mutating the cache concurrently), and android
+  // has no platform probes, so this is exactly the install half.
+  const pre = await preflight({ config, platform: "android" });
+  if (!pre.ok) return { outcome: "skipped", note: pre.reason };
+  // Await the device. If the device-boot task already initiated this boot,
+  // this acquire converges on the same registry entry and awaits its
+  // in-flight `ready`; otherwise it performs the full acquire itself.
+  const acquired = await acquire({
+    desc,
+    registry: deviceRegistry,
+    sdkRoot: env.sdkRoot,
+    deps: env.deviceDeps,
+  });
+  if ("skip" in acquired) return { outcome: "skipped", note: acquired.skip };
+
+  let server: any;
+  let driver: any;
+  try {
+    server = await startServer(
+      pre.appiumEntry,
+      config,
+      undefined,
+      {
+        APPIUM_HOME: pre.appiumHome,
+        ANDROID_HOME: env.sdkRoot,
+        ANDROID_SDK_ROOT: env.sdkRoot,
+      },
+      ["--allow-insecure", "uiautomator2:chromedriver_autodownload"]
+    );
+    driver = await startDriver(
+      buildMobileBrowserCapabilities({
+        platform: "android",
+        udid: acquired.entry.udid,
+        cacheDir: getCacheDir({ cacheDir: config?.cacheDir }),
+      }),
+      server.port,
+      2,
+      { cacheDir: config?.cacheDir }
+    );
+    return {
+      outcome: "warmed",
+      note: `chromedriver ready for device '${acquired.entry.name}'`,
+    };
+  } finally {
+    if (driver) {
+      try {
+        await driver.deleteSession();
+      } catch {
+        // best-effort teardown of the throwaway session
+      }
+    }
+    if (server) {
+      await kill(server.process?.pid);
+    }
+  }
+}
 
 /**
  * Pure predicate: does this spec carry TEST-level routing? True iff ANY of its

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -89,11 +89,14 @@ import { isMobileTargetPlatform } from "./tests/mobilePlatform.js";
 import {
   mobileBrowserGate,
   buildMobileBrowserCapabilities,
+  CHROMEDRIVER_AUTODOWNLOAD_ARGS,
 } from "./tests/mobileBrowser.js";
 import {
   planWarmTasks,
   executeWarmTasks,
   raceBootInitiation,
+  wrapInitiationEffects,
+  RUNTIME_INSTALL_RESOURCE,
   type WarmPlanDeps,
   type WarmTask,
   type WarmOutcome,
@@ -307,11 +310,11 @@ function buildWarmPlanDeps(): WarmPlanDeps {
     isAppDriverRequired,
     isMobileTargetPlatform,
     getDefaultBrowser,
-    combinationKey,
     requiredBrowserAssets,
     collectDeviceDescriptors,
     normalizeDeviceDescriptor,
     mobileBrowserGate,
+    contextRequirementsSkipMessage,
     appDriverPlatforms: APP_DRIVER_PLATFORMS,
   };
 }
@@ -1458,6 +1461,11 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
       },
     },
     specs: [],
+    // Inline warm phase results (docs/design/warm-phase.md). Present on the
+    // skeleton so a run that plans nothing (or whose planning fails —
+    // best-effort) still reports the structural empty block; the phase
+    // overwrites it with real task results below.
+    warm: { durationMs: 0, tasks: [] },
   };
 
   // Resolve concurrency up front (defensive re-resolve: API callers can hand
@@ -1898,34 +1906,43 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     // boots resolve at initiation; only the chromedriver prefetch awaits
     // readiness (and only runs with android mobile-web contexts pay it —
     // they'd pay the same boot + session at their first mobile context).
-    const warmTasks = planWarmTasks({
-      sizingJobs,
-      runnerDetails,
-      config,
-      limit,
-      hasAppiumPool: !!appiumPool,
-      hostPlatform: platform,
-      deps: buildWarmPlanDeps(),
-    });
-    if (warmTasks.length > 0) {
-      log(config, "debug", `Warm phase: ${warmTasks.length} task(s).`);
-      report.warm = await executeWarmTasks({
-        tasks: warmTasks,
-        registry: resourceRegistry,
-        runTask: buildWarmTaskRunner({
-          config,
-          runnerDetails,
-          sizingJobs,
-          appiumPool,
-          installAttempts,
-          warmUpResults,
-          deviceRegistry,
-          simulatorRegistry,
-        }),
-        log: (level, message) => log(config, level, message),
+    // The never-gates contract covers the whole phase, planning included: a
+    // throw from the planner or its bound predicates must degrade to a
+    // warning + the skeleton's empty warm block, never abort the run
+    // (executeWarmTasks already isolates per-task failures internally).
+    try {
+      const warmTasks = planWarmTasks({
+        sizingJobs,
+        runnerDetails,
+        limit,
+        hasAppiumPool: !!appiumPool,
+        deps: buildWarmPlanDeps(),
       });
-    } else {
-      report.warm = { durationMs: 0, tasks: [] };
+      if (warmTasks.length > 0) {
+        log(config, "debug", `Warm phase: ${warmTasks.length} task(s).`);
+        report.warm = await executeWarmTasks({
+          tasks: warmTasks,
+          registry: resourceRegistry,
+          runTask: buildWarmTaskRunner({
+            config,
+            runnerDetails,
+            sizingJobs,
+            appiumPool,
+            installAttempts,
+            warmUpResults,
+            deviceRegistry,
+            simulatorRegistry,
+            resourceRegistry,
+          }),
+          log: (level, message) => log(config, level, message),
+        });
+      }
+    } catch (error: any) {
+      log(
+        config,
+        "warning",
+        `Warm phase skipped (planning failed; the run proceeds with on-demand provisioning): ${error?.message ?? error}`
+      );
     }
 
     // Phase 2: run context jobs through the worker pool, gated into three
@@ -2817,6 +2834,7 @@ function buildWarmTaskRunner({
   warmUpResults,
   deviceRegistry,
   simulatorRegistry,
+  resourceRegistry,
 }: {
   config: any;
   runnerDetails: any;
@@ -2826,6 +2844,7 @@ function buildWarmTaskRunner({
   warmUpResults: Map<string, "ok" | "failed">;
   deviceRegistry: DeviceRegistry;
   simulatorRegistry: SimulatorRegistry;
+  resourceRegistry: ReturnType<typeof createResourceRegistry>;
 }): (task: WarmTask) => Promise<{ outcome: WarmOutcome; note?: string }> {
   // One Android env probe per run, shared by device boots and the
   // chromedriver prefetch.
@@ -2833,6 +2852,34 @@ function buildWarmTaskRunner({
     | Promise<{ sdkRoot: string; deviceDeps: any } | null>
     | undefined;
   const getAndroidEnv = () => (androidEnv ??= resolveAndroidWarmEnv(config));
+  // One iOS toolchain probe per run: it's a synchronous xcrun spawn (slow on
+  // a cold CoreSimulator service), so device boots and the driver install
+  // share a single result instead of each blocking the executor on it.
+  let iosToolchain: ReturnType<typeof probeIosToolchain> | undefined;
+  const getIosToolchain = () => (iosToolchain ??= probeIosToolchain());
+  // Manual lease on the shared install mutex, for work that must serialize
+  // with the runtime-install-tagged tasks but runs inside a task that
+  // deliberately does NOT hold that tag for its whole duration (the
+  // chromedriver prefetch, whose device-ready await must not block installs).
+  const withRuntimeInstallLock = async <T>(fn: () => Promise<T>): Promise<T> => {
+    while (!resourceRegistry.tryAcquire([RUNTIME_INSTALL_RESOURCE])) {
+      await resourceRegistry.waitForFree();
+    }
+    try {
+      return await fn();
+    } finally {
+      resourceRegistry.release([RUNTIME_INSTALL_RESOURCE]);
+    }
+  };
+  // One android app preflight (driver install + Appium co-homing) per run,
+  // always performed under the install lease.
+  let androidPreflight:
+    | ReturnType<typeof appSurfacePreflight>
+    | undefined;
+  const getAndroidPreflight = () =>
+    (androidPreflight ??= withRuntimeInstallLock(() =>
+      appSurfacePreflight({ config, platform: "android" })
+    ));
 
   return async (task: WarmTask) => {
     switch (task.kind) {
@@ -2845,6 +2892,25 @@ function buildWarmTaskRunner({
         });
 
       case "driver-install": {
+        // Mirror the per-context preflights' host-capability gates BEFORE
+        // installing: they probe the environment first and skip without
+        // installing on hosts that can never run the platform, and warm
+        // must not install what those gates would refuse.
+        if (task.payload.platform === "android") {
+          const env = await getAndroidEnv();
+          if (!env) {
+            return {
+              outcome: "skipped",
+              note: "Android toolchain not ready; the driver install stays with the consuming context",
+            };
+          }
+        }
+        if (task.payload.platform === "ios") {
+          const toolchain = getIosToolchain();
+          if (!toolchain.ok) {
+            return { outcome: "skipped", note: toolchain.reason };
+          }
+        }
         // Same lazy-loaded install path appSurfacePreflight uses; it skips
         // packages already resolvable, so the later per-context preflight
         // finds the driver present and pays only Appium co-homing.
@@ -2883,21 +2949,15 @@ function buildWarmTaskRunner({
                 desc,
                 registry: deviceRegistry,
                 sdkRoot: env.sdkRoot,
-                deps: {
-                  ...env.deviceDeps,
-                  createAvd: (args: any) => {
-                    signalInitiated();
-                    return env.deviceDeps.createAvd(args);
-                  },
-                  boot: (d: any, port: number) => {
-                    signalInitiated();
-                    return env.deviceDeps.boot(d, port);
-                  },
-                },
+                deps: wrapInitiationEffects(
+                  env.deviceDeps,
+                  ["createAvd", "boot"],
+                  signalInitiated
+                ),
               }),
           });
         }
-        const toolchain = probeIosToolchain();
+        const toolchain = getIosToolchain();
         if (!toolchain.ok) {
           return { outcome: "skipped", note: toolchain.reason };
         }
@@ -2910,17 +2970,11 @@ function buildWarmTaskRunner({
             acquireSimulator({
               desc,
               registry: simulatorRegistry,
-              deps: {
-                ...simDeps,
-                create: (args: any) => {
-                  signalInitiated();
-                  return simDeps.create(args);
-                },
-                boot: (udid: string) => {
-                  signalInitiated();
-                  return simDeps.boot(udid);
-                },
-              },
+              deps: wrapInitiationEffects(
+                simDeps,
+                ["create", "boot"],
+                signalInitiated
+              ),
             }),
         });
       }
@@ -2971,6 +3025,13 @@ function buildWarmTaskRunner({
           desc: task.payload.desc,
           deviceRegistry,
           getAndroidEnv,
+          deps: {
+            // The cache-mutating half (driver install + Appium co-homing)
+            // runs once per run under the manual runtime-install lease, so
+            // the prefetch task itself only holds its device tag while it
+            // awaits readiness and runs the throwaway session.
+            appSurfacePreflight: () => getAndroidPreflight(),
+          },
         });
     }
   };
@@ -3051,7 +3112,7 @@ async function prefetchMobileChromedriver({
         ANDROID_HOME: env.sdkRoot,
         ANDROID_SDK_ROOT: env.sdkRoot,
       },
-      ["--allow-insecure", "uiautomator2:chromedriver_autodownload"]
+      CHROMEDRIVER_AUTODOWNLOAD_ARGS
     );
     driver = await startDriver(
       buildMobileBrowserCapabilities({
@@ -3991,9 +4052,7 @@ async function runContext({
       // scoped to the uiautomator2 driver on this run-owned server so it can
       // fetch the chromedriver matching the device's Chrome.
       const extraArgs =
-        mobileTarget === "android"
-          ? ["--allow-insecure", "uiautomator2:chromedriver_autodownload"]
-          : [];
+        mobileTarget === "android" ? CHROMEDRIVER_AUTODOWNLOAD_ARGS : [];
       // Server start + device boot are environment work: any failure there
       // (port pressure, an emulator that can't finish booting on this host,
       // simctl trouble) is a gating SKIP with the reason named — never a

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -2814,6 +2814,52 @@ async function resolveAndroidWarmEnv(
 /* c8 ignore stop */
 
 /**
+ * Async twin of probeIosToolchain for the warm executor: the sync probe's
+ * spawnSync (up to 120s on a cold CoreSimulator service) would block the
+ * event loop and stall every "concurrent" warm task. Pre-run both probe
+ * commands with async spawns (in parallel), then hand the collected results
+ * to the real probe via its injected runner — the decision logic and every
+ * skip message stay in ONE place.
+ */
+/* c8 ignore start — real xcode-select/xcrun spawns; the decision logic is
+   probeIosToolchain's and is unit-tested there. */
+async function probeIosToolchainWarm(): Promise<
+  ReturnType<typeof probeIosToolchain>
+> {
+  if (process.platform !== "darwin") return probeIosToolchain();
+  const runAsync = (
+    command: string,
+    args: string[],
+    timeout: number
+  ): Promise<{ status: number | null; stdout: string; stderr: string }> =>
+    new Promise((resolve) => {
+      let stdout = "";
+      let stderr = "";
+      try {
+        const child = spawn(command, args, { windowsHide: true, timeout });
+        child.stdout?.on("data", (d: any) => (stdout += String(d)));
+        child.stderr?.on("data", (d: any) => (stderr += String(d)));
+        child.on("error", () => resolve({ status: null, stdout, stderr }));
+        child.on("close", (status: number | null) =>
+          resolve({ status, stdout, stderr })
+        );
+      } catch {
+        resolve({ status: null, stdout, stderr });
+      }
+    });
+  const [xcodeSelect, simctl] = await Promise.all([
+    runAsync("xcode-select", ["-p"], 15000),
+    // Same generous ceiling as the sync probe's xcrun spawn: the first cold
+    // simctl call launches CoreSimulatorService.
+    runAsync("xcrun", ["simctl", "list", "devices", "available"], 120000),
+  ]);
+  return probeIosToolchain({
+    run: (command: string) => (command === "xcrun" ? simctl : xcodeSelect),
+  });
+}
+/* c8 ignore stop */
+
+/**
  * Bind the effectful per-kind warm task bodies to the run's state. Every
  * body upholds the warm contract: best-effort (a throw is caught by the
  * executor and recorded as failed), and memo effects identical to what the
@@ -2852,11 +2898,11 @@ function buildWarmTaskRunner({
     | Promise<{ sdkRoot: string; deviceDeps: any } | null>
     | undefined;
   const getAndroidEnv = () => (androidEnv ??= resolveAndroidWarmEnv(config));
-  // One iOS toolchain probe per run: it's a synchronous xcrun spawn (slow on
-  // a cold CoreSimulator service), so device boots and the driver install
-  // share a single result instead of each blocking the executor on it.
-  let iosToolchain: ReturnType<typeof probeIosToolchain> | undefined;
-  const getIosToolchain = () => (iosToolchain ??= probeIosToolchain());
+  // One iOS toolchain probe per run, async so the (potentially slow) xcrun
+  // spawn never blocks the executor's event loop; device boots and the
+  // driver install share the single result.
+  let iosToolchain: Promise<ReturnType<typeof probeIosToolchain>> | undefined;
+  const getIosToolchain = () => (iosToolchain ??= probeIosToolchainWarm());
   // Manual leases on the run's resource registry, for work that must
   // serialize on a named mutex but can't express its hold window as a task
   // tag (runResourceAware releases tags at task RESOLUTION, and warm tasks
@@ -2916,7 +2962,7 @@ function buildWarmTaskRunner({
           }
         }
         if (task.payload.platform === "ios") {
-          const toolchain = getIosToolchain();
+          const toolchain = await getIosToolchain();
           if (!toolchain.ok) {
             return { outcome: "skipped", note: toolchain.reason };
           }
@@ -2984,7 +3030,7 @@ function buildWarmTaskRunner({
             },
           });
         }
-        const toolchain = getIosToolchain();
+        const toolchain = await getIosToolchain();
         if (!toolchain.ok) {
           return { outcome: "skipped", note: toolchain.reason };
         }

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -2959,7 +2959,9 @@ function buildWarmTaskRunner({
         // they already have per-context recorded-skip semantics downstream.
         return {
           outcome: "warmed",
-          note: `${ok} combination(s) ok${failed ? `, ${failed} failed` : ""}`,
+          note: `${ok} combination${ok === 1 ? "" : "s"} ok${
+            failed ? `, ${failed} failed` : ""
+          }`,
         };
       }
 

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -81,6 +81,7 @@ import {
   stepTargetsAppSurface,
   teardownAppSession,
   APP_DRIVER_PLATFORMS,
+  probeIosToolchain,
   type AppSessionState,
 } from "./tests/appSurface.js";
 import { startSurfaceStep } from "./tests/startSurface.js";
@@ -89,7 +90,13 @@ import {
   mobileBrowserGate,
   buildMobileBrowserCapabilities,
 } from "./tests/mobileBrowser.js";
-import { type WarmPlanDeps } from "./warmPhase.js";
+import {
+  raceBootInitiation,
+  type WarmPlanDeps,
+  type WarmTask,
+  type WarmOutcome,
+} from "./warmPhase.js";
+import { locateManagedWda } from "../runtime/wdaProducts.js";
 import { getCacheDir } from "../runtime/cacheDir.js";
 import { detectAndroidSdk } from "../runtime/androidSdk.js";
 import {
@@ -182,6 +189,7 @@ export {
   killTree,
   jobDisplayResources,
   buildWarmPlanDeps,
+  warmBrowserInstall,
 };
 // exports.appiumStart = appiumStart;
 // exports.appiumIsReady = appiumIsReady;
@@ -2571,30 +2579,20 @@ async function warmUpContexts({
       Array.isArray(context?.steps) &&
       requiredBrowserAssets(context.browser?.name).length > 0
     ) {
-      const firstAttempt = !installAttempts.has(
-        (context.browser?.name ?? "<none>").toLowerCase()
-      );
-      const outcome = await ensureContextBrowserInstalled({
+      // Extracted install + first-attempt re-detect (shared with the warm
+      // phase's browser-install task) — the memo state it leaves is exactly
+      // what this loop produced inline before.
+      await warmBrowserInstall({
         browserName: context.browser?.name,
         config,
+        runnerDetails,
         installAttempts,
-        deps: {
-          ensureBrowser: (asset, options) =>
-            ensureBrowserInstalled(asset, options),
-          log,
-        },
-        // Repair a present-but-broken driver, not just install-if-missing.
-        repair: true,
       });
-      if (firstAttempt && (outcome === "installed" || outcome === "failed")) {
-        clearAppCache(config);
-        runnerDetails.availableApps = await getAvailableApps({ config });
-        supported = isSupportedContext({
-          context,
-          apps: runnerDetails.availableApps,
-          platform,
-        });
-      }
+      supported = isSupportedContext({
+        context,
+        apps: runnerDetails.availableApps,
+        platform,
+      });
     }
     // Unsupported combinations are left unmarked; runContext skips each with the
     // appropriate per-context reason (install-but-undetected vs unsupported).
@@ -2662,6 +2660,286 @@ async function warmUpContexts({
     }
   }
 }
+
+/**
+ * On-demand browser install + first-attempt re-detect — the install half of
+ * warmUpContexts, extracted so the warm phase's browser-install task and the
+ * session-probe loop share ONE implementation of the mirror contract: the
+ * `installAttempts` / `runnerDetails.availableApps` state left behind is
+ * exactly what the first same-browser consuming context would have produced
+ * serially (no more, no less), so every later gate collapses to a cache hit.
+ * Deps are injected for hermetic tests; production callers use the defaults.
+ */
+async function warmBrowserInstall({
+  browserName,
+  config,
+  runnerDetails,
+  installAttempts,
+  deps = {},
+}: {
+  browserName: string | undefined;
+  config: any;
+  runnerDetails: any;
+  installAttempts: Map<string, "installed" | "failed" | "notInstallable">;
+  deps?: {
+    ensureBrowser?: (asset: any, options: any) => Promise<any>;
+    clearAppCache?: (config: any) => void;
+    getAvailableApps?: (args: { config: any }) => Promise<any[]>;
+  };
+}): Promise<{ outcome: WarmOutcome; note?: string }> {
+  // Already-detected engines need no install — and, mirroring the serial
+  // path (which only reaches the install when the support gate failed),
+  // no memo entry either.
+  const appName = normalizeBrowserName(browserName);
+  if (
+    runnerDetails.availableApps?.find((app: any) => app.name === appName)
+  ) {
+    return {
+      outcome: "skipped",
+      note: `'${browserName}' is already available`,
+    };
+  }
+  const firstAttempt = !installAttempts.has(
+    (browserName ?? "<none>").toLowerCase()
+  );
+  const outcome = await ensureContextBrowserInstalled({
+    browserName,
+    config,
+    installAttempts,
+    deps: {
+      ensureBrowser:
+        deps.ensureBrowser ??
+        ((asset, options) => ensureBrowserInstalled(asset, options)),
+      log,
+    },
+    // Repair a present-but-broken driver, not just install-if-missing.
+    repair: true,
+  });
+  // Re-detect only after a FIRST install attempt (installed or failed):
+  // the app cache is stale either way, and later gates must read the
+  // refreshed list or they'd misread the memo as installed-but-undetected.
+  if (firstAttempt && (outcome === "installed" || outcome === "failed")) {
+    (deps.clearAppCache ?? clearAppCache)(config);
+    runnerDetails.availableApps = await (deps.getAvailableApps ??
+      getAvailableApps)({ config });
+  }
+  if (outcome === "installed") return { outcome: "warmed" };
+  if (outcome === "failed") {
+    return { outcome: "failed", note: `couldn't install '${browserName}'` };
+  }
+  return {
+    outcome: "skipped",
+    note: `'${browserName}' has no installable assets`,
+  };
+}
+
+/**
+ * Light per-run Android environment probe for warm tasks: SDK + emulator
+ * binary + acceleration (or a running emulator). Null means "not ready" —
+ * the warm task reports skipped and the consuming context performs the full
+ * androidContextPreflight (including the loud lazy toolchain install, which
+ * warm deliberately never triggers — that decision and its warning belong on
+ * the context report).
+ */
+/* c8 ignore start — real SDK/emulator probes; exercised on the CI emulator
+   legs and dev boxes. Unit coverage targets the pure planner/executor. */
+async function resolveAndroidWarmEnv(
+  config: any
+): Promise<{ sdkRoot: string; deviceDeps: any } | null> {
+  try {
+    const abi = hostAbi();
+    const sdk = detectAndroidSdk({ cacheDir: config?.cacheDir });
+    if (!sdk?.emulator) return null;
+    const deviceDeps = buildAcquireDeviceDeps(sdk, abi, (m: string) =>
+      log(config, "debug", m)
+    );
+    const running = await deviceDeps.listRunning();
+    const capable =
+      running.length > 0 || (await checkEmulatorAcceleration(sdk.emulator));
+    if (!capable) return null;
+    return { sdkRoot: sdk.sdkRoot, deviceDeps };
+  } catch {
+    return null;
+  }
+}
+/* c8 ignore stop */
+
+/**
+ * Bind the effectful per-kind warm task bodies to the run's state. Every
+ * body upholds the warm contract: best-effort (a throw is caught by the
+ * executor and recorded as failed), and memo effects identical to what the
+ * first consuming context would have produced serially. Device boots resolve
+ * at boot initiation (raceBootInitiation); the chromedriver prefetch is the
+ * one task that awaits device readiness (it needs a live session).
+ */
+/* c8 ignore start — thin dispatch over injected/imported effects; the pure
+   pieces (planner, executor, raceBootInitiation, warmBrowserInstall) carry
+   the unit coverage, and the wiring is exercised end-to-end by the fixture
+   matrix + core-core.test.js. */
+function buildWarmTaskRunner({
+  config,
+  runnerDetails,
+  sizingJobs,
+  appiumPool,
+  installAttempts,
+  warmUpResults,
+  deviceRegistry,
+  simulatorRegistry,
+}: {
+  config: any;
+  runnerDetails: any;
+  sizingJobs: any[];
+  appiumPool?: { acquire(): Promise<number>; release(port: number): void };
+  installAttempts: Map<string, "installed" | "failed" | "notInstallable">;
+  warmUpResults: Map<string, "ok" | "failed">;
+  deviceRegistry: DeviceRegistry;
+  simulatorRegistry: SimulatorRegistry;
+}): (task: WarmTask) => Promise<{ outcome: WarmOutcome; note?: string }> {
+  // One Android env probe per run, shared by device boots and the
+  // chromedriver prefetch.
+  let androidEnv:
+    | Promise<{ sdkRoot: string; deviceDeps: any } | null>
+    | undefined;
+  const getAndroidEnv = () => (androidEnv ??= resolveAndroidWarmEnv(config));
+
+  return async (task: WarmTask) => {
+    switch (task.kind) {
+      case "browser-install":
+        return warmBrowserInstall({
+          browserName: task.payload.browserName,
+          config,
+          runnerDetails,
+          installAttempts,
+        });
+
+      case "driver-install": {
+        // Same lazy-loaded install path appSurfacePreflight uses; it skips
+        // packages already resolvable, so the later per-context preflight
+        // finds the driver present and pays only Appium co-homing.
+        const { ensureRuntimeInstalled } = await import(
+          "../runtime/loader.js"
+        );
+        await ensureRuntimeInstalled([task.payload.driverPackage], {
+          ctx: { cacheDir: config?.cacheDir },
+          deps: { logger: (m: string) => log(config, "debug", m) },
+        });
+        return { outcome: "warmed" };
+      }
+
+      case "device-boot": {
+        const desc = task.payload.desc;
+        const onError = (error: unknown) =>
+          log(
+            config,
+            "warning",
+            `Warm boot of '${task.name}' failed (a consuming context will retry): ${
+              (error as any)?.message ?? String(error)
+            }`
+          );
+        if (task.payload.platform === "android") {
+          const env = await getAndroidEnv();
+          if (!env) {
+            return {
+              outcome: "skipped",
+              note: "Android toolchain not ready; device setup stays with the consuming context",
+            };
+          }
+          return raceBootInitiation({
+            onError,
+            startAcquire: (signalInitiated) =>
+              acquireDevice({
+                desc,
+                registry: deviceRegistry,
+                sdkRoot: env.sdkRoot,
+                deps: {
+                  ...env.deviceDeps,
+                  createAvd: (args: any) => {
+                    signalInitiated();
+                    return env.deviceDeps.createAvd(args);
+                  },
+                  boot: (d: any, port: number) => {
+                    signalInitiated();
+                    return env.deviceDeps.boot(d, port);
+                  },
+                },
+              }),
+          });
+        }
+        const toolchain = probeIosToolchain();
+        if (!toolchain.ok) {
+          return { outcome: "skipped", note: toolchain.reason };
+        }
+        const simDeps = buildAcquireSimulatorDeps((m: string) =>
+          log(config, "debug", m)
+        );
+        return raceBootInitiation({
+          onError,
+          startAcquire: (signalInitiated) =>
+            acquireSimulator({
+              desc,
+              registry: simulatorRegistry,
+              deps: {
+                ...simDeps,
+                create: (args: any) => {
+                  signalInitiated();
+                  return simDeps.create(args);
+                },
+                boot: (udid: string) => {
+                  signalInitiated();
+                  return simDeps.boot(udid);
+                },
+              },
+            }),
+        });
+      }
+
+      case "wda-check": {
+        const hit = locateManagedWda({ ctx: { cacheDir: config?.cacheDir } });
+        if (hit) {
+          return {
+            outcome: "warmed",
+            note: `prebuilt WebDriverAgent available (${hit.key})`,
+          };
+        }
+        return {
+          outcome: "skipped",
+          note: "no prebuilt WebDriverAgent for the current toolchain — `doc-detective install ios` prebuilds it",
+        };
+      }
+
+      case "session-probe": {
+        if (!appiumPool) {
+          return { outcome: "skipped", note: "no browser Appium pool" };
+        }
+        await warmUpContexts({
+          jobs: sizingJobs,
+          config,
+          runnerDetails,
+          appiumPool,
+          installAttempts,
+          warmUpResults,
+        });
+        const ok = [...warmUpResults.values()].filter(
+          (v) => v === "ok"
+        ).length;
+        const failed = warmUpResults.size - ok;
+        // Failed combinations are a warm-level note, not a task failure:
+        // they already have per-context recorded-skip semantics downstream.
+        return {
+          outcome: "warmed",
+          note: `${ok} combination(s) ok${failed ? `, ${failed} failed` : ""}`,
+        };
+      }
+
+      case "chromedriver-prefetch":
+        return {
+          outcome: "skipped",
+          note: "chromedriver prefetch not implemented yet",
+        };
+    }
+  };
+}
+/* c8 ignore stop */
 
 /**
  * Pure predicate: does this spec carry TEST-level routing? True iff ANY of its

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -80,6 +80,7 @@ import {
   isAppDriverRequired,
   stepTargetsAppSurface,
   teardownAppSession,
+  APP_DRIVER_PLATFORMS,
   type AppSessionState,
 } from "./tests/appSurface.js";
 import { startSurfaceStep } from "./tests/startSurface.js";
@@ -88,6 +89,7 @@ import {
   mobileBrowserGate,
   buildMobileBrowserCapabilities,
 } from "./tests/mobileBrowser.js";
+import { type WarmPlanDeps } from "./warmPhase.js";
 import { getCacheDir } from "../runtime/cacheDir.js";
 import { detectAndroidSdk } from "../runtime/androidSdk.js";
 import {
@@ -179,6 +181,7 @@ export {
   specIsRouted,
   killTree,
   jobDisplayResources,
+  buildWarmPlanDeps,
 };
 // exports.appiumStart = appiumStart;
 // exports.appiumIsReady = appiumIsReady;
@@ -277,6 +280,29 @@ function combinationKey(context: any): string {
  */
 function warmUpDecision(prev: "ok" | "failed" | undefined): "attempt" | "skip" {
   return prev === "failed" ? "skip" : "attempt";
+}
+
+/**
+ * Bind the real selection predicates for the warm-phase planner
+ * (planWarmTasks in warmPhase.ts). The planner takes these as an injected
+ * bag because most of them live in this module — importing them from
+ * warmPhase.ts would create a tests.ts ⇄ warmPhase.ts cycle — and because
+ * the bag keeps the planner hermetically unit-testable. Exported so planner
+ * tests exercise production selection logic, not stand-ins.
+ */
+function buildWarmPlanDeps(): WarmPlanDeps {
+  return {
+    isBrowserRequired,
+    isAppDriverRequired,
+    isMobileTargetPlatform,
+    getDefaultBrowser,
+    combinationKey,
+    requiredBrowserAssets,
+    collectDeviceDescriptors,
+    normalizeDeviceDescriptor,
+    mobileBrowserGate,
+    appDriverPlatforms: APP_DRIVER_PLATFORMS,
+  };
 }
 
 // Get Appium driver capabilities and apply options.

--- a/src/core/tests/androidEmulator.ts
+++ b/src/core/tests/androidEmulator.ts
@@ -435,6 +435,18 @@ async function teardownDeviceRegistry(
 ): Promise<void> {
   for (const entry of registry.values()) {
     if (!entry.bootedByUs) continue;
+    // A warm-phase boot can still be in flight at run end (the warm task
+    // resolves at boot initiation). Await it so the entry carries its real
+    // process/udid before the kill — sweeping mid-boot would no-op on the
+    // unset process and orphan the emulator. A boot that fails booted
+    // nothing, so there's nothing to kill.
+    if (entry.ready) {
+      try {
+        await entry.ready;
+      } catch {
+        continue;
+      }
+    }
     try {
       await kill(entry);
     } catch {

--- a/src/core/tests/appSurface.ts
+++ b/src/core/tests/appSurface.ts
@@ -69,6 +69,9 @@ export {
   // (a stale manifest makes the lazily-installed driver invisible to Appium).
   invalidateStaleAppiumManifest,
   probeIosToolchain,
+  // Exported for the warm-phase planner (buildWarmPlanDeps in tests.ts): the
+  // platform → driver-package mapping is this table's single source of truth.
+  APP_DRIVER_PLATFORMS,
 };
 export type { AppSessionState, AppSurfaceEntry };
 

--- a/src/core/tests/appSurface.ts
+++ b/src/core/tests/appSurface.ts
@@ -69,9 +69,6 @@ export {
   // (a stale manifest makes the lazily-installed driver invisible to Appium).
   invalidateStaleAppiumManifest,
   probeIosToolchain,
-  // Exported for the warm-phase planner (buildWarmPlanDeps in tests.ts): the
-  // platform → driver-package mapping is this table's single source of truth.
-  APP_DRIVER_PLATFORMS,
 };
 export type { AppSessionState, AppSurfaceEntry };
 
@@ -459,7 +456,9 @@ const DESKTOP_UNSUPPORTED_MOBILE_FIELDS = ["device", "install", "activity"].map(
   })
 );
 
-const APP_DRIVER_PLATFORMS: Record<string, AppDriverPlatform> = {
+// Exported for the warm-phase planner (buildWarmPlanDeps in tests.ts): the
+// platform → driver-package mapping is this table's single source of truth.
+export const APP_DRIVER_PLATFORMS: Record<string, AppDriverPlatform> = {
   windows: {
     driverPackage: "appium-novawindows-driver",
     driverLabel: "Windows app driver",

--- a/src/core/tests/iosSimulator.ts
+++ b/src/core/tests/iosSimulator.ts
@@ -528,6 +528,18 @@ async function teardownSimulatorRegistry(
 ): Promise<void> {
   for (const entry of registry.values()) {
     if (!entry.bootedByUs) continue;
+    // A warm-phase boot can still be in flight at run end (the warm task
+    // resolves at boot initiation). Await it so the placeholder carries its
+    // real udid before shutdown — sweeping mid-create would shut down an
+    // empty udid and orphan the simulator. A boot that fails booted
+    // nothing, so there's nothing to shut down.
+    if (entry.ready) {
+      try {
+        await entry.ready;
+      } catch {
+        continue;
+      }
+    }
     try {
       await shutdown(entry);
     } catch {

--- a/src/core/tests/mobileBrowser.ts
+++ b/src/core/tests/mobileBrowser.ts
@@ -84,6 +84,15 @@ function mobileBrowserConfigError(
   return null;
 }
 
+// Appium server args that enable the UiAutomator2 chromedriver autodownload
+// (an insecure feature, scoped to the driver). Shared by runContext's
+// mobile-web branch and the warm phase's chromedriver prefetch so the two
+// session shapes cannot drift.
+export const CHROMEDRIVER_AUTODOWNLOAD_ARGS = [
+  "--allow-insecure",
+  "uiautomator2:chromedriver_autodownload",
+];
+
 // The one decision point the mobile preflights consult before any toolchain
 // work: does this context get a device-browser session, a SKIP, or a FAIL?
 // Order matters — the mixed guard first (a scope limit, so SKIP, and config

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -65,7 +65,7 @@ export {
   evaluateContextRequirements,
 };
 
-export type { BackgroundProcess };
+export type { BackgroundProcess, ResourceRegistry };
 
 // A fixed set of Appium server ports shared by concurrent runners. `acquire()`
 // hands out a free port, waiting if every port is checked out; `release()`

--- a/src/core/warmPhase.ts
+++ b/src/core/warmPhase.ts
@@ -110,8 +110,11 @@ export function wrapInitiationEffects<T extends Record<string, any>>(
     const original = deps[key];
     if (typeof original !== "function") continue;
     wrapped[key as string] = (...args: any[]) => {
+      // Invoke the effect FIRST: a synchronous throw must reach the acquire
+      // path (→ failed) rather than racing the task to "boot initiated".
+      const result = original(...args);
       signal();
-      return original(...args);
+      return result;
     };
   }
   return wrapped as T;
@@ -294,15 +297,12 @@ export function planWarmTasks({
     if (deps.isBrowserRequired({ test: context })) {
       const effBrowser = context.browser ?? getDefaultBrowser();
       const browserName = effBrowser?.name;
-      if (browserName) {
+      // Only host-platform contexts can actually be probed or installed
+      // for; a context pinned to another platform is skipped per-context
+      // and must trigger neither.
+      if (browserName && effPlatform === hostPlatform) {
         probeEligible = true;
-        // Install work only applies to the host's own platform (a context
-        // pinned to another platform is skipped per-context, never
-        // installed for) and to engines with downloadable assets.
-        if (
-          effPlatform === hostPlatform &&
-          deps.requiredBrowserAssets(browserName).length > 0
-        ) {
+        if (deps.requiredBrowserAssets(browserName).length > 0) {
           addTask({
             name: `browser-install:${browserName.toLowerCase()}`,
             kind: "browser-install",

--- a/src/core/warmPhase.ts
+++ b/src/core/warmPhase.ts
@@ -1,0 +1,428 @@
+// Inline warm phase (docs/design/warm-phase.md, phase B1): the pure planner
+// and executor for the always-on provisioning pass that runs in runSpecs
+// between test resolution and test execution. The planner derives every
+// provisioning task the run will need — driver installs, browser installs,
+// device boots, the managed-WDA availability check, the mobile chromedriver
+// prefetch, and the folded-in driver session probe — strictly from the
+// resolved sizing jobs, so a run warms only what its contexts already
+// JIT-provision today. The executor runs those tasks concurrently through the
+// run's resource-aware pool, best-effort: warm pre-pays work, it never gates
+// work (a failed task is a warning; the per-context paths retry/fail with
+// exactly today's semantics).
+//
+// This module is pure by design (unit-testable without drivers): the
+// effectful per-task bodies live in tests.ts (buildWarmTaskRunner), and the
+// predicates the planner needs are injected via WarmPlanDeps (bound to the
+// real implementations by tests.ts's buildWarmPlanDeps) because they live in
+// tests.ts — a direct import would create a module cycle.
+
+import { runResourceAware, type ResourceRegistry } from "./utils.js";
+
+export type WarmTaskKind =
+  | "driver-install"
+  | "browser-install"
+  | "device-boot"
+  | "wda-check"
+  | "session-probe"
+  | "chromedriver-prefetch";
+
+export type WarmOutcome = "warmed" | "skipped" | "failed";
+
+export type WarmTask = {
+  name: string;
+  kind: WarmTaskKind;
+  // Consumed by runResourceAware's default accessor: tasks sharing a resource
+  // name never run concurrently.
+  exclusiveResources: string[];
+  payload: Record<string, any>;
+};
+
+export type WarmTaskResult = {
+  name: string;
+  kind: WarmTaskKind;
+  outcome: WarmOutcome;
+  durationMs: number;
+  note?: string;
+};
+
+export type WarmReport = { durationMs: number; tasks: WarmTaskResult[] };
+
+// Warm tasks are I/O-heavy (npm installs, downloads, boot spawns), not
+// display-heavy, so the ceiling is a small constant independent of
+// concurrentRunners — even a fully serial test run benefits from boot ∥
+// install ∥ download overlap during warm.
+export const WARM_POOL_LIMIT = 4;
+
+// Every task that mutates the shared runtime/app cache serializes on this
+// tag: concurrent npm installs into the managed runtime dir are exactly the
+// npm-prune hazard (src/runtime/AGENTS.md, issue #501), and concurrent
+// browser installs raced before warmUpContexts serialized them.
+export const RUNTIME_INSTALL_RESOURCE = "runtime-install";
+
+// One exclusivity tag per (platform, device): boots for the same device
+// serialize (the registries would converge them anyway — the tag just avoids
+// two acquires racing to plan), and the chromedriver prefetch queues behind
+// its device's boot task, which releases at boot *initiation*.
+export function deviceResourceTag(
+  platform: string,
+  desc: { name?: string; osVersion?: string } | undefined
+): string {
+  return `warm-device:${platform}:${desc?.name ?? "<default>"}:${
+    desc?.osVersion ?? "<latest>"
+  }`;
+}
+
+// The predicates and helpers the planner borrows from tests.ts (bound by
+// buildWarmPlanDeps there). Injected to break the would-be import cycle and
+// to keep the planner hermetically unit-testable.
+export type WarmPlanDeps = {
+  isBrowserRequired(args: { test: any }): boolean;
+  isAppDriverRequired(args: { test: any }): boolean;
+  isMobileTargetPlatform(platform: unknown): "android" | "ios" | null;
+  getDefaultBrowser(args: { runnerDetails: any }): any;
+  combinationKey(context: any): string;
+  requiredBrowserAssets(name: string | undefined): unknown[];
+  collectDeviceDescriptors(context: any): any[];
+  normalizeDeviceDescriptor(args: {
+    contextDevice?: any;
+    stepDevice?: any;
+    platform: "android" | "ios";
+  }): any;
+  mobileBrowserGate(args: {
+    platform: "android" | "ios";
+    browser?: any;
+    hasBrowserStep: boolean;
+    hasAppStep: boolean;
+  }):
+    | { action: "proceed"; browserName: string | null }
+    | { action: "skip"; level: "warning"; reason: string }
+    | { action: "fail"; reason: string };
+  // platform → { driverPackage } (the APP_DRIVER_PLATFORMS projection).
+  appDriverPlatforms: Record<string, { driverPackage: string }>;
+};
+
+/**
+ * Derive the warm tasks a run needs from its sizing jobs (flat + routed).
+ * Pure: no I/O, and — unlike selectWarmUpTargets — it never writes defaults
+ * onto the job contexts; effective platform/browser are computed locally so
+ * planning leaves the jobs byte-identical for the execution paths that own
+ * those mutations.
+ *
+ * Derivation is strictly "what the run's own paths would JIT-provision":
+ * a pure-web run plans only the browser installs (and, at limit > 1 with a
+ * pool, the session probe) that today's pre-pass already performs; mobile
+ * and app contexts add their driver installs, device boots, WDA check, and
+ * chromedriver prefetch. Anything the host can't use (an ios context off
+ * darwin, a windows app context off windows) is not planned — mirroring the
+ * per-context gates that would skip it.
+ */
+export function planWarmTasks({
+  sizingJobs,
+  runnerDetails,
+  config,
+  limit,
+  hasAppiumPool,
+  hostPlatform,
+  deps,
+}: {
+  sizingJobs: any[];
+  runnerDetails: any;
+  config: any;
+  limit: number;
+  hasAppiumPool: boolean;
+  // The runner's platform in runOn vocabulary ("windows" | "mac" | "linux").
+  hostPlatform: string;
+  deps: WarmPlanDeps;
+}): WarmTask[] {
+  const tasks: WarmTask[] = [];
+  const driverInstalls = new Set<string>();
+  const browserInstalls = new Set<string>();
+  const deviceBoots = new Set<string>();
+  const prefetches = new Set<string>();
+  let wdaCheckPlanned = false;
+  let probeEligible = false;
+  const probeCombos = new Set<string>();
+
+  for (const job of sizingJobs ?? []) {
+    const context = job?.context;
+    if (!context) continue;
+    const effPlatform = context.platform || hostPlatform;
+    const mobileTarget = deps.isMobileTargetPlatform(effPlatform);
+
+    if (mobileTarget) {
+      // ios (and its WDA/simulator toolchain) only provisions on a mac host;
+      // android emulators run anywhere the SDK does.
+      if (mobileTarget === "ios" && hostPlatform !== "mac") continue;
+
+      const gate = deps.mobileBrowserGate({
+        platform: mobileTarget,
+        browser: context.browser,
+        hasBrowserStep: deps.isBrowserRequired({ test: context }),
+        hasAppStep: deps.isAppDriverRequired({ test: context }),
+      });
+      // A context the gate would SKIP/FAIL never reaches device work in
+      // runContext — warm nothing for it.
+      if (gate.action !== "proceed") continue;
+      const isMobileWeb = typeof gate.browserName === "string";
+      const needsDevice =
+        isMobileWeb || deps.isAppDriverRequired({ test: context });
+      if (!needsDevice) continue;
+
+      const driverPackage =
+        deps.appDriverPlatforms[mobileTarget]?.driverPackage;
+      if (driverPackage && !driverInstalls.has(driverPackage)) {
+        driverInstalls.add(driverPackage);
+        tasks.push({
+          name: `driver-install:${driverPackage}`,
+          kind: "driver-install",
+          exclusiveResources: [RUNTIME_INSTALL_RESOURCE],
+          payload: { driverPackage, platform: mobileTarget },
+        });
+      }
+
+      for (const stepDevice of deps.collectDeviceDescriptors(context)) {
+        const desc = deps.normalizeDeviceDescriptor({
+          contextDevice: context.device,
+          stepDevice,
+          platform: mobileTarget,
+        });
+        const deviceKey = `${mobileTarget}::${desc?.name ?? "<default>"}::${
+          desc?.osVersion ?? "<latest>"
+        }`;
+        if (!deviceBoots.has(deviceKey)) {
+          deviceBoots.add(deviceKey);
+          const tag = deviceResourceTag(mobileTarget, desc);
+          tasks.push({
+            name: `device-boot:${deviceKey.replaceAll("::", ":")}`,
+            kind: "device-boot",
+            exclusiveResources:
+              mobileTarget === "android" ? [tag, "android-emulator"] : [tag],
+            payload: { platform: mobileTarget, desc },
+          });
+        }
+        // The chromedriver autodownload is a mobile-WEB-android cost: the
+        // UiAutomator2 server fetches a chromedriver matching the device's
+        // Chrome at session creation. One prefetch per device.
+        if (mobileTarget === "android" && isMobileWeb) {
+          if (!prefetches.has(deviceKey)) {
+            prefetches.add(deviceKey);
+            tasks.push({
+              name: `chromedriver-prefetch:${deviceKey.replaceAll("::", ":")}`,
+              kind: "chromedriver-prefetch",
+              // The device tag queues the prefetch behind its device's boot
+              // task; runtime-install covers its (idempotent) driver/appium
+              // preflight, which may install into the shared cache.
+              exclusiveResources: [
+                deviceResourceTag(mobileTarget, desc),
+                RUNTIME_INSTALL_RESOURCE,
+              ],
+              payload: { platform: mobileTarget, desc },
+            });
+          }
+        }
+      }
+
+      if (mobileTarget === "ios" && !wdaCheckPlanned) {
+        wdaCheckPlanned = true;
+        tasks.push({
+          name: "wda-check",
+          kind: "wda-check",
+          // Read-only (plus the last-used stamp) — contends with nothing.
+          exclusiveResources: [],
+          payload: {},
+        });
+      }
+      continue;
+    }
+
+    // Desktop contexts.
+    if (deps.isBrowserRequired({ test: context })) {
+      const effBrowser =
+        context.browser ?? deps.getDefaultBrowser({ runnerDetails });
+      const browserName = effBrowser?.name;
+      if (browserName) {
+        probeEligible = true;
+        probeCombos.add(
+          deps.combinationKey({
+            platform: effPlatform,
+            browser: { name: browserName },
+          })
+        );
+        // Install work only applies to the host's own platform (a context
+        // pinned to another platform is skipped per-context, never
+        // installed for) and to engines with downloadable assets.
+        if (
+          effPlatform === hostPlatform &&
+          deps.requiredBrowserAssets(browserName).length > 0
+        ) {
+          const installKey = browserName.toLowerCase();
+          if (!browserInstalls.has(installKey)) {
+            browserInstalls.add(installKey);
+            tasks.push({
+              name: `browser-install:${installKey}`,
+              kind: "browser-install",
+              exclusiveResources: [RUNTIME_INSTALL_RESOURCE],
+              payload: { browserName },
+            });
+          }
+        }
+      }
+    }
+
+    if (
+      (effPlatform === "windows" || effPlatform === "mac") &&
+      effPlatform === hostPlatform &&
+      deps.isAppDriverRequired({ test: context })
+    ) {
+      const driverPackage = deps.appDriverPlatforms[effPlatform]?.driverPackage;
+      if (driverPackage && !driverInstalls.has(driverPackage)) {
+        driverInstalls.add(driverPackage);
+        tasks.push({
+          name: `driver-install:${driverPackage}`,
+          kind: "driver-install",
+          exclusiveResources: [RUNTIME_INSTALL_RESOURCE],
+          payload: { driverPackage, platform: effPlatform },
+        });
+      }
+    }
+  }
+
+  // The folded-in session probe keeps its historical gate: a throwaway
+  // driver session is only worth paying when it prevents concurrent
+  // first-session races (limit > 1), and it needs the browser Appium pool.
+  // The warm PHASE always runs; only this task kind stays gated — preserving
+  // the documented byte-identical serial-run behavior.
+  if (limit > 1 && hasAppiumPool && probeEligible) {
+    tasks.push({
+      name: "session-probe",
+      kind: "session-probe",
+      // Its install half mutates the shared caches, exactly like the
+      // dedicated install tasks (usually a memo hit by the time it runs).
+      exclusiveResources: [RUNTIME_INSTALL_RESOURCE],
+      payload: { combos: [...probeCombos].sort() },
+    });
+  }
+
+  return tasks;
+}
+
+/**
+ * Run planned warm tasks through the run's resource registry, bounded by
+ * WARM_POOL_LIMIT. Best-effort by contract: a task that throws is recorded
+ * as failed and logged as a warning — the returned promise never rejects,
+ * and nothing here can gate the run.
+ */
+export async function executeWarmTasks({
+  tasks,
+  registry,
+  runTask,
+  log,
+  now = Date.now,
+}: {
+  tasks: WarmTask[];
+  registry: ResourceRegistry;
+  runTask: (task: WarmTask) => Promise<{ outcome: WarmOutcome; note?: string }>;
+  log: (level: string, message: string) => void;
+  now?: () => number;
+}): Promise<WarmReport> {
+  const results: WarmTaskResult[] = [];
+  const start = now();
+  await runResourceAware(
+    tasks,
+    Math.min(WARM_POOL_LIMIT, tasks.length),
+    registry,
+    async (task) => {
+      const taskStart = now();
+      try {
+        const { outcome, note } = await runTask(task);
+        results.push({
+          name: task.name,
+          kind: task.kind,
+          outcome,
+          durationMs: now() - taskStart,
+          ...(note ? { note } : {}),
+        });
+        if (outcome === "failed") {
+          log(
+            "warning",
+            `Warm task '${task.name}' failed (continuing)${note ? `: ${note}` : "."}`
+          );
+        } else {
+          log("debug", `Warm task '${task.name}': ${outcome}${note ? ` (${note})` : ""}.`);
+        }
+      } catch (error: any) {
+        const note = error?.message ?? String(error);
+        results.push({
+          name: task.name,
+          kind: task.kind,
+          outcome: "failed",
+          durationMs: now() - taskStart,
+          note,
+        });
+        log("warning", `Warm task '${task.name}' failed (continuing): ${note}`);
+      }
+    }
+  );
+  return { durationMs: now() - start, tasks: results };
+}
+
+/**
+ * Resolve a device-boot task at boot INITIATION rather than boot completion:
+ * warm's job is to start the clock early, not to block on it — the first
+ * consuming context awaits the registry entry's `ready` promise exactly
+ * where it does today.
+ *
+ * `startAcquire` receives a `signalInitiated` callback the caller wires into
+ * the acquire deps' create/boot effects. acquireDevice/acquireSimulator
+ * invoke those effects synchronously inside the ready-promise body and then
+ * synchronously register the `bootedByUs: true` placeholder before any
+ * microtask runs — so by the time the race resolves on the signal, the
+ * registry entry (with its in-flight `ready`) is already visible to
+ * consumers. Fast paths (registry hit, reuse-running, plan skip) never
+ * signal and settle through the acquire promise itself.
+ *
+ * The catch is chained onto the acquire promise BEFORE the race, so a boot
+ * that fails after the task already resolved can never surface as an
+ * unhandled rejection; `onError` is the caller's warn hook. acquire deletes
+ * its registry placeholder on failure, so a consuming context retries fresh.
+ */
+export function raceBootInitiation({
+  startAcquire,
+  onError,
+}: {
+  startAcquire: (
+    signalInitiated: () => void
+  ) => Promise<{ entry?: any; skip?: string }>;
+  onError: (error: unknown) => void;
+}): Promise<{ outcome: WarmOutcome; note?: string }> {
+  let initiatedResolve!: () => void;
+  const initiated = new Promise<void>((resolve) => {
+    initiatedResolve = resolve;
+  });
+  let settled = false;
+  const acquired: Promise<{ outcome: WarmOutcome; note?: string }> = (async () => {
+    try {
+      const result = await startAcquire(() => initiatedResolve());
+      settled = true;
+      if (result && typeof (result as any).skip === "string") {
+        return { outcome: "skipped" as const, note: (result as any).skip };
+      }
+      return { outcome: "warmed" as const, note: "device ready" };
+    } catch (error) {
+      settled = true;
+      onError(error);
+      return {
+        outcome: "failed" as const,
+        note: (error as any)?.message ?? String(error),
+      };
+    }
+  })();
+  return Promise.race([
+    initiated.then(() =>
+      settled
+        ? acquired
+        : { outcome: "warmed" as const, note: "boot initiated" }
+    ),
+    acquired,
+  ]);
+}

--- a/src/core/warmPhase.ts
+++ b/src/core/warmPhase.ts
@@ -192,6 +192,14 @@ export function planWarmTasks({
   let defaultBrowser: any;
   const getDefaultBrowser = () =>
     (defaultBrowser ??= deps.getDefaultBrowser({ runnerDetails }));
+  // Warm boots at most ONE device per mobile platform: emulator/simulator
+  // boots are the heaviest thing a CI host runs, and overlapping them
+  // starves everything (four concurrent emulator boots on a 2-core KVM
+  // runner starve the very sessions the tests need). The first device's
+  // boot overlaps the install tasks — the win the phase exists for — and
+  // every additional device boots exactly where it does today: inside its
+  // consuming context, serialized on the Phase-2 exclusivity tags.
+  const bootPlannedFor = new Set<string>();
 
   for (const job of sizingJobs ?? []) {
     const context = job?.context;
@@ -240,13 +248,20 @@ export function planWarmTasks({
         });
         const identity = deviceIdentity(mobileTarget, desc);
         const tag = deviceResourceTag(mobileTarget, desc);
-        addTask({
-          name: `device-boot:${identity}`,
-          kind: "device-boot",
-          exclusiveResources:
-            mobileTarget === "android" ? [tag, "android-emulator"] : [tag],
-          payload: { platform: mobileTarget, desc },
-        });
+        if (!bootPlannedFor.has(mobileTarget)) {
+          bootPlannedFor.add(mobileTarget);
+          // No "android-emulator" tag here: runResourceAware would release
+          // it at task resolution (boot initiation), before the boot
+          // finishes. The runner instead holds a manual lease on that name
+          // from initiation until the boot settles, so Phase-2 jobs (which
+          // tag it) still see one-emulator-at-a-time across phases.
+          addTask({
+            name: `device-boot:${identity}`,
+            kind: "device-boot",
+            exclusiveResources: [tag],
+            payload: { platform: mobileTarget, desc },
+          });
+        }
         // The chromedriver autodownload is a mobile-WEB-android cost: the
         // UiAutomator2 server fetches a chromedriver matching the device's
         // Chrome at session creation. One prefetch per device. Only the

--- a/src/core/warmPhase.ts
+++ b/src/core/warmPhase.ts
@@ -59,17 +59,62 @@ export const WARM_POOL_LIMIT = 4;
 // browser installs raced before warmUpContexts serialized them.
 export const RUNTIME_INSTALL_RESOURCE = "runtime-install";
 
-// One exclusivity tag per (platform, device): boots for the same device
+/**
+ * The single identity a warm device task is deduped, named, and
+ * tag-serialized by. It mirrors how the acquisition planners converge on a
+ * device: a NAMED descriptor always resolves to that registry name (whatever
+ * its other fields say), so two same-named descriptors are one device even
+ * when their osVersions differ — a second boot task would just registry-hit
+ * and block a warm worker on the full boot. Unnamed (default) descriptors
+ * resolve by deviceType + osVersion, so those fields distinguish devices.
+ */
+export function deviceIdentity(
+  platform: string,
+  desc:
+    | { name?: string; deviceType?: string; osVersion?: string }
+    | undefined
+): string {
+  if (desc?.name) return `${platform}:name:${desc.name}`;
+  return `${platform}:default:${desc?.deviceType ?? "<any>"}:${
+    desc?.osVersion ?? "<latest>"
+  }`;
+}
+
+// One exclusivity tag per device identity: boots for the same device
 // serialize (the registries would converge them anyway — the tag just avoids
 // two acquires racing to plan), and the chromedriver prefetch queues behind
 // its device's boot task, which releases at boot *initiation*.
 export function deviceResourceTag(
   platform: string,
-  desc: { name?: string; osVersion?: string } | undefined
+  desc:
+    | { name?: string; deviceType?: string; osVersion?: string }
+    | undefined
 ): string {
-  return `warm-device:${platform}:${desc?.name ?? "<default>"}:${
-    desc?.osVersion ?? "<latest>"
-  }`;
+  return `warm-device:${deviceIdentity(platform, desc)}`;
+}
+
+/**
+ * Re-wrap the named effect functions on an acquire-deps object so the first
+ * invocation of any of them fires `signal` — the boot-initiation hook
+ * raceBootInitiation races against. Shared by the android (createAvd/boot)
+ * and ios (create/boot) device-boot bodies so the initiation contract lives
+ * in one place.
+ */
+export function wrapInitiationEffects<T extends Record<string, any>>(
+  deps: T,
+  keys: (keyof T)[],
+  signal: () => void
+): T {
+  const wrapped: Record<string, any> = { ...deps };
+  for (const key of keys) {
+    const original = deps[key];
+    if (typeof original !== "function") continue;
+    wrapped[key as string] = (...args: any[]) => {
+      signal();
+      return original(...args);
+    };
+  }
+  return wrapped as T;
 }
 
 // The predicates and helpers the planner borrows from tests.ts (bound by
@@ -80,7 +125,6 @@ export type WarmPlanDeps = {
   isAppDriverRequired(args: { test: any }): boolean;
   isMobileTargetPlatform(platform: unknown): "android" | "ios" | null;
   getDefaultBrowser(args: { runnerDetails: any }): any;
-  combinationKey(context: any): string;
   requiredBrowserAssets(name: string | undefined): unknown[];
   collectDeviceDescriptors(context: any): any[];
   normalizeDeviceDescriptor(args: {
@@ -97,55 +141,65 @@ export type WarmPlanDeps = {
     | { action: "proceed"; browserName: string | null }
     | { action: "skip"; level: "warning"; reason: string }
     | { action: "fail"; reason: string };
+  // Null when the context's `requires` gate is absent or met; a skip message
+  // when unmet — the same gate runContext applies BEFORE any provisioning.
+  contextRequirementsSkipMessage(args: { context: any }): string | null;
   // platform → { driverPackage } (the APP_DRIVER_PLATFORMS projection).
   appDriverPlatforms: Record<string, { driverPackage: string }>;
 };
 
 /**
  * Derive the warm tasks a run needs from its sizing jobs (flat + routed).
- * Pure: no I/O, and — unlike selectWarmUpTargets — it never writes defaults
- * onto the job contexts; effective platform/browser are computed locally so
- * planning leaves the jobs byte-identical for the execution paths that own
- * those mutations.
+ * Pure: no I/O of its own, and — unlike selectWarmUpTargets — it never
+ * writes defaults onto the job contexts; effective platform/browser are
+ * computed locally so planning leaves the jobs byte-identical for the
+ * execution paths that own those mutations.
  *
  * Derivation is strictly "what the run's own paths would JIT-provision":
  * a pure-web run plans only the browser installs (and, at limit > 1 with a
  * pool, the session probe) that today's pre-pass already performs; mobile
  * and app contexts add their driver installs, device boots, WDA check, and
- * chromedriver prefetch. Anything the host can't use (an ios context off
- * darwin, a windows app context off windows) is not planned — mirroring the
- * per-context gates that would skip it.
+ * chromedriver prefetch. Anything the run's own gates would refuse before
+ * provisioning — an unmet `requires` gate, an ios context off darwin, a
+ * windows app context off windows, a mobile context the browser gate
+ * skips/fails — is not planned, mirroring the per-context gates.
  */
 export function planWarmTasks({
   sizingJobs,
   runnerDetails,
-  config,
   limit,
   hasAppiumPool,
-  hostPlatform,
   deps,
 }: {
   sizingJobs: any[];
   runnerDetails: any;
-  config: any;
   limit: number;
   hasAppiumPool: boolean;
-  // The runner's platform in runOn vocabulary ("windows" | "mac" | "linux").
-  hostPlatform: string;
   deps: WarmPlanDeps;
 }): WarmTask[] {
+  // The runner's platform in runOn vocabulary ("windows" | "mac" | "linux") —
+  // the same source every peer (selectWarmUpTargets, runContext) reads.
+  const hostPlatform = runnerDetails?.environment?.platform;
   const tasks: WarmTask[] = [];
-  const driverInstalls = new Set<string>();
-  const browserInstalls = new Set<string>();
-  const deviceBoots = new Set<string>();
-  const prefetches = new Set<string>();
-  let wdaCheckPlanned = false;
+  const seen = new Set<string>();
+  const addTask = (task: WarmTask) => {
+    if (seen.has(task.name)) return;
+    seen.add(task.name);
+    tasks.push(task);
+  };
   let probeEligible = false;
-  const probeCombos = new Set<string>();
+  // The run-constant default browser, resolved at most once.
+  let defaultBrowser: any;
+  const getDefaultBrowser = () =>
+    (defaultBrowser ??= deps.getDefaultBrowser({ runnerDetails }));
 
   for (const job of sizingJobs ?? []) {
     const context = job?.context;
     if (!context) continue;
+    // runContext evaluates the `requires` capability gate before ANY
+    // provisioning (install, preflight, boot) — a context it would skip
+    // must warm nothing.
+    if (deps.contextRequirementsSkipMessage({ context })) continue;
     const effPlatform = context.platform || hostPlatform;
     const mobileTarget = deps.isMobileTargetPlatform(effPlatform);
 
@@ -154,25 +208,23 @@ export function planWarmTasks({
       // android emulators run anywhere the SDK does.
       if (mobileTarget === "ios" && hostPlatform !== "mac") continue;
 
+      const hasAppStep = deps.isAppDriverRequired({ test: context });
       const gate = deps.mobileBrowserGate({
         platform: mobileTarget,
         browser: context.browser,
         hasBrowserStep: deps.isBrowserRequired({ test: context }),
-        hasAppStep: deps.isAppDriverRequired({ test: context }),
+        hasAppStep,
       });
       // A context the gate would SKIP/FAIL never reaches device work in
       // runContext — warm nothing for it.
       if (gate.action !== "proceed") continue;
       const isMobileWeb = typeof gate.browserName === "string";
-      const needsDevice =
-        isMobileWeb || deps.isAppDriverRequired({ test: context });
-      if (!needsDevice) continue;
+      if (!isMobileWeb && !hasAppStep) continue;
 
       const driverPackage =
         deps.appDriverPlatforms[mobileTarget]?.driverPackage;
-      if (driverPackage && !driverInstalls.has(driverPackage)) {
-        driverInstalls.add(driverPackage);
-        tasks.push({
+      if (driverPackage) {
+        addTask({
           name: `driver-install:${driverPackage}`,
           kind: "driver-install",
           exclusiveResources: [RUNTIME_INSTALL_RESOURCE],
@@ -186,45 +238,33 @@ export function planWarmTasks({
           stepDevice,
           platform: mobileTarget,
         });
-        const deviceKey = `${mobileTarget}::${desc?.name ?? "<default>"}::${
-          desc?.osVersion ?? "<latest>"
-        }`;
-        if (!deviceBoots.has(deviceKey)) {
-          deviceBoots.add(deviceKey);
-          const tag = deviceResourceTag(mobileTarget, desc);
-          tasks.push({
-            name: `device-boot:${deviceKey.replaceAll("::", ":")}`,
-            kind: "device-boot",
-            exclusiveResources:
-              mobileTarget === "android" ? [tag, "android-emulator"] : [tag],
+        const identity = deviceIdentity(mobileTarget, desc);
+        const tag = deviceResourceTag(mobileTarget, desc);
+        addTask({
+          name: `device-boot:${identity}`,
+          kind: "device-boot",
+          exclusiveResources:
+            mobileTarget === "android" ? [tag, "android-emulator"] : [tag],
+          payload: { platform: mobileTarget, desc },
+        });
+        // The chromedriver autodownload is a mobile-WEB-android cost: the
+        // UiAutomator2 server fetches a chromedriver matching the device's
+        // Chrome at session creation. One prefetch per device. Only the
+        // device tag: its cache-mutating preflight half runs under a
+        // manually-acquired runtime-install lease inside the task body, so
+        // the long device-ready await never holds the install mutex.
+        if (mobileTarget === "android" && isMobileWeb) {
+          addTask({
+            name: `chromedriver-prefetch:${identity}`,
+            kind: "chromedriver-prefetch",
+            exclusiveResources: [tag],
             payload: { platform: mobileTarget, desc },
           });
         }
-        // The chromedriver autodownload is a mobile-WEB-android cost: the
-        // UiAutomator2 server fetches a chromedriver matching the device's
-        // Chrome at session creation. One prefetch per device.
-        if (mobileTarget === "android" && isMobileWeb) {
-          if (!prefetches.has(deviceKey)) {
-            prefetches.add(deviceKey);
-            tasks.push({
-              name: `chromedriver-prefetch:${deviceKey.replaceAll("::", ":")}`,
-              kind: "chromedriver-prefetch",
-              // The device tag queues the prefetch behind its device's boot
-              // task; runtime-install covers its (idempotent) driver/appium
-              // preflight, which may install into the shared cache.
-              exclusiveResources: [
-                deviceResourceTag(mobileTarget, desc),
-                RUNTIME_INSTALL_RESOURCE,
-              ],
-              payload: { platform: mobileTarget, desc },
-            });
-          }
-        }
       }
 
-      if (mobileTarget === "ios" && !wdaCheckPlanned) {
-        wdaCheckPlanned = true;
-        tasks.push({
+      if (mobileTarget === "ios") {
+        addTask({
           name: "wda-check",
           kind: "wda-check",
           // Read-only (plus the last-used stamp) — contends with nothing.
@@ -237,17 +277,10 @@ export function planWarmTasks({
 
     // Desktop contexts.
     if (deps.isBrowserRequired({ test: context })) {
-      const effBrowser =
-        context.browser ?? deps.getDefaultBrowser({ runnerDetails });
+      const effBrowser = context.browser ?? getDefaultBrowser();
       const browserName = effBrowser?.name;
       if (browserName) {
         probeEligible = true;
-        probeCombos.add(
-          deps.combinationKey({
-            platform: effPlatform,
-            browser: { name: browserName },
-          })
-        );
         // Install work only applies to the host's own platform (a context
         // pinned to another platform is skipped per-context, never
         // installed for) and to engines with downloadable assets.
@@ -255,16 +288,12 @@ export function planWarmTasks({
           effPlatform === hostPlatform &&
           deps.requiredBrowserAssets(browserName).length > 0
         ) {
-          const installKey = browserName.toLowerCase();
-          if (!browserInstalls.has(installKey)) {
-            browserInstalls.add(installKey);
-            tasks.push({
-              name: `browser-install:${installKey}`,
-              kind: "browser-install",
-              exclusiveResources: [RUNTIME_INSTALL_RESOURCE],
-              payload: { browserName },
-            });
-          }
+          addTask({
+            name: `browser-install:${browserName.toLowerCase()}`,
+            kind: "browser-install",
+            exclusiveResources: [RUNTIME_INSTALL_RESOURCE],
+            payload: { browserName },
+          });
         }
       }
     }
@@ -275,9 +304,8 @@ export function planWarmTasks({
       deps.isAppDriverRequired({ test: context })
     ) {
       const driverPackage = deps.appDriverPlatforms[effPlatform]?.driverPackage;
-      if (driverPackage && !driverInstalls.has(driverPackage)) {
-        driverInstalls.add(driverPackage);
-        tasks.push({
+      if (driverPackage) {
+        addTask({
           name: `driver-install:${driverPackage}`,
           kind: "driver-install",
           exclusiveResources: [RUNTIME_INSTALL_RESOURCE],
@@ -293,13 +321,13 @@ export function planWarmTasks({
   // The warm PHASE always runs; only this task kind stays gated — preserving
   // the documented byte-identical serial-run behavior.
   if (limit > 1 && hasAppiumPool && probeEligible) {
-    tasks.push({
+    addTask({
       name: "session-probe",
       kind: "session-probe",
       // Its install half mutates the shared caches, exactly like the
       // dedicated install tasks (usually a memo hit by the time it runs).
       exclusiveResources: [RUNTIME_INSTALL_RESOURCE],
-      payload: { combos: [...probeCombos].sort() },
+      payload: {},
     });
   }
 
@@ -327,42 +355,40 @@ export async function executeWarmTasks({
 }): Promise<WarmReport> {
   const results: WarmTaskResult[] = [];
   const start = now();
-  await runResourceAware(
-    tasks,
-    Math.min(WARM_POOL_LIMIT, tasks.length),
-    registry,
-    async (task) => {
-      const taskStart = now();
-      try {
-        const { outcome, note } = await runTask(task);
-        results.push({
-          name: task.name,
-          kind: task.kind,
-          outcome,
-          durationMs: now() - taskStart,
-          ...(note ? { note } : {}),
-        });
-        if (outcome === "failed") {
-          log(
-            "warning",
-            `Warm task '${task.name}' failed (continuing)${note ? `: ${note}` : "."}`
-          );
-        } else {
-          log("debug", `Warm task '${task.name}': ${outcome}${note ? ` (${note})` : ""}.`);
-        }
-      } catch (error: any) {
-        const note = error?.message ?? String(error);
-        results.push({
-          name: task.name,
-          kind: task.kind,
-          outcome: "failed",
-          durationMs: now() - taskStart,
-          note,
-        });
-        log("warning", `Warm task '${task.name}' failed (continuing): ${note}`);
+  await runResourceAware(tasks, WARM_POOL_LIMIT, registry, async (task) => {
+    const taskStart = now();
+    try {
+      const { outcome, note } = await runTask(task);
+      results.push({
+        name: task.name,
+        kind: task.kind,
+        outcome,
+        durationMs: now() - taskStart,
+        ...(note ? { note } : {}),
+      });
+      if (outcome === "failed") {
+        log(
+          "warning",
+          `Warm task '${task.name}' failed (continuing)${note ? `: ${note}` : "."}`
+        );
+      } else {
+        log(
+          "debug",
+          `Warm task '${task.name}': ${outcome}${note ? ` (${note})` : ""}.`
+        );
       }
+    } catch (error: any) {
+      const note = error?.message ?? String(error);
+      results.push({
+        name: task.name,
+        kind: task.kind,
+        outcome: "failed",
+        durationMs: now() - taskStart,
+        note,
+      });
+      log("warning", `Warm task '${task.name}' failed (continuing): ${note}`);
     }
-  );
+  });
   return { durationMs: now() - start, tasks: results };
 }
 
@@ -373,13 +399,14 @@ export async function executeWarmTasks({
  * where it does today.
  *
  * `startAcquire` receives a `signalInitiated` callback the caller wires into
- * the acquire deps' create/boot effects. acquireDevice/acquireSimulator
- * invoke those effects synchronously inside the ready-promise body and then
- * synchronously register the `bootedByUs: true` placeholder before any
- * microtask runs — so by the time the race resolves on the signal, the
- * registry entry (with its in-flight `ready`) is already visible to
- * consumers. Fast paths (registry hit, reuse-running, plan skip) never
- * signal and settle through the acquire promise itself.
+ * the acquire deps' create/boot effects (wrapInitiationEffects).
+ * acquireDevice/acquireSimulator invoke those effects synchronously inside
+ * the ready-promise body and then synchronously register the
+ * `bootedByUs: true` placeholder before any microtask runs — so by the time
+ * the race resolves on the signal, the registry entry (with its in-flight
+ * `ready`) is already visible to consumers. Fast paths (registry hit,
+ * reuse-running, plan skip) never signal and settle through the acquire
+ * promise itself.
  *
  * The catch is chained onto the acquire promise BEFORE the race, so a boot
  * that fails after the task already resolved can never surface as an
@@ -399,30 +426,27 @@ export function raceBootInitiation({
   const initiated = new Promise<void>((resolve) => {
     initiatedResolve = resolve;
   });
-  let settled = false;
-  const acquired: Promise<{ outcome: WarmOutcome; note?: string }> = (async () => {
-    try {
-      const result = await startAcquire(() => initiatedResolve());
-      settled = true;
-      if (result && typeof (result as any).skip === "string") {
-        return { outcome: "skipped" as const, note: (result as any).skip };
+  const acquired: Promise<{ outcome: WarmOutcome; note?: string }> =
+    (async () => {
+      try {
+        const result = await startAcquire(() => initiatedResolve());
+        if (result && typeof result === "object" && "skip" in result) {
+          return { outcome: "skipped" as const, note: result.skip };
+        }
+        return { outcome: "warmed" as const, note: "device ready" };
+      } catch (error) {
+        onError(error);
+        return {
+          outcome: "failed" as const,
+          note: (error as any)?.message ?? String(error),
+        };
       }
-      return { outcome: "warmed" as const, note: "device ready" };
-    } catch (error) {
-      settled = true;
-      onError(error);
-      return {
-        outcome: "failed" as const,
-        note: (error as any)?.message ?? String(error),
-      };
-    }
-  })();
+    })();
   return Promise.race([
-    initiated.then(() =>
-      settled
-        ? acquired
-        : { outcome: "warmed" as const, note: "boot initiated" }
-    ),
+    initiated.then(() => ({
+      outcome: "warmed" as const,
+      note: "boot initiated",
+    })),
     acquired,
   ]);
 }

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -43,24 +43,17 @@ describe("Run tests successfully", function () {
       );
       // The inline warm phase ran before Phase 2 and reported its tasks: a
       // browser run at concurrentRunners 2 always plans the browser install
-      // (skipped when already available) and the session probe.
+      // (skipped when already available) and the session probe. Enum
+      // membership (kind/outcome values) is the report_v3 schema's contract,
+      // policed by src/common/test/validate.test.js — this smoke asserts the
+      // shape and the browser tasks only.
       assert.ok(result.warm, "report.warm missing");
       assert.equal(typeof result.warm.durationMs, "number");
       assert.ok(Array.isArray(result.warm.tasks));
-      const validKinds = [
-        "driver-install",
-        "browser-install",
-        "device-boot",
-        "wda-check",
-        "session-probe",
-        "chromedriver-prefetch",
-      ];
       for (const task of result.warm.tasks) {
-        assert.ok(validKinds.includes(task.kind), `unknown kind ${task.kind}`);
-        assert.ok(
-          ["warmed", "skipped", "failed"].includes(task.outcome),
-          `unknown outcome ${task.outcome}`
-        );
+        assert.equal(typeof task.name, "string");
+        assert.equal(typeof task.kind, "string");
+        assert.equal(typeof task.outcome, "string");
         assert.equal(typeof task.durationMs, "number");
       }
       assert.ok(

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -41,7 +41,53 @@ describe("Run tests successfully", function () {
         0,
         `${failedSpecs.length} spec(s) failed: ${failedSpecs.map((s) => s.specId).join(", ")}`
       );
+      // The inline warm phase ran before Phase 2 and reported its tasks: a
+      // browser run at concurrentRunners 2 always plans the browser install
+      // (skipped when already available) and the session probe.
+      assert.ok(result.warm, "report.warm missing");
+      assert.equal(typeof result.warm.durationMs, "number");
+      assert.ok(Array.isArray(result.warm.tasks));
+      const validKinds = [
+        "driver-install",
+        "browser-install",
+        "device-boot",
+        "wda-check",
+        "session-probe",
+        "chromedriver-prefetch",
+      ];
+      for (const task of result.warm.tasks) {
+        assert.ok(validKinds.includes(task.kind), `unknown kind ${task.kind}`);
+        assert.ok(
+          ["warmed", "skipped", "failed"].includes(task.outcome),
+          `unknown outcome ${task.outcome}`
+        );
+        assert.equal(typeof task.durationMs, "number");
+      }
+      assert.ok(
+        result.warm.tasks.some(
+          (t) => t.kind === "browser-install" || t.kind === "session-probe"
+        ),
+        `expected browser warm tasks, got: ${JSON.stringify(result.warm.tasks)}`
+      );
     });
+  });
+
+  it("A run with no provisioning needs reports an empty warm phase", async () => {
+    // Shell-only spec: the warm planner derives nothing, so the phase is a
+    // no-op by construction — baseline latency unchanged. Hermetic on every OS.
+    const shellOnly = {
+      tests: [{ testId: "warm-noop", steps: [{ runShell: "echo warm" }] }],
+    };
+    fs.mkdirSync(path.resolve("./.tmp"), { recursive: true });
+    const tempFilePath = path.resolve("./.tmp/temp-warm-noop-test.json");
+    fs.writeFileSync(tempFilePath, JSON.stringify(shellOnly, null, 2));
+    try {
+      const result = await runTests({ input: tempFilePath });
+      assert.equal(result.summary.specs.fail, 0);
+      assert.deepEqual(result.warm, { durationMs: 0, tasks: [] });
+    } finally {
+      fs.unlinkSync(tempFilePath);
+    }
   });
 
   it("An unmet context `requires` gate SKIPs the context with the unmet-requirements reason (and a met gate runs)", async () => {

--- a/test/warm-phase-device-boot.test.js
+++ b/test/warm-phase-device-boot.test.js
@@ -1,0 +1,172 @@
+// Device-boot warm semantics (docs/design/warm-phase.md, phase B1):
+// raceBootInitiation resolves at boot INITIATION (the registry placeholder is
+// already registered with bootedByUs + an in-flight `ready` promise), a boot
+// that later fails surfaces through onError — never as an unhandled rejection
+// — and a warm-booted, never-consumed device is swept by the existing
+// run-end teardown. Hermetic: acquireSimulator's effects are injected fakes.
+import assert from "node:assert/strict";
+import { raceBootInitiation } from "../dist/core/warmPhase.js";
+import {
+  acquireSimulator,
+  createSimulatorRegistry,
+  teardownSimulatorRegistry,
+} from "../dist/core/tests/iosSimulator.js";
+
+const RUNTIME = {
+  identifier: "com.apple.CoreSimulator.SimRuntime.iOS-17-0",
+  version: "17.0",
+  name: "iOS 17.0",
+  isAvailable: true,
+  platform: "iOS",
+};
+
+function shutdownDevice() {
+  return {
+    name: "warm-sim",
+    udid: "UDID-1",
+    state: "Shutdown",
+    runtime: RUNTIME.identifier,
+    isAvailable: true,
+    deviceTypeIdentifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-15",
+  };
+}
+
+function fakeDeps({ boot, devices = [shutdownDevice()], runtimes = [RUNTIME] }) {
+  return {
+    listDevices: async () => devices,
+    listRuntimes: async () => runtimes,
+    listDeviceTypes: async () => [],
+    create: async () => ({ udid: "CREATED" }),
+    boot,
+  };
+}
+
+function warmAcquire({ registry, deps, desc = { name: "warm-sim" }, onError = () => {} }) {
+  return raceBootInitiation({
+    onError,
+    startAcquire: (signal) =>
+      acquireSimulator({
+        desc,
+        registry,
+        deps: {
+          ...deps,
+          create: (args) => {
+            signal();
+            return deps.create(args);
+          },
+          boot: (udid) => {
+            signal();
+            return deps.boot(udid);
+          },
+        },
+      }),
+  });
+}
+
+describe("warm phase: device-boot initiation and ownership", function () {
+  it("resolves at boot initiation with the owned placeholder already registered", async function () {
+    const registry = createSimulatorRegistry();
+    let bootCalls = 0;
+    // A boot that never finishes: the task must still resolve.
+    const deps = fakeDeps({
+      boot: () => {
+        bootCalls++;
+        return new Promise(() => {});
+      },
+    });
+    const result = await warmAcquire({ registry, deps });
+    assert.equal(result.outcome, "warmed");
+    assert.match(result.note, /initiated/);
+    assert.equal(bootCalls, 1);
+    const entry = registry.get("warm-sim");
+    assert.ok(entry, "placeholder must be registered before the task resolves");
+    assert.equal(entry.bootedByUs, true);
+    assert.ok(entry.ready instanceof Promise, "in-flight ready promise shared with consumers");
+  });
+
+  it("routes a post-resolution boot failure to onError, deletes the placeholder, and leaks no unhandled rejection", async function () {
+    const registry = createSimulatorRegistry();
+    let rejectBoot;
+    const deps = fakeDeps({
+      boot: () => new Promise((_, reject) => (rejectBoot = reject)),
+    });
+    const errors = [];
+    const unhandled = [];
+    const trap = (err) => unhandled.push(err);
+    process.on("unhandledRejection", trap);
+    try {
+      const result = await warmAcquire({
+        registry,
+        deps,
+        onError: (e) => errors.push(e),
+      });
+      assert.equal(result.outcome, "warmed");
+      rejectBoot(new Error("boot exploded"));
+      // Let the rejection propagate through the acquire chain.
+      await new Promise((r) => setTimeout(r, 30));
+      assert.equal(errors.length, 1);
+      assert.match(String(errors[0]), /boot exploded/);
+      assert.equal(
+        registry.has("warm-sim"),
+        false,
+        "failed placeholder must be dropped so a consuming context retries fresh"
+      );
+      assert.deepEqual(unhandled, []);
+    } finally {
+      process.off("unhandledRejection", trap);
+    }
+  });
+
+  it("settles as skipped through the acquire promise when the plan can't boot anything", async function () {
+    const registry = createSimulatorRegistry();
+    const deps = fakeDeps({ boot: async () => {}, devices: [], runtimes: [] });
+    const result = await warmAcquire({ registry, deps, desc: {} });
+    assert.equal(result.outcome, "skipped");
+    assert.match(result.note, /runtime/i);
+    assert.equal(registry.size, 0);
+  });
+
+  it("reuses an already-booted device without claiming ownership", async function () {
+    const registry = createSimulatorRegistry();
+    const deps = fakeDeps({
+      boot: async () => {
+        throw new Error("must not boot a booted device");
+      },
+      devices: [{ ...shutdownDevice(), state: "Booted" }],
+    });
+    const result = await warmAcquire({ registry, deps });
+    assert.equal(result.outcome, "warmed");
+    const entry = registry.get("warm-sim");
+    assert.equal(entry.bootedByUs, false);
+  });
+
+  it("sweeps a warm-booted, never-consumed device exactly once at teardown", async function () {
+    const registry = createSimulatorRegistry();
+    const deps = fakeDeps({ boot: async () => {} });
+    const result = await warmAcquire({ registry, deps });
+    assert.equal(result.outcome, "warmed");
+    const entry = registry.get("warm-sim");
+    // No test ever consumes the device; let its boot finish.
+    await entry.ready;
+    const swept = [];
+    await teardownSimulatorRegistry(registry, async (e) => {
+      swept.push(e.name);
+    });
+    assert.deepEqual(swept, ["warm-sim"]);
+    assert.equal(registry.size, 0);
+  });
+
+  it("leaves reused (not-owned) devices alone at teardown", async function () {
+    const registry = createSimulatorRegistry();
+    const deps = fakeDeps({
+      boot: async () => {},
+      devices: [{ ...shutdownDevice(), state: "Booted" }],
+    });
+    await warmAcquire({ registry, deps });
+    const swept = [];
+    await teardownSimulatorRegistry(registry, async (e) => {
+      swept.push(e.name);
+    });
+    assert.deepEqual(swept, []);
+  });
+});

--- a/test/warm-phase-device-boot.test.js
+++ b/test/warm-phase-device-boot.test.js
@@ -156,6 +156,48 @@ describe("warm phase: device-boot initiation and ownership", function () {
     assert.equal(registry.size, 0);
   });
 
+  it("awaits an in-flight warm boot at teardown so the device is never orphaned", async function () {
+    // The warm task resolves at boot INITIATION, so a run can end while the
+    // boot is still in flight (the consuming context skipped, the other
+    // tests were fast). The sweep must await readiness before shutting the
+    // device down — otherwise it would sweep a placeholder with no udid yet
+    // and orphan the real device.
+    const registry = createSimulatorRegistry();
+    let resolveBoot;
+    const deps = fakeDeps({
+      boot: () => new Promise((r) => (resolveBoot = r)),
+    });
+    const result = await warmAcquire({ registry, deps });
+    assert.equal(result.outcome, "warmed");
+    const swept = [];
+    const teardown = teardownSimulatorRegistry(registry, async (e) => {
+      swept.push(e.udid);
+    });
+    // Boot completes only after teardown already started.
+    resolveBoot();
+    await teardown;
+    assert.deepEqual(swept, ["UDID-1"]);
+    assert.equal(registry.size, 0);
+  });
+
+  it("skips a warm boot that fails while teardown is waiting on it", async function () {
+    const registry = createSimulatorRegistry();
+    let rejectBoot;
+    const deps = fakeDeps({
+      boot: () => new Promise((_, r) => (rejectBoot = r)),
+    });
+    await warmAcquire({ registry, deps, onError: () => {} });
+    const swept = [];
+    const teardown = teardownSimulatorRegistry(registry, async (e) => {
+      swept.push(e.udid);
+    });
+    rejectBoot(new Error("boot exploded"));
+    await teardown;
+    // Nothing booted, so nothing to shut down — and no throw from teardown.
+    assert.deepEqual(swept, []);
+    assert.equal(registry.size, 0);
+  });
+
   it("leaves reused (not-owned) devices alone at teardown", async function () {
     const registry = createSimulatorRegistry();
     const deps = fakeDeps({

--- a/test/warm-phase-executor.test.js
+++ b/test/warm-phase-executor.test.js
@@ -1,0 +1,142 @@
+// Unit tests for the warm-phase executor (src/core/warmPhase.ts).
+// executeWarmTasks runs planned tasks through the run's resource-aware pool:
+// best-effort (a failed task warns and never rejects the phase), tag-exclusive
+// (cache-mutating tasks serialize on RUNTIME_INSTALL_RESOURCE), and bounded by
+// WARM_POOL_LIMIT (docs/design/warm-phase.md, phase B1).
+import assert from "node:assert/strict";
+import {
+  executeWarmTasks,
+  WARM_POOL_LIMIT,
+  RUNTIME_INSTALL_RESOURCE,
+} from "../dist/core/warmPhase.js";
+import { createResourceRegistry } from "../dist/core/utils.js";
+
+function task(name, kind, exclusiveResources = []) {
+  return { name, kind, exclusiveResources, payload: {} };
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+describe("warm phase: executeWarmTasks", function () {
+  it("returns an empty report for an empty plan", async function () {
+    const report = await executeWarmTasks({
+      tasks: [],
+      registry: createResourceRegistry(),
+      runTask: async () => ({ outcome: "warmed" }),
+      log: () => {},
+    });
+    assert.deepEqual(report.tasks, []);
+    assert.equal(typeof report.durationMs, "number");
+  });
+
+  it("isolates a failing task: siblings complete, the phase resolves, a warning logs", async function () {
+    const logs = [];
+    const report = await executeWarmTasks({
+      tasks: [
+        task("a", "browser-install"),
+        task("b", "browser-install"),
+        task("c", "device-boot"),
+      ],
+      registry: createResourceRegistry(),
+      runTask: async (t) => {
+        if (t.name === "b") throw new Error("boom");
+        return { outcome: "warmed" };
+      },
+      log: (level, msg) => logs.push({ level, msg }),
+    });
+    assert.equal(report.tasks.length, 3);
+    const byName = new Map(report.tasks.map((r) => [r.name, r]));
+    assert.equal(byName.get("a").outcome, "warmed");
+    assert.equal(byName.get("b").outcome, "failed");
+    assert.match(byName.get("b").note, /boom/);
+    assert.equal(byName.get("c").outcome, "warmed");
+    assert.ok(
+      logs.some((l) => l.level === "warning" && /warm task 'b' failed/i.test(l.msg)),
+      `expected a warning about task b, got: ${JSON.stringify(logs)}`
+    );
+  });
+
+  it("carries skipped outcomes and notes through to the report", async function () {
+    const report = await executeWarmTasks({
+      tasks: [task("w", "wda-check")],
+      registry: createResourceRegistry(),
+      runTask: async () => ({ outcome: "skipped", note: "no prebuilt WDA" }),
+      log: () => {},
+    });
+    assert.equal(report.tasks[0].outcome, "skipped");
+    assert.equal(report.tasks[0].note, "no prebuilt WDA");
+  });
+
+  it("never runs two runtime-install tasks concurrently", async function () {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const gates = [deferred(), deferred()];
+    let started = 0;
+    const run = executeWarmTasks({
+      tasks: [
+        task("i1", "browser-install", [RUNTIME_INSTALL_RESOURCE]),
+        task("i2", "driver-install", [RUNTIME_INSTALL_RESOURCE]),
+      ],
+      registry: createResourceRegistry(),
+      runTask: async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await gates[started++].promise;
+        inFlight--;
+        return { outcome: "warmed" };
+      },
+      log: () => {},
+    });
+    // Let the pool spin up, then release the tasks one at a time.
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(maxInFlight, 1);
+    gates[0].resolve();
+    await new Promise((r) => setTimeout(r, 20));
+    gates[1].resolve();
+    const report = await run;
+    assert.equal(maxInFlight, 1);
+    assert.equal(report.tasks.length, 2);
+  });
+
+  it("overlaps untagged tasks up to the warm pool ceiling", async function () {
+    const total = WARM_POOL_LIMIT + 2;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const gate = deferred();
+    const run = executeWarmTasks({
+      tasks: Array.from({ length: total }, (_, i) => task(`t${i}`, "device-boot")),
+      registry: createResourceRegistry(),
+      runTask: async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await gate.promise;
+        inFlight--;
+        return { outcome: "warmed" };
+      },
+      log: () => {},
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(maxInFlight, WARM_POOL_LIMIT);
+    gate.resolve();
+    const report = await run;
+    assert.equal(report.tasks.length, total);
+    assert.equal(maxInFlight, WARM_POOL_LIMIT);
+  });
+
+  it("records per-task and total durations from the injected clock", async function () {
+    let t = 0;
+    const report = await executeWarmTasks({
+      tasks: [task("a", "wda-check")],
+      registry: createResourceRegistry(),
+      runTask: async () => ({ outcome: "warmed" }),
+      log: () => {},
+      now: () => (t += 5),
+    });
+    assert.ok(report.tasks[0].durationMs >= 0);
+    assert.ok(report.durationMs >= report.tasks[0].durationMs);
+  });
+});

--- a/test/warm-phase-executor.test.js
+++ b/test/warm-phase-executor.test.js
@@ -72,8 +72,12 @@ describe("warm phase: executeWarmTasks", function () {
   });
 
   it("never runs two runtime-install tasks concurrently", async function () {
+    // Deterministic: each task blocks on its own gate, and the first task
+    // signals when it has ENTERED runTask — so the assertion that the second
+    // task hasn't started can't race the pool's scheduling.
     let inFlight = 0;
     let maxInFlight = 0;
+    const firstStarted = deferred();
     const gates = [deferred(), deferred()];
     let started = 0;
     const run = executeWarmTasks({
@@ -83,19 +87,21 @@ describe("warm phase: executeWarmTasks", function () {
       ],
       registry: createResourceRegistry(),
       runTask: async () => {
+        const mine = started++;
+        if (mine === 0) firstStarted.resolve();
         inFlight++;
         maxInFlight = Math.max(maxInFlight, inFlight);
-        await gates[started++].promise;
+        await gates[mine].promise;
         inFlight--;
         return { outcome: "warmed" };
       },
       log: () => {},
     });
-    // Let the pool spin up, then release the tasks one at a time.
-    await new Promise((r) => setTimeout(r, 20));
+    await firstStarted.promise;
+    // The first holder is parked on its gate; the shared tag must keep the
+    // second task out until the first releases.
     assert.equal(maxInFlight, 1);
     gates[0].resolve();
-    await new Promise((r) => setTimeout(r, 20));
     gates[1].resolve();
     const report = await run;
     assert.equal(maxInFlight, 1);
@@ -106,20 +112,26 @@ describe("warm phase: executeWarmTasks", function () {
     const total = WARM_POOL_LIMIT + 2;
     let inFlight = 0;
     let maxInFlight = 0;
+    let started = 0;
+    const poolFull = deferred();
     const gate = deferred();
     const run = executeWarmTasks({
       tasks: Array.from({ length: total }, (_, i) => task(`t${i}`, "device-boot")),
       registry: createResourceRegistry(),
       runTask: async () => {
+        started++;
         inFlight++;
         maxInFlight = Math.max(maxInFlight, inFlight);
+        if (started === WARM_POOL_LIMIT) poolFull.resolve();
         await gate.promise;
         inFlight--;
         return { outcome: "warmed" };
       },
       log: () => {},
     });
-    await new Promise((r) => setTimeout(r, 20));
+    // Wait until the pool provably has WARM_POOL_LIMIT tasks in flight (all
+    // parked on the shared gate), then release everything at once.
+    await poolFull.promise;
     assert.equal(maxInFlight, WARM_POOL_LIMIT);
     gate.resolve();
     const report = await run;

--- a/test/warm-phase-memo.test.js
+++ b/test/warm-phase-memo.test.js
@@ -1,0 +1,137 @@
+// The warm-phase mirror contract (docs/design/warm-phase.md, phase B1):
+// warmBrowserInstall must leave installAttempts / runnerDetails.availableApps
+// in EXACTLY the state the first same-browser consuming context would have
+// produced serially — install + first-attempt re-detect, memoized thereafter —
+// so later gates (warmUpContexts, runContext) collapse to cache hits and
+// never misread the memo against a stale app list.
+import assert from "node:assert/strict";
+import {
+  warmBrowserInstall,
+  ensureContextBrowserInstalled,
+} from "../dist/core/tests.js";
+
+function makeSpies({ ensureBrowserError, detected = [] } = {}) {
+  const calls = { ensureBrowser: [], clearAppCache: 0, getAvailableApps: 0 };
+  return {
+    calls,
+    deps: {
+      ensureBrowser: async (asset) => {
+        calls.ensureBrowser.push(asset);
+        if (ensureBrowserError) throw new Error(ensureBrowserError);
+      },
+      clearAppCache: () => {
+        calls.clearAppCache++;
+      },
+      getAvailableApps: async () => {
+        calls.getAvailableApps++;
+        return detected;
+      },
+    },
+  };
+}
+
+function run({ browserName = "chrome", availableApps = [], installAttempts, spies }) {
+  const runnerDetails = { environment: { platform: "windows" }, availableApps };
+  return {
+    runnerDetails,
+    result: warmBrowserInstall({
+      browserName,
+      config: {},
+      runnerDetails,
+      installAttempts,
+      deps: spies.deps,
+    }),
+  };
+}
+
+describe("warm phase: warmBrowserInstall memo-sharing / mirror contract", function () {
+  it("skips without touching the memo when the browser is already available", async function () {
+    const spies = makeSpies();
+    const installAttempts = new Map();
+    const { result } = run({
+      availableApps: [{ name: "chrome" }],
+      installAttempts,
+      spies,
+    });
+    const outcome = await result;
+    assert.equal(outcome.outcome, "skipped");
+    assert.equal(installAttempts.size, 0);
+    assert.deepEqual(spies.calls.ensureBrowser, []);
+    assert.equal(spies.calls.getAvailableApps, 0);
+  });
+
+  it("treats webkit as the safari engine for the availability check", async function () {
+    const spies = makeSpies();
+    const installAttempts = new Map();
+    const { result } = run({
+      browserName: "webkit",
+      availableApps: [{ name: "safari" }],
+      installAttempts,
+      spies,
+    });
+    assert.equal((await result).outcome, "skipped");
+    assert.deepEqual(spies.calls.ensureBrowser, []);
+  });
+
+  it("installs + re-detects on the first attempt, exactly like the serial first consumer", async function () {
+    const detected = [{ name: "chrome" }];
+    const spies = makeSpies({ detected });
+    const installAttempts = new Map();
+    const { runnerDetails, result } = run({ installAttempts, spies });
+    const outcome = await result;
+    assert.equal(outcome.outcome, "warmed");
+    assert.equal(installAttempts.get("chrome"), "installed");
+    assert.ok(spies.calls.ensureBrowser.length > 0, "must install the browser assets");
+    assert.equal(spies.calls.clearAppCache, 1);
+    assert.equal(spies.calls.getAvailableApps, 1);
+    assert.equal(runnerDetails.availableApps, detected, "re-detected app list replaces the snapshot");
+
+    // Parity: a fresh direct ensureContextBrowserInstalled + first-attempt
+    // re-detect (runContext's serial path) produces the identical memo state.
+    const directSpies = makeSpies({ detected });
+    const directAttempts = new Map();
+    const directOutcome = await ensureContextBrowserInstalled({
+      browserName: "chrome",
+      config: {},
+      installAttempts: directAttempts,
+      deps: { ensureBrowser: directSpies.deps.ensureBrowser },
+      repair: true,
+    });
+    assert.equal(directOutcome, "installed");
+    assert.deepEqual([...installAttempts.entries()], [...directAttempts.entries()]);
+    assert.deepEqual(spies.calls.ensureBrowser, directSpies.calls.ensureBrowser);
+  });
+
+  it("memo-hits on the second call: no new install or re-detect work", async function () {
+    const spies = makeSpies({ detected: [] }); // installed but undetected
+    const installAttempts = new Map();
+    await run({ installAttempts, spies }).result;
+    const installCalls = spies.calls.ensureBrowser.length;
+    const outcome = await run({ installAttempts, spies }).result;
+    assert.equal(outcome.outcome, "warmed");
+    assert.equal(spies.calls.ensureBrowser.length, installCalls, "memo hit must not reinstall");
+    assert.equal(spies.calls.getAvailableApps, 1, "re-detect only follows a FIRST attempt");
+  });
+
+  it("records a failed install and still re-detects, mirroring the serial path", async function () {
+    const spies = makeSpies({ ensureBrowserError: "download 503" });
+    const installAttempts = new Map();
+    const { result } = run({ installAttempts, spies });
+    const outcome = await result;
+    assert.equal(outcome.outcome, "failed");
+    assert.match(outcome.note, /chrome/);
+    assert.equal(installAttempts.get("chrome"), "failed");
+    assert.equal(spies.calls.clearAppCache, 1);
+    assert.equal(spies.calls.getAvailableApps, 1);
+  });
+
+  it("reports engines with no installable assets as skipped", async function () {
+    const spies = makeSpies();
+    const installAttempts = new Map();
+    const { result } = run({ browserName: "safari", installAttempts, spies });
+    const outcome = await result;
+    assert.equal(outcome.outcome, "skipped");
+    assert.equal(installAttempts.get("safari"), "notInstallable");
+    assert.deepEqual(spies.calls.ensureBrowser, []);
+  });
+});

--- a/test/warm-phase-plan.test.js
+++ b/test/warm-phase-plan.test.js
@@ -165,7 +165,11 @@ describe("warm phase: planWarmTasks", function () {
     assert.deepEqual(install.exclusiveResources, [RUNTIME_INSTALL_RESOURCE]);
     const boot = tasks.find((t) => t.kind === "device-boot");
     const tag = deviceResourceTag("android", {});
-    assert.deepEqual(boot.exclusiveResources, [tag, "android-emulator"]);
+    // No "android-emulator" task tag: the runner holds a manual lease on
+    // that name from initiation until the boot settles instead (a task tag
+    // would be released at task resolution — boot initiation — and CI
+    // proved concurrent boots starve small runners).
+    assert.deepEqual(boot.exclusiveResources, [tag]);
     // The prefetch holds ONLY its device tag: its cache-mutating preflight
     // half runs under a manual runtime-install lease inside the task body,
     // so the long device-ready await never blocks the install tasks.
@@ -173,63 +177,43 @@ describe("warm phase: planWarmTasks", function () {
     assert.deepEqual(prefetch.exclusiveResources, [tag]);
   });
 
-  it("dedupes device boots by normalized descriptor and splits distinct devices", function () {
+  it("boots at most one device per mobile platform, deduped across contexts", function () {
+    // Emulator/simulator boots are the heaviest thing a CI host runs —
+    // overlapping them starves everything (proven on the 2-core KVM leg).
+    // Warm pre-pays the FIRST device's boot; every additional device boots
+    // inside its consuming context, serialized as today.
     const device = { name: "pixel", osVersion: "14" };
     const tasks = plan({
       jobs: [
         job({ platform: "android", device, steps: [browserStep] }),
         job({ platform: "android", device, steps: [browserStep] }),
         job({ platform: "android", steps: [browserStep] }),
+        job({ platform: "android", device: { name: "other" }, steps: [appStep] }),
       ],
       platform: "linux",
     });
     const boots = tasks.filter((t) => t.kind === "device-boot").map((t) => t.name);
-    assert.equal(boots.length, 2);
-    assert.ok(boots.some((n) => n.includes("pixel")));
+    assert.equal(boots.length, 1);
+    assert.ok(boots[0].includes("pixel"));
+    // The prefetch stays per-device (it serializes on the emulator lease at
+    // run time), still deduped by identity.
+    const prefetches = tasks.filter((t) => t.kind === "chromedriver-prefetch");
+    assert.equal(prefetches.length, 2);
   });
 
-  it("dedupes same-named devices even when osVersions differ (the registry keys by name)", function () {
-    // A named device resolves to one registry entry regardless of osVersion;
-    // a second boot task would just registry-hit and block a warm worker on
-    // the FULL boot, defeating resolve-at-initiation.
+  it("plans one boot per platform in a mixed android + ios run", function () {
     const tasks = plan({
       jobs: [
-        job({
-          platform: "android",
-          device: { name: "pixel", osVersion: "35" },
-          steps: [browserStep],
-        }),
-        job({
-          platform: "android",
-          device: { name: "pixel", osVersion: "36" },
-          steps: [browserStep],
-        }),
-      ],
-      platform: "linux",
-    });
-    assert.equal(tasks.filter((t) => t.kind === "device-boot").length, 1);
-  });
-
-  it("splits unnamed devices that differ only in deviceType", function () {
-    // Default (unnamed) descriptors resolve by deviceType + osVersion —
-    // an iPhone and an iPad are two simulators and both need warming.
-    const tasks = plan({
-      jobs: [
-        job({
-          platform: "ios",
-          device: { deviceType: "phone" },
-          steps: [appStep],
-        }),
-        job({
-          platform: "ios",
-          device: { deviceType: "tablet" },
-          steps: [appStep],
-        }),
+        job({ platform: "android", steps: [browserStep] }),
+        job({ platform: "ios", steps: [appStep] }),
       ],
       platform: "mac",
       apps: [{ name: "safari" }],
     });
-    assert.equal(tasks.filter((t) => t.kind === "device-boot").length, 2);
+    const boots = tasks.filter((t) => t.kind === "device-boot").map((t) => t.name);
+    assert.equal(boots.length, 2);
+    assert.ok(boots.some((n) => n.includes("android")));
+    assert.ok(boots.some((n) => n.includes("ios")));
   });
 
   it("warms nothing for a context whose `requires` gate is unmet", function () {

--- a/test/warm-phase-plan.test.js
+++ b/test/warm-phase-plan.test.js
@@ -1,0 +1,252 @@
+// Unit tests for the pure warm-phase planner (src/core/warmPhase.ts).
+// planWarmTasks derives the provisioning tasks a run needs from the sizing
+// jobs — pure derivation, no I/O, no context mutation — using the REAL
+// predicates bound by buildWarmPlanDeps so these tests exercise production
+// selection logic (docs/design/warm-phase.md, phase B1).
+import assert from "node:assert/strict";
+import {
+  planWarmTasks,
+  WARM_POOL_LIMIT,
+  RUNTIME_INSTALL_RESOURCE,
+  deviceResourceTag,
+} from "../dist/core/warmPhase.js";
+import { buildWarmPlanDeps } from "../dist/core/tests.js";
+
+const deps = buildWarmPlanDeps();
+
+function runnerDetails(platform = "windows", apps = [{ name: "chrome" }]) {
+  return {
+    environment: { platform },
+    availableApps: apps,
+    allowUnsafeSteps: true,
+  };
+}
+
+function job(context) {
+  return { context };
+}
+
+const browserStep = { goTo: "http://localhost:8092" };
+const shellStep = { runShell: { command: "echo hi" } };
+const appStep = { startSurface: { app: "notepad" } };
+
+function plan({
+  jobs,
+  platform = "windows",
+  apps = [{ name: "chrome" }],
+  limit = 1,
+  hasAppiumPool = false,
+  config = {},
+}) {
+  return planWarmTasks({
+    sizingJobs: jobs,
+    runnerDetails: runnerDetails(platform, apps),
+    config,
+    limit,
+    hasAppiumPool,
+    hostPlatform: platform,
+    deps,
+  });
+}
+
+function kinds(tasks) {
+  return tasks.map((t) => t.kind).sort();
+}
+
+describe("warm phase: planWarmTasks", function () {
+  it("plans nothing for an empty run", function () {
+    assert.deepEqual(plan({ jobs: [] }), []);
+  });
+
+  it("plans nothing for a shell-only run", function () {
+    const tasks = plan({
+      jobs: [job({ steps: [shellStep] }), job({ steps: [shellStep] })],
+    });
+    assert.deepEqual(tasks, []);
+  });
+
+  it("never mutates the sizing jobs' contexts", function () {
+    const contexts = [
+      { steps: [browserStep] },
+      { platform: "android", steps: [browserStep] },
+      { platform: "ios", steps: [appStep] },
+    ];
+    const jobs = contexts.map((c) => job(c));
+    const before = JSON.stringify(jobs);
+    plan({ jobs, platform: "mac", limit: 2, hasAppiumPool: true });
+    assert.equal(JSON.stringify(jobs), before);
+  });
+
+  it("desktop web at limit 1: only a browser-install task, deduped by browser", function () {
+    const tasks = plan({
+      jobs: [job({ steps: [browserStep] }), job({ steps: [browserStep] })],
+      limit: 1,
+    });
+    assert.equal(tasks.length, 1);
+    assert.equal(tasks[0].kind, "browser-install");
+    // Browser defaults from availableApps exactly as runContext would.
+    assert.equal(tasks[0].name, "browser-install:chrome");
+    assert.deepEqual(tasks[0].exclusiveResources, [RUNTIME_INSTALL_RESOURCE]);
+  });
+
+  it("desktop web at limit > 1 with a pool adds exactly one session-probe", function () {
+    const tasks = plan({
+      jobs: [
+        job({ steps: [browserStep] }),
+        job({ browser: { name: "firefox" }, steps: [browserStep] }),
+      ],
+      limit: 2,
+      hasAppiumPool: true,
+    });
+    const probes = tasks.filter((t) => t.kind === "session-probe");
+    assert.equal(probes.length, 1);
+    assert.deepEqual(probes[0].exclusiveResources, [RUNTIME_INSTALL_RESOURCE]);
+    // Both unique browsers get an install task.
+    const installs = tasks
+      .filter((t) => t.kind === "browser-install")
+      .map((t) => t.name)
+      .sort();
+    assert.deepEqual(installs, [
+      "browser-install:chrome",
+      "browser-install:firefox",
+    ]);
+  });
+
+  it("keeps the session-probe behind the appium-pool gate", function () {
+    const tasks = plan({
+      jobs: [job({ steps: [browserStep] })],
+      limit: 2,
+      hasAppiumPool: false,
+    });
+    assert.deepEqual(
+      tasks.filter((t) => t.kind === "session-probe"),
+      []
+    );
+  });
+
+  it("skips browser-install for browsers without installable assets", function () {
+    // safari has no downloadable assets (requiredBrowserAssets → []).
+    const tasks = plan({
+      jobs: [job({ browser: { name: "safari" }, steps: [browserStep] })],
+      platform: "mac",
+      apps: [{ name: "safari" }],
+    });
+    assert.deepEqual(
+      tasks.filter((t) => t.kind === "browser-install"),
+      []
+    );
+  });
+
+  it("skips browser-install when no browser resolves", function () {
+    const tasks = plan({
+      jobs: [job({ steps: [browserStep] })],
+      apps: [],
+    });
+    assert.deepEqual(
+      tasks.filter((t) => t.kind === "browser-install"),
+      []
+    );
+  });
+
+  it("android mobile-web: driver-install + device-boot + chromedriver-prefetch, no desktop tasks", function () {
+    const tasks = plan({
+      jobs: [
+        job({ platform: "android", steps: [browserStep] }),
+        job({ platform: "android", steps: [browserStep] }),
+      ],
+      platform: "linux",
+      limit: 2,
+      hasAppiumPool: true,
+    });
+    assert.deepEqual(kinds(tasks), [
+      "chromedriver-prefetch",
+      "device-boot",
+      "driver-install",
+    ]);
+    const install = tasks.find((t) => t.kind === "driver-install");
+    assert.equal(install.name, "driver-install:appium-uiautomator2-driver");
+    assert.deepEqual(install.exclusiveResources, [RUNTIME_INSTALL_RESOURCE]);
+    const boot = tasks.find((t) => t.kind === "device-boot");
+    const tag = deviceResourceTag("android", {});
+    assert.deepEqual(boot.exclusiveResources, [tag, "android-emulator"]);
+    const prefetch = tasks.find((t) => t.kind === "chromedriver-prefetch");
+    assert.deepEqual(prefetch.exclusiveResources, [
+      tag,
+      RUNTIME_INSTALL_RESOURCE,
+    ]);
+  });
+
+  it("dedupes device boots by normalized descriptor and splits distinct devices", function () {
+    const device = { name: "pixel", osVersion: "14" };
+    const tasks = plan({
+      jobs: [
+        job({ platform: "android", device, steps: [browserStep] }),
+        job({ platform: "android", device, steps: [browserStep] }),
+        job({ platform: "android", steps: [browserStep] }),
+      ],
+      platform: "linux",
+    });
+    const boots = tasks.filter((t) => t.kind === "device-boot").map((t) => t.name);
+    assert.equal(boots.length, 2);
+    assert.ok(boots.some((n) => n.includes("pixel")));
+  });
+
+  it("android native-app context boots a device but plans no chromedriver-prefetch", function () {
+    const tasks = plan({
+      jobs: [job({ platform: "android", steps: [appStep] })],
+      platform: "linux",
+    });
+    assert.deepEqual(kinds(tasks), ["device-boot", "driver-install"]);
+  });
+
+  it("mixed app+web mobile context (gate skip) warms nothing", function () {
+    const tasks = plan({
+      jobs: [job({ platform: "android", steps: [appStep, browserStep] })],
+      platform: "linux",
+    });
+    assert.deepEqual(tasks, []);
+  });
+
+  it("ios on a mac host: driver-install + device-boot + one wda-check", function () {
+    const tasks = plan({
+      jobs: [
+        job({ platform: "ios", steps: [appStep] }),
+        job({ platform: "ios", steps: [browserStep] }),
+      ],
+      platform: "mac",
+      apps: [{ name: "safari" }],
+    });
+    const install = tasks.find((t) => t.kind === "driver-install");
+    assert.equal(install.name, "driver-install:appium-xcuitest-driver");
+    const wda = tasks.filter((t) => t.kind === "wda-check");
+    assert.equal(wda.length, 1);
+    assert.deepEqual(wda[0].exclusiveResources, []);
+    const boot = tasks.find((t) => t.kind === "device-boot");
+    assert.deepEqual(boot.exclusiveResources, [deviceResourceTag("ios", {})]);
+  });
+
+  it("plans no ios or mac tasks off-darwin", function () {
+    const tasks = plan({
+      jobs: [
+        job({ platform: "ios", steps: [appStep] }),
+        job({ platform: "mac", steps: [appStep] }),
+      ],
+      platform: "windows",
+    });
+    assert.deepEqual(tasks, []);
+  });
+
+  it("desktop app context on its host platform installs the native driver", function () {
+    const tasks = plan({
+      jobs: [job({ steps: [appStep] })],
+      platform: "windows",
+    });
+    const installs = tasks.filter((t) => t.kind === "driver-install");
+    assert.equal(installs.length, 1);
+    assert.equal(installs[0].name, "driver-install:appium-novawindows-driver");
+  });
+
+  it("exports a small fixed warm pool ceiling", function () {
+    assert.ok(Number.isInteger(WARM_POOL_LIMIT) && WARM_POOL_LIMIT >= 2);
+  });
+});

--- a/test/warm-phase-plan.test.js
+++ b/test/warm-phase-plan.test.js
@@ -36,15 +36,12 @@ function plan({
   apps = [{ name: "chrome" }],
   limit = 1,
   hasAppiumPool = false,
-  config = {},
 }) {
   return planWarmTasks({
     sizingJobs: jobs,
     runnerDetails: runnerDetails(platform, apps),
-    config,
     limit,
     hasAppiumPool,
-    hostPlatform: platform,
     deps,
   });
 }
@@ -169,11 +166,11 @@ describe("warm phase: planWarmTasks", function () {
     const boot = tasks.find((t) => t.kind === "device-boot");
     const tag = deviceResourceTag("android", {});
     assert.deepEqual(boot.exclusiveResources, [tag, "android-emulator"]);
+    // The prefetch holds ONLY its device tag: its cache-mutating preflight
+    // half runs under a manual runtime-install lease inside the task body,
+    // so the long device-ready await never blocks the install tasks.
     const prefetch = tasks.find((t) => t.kind === "chromedriver-prefetch");
-    assert.deepEqual(prefetch.exclusiveResources, [
-      tag,
-      RUNTIME_INSTALL_RESOURCE,
-    ]);
+    assert.deepEqual(prefetch.exclusiveResources, [tag]);
   });
 
   it("dedupes device boots by normalized descriptor and splits distinct devices", function () {
@@ -189,6 +186,83 @@ describe("warm phase: planWarmTasks", function () {
     const boots = tasks.filter((t) => t.kind === "device-boot").map((t) => t.name);
     assert.equal(boots.length, 2);
     assert.ok(boots.some((n) => n.includes("pixel")));
+  });
+
+  it("dedupes same-named devices even when osVersions differ (the registry keys by name)", function () {
+    // A named device resolves to one registry entry regardless of osVersion;
+    // a second boot task would just registry-hit and block a warm worker on
+    // the FULL boot, defeating resolve-at-initiation.
+    const tasks = plan({
+      jobs: [
+        job({
+          platform: "android",
+          device: { name: "pixel", osVersion: "35" },
+          steps: [browserStep],
+        }),
+        job({
+          platform: "android",
+          device: { name: "pixel", osVersion: "36" },
+          steps: [browserStep],
+        }),
+      ],
+      platform: "linux",
+    });
+    assert.equal(tasks.filter((t) => t.kind === "device-boot").length, 1);
+  });
+
+  it("splits unnamed devices that differ only in deviceType", function () {
+    // Default (unnamed) descriptors resolve by deviceType + osVersion —
+    // an iPhone and an iPad are two simulators and both need warming.
+    const tasks = plan({
+      jobs: [
+        job({
+          platform: "ios",
+          device: { deviceType: "phone" },
+          steps: [appStep],
+        }),
+        job({
+          platform: "ios",
+          device: { deviceType: "tablet" },
+          steps: [appStep],
+        }),
+      ],
+      platform: "mac",
+      apps: [{ name: "safari" }],
+    });
+    assert.equal(tasks.filter((t) => t.kind === "device-boot").length, 2);
+  });
+
+  it("warms nothing for a context whose `requires` gate is unmet", function () {
+    // runContext skips an unmet-requirements context BEFORE any provisioning
+    // — warm must not download a browser (or boot a device) for it.
+    const tasks = plan({
+      jobs: [
+        job({
+          requires: "doc-detective-no-such-binary-xyz",
+          steps: [browserStep],
+        }),
+        job({
+          platform: "android",
+          requires: "doc-detective-no-such-binary-xyz",
+          steps: [browserStep],
+        }),
+      ],
+      platform: "linux",
+      apps: [{ name: "chrome" }],
+    });
+    assert.deepEqual(tasks, []);
+  });
+
+  it("warms normally when the `requires` gate is met", function () {
+    const tasks = plan({
+      jobs: [job({ requires: "node", steps: [browserStep] })],
+      platform: "linux",
+      apps: [{ name: "chrome" }],
+    });
+    assert.equal(
+      tasks.filter((t) => t.kind === "browser-install").length,
+      1
+    );
   });
 
   it("android native-app context boots a device but plans no chromedriver-prefetch", function () {

--- a/test/warm-phase-prefetch.test.js
+++ b/test/warm-phase-prefetch.test.js
@@ -1,0 +1,129 @@
+// The chromedriver-prefetch warm task (docs/design/warm-phase.md, phase B1 +
+// the chained-throwaway-session decision): on-device chromedriver is only
+// downloadable through a live UiAutomator2 session, so the task awaits the
+// device, opens a disposable mobile-web session on a short-lived Appium
+// server with the autodownload flag, and tears both down in a finally.
+// Hermetic: every effect is injected.
+import assert from "node:assert/strict";
+import { prefetchMobileChromedriver } from "../dist/core/tests.js";
+
+function harness(overrides = {}) {
+  const calls = [];
+  const deps = {
+    appSurfacePreflight: async () => {
+      calls.push("preflight");
+      return { ok: true, appiumEntry: "/entry.js", appiumHome: "/appium-home" };
+    },
+    acquireDevice: async () => {
+      calls.push("acquire");
+      return { entry: { name: "pixel", udid: "emulator-5554" } };
+    },
+    startAppiumServer: async (entry, config, display, env, extraArgs) => {
+      calls.push("server");
+      deps._serverArgs = { entry, env, extraArgs };
+      return { port: 4725, process: { pid: 4242 } };
+    },
+    driverStart: async (capabilities, port) => {
+      calls.push("session");
+      deps._session = { capabilities, port };
+      return {
+        deleteSession: async () => {
+          calls.push("deleteSession");
+        },
+      };
+    },
+    killTree: async (pid) => {
+      calls.push(`killTree:${pid}`);
+    },
+    ...overrides,
+  };
+  return { calls, deps };
+}
+
+function run(deps, { envReady = true } = {}) {
+  return prefetchMobileChromedriver({
+    config: {},
+    desc: {},
+    deviceRegistry: new Map(),
+    getAndroidEnv: async () =>
+      envReady ? { sdkRoot: "/sdk", deviceDeps: {} } : null,
+    deps,
+  });
+}
+
+describe("warm phase: chromedriver prefetch via throwaway session", function () {
+  it("runs preflight → acquire → server → session and tears both down", async function () {
+    const { calls, deps } = harness();
+    const result = await run(deps);
+    assert.equal(result.outcome, "warmed");
+    assert.match(result.note, /pixel/);
+    assert.deepEqual(calls, [
+      "preflight",
+      "acquire",
+      "server",
+      "session",
+      "deleteSession",
+      "killTree:4242",
+    ]);
+    // The server is homed with the driver and allows the scoped
+    // autodownload insecure feature — same shape as the real session path.
+    assert.equal(deps._serverArgs.env.APPIUM_HOME, "/appium-home");
+    assert.equal(deps._serverArgs.env.ANDROID_HOME, "/sdk");
+    assert.deepEqual(deps._serverArgs.extraArgs, [
+      "--allow-insecure",
+      "uiautomator2:chromedriver_autodownload",
+    ]);
+    // The session carries the autodownload capabilities on the device.
+    assert.equal(deps._session.capabilities["appium:udid"], "emulator-5554");
+    assert.equal(
+      deps._session.capabilities["appium:chromedriverAutodownload"],
+      true
+    );
+    assert.equal(deps._session.port, 4725);
+  });
+
+  it("skips in milliseconds when the android toolchain isn't ready", async function () {
+    const { calls, deps } = harness();
+    const result = await run(deps, { envReady: false });
+    assert.equal(result.outcome, "skipped");
+    assert.deepEqual(calls, []);
+  });
+
+  it("skips with the preflight's reason when the driver can't be homed", async function () {
+    const { calls, deps } = harness({
+      appSurfacePreflight: async () => {
+        calls.push("preflight");
+        return { ok: false, reason: "driver install failed" };
+      },
+    });
+    const result = await run(deps);
+    assert.equal(result.outcome, "skipped");
+    assert.match(result.note, /driver install failed/);
+    assert.deepEqual(calls, ["preflight"]);
+  });
+
+  it("skips when the device plan can't resolve, without starting a server", async function () {
+    const { calls, deps } = harness({
+      acquireDevice: async () => {
+        calls.push("acquire");
+        return { skip: "no AVD resolvable" };
+      },
+    });
+    const result = await run(deps);
+    assert.equal(result.outcome, "skipped");
+    assert.match(result.note, /no AVD resolvable/);
+    assert.ok(!calls.includes("server"));
+  });
+
+  it("still kills the server when the throwaway session fails", async function () {
+    const { calls, deps } = harness({
+      driverStart: async () => {
+        calls.push("session");
+        throw new Error("Chrome not present on image");
+      },
+    });
+    await assert.rejects(() => run(deps), /Chrome not present/);
+    assert.ok(calls.includes("killTree:4242"), `calls: ${calls}`);
+    assert.ok(!calls.includes("deleteSession"));
+  });
+});

--- a/test/warm-phase-prefetch.test.js
+++ b/test/warm-phase-prefetch.test.js
@@ -115,6 +115,41 @@ describe("warm phase: chromedriver prefetch via throwaway session", function () 
     assert.ok(!calls.includes("server"));
   });
 
+  it("holds the emulator lease around the acquire and releases it either way", async function () {
+    const { calls, deps } = harness();
+    let released = 0;
+    deps.acquireEmulatorLease = async () => {
+      calls.push("lease");
+      return () => {
+        released++;
+        calls.push("release");
+      };
+    };
+    const result = await run(deps);
+    assert.equal(result.outcome, "warmed");
+    assert.equal(released, 1);
+    // The lease brackets exactly the acquire (the boot window), not the
+    // throwaway session.
+    assert.deepEqual(calls.slice(calls.indexOf("lease"), calls.indexOf("release") + 1), [
+      "lease",
+      "acquire",
+      "release",
+    ]);
+  });
+
+  it("releases the emulator lease when the device plan skips", async function () {
+    let released = 0;
+    const { deps } = harness({
+      acquireDevice: async () => ({ skip: "no AVD resolvable" }),
+    });
+    deps.acquireEmulatorLease = async () => () => {
+      released++;
+    };
+    const result = await run(deps);
+    assert.equal(result.outcome, "skipped");
+    assert.equal(released, 1);
+  });
+
   it("still kills the server when the throwaway session fails", async function () {
     const { calls, deps } = harness({
       driverStart: async () => {


### PR DESCRIPTION
Implements the inline warm phase from [docs/design/warm-phase.md](https://github.com/doc-detective/doc-detective/blob/main/docs/design/warm-phase.md) (phases **B1 + B2**; B3, the standalone `doc-detective warm` CLI, stays deferred): an always-on, best-effort provisioning pass in `runSpecs` between test resolution and execution. It derives every task the run's contexts would JIT-provision anyway — browser installs, native app-driver installs, simulator/emulator boots, the managed-WDA availability check (enabled by ADR 01059 landing first), the android mobile-web chromedriver prefetch, and the folded-in driver session probe — and overlaps them under the run's resource registry, so boot ∥ npm install ∥ browser download overlap each other even for a fully serial run.

## Design contracts

- **Always-on, no flag.** The plan derives strictly from resolved needs: a shell-only run plans nothing (`warm: { durationMs: 0, tasks: [] }` by construction); a pure desktop-web run plans exactly what today's `limit > 1` pre-pass performed.
- **Best-effort, never gates — planning included.** Every task resolves `warmed | skipped | failed`; failures warn and the run proceeds with today's per-context retry/skip semantics. A planner throw degrades to a warning + the empty warm block.
- **Mirror contract.** `warmBrowserInstall` (the install + first-attempt re-detect half of `warmUpContexts`, extracted and shared) leaves `installAttempts` / `availableApps` exactly as the first same-browser consuming context would have serially. The session probe keeps its historical `limit > 1 && pool` gate.
- **Ownership at provision time.** Boots acquire into the existing run registries (`bootedByUs: true` + in-flight `ready`); the run-end sweeps now await an in-flight `ready` so a warm-booted, never-consumed device is reclaimed, never orphaned. Boot tasks resolve at boot *initiation*; only the chromedriver prefetch awaits readiness (it needs a live session), and it holds only its device tag — its cache-mutating preflight runs under a manual `runtime-install` lease so the boot await never blocks installs.
- **Warm plans only what the run's own gates would provision:** the per-context `requires` gate and the mobile host-capability probes are honored before any install/boot.
- **`report.warm = { durationMs, tasks[] }`** (B2) — the first structured provisioning-timing surface, added schema-first to `report_v3` as an optional `readOnly` block.

## Companions (repo policy)

- **ADR:** [adrs/01060-inline-warm-phase.md](../blob/HEAD/adrs/01060-inline-warm-phase.md) (number re-picked at merge per the collision rule) — records the decisions, the prefetch trade-off, and the accepted serial-run divergences surfaced in review.
- **Fixtures:** no new fixture files — warm never changes a fixture's PASS/SKIPPED (the existing matrix is the regression net, and every leg now exercises the phase end-to-end since it's always-on). The precise assertions the gate can't express live in focused `it(...)`s in `test/core-core.test.js` (`report.warm` shape on the browser smoke; the exact empty block on a shell-only run) per the CLAUDE.md rule.
- **Docs impact: yes** — `Read the warm-phase timings` section on the CI reporters page, a cross-link from the CI caching guidance, and the design doc's status flip to B1+B2 shipped. (Persona Priya, P-series CUJs.)

## Testing

- Hermetic unit suites (all injected effects): planner derivation/dedup/gating (`test/warm-phase-plan.test.js`), executor isolation/tag exclusivity/pool ceiling (`test/warm-phase-executor.test.js`), boot-initiation + unhandled-rejection guard + ownership sweep incl. in-flight-boot teardown (`test/warm-phase-device-boot.test.js`), the mirror contract (`test/warm-phase-memo.test.js`), the prefetch chain + teardown-in-finally (`test/warm-phase-prefetch.test.js`).
- Schema: positive/negative `report_v3` warm cases in `src/common/test/validate.test.js`; src/common 100% coverage ratchet passes.
- Full local suites green (3470 root + 942 common passing, Windows). Manual end-to-end proof:

```json
"warm": {
  "durationMs": 1640,
  "tasks": [
    { "name": "browser-install:chrome", "kind": "browser-install", "outcome": "skipped", "durationMs": 0, "note": "'chrome' is already available" },
    { "name": "session-probe", "kind": "session-probe", "outcome": "warmed", "durationMs": 1640, "note": "1 combination ok" }
  ]
}
```

- A multi-agent code review ran over the branch; all confirmed findings were applied in the final commit (orphaned in-flight boot at teardown, never-gates coverage for planning, `requires`/capability gating, prefetch mutex hold, device-identity dedup, plus cleanups). Accepted-and-documented: two serial-run edges now match concurrent-run behavior, and the `android-emulator` bound doesn't span a warm boot's background window (ADR consequences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an always-on inline warm phase that provisions drivers, browsers, and devices ahead of test execution.
  * Warm tasks execute concurrently with resource-aware limits and best-effort behavior.
  * JSON reports now include a structured `warm` section with per-task outcomes, notes, and timing.
* **Bug Fixes**
  * Improved end-of-run cleanup by waiting for in-flight emulator/simulator readiness and avoiding teardown when startup is incomplete.
* **Documentation**
  * Expanded CI docs with warm-phase behavior and a new guide to reading warm-phase timings in artifacts.
* **Tests**
  * Added coverage for warm-phase planning, execution, schema validation, and device-boot/warm ownership semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->