### PR TITLE
feat(cli): standalone doc-detective warm with device ownership handoff

### DIFF
--- a/adrs/01061-standalone-warm-command-ownership-handoff.md
+++ b/adrs/01061-standalone-warm-command-ownership-handoff.md
@@ -1,0 +1,113 @@
+---
+status: accepted
+date: 2026-07-14
+decision-makers: [hawkeyexl]
+---
+
+# Standalone `doc-detective warm` with a manifest-based device ownership handoff
+
+## Context and Problem Statement
+
+ADR 01060's inline warm phase moves provisioning to the front of a run, but the cost still lives
+*inside* the run: a CI job pays device boots after its build finished, serial with everything the
+runner could have done earlier. The biggest remaining win is overlapping provisioning with work
+Doc Detective doesn't own (the project's build, dependency install), which requires a warm that
+runs as its own process and exits — leaving booted devices up for a later run to use. That raises
+the actual design problem: **who owns a device that outlives the process that booted it**, when N
+runs may start concurrently, adopters can crash, and stale devices must never be trusted?
+[docs/design/warm-phase.md](../docs/design/warm-phase.md) phase B3 sketched the answer this ADR
+locks in.
+
+## Decision Drivers
+
+- Overlap provisioning with CI build steps — the wall-clock win the inline phase can't reach.
+- Exactly one of N concurrent runners may adopt a handoff; the rest must behave as if it never
+  existed.
+- Every crash window (warm dies, adopter dies post-claim pre-sweep) must leave a durable,
+  discoverable record — or nothing — never silently orphaned devices.
+- Staleness is a first-class state: an old handoff or a dead recorded process is swept, not
+  adopted.
+- No new lifecycle machinery in the runner: adoption must reuse the launch-ownership ledger
+  (`bootedByUs`) and the existing run-end sweeps.
+
+## Considered Options
+
+1. **Ownership-handoff manifest in the cache root, claimed by atomic same-directory rename** —
+   `warm-manifest.json` → `warm-manifest.claimed-<runId>.json`; the adopter seeds its registries
+   (`bootedByUs: true`), sweeps at run end, then deletes the claim record.
+2. **A device-pool daemon** — a long-lived broker owning devices across runs.
+3. **No handoff** — `warm` tears its devices down at exit and only pre-pays installs/downloads.
+
+## Decision Outcome
+
+Chosen option: **option 1**, because it is exactly as durable as it needs to be with zero new
+runtime surface (a file, two renames, and the sweeps that already exist). A daemon (option 2) is
+the explicitly-rejected long-lived version of this — recorded as a non-goal in the design doc —
+and option 3 forfeits the boots, which dominate the cost the command exists to move.
+
+Specifics settled here:
+
+- **`doc-detective warm` shares the run's whole front half.** Same config discovery, same
+  resolve, same JIT preflight, same inline warm planner/executor — then it awaits its owned boots,
+  writes the manifest, and exits leaving only the device registries alive (Appium servers, Xvfb,
+  and background processes still tear down). A warm with no booted devices writes **no** manifest.
+- **The claim is an atomic same-directory rename.** Exactly one concurrent runner wins the rename;
+  the claimed file is then stamped with the adopter's `runId`/`pid`, so the claimed state is
+  durable and discoverable across an adopter crash — a rename-to-nowhere would leave devices up
+  with no record. The adopter deletes the claim **only after** its run-end sweep, so the record
+  always outlives the resources it describes.
+- **Adoption reuses launch-ownership.** Adopted devices seed the run registries as
+  `bootedByUs: true` (android entries carry `{ pid }` for the tree-kill; simulators shut down by
+  udid); the existing sweeps reclaim them whether or not any test used them, and warm boot tasks /
+  consuming contexts registry-hit them instantly.
+- **Staleness is swept, never adopted.** A manifest older than the TTL (60 minutes) or a device
+  whose recorded pid is dead is torn down at claim time. Every run also scans for claimed files
+  whose adopter pid is dead and sweeps what they recorded. `doc-detective warm --down` is the
+  operator's indiscriminate teardown: every manifest, every claim, every recorded device.
+- **API-dispatched configurations don't warm.** Their tests execute remotely; `warm` warns and
+  exits instead of provisioning a host nothing will use.
+
+### Consequences
+
+- Good: CI can boot devices while the project builds; the test run adopts ready devices and its
+  warm phase reports `device ready` in milliseconds.
+- Good: every crash window converges to "swept by the next run or `--down`"; hosted-runner VM
+  disposal remains the backstop.
+- Bad: a crashed `warm` (no manifest yet) can leave devices up with no record until `--down` or
+  VM disposal — accepted; writing the manifest earlier would hand off unready devices.
+- Bad: the TTL is a heuristic; a warm followed by a >60-minute build hands off nothing (the run
+  boots its own devices, exactly as today).
+- Neutral: the fixtures.yml iOS pre-boot step can now be replaced by `doc-detective warm` — a CI
+  change tracked separately from this ADR.
+
+### Confirmation
+
+Hermetic unit suites: manifest write/claim/race/corrupt/TTL/dead-pid/release/orphan/leftover
+partitioning (`test/warm-manifest.test.js`), registry seeding + sweep interplay and handoff
+round-trip (`test/warm-handoff.test.js`). End-to-end (`test/warm-cli.test.js`): the CLI warms a
+shell-only input (full resolve → warm → handoff path, exits 0, hands nothing off),
+`warm --down` reports a clean cache and sweeps + deletes a synthetic manifest, and
+`runTests({warmOnly: true})` returns the warm report with zero executed steps. Device-bearing
+handoffs ride the mobile CI legs, where any orphaned emulator would fail the next run's boot on a
+busy port.
+
+## Pros and Cons of the Options
+
+### Option 1 — manifest + atomic claim
+
+- Good: durable across every crash window; zero new runtime surface; ownership model unchanged.
+- Good: N-runner safe by construction (one rename wins).
+- Bad: file-based, so it only coordinates runs sharing a cache dir — which is the actual scope
+  (self-hosted runners and dev machines; the design doc records this).
+
+### Option 2 — device-pool daemon
+
+- Good: could share devices across many runs and hosts.
+- Bad: a service to install, supervise, and secure; rejected as out of scope in the design doc's
+  non-goals ("anything longer-lived is out of scope").
+
+### Option 3 — warm without handoff
+
+- Good: trivially safe.
+- Bad: keeps the dominant cost (boots) inside the test run; the fixtures.yml pre-boot hack would
+  live forever.

--- a/adrs/01061-standalone-warm-command-ownership-handoff.md
+++ b/adrs/01061-standalone-warm-command-ownership-handoff.md
@@ -71,10 +71,20 @@ Specifics settled here:
 
 - Good: CI can boot devices while the project builds; the test run adopts ready devices and its
   warm phase reports `device ready` in milliseconds.
-- Good: every crash window converges to "swept by the next run or `--down`"; hosted-runner VM
-  disposal remains the backstop.
-- Bad: a crashed `warm` (no manifest yet) can leave devices up with no record until `--down` or
-  VM disposal — accepted; writing the manifest earlier would hand off unready devices.
+- Good: every RECORDED crash window converges to "swept by the next run or `--down`";
+  hosted-runner VM disposal remains the backstop.
+- Bad: a `warm` that crashes before writing the manifest leaves devices up with **no record** —
+  `--down` can only sweep recorded devices, so this window falls to platform process cleanup / VM
+  disposal. Accepted; writing the manifest earlier would hand off unready devices.
+- Bad: two warms racing on one cache merge their manifests at write time (deduped by udid, newer
+  entry wins), so neither orphans the other's records — but the read-merge-write itself is not
+  atomic, leaving a small residual overwrite window. Accepted: concurrent warms against one cache
+  dir are an operator error the merge merely softens; a cross-process lock (src/runtime/lock.ts)
+  can harden this later if real usage hits it.
+- Bad: pid liveness can misread a recycled pid as the recorded emulator within the TTL (adopting
+  a dead device, or worse, sweeping the recycling process). Bounded by the 60-minute TTL and the
+  ESRCH-only death rule; verifying by udid against `adb devices` at claim time is the future
+  hardening if this bites in practice.
 - Bad: the TTL is a heuristic; a warm followed by a >60-minute build hands off nothing (the run
   boots its own devices, exactly as today).
 - Neutral: the fixtures.yml iOS pre-boot step can now be replaced by `doc-detective warm` — a CI

--- a/docs/design/warm-phase.md
+++ b/docs/design/warm-phase.md
@@ -1,12 +1,14 @@
 # Design: inline warm phase (resolve → warm → run → sweep)
 
-Status: **B1 + B2 shipped** ([ADR 01060](../../adrs/01060-inline-warm-phase.md)) — the always-on
+Status: **B1 + B2 + B3 shipped** ([ADR 01060](../../adrs/01060-inline-warm-phase.md),
+[ADR 01061](../../adrs/01061-standalone-warm-command-ownership-handoff.md)) — the always-on
 inline phase (planner + executor, `src/core/warmPhase.ts`) and the `report.warm` timing block are
 live, including `wda-check` (enabled by the ADR 01059 managed WDA prebuild landing first) and
 `chromedriver-prefetch` (implemented as a chained throwaway session — the one task that awaits
 device readiness, scoped to runs with android mobile-web contexts). The standalone
-`doc-detective warm` CLI (**B3**, CI overlap with build steps + ownership handoff) remains
-**deferred**; until it lands, the fixtures.yml iOS pre-boot step stays. This document is the
+`doc-detective warm` CLI (**B3**) is live with the manifest ownership handoff
+(`src/core/warmManifest.ts`); retiring the fixtures.yml iOS pre-boot step in favor of it is
+tracked as a follow-up CI change. This document is the
 implementation plan for an always-on provisioning phase that runs between test resolution and test
 execution: it concurrently resolves, repairs, and warms everything the run will need — driver
 installs, browser installs, device boots, WDA availability, chromedriver prefetch — and only then
@@ -146,7 +148,7 @@ Schema note: `report_v3` gains an optional `warm` block — schema-first in
 `src/common/src/schemas/src_schemas/`, positive+negative validation tests, `npm run build:common`,
 per the CLAUDE.md schema workflow.
 
-## Phase B3 (deferred) — standalone `doc-detective warm` + ownership handoff
+## Phase B3 (shipped — ADR 01061) — standalone `doc-detective warm` + ownership handoff
 
 Sketch only; own ADR when picked up. `doc-detective warm --input <specs>` runs resolve + B1's
 planner/executor and **exits with devices left up**, writing an ownership handoff manifest

--- a/docs/design/warm-phase.md
+++ b/docs/design/warm-phase.md
@@ -150,7 +150,8 @@ per the CLAUDE.md schema workflow.
 
 ## Phase B3 (shipped — ADR 01061) — standalone `doc-detective warm` + ownership handoff
 
-Sketch only; own ADR when picked up. `doc-detective warm --input <specs>` runs resolve + B1's
+Shipped as sketched — [ADR 01061](../../adrs/01061-standalone-warm-command-ownership-handoff.md)
+records the locked decisions. `doc-detective warm --input <specs>` runs resolve + B1's
 planner/executor and **exits with devices left up**, writing an ownership handoff manifest
 (`<cacheDir>/warm-manifest.json`: UDIDs, AVD names, PIDs, timestamp). The next `runTests`
 atomically claims it — rename to `warm-manifest.claimed-<runId>.json` **in the same directory**,

--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -303,6 +303,9 @@ navigation:
               - page: install
                 path: pages/reference/cli/install.mdx
                 slug: install
+              - page: warm
+                path: pages/reference/cli/warm.mdx
+                slug: warm
       - folder: pages/reference/schemas
         title: Schemas
 

--- a/docs/fern/pages/docs/ci/docker-and-headless.mdx
+++ b/docs/fern/pages/docs/ci/docker-and-headless.mdx
@@ -48,6 +48,8 @@ On a fresh `npm install`, Doc Detective also pre-warms these assets automaticall
 
 Whatever the cache is missing, each run front-loads for itself: before executing tests, Doc Detective plans the installs, device boots, and downloads its tests need and runs them concurrently as a warm phase. With a persisted cache the phase completes in milliseconds. On a cold cache it overlaps the downloads instead of paying them one test at a time. The per-task timings land in the JSON results—see [Read the warm-phase timings](/docs/ci/reporters-and-artifacts#read-the-warm-phase-timings).
 
+To move that cost out of the test run entirely—for example, to boot a mobile emulator while your project builds—run the standalone [`doc-detective warm`](/reference/cli/warm) command earlier in the job. It provisions the same set and exits with devices left up, handed off to the run that follows.
+
 <Note>
 `docdetective/docdetective:linux` is a multi-arch image (`linux/amd64` and `linux/arm64`), but Chrome and ChromeDriver have no native `linux/arm64` build upstream—Google's Chrome for Testing only publishes x64 binaries. On the `linux/arm64` variant, Chrome/ChromeDriver pre-warming is skipped rather than failing the image; if you need Chrome-driven tests on arm64 hosts, run the `linux/amd64` variant under emulation, or use Firefox instead.
 </Note>

--- a/docs/fern/pages/reference/cli/warm.mdx
+++ b/docs/fern/pages/reference/cli/warm.mdx
@@ -1,5 +1,6 @@
 ---
 title: warm
+description: Provision runtime assets ahead of a run and hand booted devices off to the test run that follows.
 ---
 
 The `warm` command provisions everything a set of tests needs—browser and driver installs, simulator and emulator boots, and related downloads—then exits with the booted devices **left up**, handed off to the next run. Run it early in a CI job (for example, while your project builds) so the test run that follows starts on ready devices instead of paying the boots itself.
@@ -13,21 +14,21 @@ doc-detective warm [--input <path>] [options]
 doc-detective warm --down
 ```
 
-`warm` accepts the same `--input`, `--config`, and logging options as a normal run: it resolves the same tests a run would and provisions exactly what they need. A test set that needs no devices (for example, shell or API tests) provisions its browsers and drivers and hands nothing off.
+`warm` accepts the same `--input`, `--config`, and logging options as a normal run: it resolves the same tests a run would and provisions exactly what they need. A test set that needs no devices (such as shell or API tests) provisions its browsers and drivers and hands nothing off.
 
 ## The handoff
 
-Booted devices are recorded in a manifest at `<cacheDir>/warm-manifest.json`. The next Doc Detective run claims the manifest atomically—when several runs start at once, exactly one adopts the devices—and takes over their ownership: the devices serve its tests and its normal end-of-run cleanup shuts them down.
+`warm` records the booted devices in a manifest at `<cacheDir>/warm-manifest.json`. The next Doc Detective run claims the manifest atomically—when several runs start at once, exactly one adopts the devices—and takes over their ownership: the devices serve its tests and its normal end-of-run cleanup shuts them down.
 
-The handoff is guarded, never trusted blindly:
+The run guards the handoff rather than trusting it blindly:
 
-- A manifest older than an hour, or a device whose recorded process has exited, is cleaned up rather than adopted.
+- A manifest older than an hour, or a device whose recorded process has exited, gets cleaned up rather than adopted.
 - If the adopting run dies before its cleanup, the next run (or `warm --down`) detects the dead claim and sweeps the devices.
-- A crashed `warm` leaves no manifest, so there is nothing stale to adopt—but the devices it booted may still be up; `warm --down` clears them.
+- A `warm` that crashes before writing the manifest leaves no record of its devices—`warm --down` can only tear down recorded devices, so clear that window with your platform's process cleanup (on hosted CI runners, VM disposal covers it).
 
 ## `warm --down`
 
-Tears down every device recorded in warm handoff manifests—including claims left behind by dead runs—and deletes the manifests. Use it on self-hosted runners and dev machines when you want nothing left running; on hosted CI runners, VM disposal is the backstop.
+Tears down every device recorded in warm handoff manifests—including claims left behind by dead runs—and deletes the manifests. If any device refuses to shut down, the manifests stay in place so a rerun can retry. Use it on self-hosted runners and dev machines when you want nothing left running.
 
 ```bash
 doc-detective warm --down
@@ -35,12 +36,15 @@ doc-detective warm --down
 
 ## Example: overlap provisioning with a CI build
 
+Keep the background `warm` and the `wait` in the same step—CI steps run in separate shells, so a `wait` in a later step can't see the earlier step's background process:
+
 ```yaml
 steps:
-  - run: doc-detective warm --input docs/ &   # boots devices while the build runs
-  - run: npm run build
-  - run: wait                                  # warm finished during the build
-  - run: doc-detective --input docs/          # adopts the warmed devices
+  - run: |
+      doc-detective warm --input docs/ &   # boots devices while the build runs
+      npm run build
+      wait                                  # warm finished during the build
+  - run: doc-detective --input docs/       # adopts the warmed devices
 ```
 
 The run's JSON results record what it adopted and what its own warm phase still had to do—see [Read the warm-phase timings](/docs/ci/reporters-and-artifacts#read-the-warm-phase-timings).

--- a/docs/fern/pages/reference/cli/warm.mdx
+++ b/docs/fern/pages/reference/cli/warm.mdx
@@ -1,0 +1,46 @@
+---
+title: warm
+---
+
+The `warm` command provisions everything a set of tests needs—browser and driver installs, simulator and emulator boots, and related downloads—then exits with the booted devices **left up**, handed off to the next run. Run it early in a CI job (for example, while your project builds) so the test run that follows starts on ready devices instead of paying the boots itself.
+
+Every run already performs this provisioning inline as its [warm phase](/docs/ci/reporters-and-artifacts#read-the-warm-phase-timings). The standalone command exists to move that cost even earlier: out of the test run entirely.
+
+## Synopsis
+
+```bash
+doc-detective warm [--input <path>] [options]
+doc-detective warm --down
+```
+
+`warm` accepts the same `--input`, `--config`, and logging options as a normal run: it resolves the same tests a run would and provisions exactly what they need. A test set that needs no devices (for example, shell or API tests) provisions its browsers and drivers and hands nothing off.
+
+## The handoff
+
+Booted devices are recorded in a manifest at `<cacheDir>/warm-manifest.json`. The next Doc Detective run claims the manifest atomically—when several runs start at once, exactly one adopts the devices—and takes over their ownership: the devices serve its tests and its normal end-of-run cleanup shuts them down.
+
+The handoff is guarded, never trusted blindly:
+
+- A manifest older than an hour, or a device whose recorded process has exited, is cleaned up rather than adopted.
+- If the adopting run dies before its cleanup, the next run (or `warm --down`) detects the dead claim and sweeps the devices.
+- A crashed `warm` leaves no manifest, so there is nothing stale to adopt—but the devices it booted may still be up; `warm --down` clears them.
+
+## `warm --down`
+
+Tears down every device recorded in warm handoff manifests—including claims left behind by dead runs—and deletes the manifests. Use it on self-hosted runners and dev machines when you want nothing left running; on hosted CI runners, VM disposal is the backstop.
+
+```bash
+doc-detective warm --down
+```
+
+## Example: overlap provisioning with a CI build
+
+```yaml
+steps:
+  - run: doc-detective warm --input docs/ &   # boots devices while the build runs
+  - run: npm run build
+  - run: wait                                  # warm finished during the build
+  - run: doc-detective --input docs/          # adopts the warmed devices
+```
+
+The run's JSON results record what it adopted and what its own warm phase still had to do—see [Read the warm-phase timings](/docs/ci/reporters-and-artifacts#read-the-warm-phase-timings).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import {
   getResolvedTestsFromEnv,
   reportResults,
   isDebugRequested,
+  discoverConfigPath,
 } from "./utils.js";
 import { installAgentsCommand } from "./agents/command.js";
 import { maybeShowHint } from "./hints/index.js";
@@ -75,24 +76,10 @@ async function main(argv: string[]) {
 
 // Legacy "run tests" flow — unchanged behavior when no subcommand is given.
 async function runTestsHandler(args: any) {
-  // Get .doc-detective JSON or YAML config, if it exists, preferring a config arg if provided
-  const configPathJSON = path.resolve(process.cwd(), ".doc-detective.json");
-  const configPathYAML = path.resolve(process.cwd(), ".doc-detective.yaml");
-  const configPathYML = path.resolve(process.cwd(), ".doc-detective.yml");
-  // Treat any non-empty `--config` as authoritative (resolved to an
-  // absolute path). A mistyped path then fails deterministically via
-  // setConfig rather than silently falling back to auto-discovery.
-  const hasExplicitConfig =
-    typeof args.config === "string" && args.config.trim().length > 0;
-  const configPath = hasExplicitConfig
-    ? path.resolve(args.config.trim())
-    : fs.existsSync(configPathJSON)
-    ? configPathJSON
-    : fs.existsSync(configPathYAML)
-    ? configPathYAML
-    : fs.existsSync(configPathYML)
-    ? configPathYML
-    : null;
+  // Get .doc-detective JSON or YAML config, if it exists, preferring a
+  // config arg if provided (see discoverConfigPath in utils.ts — shared with
+  // the debug and warm commands).
+  const configPath = discoverConfigPath(args);
 
   // Detect env-var debug intent before setConfig so we can still emit
   // the diagnostic dump when validation fails. `isDebugRequested`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { installCommand } from "./runtime/installCommand.js";
 import { lspCommand } from "./lsp/command.js";
 import { printDebug, defaultDebugDir } from "./debug/index.js";
 import { debugCommand } from "./debug/command.js";
+import { warmCommand } from "./warm/command.js";
 import { argv as processArgv } from "node:process";
 import path from "node:path";
 import fs from "node:fs";
@@ -60,6 +61,7 @@ async function main(argv: string[]) {
     .command(installCommand as any)
     .command(lspCommand as any)
     .command(debugCommand)
+    .command(warmCommand as any)
     .strict()
     .demandCommand(0)
     // Suppress yargs' default help-dump on failure; surface the concrete error

--- a/src/common/src/schemas/src_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/report_v3.schema.json
@@ -145,6 +145,28 @@
           "$ref": "spec_v3.schema.json#/examples/2"
         }
       ]
+    },
+    {
+      "specs": [],
+      "warm": {
+        "durationMs": 96500,
+        "tasks": [
+          {
+            "name": "driver-install:appium-uiautomator2-driver",
+            "kind": "driver-install",
+            "outcome": "warmed",
+            "durationMs": 12040
+          },
+          {
+            "name": "device-boot:android:default:<any>:<latest>",
+            "kind": "device-boot",
+            "outcome": "warmed",
+            "durationMs": 850,
+            "note": "boot initiated"
+          }
+        ]
+      },
+      "warmManifest": "/home/runner/.dd-cache/warm-manifest.json"
     }
   ]
 }

--- a/src/common/src/schemas/src_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/report_v3.schema.json
@@ -32,6 +32,11 @@
         ]
       }
     },
+    "warmManifest": {
+      "type": "string",
+      "description": "Absolute path of the device ownership-handoff manifest a `doc-detective warm` run wrote (`<cacheDir>/warm-manifest.json`). Present only on warm-only runs that left devices up for the next run to adopt. System-populated.",
+      "readOnly": true
+    },
     "warm": {
       "type": "object",
       "description": "Results of the run's inline warm phase — the always-on, best-effort provisioning pass (dependency installs, device boots, session probes) performed between test resolution and test execution. A failed task never gates the run; the per-context paths retry or skip with their normal semantics. Absent when the run ended before the phase (for example, when no specs matched). System-populated.",

--- a/src/common/src/schemas/src_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/report_v3.schema.json
@@ -21,9 +21,8 @@
       "readOnly": true
     },
     "specs": {
-      "description": "Test specifications that were performed.",
+      "description": "Test specifications that were performed. Empty when the run executed no specs — a fully filtered run, or a warm-only run (`doc-detective warm`), which provisions and exits without running tests.",
       "type": "array",
-      "minItems": 1,
       "items": {
         "anyOf": [
           {

--- a/src/common/src/types/generated/report_v3.ts
+++ b/src/common/src/types/generated/report_v3.ts
@@ -50,6 +50,10 @@ export interface Report {
    */
   specs: [Specification, ...Specification[]];
   /**
+   * Absolute path of the device ownership-handoff manifest a `doc-detective warm` run wrote (`<cacheDir>/warm-manifest.json`). Present only on warm-only runs that left devices up for the next run to adopt. System-populated.
+   */
+  warmManifest?: string;
+  /**
    * Results of the run's inline warm phase — the always-on, best-effort provisioning pass (dependency installs, device boots, session probes) performed between test resolution and test execution. A failed task never gates the run; the per-context paths retry or skip with their normal semantics. Absent when the run ended before the phase (for example, when no specs matched). System-populated.
    */
   warm?: {

--- a/src/common/src/types/generated/report_v3.ts
+++ b/src/common/src/types/generated/report_v3.ts
@@ -12,13 +12,9 @@ export type DeviceByName = string;
 /**
  * OpenAPI description and configuration.
  */
-export type OpenApi =
-  | {
-      [k: string]: unknown;
-    }
-  | {
-      [k: string]: unknown;
-    };
+export type OpenApi = {
+  [k: string]: unknown;
+};
 /**
  * A Doc Detective test.
  */
@@ -44,11 +40,9 @@ export interface Report {
    */
   runDir?: string;
   /**
-   * Test specifications that were performed.
-   *
-   * @minItems 1
+   * Test specifications that were performed. Empty when the run executed no specs — a fully filtered run, or a warm-only run (`doc-detective warm`), which provisions and exits without running tests.
    */
-  specs: [Specification, ...Specification[]];
+  specs: Specification[];
   /**
    * Absolute path of the device ownership-handoff manifest a `doc-detective warm` run wrote (`<cacheDir>/warm-manifest.json`). Present only on warm-only runs that left devices up for the next run to adopt. System-populated.
    */

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -1413,6 +1413,21 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.object.warm.tasks[0].kind).to.equal("browser-install");
       });
 
+      it("should validate a report_v3 object with a warmManifest path", function () {
+        const result = validate({
+          schemaKey: "report_v3",
+          object: {
+            specs: minimalSpecs,
+            warm: { durationMs: 1, tasks: [] },
+            warmManifest: "C:\\cache\\warm-manifest.json",
+          },
+        });
+        expect(result.valid, result.errors).to.be.true;
+        expect(result.object.warmManifest).to.equal(
+          "C:\\cache\\warm-manifest.json"
+        );
+      });
+
       it("should validate a report_v3 object without a warm block (back-compat)", function () {
         const result = validate({
           schemaKey: "report_v3",

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -1413,6 +1413,17 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.object.warm.tasks[0].kind).to.equal("browser-install");
       });
 
+      it("should validate a warm-only report shape (no specs executed)", function () {
+        const result = validate({
+          schemaKey: "report_v3",
+          object: {
+            specs: [],
+            warm: { durationMs: 0, tasks: [] },
+          },
+        });
+        expect(result.valid, result.errors).to.be.true;
+      });
+
       it("should validate a report_v3 object with a warmManifest path", function () {
         const result = validate({
           schemaKey: "report_v3",

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -1439,6 +1439,22 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         );
       });
 
+      it("should reject a warmManifest that is not a path string", function () {
+        // An object can't coerce to string under coerceTypes, so this pins
+        // the field's type (scalars would coerce and are not a useful
+        // negative).
+        const result = validate({
+          schemaKey: "report_v3",
+          object: {
+            specs: minimalSpecs,
+            warmManifest: { path: "C:\\cache\\warm-manifest.json" },
+          },
+        });
+        expect(result.valid).to.be.false;
+        expect(result.errors).to.be.a("string");
+        expect(result.errors).to.include("warmManifest");
+      });
+
       it("should validate a report_v3 object without a warm block (back-compat)", function () {
         const result = validate({
           schemaKey: "report_v3",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -284,14 +284,30 @@ async function runTests(config: any, options: any = {}) {
 
   // If config.integrations.docDetectiveApi.apiKey is set, run tests via API instead of locally
   if (willRunViaApi) {
+    // Warming provisions the LOCAL host; an API-dispatched run executes
+    // remotely, so there is nothing here to warm for it.
+    if (options.warmOnly) {
+      log(
+        config,
+        "warning",
+        "Nothing to warm: this configuration dispatches runs via the Doc Detective Orchestration API, which executes tests remotely."
+      );
+      return null;
+    }
     // Run test specs via API
     results = await runViaApi({
       resolvedTests,
       apiKey: config.integrations.docDetectiveApi.apiKey,
     });
   } else {
-    // Run test specs locally
-    results = await runSpecs({ resolvedTests });
+    // Run test specs locally. warmOnly (the `doc-detective warm` command,
+    // design phase B3) shares the exact resolve + JIT-preflight path above,
+    // then provisions and exits with devices handed off instead of running
+    // tests.
+    results = await runSpecs({
+      resolvedTests,
+      warmOnly: options.warmOnly === true,
+    });
   }
   // The full results tree is a debug-only dump — the reporters (terminal
   // summary, json/runFolder files) already render results for the user, and at
@@ -305,8 +321,8 @@ async function runTests(config: any, options: any = {}) {
   cleanTemp();
 
   // Send telemetry
-  sendTelemetry(config, "runTests", results);
-  log(config, "info", supportMessage);
+  sendTelemetry(config, options.warmOnly ? "warm" : "runTests", results);
+  if (!options.warmOnly) log(config, "info", supportMessage);
 
   return results;
 }

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -2053,19 +2053,17 @@ async function runSpecs({
        manifest/collection pieces carry hermetic unit suites. */
     if (warmOnly) {
       // Boots resolve at initiation; the handoff must record READY devices
-      // (a consuming run adopts them without awaiting anything).
-      for (const entry of [
-        ...deviceRegistry.values(),
-        ...simulatorRegistry.values(),
-      ]) {
-        if (entry.bootedByUs && entry.ready) {
-          try {
-            await entry.ready;
-          } catch {
-            // A failed boot deleted its placeholder; nothing to hand off.
-          }
-        }
-      }
+      // (a consuming run adopts them without awaiting anything). In-flight
+      // boots are independent — await them together.
+      await Promise.all(
+        [...deviceRegistry.values(), ...simulatorRegistry.values()]
+          .filter((entry: any) => entry.bootedByUs && entry.ready)
+          .map((entry: any) =>
+            entry.ready.catch(() => {
+              // A failed boot deleted its placeholder; nothing to hand off.
+            })
+          )
+      );
       const devices = collectHandoffDevices({
         deviceRegistry,
         simulatorRegistry,
@@ -3486,12 +3484,13 @@ async function sweepHandoffDevices(
   devices: WarmDeviceHandoff[],
   { config }: { config: any }
 ): Promise<void> {
+  let simDeps: ReturnType<typeof buildAcquireSimulatorDeps> | undefined;
   for (const device of devices ?? []) {
     try {
       if (device.platform === "android" && typeof device.pid === "number") {
         await killTree(device.pid);
       } else if (device.platform === "ios" && device.udid) {
-        const simDeps = buildAcquireSimulatorDeps((m: string) =>
+        simDeps ??= buildAcquireSimulatorDeps((m: string) =>
           log(config, "debug", m)
         );
         await simDeps.shutdown({

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -108,6 +108,7 @@ import {
   claimWarmManifest,
   releaseWarmClaim,
   listOrphanedClaims,
+  collectWarmLeftovers,
   type WarmDeviceHandoff,
 } from "./warmManifest.js";
 import { getCacheDir } from "../runtime/cacheDir.js";
@@ -207,6 +208,7 @@ export {
   appiumIsReady,
   seedRegistriesFromHandoff,
   collectHandoffDevices,
+  warmDown,
 };
 // exports.driverStart = driverStart;
 
@@ -3513,6 +3515,43 @@ async function sweepHandoffDevices(
   }
 }
 /* c8 ignore stop */
+
+/**
+ * `doc-detective warm --down` — the operator's "leave nothing running"
+ * switch: tear down every device recorded in the unclaimed manifest AND
+ * every claimed file (a live adopter's run-end sweep tolerates the loss:
+ * its kills/shutdowns are already best-effort), then delete the files.
+ */
+async function warmDown({
+  config,
+}: {
+  config: any;
+}): Promise<{ files: number; devices: number }> {
+  const cacheRoot = getCacheDir({ cacheDir: config?.cacheDir });
+  const { files, devices } = collectWarmLeftovers({ cacheDir: cacheRoot });
+  if (!files.length) {
+    log(
+      config,
+      "info",
+      "No warm handoff manifests found; nothing to tear down."
+    );
+    return { files: 0, devices: 0 };
+  }
+  await sweepHandoffDevices(devices, { config });
+  for (const file of files) {
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // best-effort
+    }
+  }
+  log(
+    config,
+    "info",
+    `Warm teardown complete: ${devices.length} device(s) swept, ${files.length} manifest file(s) removed.`
+  );
+  return { files: files.length, devices: devices.length };
+}
 
 /**
  * Pure predicate: does this spec carry TEST-level routing? True iff ANY of its

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -3483,8 +3483,9 @@ function collectHandoffDevices({
 async function sweepHandoffDevices(
   devices: WarmDeviceHandoff[],
   { config }: { config: any }
-): Promise<void> {
+): Promise<{ failed: WarmDeviceHandoff[] }> {
   let simDeps: ReturnType<typeof buildAcquireSimulatorDeps> | undefined;
+  const failed: WarmDeviceHandoff[] = [];
   for (const device of devices ?? []) {
     try {
       if (device.platform === "android" && typeof device.pid === "number") {
@@ -3505,6 +3506,7 @@ async function sweepHandoffDevices(
         `Swept stale warm device '${device.name}' (${device.udid}).`
       );
     } catch (error: any) {
+      failed.push(device);
       log(
         config,
         "warning",
@@ -3512,6 +3514,7 @@ async function sweepHandoffDevices(
       );
     }
   }
+  return { failed };
 }
 /* c8 ignore stop */
 
@@ -3539,7 +3542,18 @@ async function warmDown({
     );
     return { files: 0, devices: 0 };
   }
-  await sweepHandoffDevices(devices, { config });
+  const { failed } = await sweepHandoffDevices(devices, { config });
+  if (failed.length) {
+    // Ownership records must outlive the resources they describe: a device
+    // whose teardown failed stays recorded, so a rerun (or the next run's
+    // orphan sweep) can retry instead of forgetting it exists.
+    log(
+      config,
+      "warning",
+      `Warm teardown incomplete: ${failed.length} of ${devices.length} device(s) couldn't be swept — keeping the manifest file(s); rerun \`doc-detective warm --down\` to retry.`
+    );
+    return { files: 0, devices: devices.length - failed.length };
+  }
   for (const file of files) {
     try {
       fs.unlinkSync(file);

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -3521,6 +3521,9 @@ async function sweepHandoffDevices(
  * every claimed file (a live adopter's run-end sweep tolerates the loss:
  * its kills/shutdowns are already best-effort), then delete the files.
  */
+/* c8 ignore start — thin effect wrapper (real fs + device kills); the
+   selection logic lives in warmManifest.ts's hermetic suite, and the CLI
+   path is exercised end-to-end (out of process) by test/warm-cli.test.js. */
 async function warmDown({
   config,
 }: {
@@ -3551,6 +3554,7 @@ async function warmDown({
   );
   return { files: files.length, devices: devices.length };
 }
+/* c8 ignore stop */
 
 /**
  * Pure predicate: does this spec carry TEST-level routing? True iff ANY of its

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -103,6 +103,13 @@ import {
   type WarmOutcome,
 } from "./warmPhase.js";
 import { locateManagedWda } from "../runtime/wdaProducts.js";
+import {
+  writeWarmManifest,
+  claimWarmManifest,
+  releaseWarmClaim,
+  listOrphanedClaims,
+  type WarmDeviceHandoff,
+} from "./warmManifest.js";
 import { getCacheDir } from "../runtime/cacheDir.js";
 import { detectAndroidSdk } from "../runtime/androidSdk.js";
 import {
@@ -198,6 +205,8 @@ export {
   warmBrowserInstall,
   prefetchMobileChromedriver,
   appiumIsReady,
+  seedRegistriesFromHandoff,
+  collectHandoffDevices,
 };
 // exports.driverStart = driverStart;
 
@@ -1360,7 +1369,16 @@ async function runViaApi({ resolvedTests, apiKey, config = {} }: { resolvedTests
  *    specs: [ { specId, description, contentPath, result, tests: [ { testId, description, contentPath, result, contexts: [ { platform, browser, result, steps: [...] } ] } ] } ]
  *  }
  */
-async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
+async function runSpecs({
+  resolvedTests,
+  warmOnly = false,
+}: {
+  resolvedTests: any;
+  // `doc-detective warm` (design phase B3): resolve + warm, then exit with
+  // devices left up and an ownership-handoff manifest instead of running
+  // tests.
+  warmOnly?: boolean;
+}) {
   const config: any = resolvedTests.config;
   // Narrow the spec set to what specFilter / testFilter allow before running.
   // Filtered-out specs / tests do not appear in the report (true filter, not
@@ -1901,11 +1919,74 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   process.on("SIGINT", onSignal);
   process.on("SIGTERM", onSignal);
 
+  // Warm ownership handoff (design phase B3). Both directions share the
+  // cache-rooted manifest: a normal run CLAIMS a prior `doc-detective warm`'s
+  // devices (adopting them as bootedByUs so the run-end sweep reclaims
+  // them), and a warm-only run WRITES the manifest and exits with its
+  // devices left up. `keepDevicesUp` gates the finally's device sweeps for
+  // the warm-only path only.
+  const warmCacheRoot = getCacheDir({ cacheDir: config?.cacheDir });
+  let warmClaimActive = false;
+  let keepDevicesUp = false;
+
   // Everything that uses the Appium servers runs inside this try so the
   // shutdown in `finally` always reaches them — otherwise a throw in
   // warmUpContexts (e.g. getAvailableApps failing during the re-detect) would
   // leak the started servers, leaving orphaned processes bound to their ports.
   try {
+    // Adopt (or clean up after) prior warm runs — best-effort, never gates.
+    /* c8 ignore start — effectful manifest/device sweeps; the claim/adopt/
+       staleness logic is hermetically unit-tested in warm-manifest.test.js
+       and warm-handoff.test.js. */
+    try {
+      for (const orphan of listOrphanedClaims({ cacheDir: warmCacheRoot })) {
+        log(
+          config,
+          "warning",
+          `Sweeping ${orphan.devices.length} device(s) left by a dead warm adopter (${orphan.path}).`
+        );
+        await sweepHandoffDevices(orphan.devices, { config });
+        try {
+          fs.unlinkSync(orphan.path);
+        } catch {
+          // best-effort
+        }
+      }
+      const claim = claimWarmManifest({ cacheDir: warmCacheRoot, runId });
+      if (claim) {
+        warmClaimActive = true;
+        if (claim.sweep.length) {
+          log(
+            config,
+            "warning",
+            `Sweeping ${claim.sweep.length} stale warm device(s) instead of adopting them.`
+          );
+          await sweepHandoffDevices(claim.sweep, { config });
+        }
+        if (claim.adopt.length) {
+          seedRegistriesFromHandoff({
+            devices: claim.adopt,
+            deviceRegistry,
+            simulatorRegistry,
+          });
+          log(
+            config,
+            "info",
+            `Adopted ${claim.adopt.length} pre-warmed device(s): ${claim.adopt
+              .map((d) => `${d.name} (${d.platform})`)
+              .join(", ")}.`
+          );
+        }
+      }
+    } catch (error: any) {
+      log(
+        config,
+        "warning",
+        `Warm handoff adoption skipped: ${error?.message ?? error}`
+      );
+    }
+    /* c8 ignore stop */
+
     // Inline warm phase (docs/design/warm-phase.md): always-on, best-effort
     // provisioning between resolution and execution. The planner derives
     // every task the run's contexts would JIT-provision anyway (browser and
@@ -1960,6 +2041,64 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
         `Warm phase skipped (planning failed; the run proceeds with on-demand provisioning): ${error?.message ?? error}`
       );
     }
+
+    // `doc-detective warm` stops here: hand the owned devices off through
+    // the manifest and exit with them left up (the finally below still
+    // sweeps Appium servers, Xvfb, and background processes — only the
+    // device registries survive).
+    /* c8 ignore start — device-bearing path is CI/dev-box territory; the
+       shell-only path is exercised end-to-end by the warm CLI test, and the
+       manifest/collection pieces carry hermetic unit suites. */
+    if (warmOnly) {
+      // Boots resolve at initiation; the handoff must record READY devices
+      // (a consuming run adopts them without awaiting anything).
+      for (const entry of [
+        ...deviceRegistry.values(),
+        ...simulatorRegistry.values(),
+      ]) {
+        if (entry.bootedByUs && entry.ready) {
+          try {
+            await entry.ready;
+          } catch {
+            // A failed boot deleted its placeholder; nothing to hand off.
+          }
+        }
+      }
+      const devices = collectHandoffDevices({
+        deviceRegistry,
+        simulatorRegistry,
+      });
+      const manifestFile = writeWarmManifest({
+        cacheDir: warmCacheRoot,
+        devices,
+      });
+      if (manifestFile) {
+        keepDevicesUp = true;
+        report.warmManifest = manifestFile;
+        log(
+          config,
+          "info",
+          `Warm complete: ${devices.length} device(s) left up and handed off via ${manifestFile}. The next run adopts them; \`doc-detective warm --down\` tears them down manually.`
+        );
+      } else {
+        log(
+          config,
+          "info",
+          "Warm complete: nothing to hand off (no devices were booted)."
+        );
+      }
+      // Any manifest this warm itself claimed has been superseded by the
+      // fresh one (its adopted devices are re-listed there).
+      if (warmClaimActive) {
+        releaseWarmClaim({ cacheDir: warmCacheRoot, runId });
+        warmClaimActive = false;
+      }
+      // No tests ran: return the skeleton (zero summary) plus the warm
+      // block — not half-initialized spec reports.
+      report.specs = [];
+      return report;
+    }
+    /* c8 ignore stop */
 
     // Phase 2: run context jobs through the worker pool, gated into three
     // sequential phases. Config-level `beforeAny` specs all finish before any
@@ -2134,21 +2273,31 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     // pre-existing ones (bootedByUs=false, no process) running. tree-kill the
     // emulator process the same way Appium servers are swept above.
     /* c8 ignore start */
-    if (deviceRegistry.size > 0) {
-      await teardownDeviceRegistry(deviceRegistry, async (entry) => {
-        log(config, "debug", `Shutting down emulator "${entry.name}" (${entry.udid}).`);
-        await killTree(entry.process?.pid);
-      });
-    }
-    // Sweep the iOS simulator registry (native app phase A4): shut down only the
-    // simulators Doc Detective booted (bootedByUs), leaving pre-existing booted
-    // ones running. `simctl shutdown` via the injected effect bundle.
-    if (simulatorRegistry.size > 0) {
-      const simDeps = buildAcquireSimulatorDeps();
-      await teardownSimulatorRegistry(simulatorRegistry, async (entry) => {
-        log(config, "debug", `Shutting down simulator "${entry.name}" (${entry.udid}).`);
-        await simDeps.shutdown(entry);
-      });
+    // A warm-only run's whole purpose is to leave its devices up for the
+    // next run to adopt (via the manifest written above) — everything else
+    // in this finally still tears down.
+    if (!keepDevicesUp) {
+      if (deviceRegistry.size > 0) {
+        await teardownDeviceRegistry(deviceRegistry, async (entry) => {
+          log(config, "debug", `Shutting down emulator "${entry.name}" (${entry.udid}).`);
+          await killTree(entry.process?.pid);
+        });
+      }
+      // Sweep the iOS simulator registry (native app phase A4): shut down only the
+      // simulators Doc Detective booted (bootedByUs), leaving pre-existing booted
+      // ones running. `simctl shutdown` via the injected effect bundle.
+      if (simulatorRegistry.size > 0) {
+        const simDeps = buildAcquireSimulatorDeps();
+        await teardownSimulatorRegistry(simulatorRegistry, async (entry) => {
+          log(config, "debug", `Shutting down simulator "${entry.name}" (${entry.udid}).`);
+          await simDeps.shutdown(entry);
+        });
+      }
+      // The claim record must outlive the resources it describes: delete it
+      // only after the sweeps above reclaimed the adopted devices.
+      if (warmClaimActive) {
+        releaseWarmClaim({ cacheDir: warmCacheRoot, runId });
+      }
     }
     /* c8 ignore stop */
     process.off("SIGINT", onSignal);
@@ -3244,6 +3393,126 @@ async function prefetchMobileChromedriver({
     }
   }
 }
+
+/**
+ * Merge an adopted warm handoff into the run registries. Entries land with
+ * `bootedByUs: true` — the ownership transferred WITH the devices — so the
+ * existing run-end sweeps reclaim them with no new lifecycle code, and warm
+ * device-boot tasks / consuming contexts registry-hit them instantly.
+ * Malformed entries are dropped: seeding a nameless or udid-less entry would
+ * wedge later acquires of that key. Pure (Map writes only); exported for
+ * unit tests.
+ */
+function seedRegistriesFromHandoff({
+  devices,
+  deviceRegistry,
+  simulatorRegistry,
+}: {
+  devices: WarmDeviceHandoff[];
+  deviceRegistry: DeviceRegistry;
+  simulatorRegistry: SimulatorRegistry;
+}): void {
+  for (const device of devices ?? []) {
+    if (!device?.name || !device?.udid) continue;
+    if (device.platform === "android") {
+      deviceRegistry.set(device.name, {
+        name: device.name,
+        udid: device.udid,
+        bootedByUs: true,
+        // A plain { pid } is all the sweep's killTree needs — the spawning
+        // process belonged to the warm run and is gone.
+        ...(typeof device.pid === "number"
+          ? { process: { pid: device.pid } }
+          : {}),
+        sdkRoot: device.sdkRoot ?? "",
+        ...(device.headless !== undefined ? { headless: device.headless } : {}),
+      } as any);
+    } else if (device.platform === "ios") {
+      simulatorRegistry.set(device.name, {
+        name: device.name,
+        udid: device.udid,
+        bootedByUs: true,
+      });
+    }
+  }
+}
+
+/**
+ * The inverse: collect this run's owned, booted devices into handoff shape
+ * for the warm manifest. Only `bootedByUs` entries transfer (a reused
+ * pre-existing device was never ours to hand off), and only entries with a
+ * resolved udid (a mid-create placeholder has nothing adoptable — warm-only
+ * awaits `ready` before collecting, so this is the failed-boot leftover
+ * guard). Exported for unit tests.
+ */
+function collectHandoffDevices({
+  deviceRegistry,
+  simulatorRegistry,
+}: {
+  deviceRegistry: DeviceRegistry;
+  simulatorRegistry: SimulatorRegistry;
+}): WarmDeviceHandoff[] {
+  const devices: WarmDeviceHandoff[] = [];
+  for (const entry of deviceRegistry.values()) {
+    if (!entry.bootedByUs || !entry.udid) continue;
+    devices.push({
+      platform: "android",
+      name: entry.name,
+      udid: entry.udid,
+      ...(typeof entry.process?.pid === "number"
+        ? { pid: entry.process.pid }
+        : {}),
+      ...(entry.sdkRoot ? { sdkRoot: entry.sdkRoot } : {}),
+      ...(entry.headless !== undefined ? { headless: entry.headless } : {}),
+    });
+  }
+  for (const entry of simulatorRegistry.values()) {
+    if (!entry.bootedByUs || !entry.udid) continue;
+    devices.push({ platform: "ios", name: entry.name, udid: entry.udid });
+  }
+  return devices;
+}
+
+/**
+ * Best-effort teardown of handoff devices that must not be adopted (stale
+ * manifests, dead adopters, `warm --down`): kill android emulators by
+ * recorded pid tree, shut down iOS simulators by udid.
+ */
+/* c8 ignore start — real killTree/simctl effects; the selection logic lives
+   in warmManifest.ts and is hermetically unit-tested there. */
+async function sweepHandoffDevices(
+  devices: WarmDeviceHandoff[],
+  { config }: { config: any }
+): Promise<void> {
+  for (const device of devices ?? []) {
+    try {
+      if (device.platform === "android" && typeof device.pid === "number") {
+        await killTree(device.pid);
+      } else if (device.platform === "ios" && device.udid) {
+        const simDeps = buildAcquireSimulatorDeps((m: string) =>
+          log(config, "debug", m)
+        );
+        await simDeps.shutdown({
+          name: device.name,
+          udid: device.udid,
+          bootedByUs: true,
+        });
+      }
+      log(
+        config,
+        "debug",
+        `Swept stale warm device '${device.name}' (${device.udid}).`
+      );
+    } catch (error: any) {
+      log(
+        config,
+        "warning",
+        `Couldn't sweep stale warm device '${device.name}' (${device.udid}): ${error?.message ?? error}`
+      );
+    }
+  }
+}
+/* c8 ignore stop */
 
 /**
  * Pure predicate: does this spec carry TEST-level routing? True iff ANY of its

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -3499,6 +3499,15 @@ async function sweepHandoffDevices(
           udid: device.udid,
           bootedByUs: true,
         });
+      } else {
+        // Nothing actionable recorded (e.g. an android entry without a
+        // pid) — say so rather than logging a sweep that never happened.
+        log(
+          config,
+          "debug",
+          `No sweep action for warm device '${device.name}' (${device.udid}): no recorded process.`
+        );
+        continue;
       }
       log(
         config,

--- a/src/core/warmManifest.ts
+++ b/src/core/warmManifest.ts
@@ -113,10 +113,43 @@ function parseManifest(text: string | Buffer): WarmManifestFile | null {
     ) {
       return null;
     }
-    return parsed as WarmManifestFile;
+    // Sanitize device entries rather than trusting the cast: a malformed
+    // entry (foreign writer, partial edit) must never seed a registry or
+    // reach a sweep's kill path. Dropped entries are simply not ours to
+    // manage. createdAt stays lenient here — an unparseable timestamp is
+    // handled at the expiry sites (treated as expired → swept), which keeps
+    // the DEVICES recoverable instead of orphaning them with the file.
+    const devices: WarmDeviceHandoff[] = [];
+    for (const entry of parsed.devices) {
+      if (!entry || typeof entry !== "object") continue;
+      if (entry.platform !== "android" && entry.platform !== "ios") continue;
+      if (typeof entry.name !== "string" || !entry.name) continue;
+      if (typeof entry.udid !== "string" || !entry.udid) continue;
+      devices.push({
+        platform: entry.platform,
+        name: entry.name,
+        udid: entry.udid,
+        ...(typeof entry.pid === "number" ? { pid: entry.pid } : {}),
+        ...(typeof entry.sdkRoot === "string"
+          ? { sdkRoot: entry.sdkRoot }
+          : {}),
+        ...(typeof entry.headless === "boolean"
+          ? { headless: entry.headless }
+          : {}),
+      });
+    }
+    return { ...(parsed as WarmManifestFile), devices };
   } catch {
     return null;
   }
+}
+
+// NaN-safe staleness: Date.parse on a corrupt timestamp is NaN, and every
+// NaN comparison is false — without this guard a mangled createdAt would
+// read as "fresh forever" and its devices would be adopted indefinitely.
+function isExpired(createdAt: string, nowMs: number, ttlMs: number): boolean {
+  const created = Date.parse(createdAt);
+  return !Number.isFinite(created) || nowMs - created > ttlMs;
 }
 
 // Atomic temp+rename publish (the installed.json pattern) so a concurrent
@@ -275,7 +308,7 @@ export function claimWarmManifest({
     // The rename already succeeded; a failed stamp only degrades the
     // orphan scan (the file falls back to the TTL heuristic).
   }
-  const expired = now() - Date.parse(manifest.createdAt) > ttlMs;
+  const expired = isExpired(manifest.createdAt, now(), ttlMs);
   const adopt: WarmDeviceHandoff[] = [];
   const sweep: WarmDeviceHandoff[] = [];
   for (const device of manifest.devices) {
@@ -308,26 +341,30 @@ export function releaseWarmClaim({
   }
 }
 
+// Enumerate every claimed file, parseable or not: path discovery and manifest
+// parsing are separate concerns, because `--down` must be able to DELETE a
+// mangled claim file even though nothing in it is safe to sweep.
 function listClaimedFiles(
   cacheDir: string,
   fs: WarmManifestFs
-): Array<{ path: string; manifest: WarmManifestFile }> {
+): Array<{ path: string; manifest: WarmManifestFile | null }> {
   let names: string[];
   try {
     names = fs.readdirSync(cacheDir);
   } catch {
     return [];
   }
-  const out: Array<{ path: string; manifest: WarmManifestFile }> = [];
+  const out: Array<{ path: string; manifest: WarmManifestFile | null }> = [];
   for (const name of names) {
     if (!name.startsWith(CLAIMED_PREFIX) || !name.endsWith(".json")) continue;
     const filePath = path.join(cacheDir, name);
+    let manifest: WarmManifestFile | null = null;
     try {
-      const manifest = parseManifest(fs.readFileSync(filePath));
-      if (manifest) out.push({ path: filePath, manifest });
+      manifest = parseManifest(fs.readFileSync(filePath));
     } catch {
-      // Unreadable claim files are left for --down.
+      // Unreadable — still enumerated so --down can remove it.
     }
+    out.push({ path: filePath, manifest });
   }
   return out;
 }
@@ -349,9 +386,12 @@ export function listOrphanedClaims({
   const { fs, now, isPidAlive } = resolveDeps(deps);
   const orphans: Array<{ path: string; devices: WarmDeviceHandoff[] }> = [];
   for (const { path: filePath, manifest } of listClaimedFiles(cacheDir, fs)) {
+    // Unparseable claims carry nothing safe to sweep; they surface (and get
+    // deleted) through --down's collectWarmLeftovers instead.
+    if (!manifest) continue;
     const ownerDead = manifest.claimedBy
       ? !isPidAlive(manifest.claimedBy.pid)
-      : now() - Date.parse(manifest.createdAt) > ttlMs;
+      : isExpired(manifest.createdAt, now(), ttlMs);
     if (ownerDead) orphans.push({ path: filePath, devices: manifest.devices });
   }
   return orphans;
@@ -387,7 +427,9 @@ export function collectWarmLeftovers({
   }
   for (const { path: filePath, manifest } of listClaimedFiles(cacheDir, fs)) {
     files.push(filePath);
-    for (const device of manifest.devices) byUdid.set(device.udid, device);
+    for (const device of manifest?.devices ?? []) {
+      byUdid.set(device.udid, device);
+    }
   }
   return { files, devices: [...byUdid.values()] };
 }

--- a/src/core/warmManifest.ts
+++ b/src/core/warmManifest.ts
@@ -1,0 +1,334 @@
+// The warm ownership-handoff manifest (docs/design/warm-phase.md, phase B3).
+//
+// `doc-detective warm` provisions ahead of a run and EXITS with devices left
+// up; ownership is handed to the next run through a manifest in the cache
+// root:
+//
+//   <cacheDir>/warm-manifest.json                    unclaimed handoff
+//   <cacheDir>/warm-manifest.claimed-<runId>.json    claimed by one run
+//
+// The claim is an atomic rename IN THE SAME DIRECTORY, so exactly one of N
+// concurrent runners adopts, and the claimed state stays durable and
+// discoverable — a rename-to-nowhere would leave a crash window (adopter
+// dies post-claim, pre-adoption) with devices up and no record. The adopter
+// merges the devices into its run registries as `bootedByUs: true` (the
+// existing run-end sweep then reclaims them) and deletes the claimed file
+// only after that sweep. Staleness is a guard, not an error: a manifest
+// older than the TTL, or a device whose recorded pid is dead, is swept —
+// never adopted. Effects (fs, clock, pid liveness) are injected so every
+// branch is hermetically unit-testable.
+
+import fsDefault from "node:fs";
+import path from "node:path";
+
+export const WARM_MANIFEST_NAME = "warm-manifest.json";
+const CLAIMED_PREFIX = "warm-manifest.claimed-";
+
+// A warm handoff is only useful to a run that starts soon after the warm —
+// past this, emulator/simulator state (and the assumption that nothing else
+// claimed the host's resources) is too stale to trust; sweep instead.
+export const DEFAULT_WARM_MANIFEST_TTL_MS = 60 * 60 * 1000;
+
+export type WarmDeviceHandoff = {
+  platform: "android" | "ios";
+  name: string;
+  udid: string;
+  // Android emulators are killed by process tree; simulators shut down by
+  // udid and carry no pid.
+  pid?: number;
+  sdkRoot?: string;
+  headless?: boolean;
+};
+
+type WarmManifestFile = {
+  version: 1;
+  createdAt: string;
+  devices: WarmDeviceHandoff[];
+  claimedBy?: { runId: string; pid: number; claimedAt: string };
+};
+
+// The minimal fs surface the manifest ops use — node:fs in production,
+// injected in unit tests.
+export interface WarmManifestFs {
+  existsSync(p: string): boolean;
+  readFileSync(p: string): string | Buffer;
+  writeFileSync(p: string, data: string): void;
+  renameSync(from: string, to: string): void;
+  unlinkSync(p: string): void;
+  readdirSync(p: string): string[];
+}
+
+export type WarmManifestDeps = {
+  fs?: WarmManifestFs;
+  now?: () => number;
+  isPidAlive?: (pid: number) => boolean;
+  // The claiming process's own pid, recorded so a later scan can tell a live
+  // adopter from a crashed one.
+  pid?: number;
+};
+
+function resolveDeps(deps: WarmManifestDeps = {}) {
+  return {
+    fs: deps.fs ?? (fsDefault as unknown as WarmManifestFs),
+    now: deps.now ?? Date.now,
+    isPidAlive: deps.isPidAlive ?? defaultIsPidAlive,
+    pid: deps.pid ?? process.pid,
+  };
+}
+
+/* c8 ignore start — real signal probe; unit tests inject isPidAlive. */
+function defaultIsPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: any) {
+    // EPERM means the process exists but isn't ours — alive.
+    return error?.code === "EPERM";
+  }
+}
+/* c8 ignore stop */
+
+function manifestPath(cacheDir: string): string {
+  return path.join(cacheDir, WARM_MANIFEST_NAME);
+}
+
+function claimedPath(cacheDir: string, runId: string): string {
+  return path.join(cacheDir, `${CLAIMED_PREFIX}${runId}.json`);
+}
+
+function parseManifest(text: string | Buffer): WarmManifestFile | null {
+  try {
+    const parsed = JSON.parse(String(text));
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      parsed.version !== 1 ||
+      typeof parsed.createdAt !== "string" ||
+      !Array.isArray(parsed.devices)
+    ) {
+      return null;
+    }
+    return parsed as WarmManifestFile;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Atomically publish the handoff manifest (write-to-tmp + rename, the
+ * installed.json pattern) so a concurrent claimer never observes a
+ * half-written file. Returns the manifest path, or null when there are no
+ * devices to hand off (an empty manifest would only make the next run pay a
+ * claim/release round-trip for nothing).
+ */
+export function writeWarmManifest({
+  cacheDir,
+  devices,
+  deps,
+}: {
+  cacheDir: string;
+  devices: WarmDeviceHandoff[];
+  deps?: WarmManifestDeps;
+}): string | null {
+  const { fs, now, pid } = resolveDeps(deps);
+  if (!devices.length) return null;
+  const target = manifestPath(cacheDir);
+  const record: WarmManifestFile = {
+    version: 1,
+    createdAt: new Date(now()).toISOString(),
+    devices,
+  };
+  const tmp = path.join(cacheDir, `${WARM_MANIFEST_NAME}.${pid}.${now()}.tmp`);
+  fs.writeFileSync(tmp, JSON.stringify(record, null, 2));
+  try {
+    fs.renameSync(tmp, target);
+  } catch {
+    // Windows can refuse an overwrite-rename; remove-then-rename, same
+    // degradation as writeInstalledRecord.
+    try {
+      fs.unlinkSync(target);
+    } catch {
+      // best-effort
+    }
+    fs.renameSync(tmp, target);
+  }
+  return target;
+}
+
+/**
+ * Atomically claim the handoff for `runId`: rename the manifest to the
+ * claimed name (exactly one concurrent runner wins the rename), stamp the
+ * claimer's identity into the claimed file, and partition the devices into
+ * `adopt` (fresh, live) and `sweep` (past the TTL, or a dead recorded pid —
+ * cleaned, never adopted). Null when there is no manifest, it is corrupt
+ * (deleted), or another runner won the race.
+ */
+export function claimWarmManifest({
+  cacheDir,
+  runId,
+  ttlMs = DEFAULT_WARM_MANIFEST_TTL_MS,
+  deps,
+}: {
+  cacheDir: string;
+  runId: string;
+  ttlMs?: number;
+  deps?: WarmManifestDeps;
+}): {
+  adopt: WarmDeviceHandoff[];
+  sweep: WarmDeviceHandoff[];
+  claimedPath: string;
+} | null {
+  const { fs, now, isPidAlive, pid } = resolveDeps(deps);
+  const source = manifestPath(cacheDir);
+  if (!fs.existsSync(source)) return null;
+  let manifest: WarmManifestFile | null;
+  try {
+    manifest = parseManifest(fs.readFileSync(source));
+  } catch {
+    return null;
+  }
+  if (!manifest) {
+    // Corrupt: a half-written or foreign file. Remove it so it stops
+    // shadowing future handoffs; there is nothing safe to adopt.
+    try {
+      fs.unlinkSync(source);
+    } catch {
+      // best-effort
+    }
+    return null;
+  }
+  const target = claimedPath(cacheDir, runId);
+  try {
+    fs.renameSync(source, target);
+  } catch {
+    // Another runner claimed between our read and rename.
+    return null;
+  }
+  // Durable claim record: a later scan can tell whether the adopter is
+  // still alive (releaseWarmClaim deletes this after the run-end sweep).
+  const claimed: WarmManifestFile = {
+    ...manifest,
+    claimedBy: { runId, pid, claimedAt: new Date(now()).toISOString() },
+  };
+  try {
+    fs.writeFileSync(target, JSON.stringify(claimed, null, 2));
+  } catch {
+    // The rename already succeeded; a failed stamp only degrades the
+    // orphan scan (the file falls back to the TTL heuristic).
+  }
+  const expired = now() - Date.parse(manifest.createdAt) > ttlMs;
+  const adopt: WarmDeviceHandoff[] = [];
+  const sweep: WarmDeviceHandoff[] = [];
+  for (const device of manifest.devices) {
+    const dead =
+      expired || (typeof device.pid === "number" && !isPidAlive(device.pid));
+    (dead ? sweep : adopt).push(device);
+  }
+  return { adopt, sweep, claimedPath: target };
+}
+
+/**
+ * Delete the claimed file — called only after the adopter's run-end sweep
+ * has reclaimed the devices, so the record outlives the resources it
+ * describes, never the other way around. Idempotent and best-effort.
+ */
+export function releaseWarmClaim({
+  cacheDir,
+  runId,
+  deps,
+}: {
+  cacheDir: string;
+  runId: string;
+  deps?: WarmManifestDeps;
+}): void {
+  const { fs } = resolveDeps(deps);
+  try {
+    fs.unlinkSync(claimedPath(cacheDir, runId));
+  } catch {
+    // Already gone (or never stamped) — fine either way.
+  }
+}
+
+function listClaimedFiles(
+  cacheDir: string,
+  fs: WarmManifestFs
+): Array<{ path: string; manifest: WarmManifestFile }> {
+  let names: string[];
+  try {
+    names = fs.readdirSync(cacheDir);
+  } catch {
+    return [];
+  }
+  const out: Array<{ path: string; manifest: WarmManifestFile }> = [];
+  for (const name of names) {
+    if (!name.startsWith(CLAIMED_PREFIX) || !name.endsWith(".json")) continue;
+    const filePath = path.join(cacheDir, name);
+    try {
+      const manifest = parseManifest(fs.readFileSync(filePath));
+      if (manifest) out.push({ path: filePath, manifest });
+    } catch {
+      // Unreadable claim files are left for --down.
+    }
+  }
+  return out;
+}
+
+/**
+ * Claimed files whose owning run is dead (recorded adopter pid no longer
+ * alive, or an unstamped claim older than the TTL): their devices were
+ * adopted but never swept — the caller sweeps them and deletes the file.
+ */
+export function listOrphanedClaims({
+  cacheDir,
+  ttlMs = DEFAULT_WARM_MANIFEST_TTL_MS,
+  deps,
+}: {
+  cacheDir: string;
+  ttlMs?: number;
+  deps?: WarmManifestDeps;
+}): Array<{ path: string; devices: WarmDeviceHandoff[] }> {
+  const { fs, now, isPidAlive } = resolveDeps(deps);
+  const orphans: Array<{ path: string; devices: WarmDeviceHandoff[] }> = [];
+  for (const { path: filePath, manifest } of listClaimedFiles(cacheDir, fs)) {
+    const ownerDead = manifest.claimedBy
+      ? !isPidAlive(manifest.claimedBy.pid)
+      : now() - Date.parse(manifest.createdAt) > ttlMs;
+    if (ownerDead) orphans.push({ path: filePath, devices: manifest.devices });
+  }
+  return orphans;
+}
+
+/**
+ * Everything `doc-detective warm --down` tears down: the unclaimed manifest
+ * plus every claimed file, with their devices deduped by udid. Manual
+ * teardown is deliberately indiscriminate — it is the operator's "leave
+ * nothing running" switch.
+ */
+export function collectWarmLeftovers({
+  cacheDir,
+  deps,
+}: {
+  cacheDir: string;
+  deps?: WarmManifestDeps;
+}): { files: string[]; devices: WarmDeviceHandoff[] } {
+  const { fs } = resolveDeps(deps);
+  const files: string[] = [];
+  const byUdid = new Map<string, WarmDeviceHandoff>();
+  const source = manifestPath(cacheDir);
+  if (fs.existsSync(source)) {
+    try {
+      const manifest = parseManifest(fs.readFileSync(source));
+      files.push(source);
+      for (const device of manifest?.devices ?? []) {
+        byUdid.set(device.udid, device);
+      }
+    } catch {
+      files.push(source);
+    }
+  }
+  for (const { path: filePath, manifest } of listClaimedFiles(cacheDir, fs)) {
+    files.push(filePath);
+    for (const device of manifest.devices) byUdid.set(device.udid, device);
+  }
+  return { files, devices: [...byUdid.values()] };
+}

--- a/src/core/warmManifest.ts
+++ b/src/core/warmManifest.ts
@@ -119,12 +119,43 @@ function parseManifest(text: string | Buffer): WarmManifestFile | null {
   }
 }
 
+// Atomic temp+rename publish (the installed.json pattern) so a concurrent
+// reader never observes a half-written file.
+function publishAtomically(
+  cacheDir: string,
+  target: string,
+  content: string,
+  fs: WarmManifestFs,
+  pid: number,
+  nowMs: number
+): void {
+  const tmp = path.join(
+    cacheDir,
+    `${path.basename(target)}.${pid}.${nowMs}.tmp`
+  );
+  fs.writeFileSync(tmp, content);
+  try {
+    fs.renameSync(tmp, target);
+  } catch {
+    // Windows can refuse an overwrite-rename; remove-then-rename, same
+    // degradation as writeInstalledRecord.
+    try {
+      fs.unlinkSync(target);
+    } catch {
+      // best-effort
+    }
+    fs.renameSync(tmp, target);
+  }
+}
+
 /**
- * Atomically publish the handoff manifest (write-to-tmp + rename, the
- * installed.json pattern) so a concurrent claimer never observes a
- * half-written file. Returns the manifest path, or null when there are no
- * devices to hand off (an empty manifest would only make the next run pay a
- * claim/release round-trip for nothing).
+ * Atomically publish the handoff manifest. An existing UNCLAIMED manifest is
+ * merged, not replaced: two warms racing (neither saw the other's write at
+ * claim time) must not orphan the loser's devices by clobbering its only
+ * ownership record — the union, deduped by udid with the newer entry
+ * winning, keeps every booted device discoverable. Returns the manifest
+ * path, or null when there are no devices to hand off (an empty manifest
+ * would only make the next run pay a claim/release round-trip for nothing).
  */
 export function writeWarmManifest({
   cacheDir,
@@ -141,25 +172,31 @@ export function writeWarmManifest({
   // the cache root (getCacheDir only resolves the path).
   fs.mkdirSync(cacheDir, { recursive: true });
   const target = manifestPath(cacheDir);
+  const byUdid = new Map<string, WarmDeviceHandoff>();
+  if (fs.existsSync(target)) {
+    try {
+      const existing = parseManifest(fs.readFileSync(target));
+      for (const device of existing?.devices ?? []) {
+        byUdid.set(device.udid, device);
+      }
+    } catch {
+      // Unreadable prior manifest: nothing recoverable to merge.
+    }
+  }
+  for (const device of devices) byUdid.set(device.udid, device);
   const record: WarmManifestFile = {
     version: 1,
     createdAt: new Date(now()).toISOString(),
-    devices,
+    devices: [...byUdid.values()],
   };
-  const tmp = path.join(cacheDir, `${WARM_MANIFEST_NAME}.${pid}.${now()}.tmp`);
-  fs.writeFileSync(tmp, JSON.stringify(record, null, 2));
-  try {
-    fs.renameSync(tmp, target);
-  } catch {
-    // Windows can refuse an overwrite-rename; remove-then-rename, same
-    // degradation as writeInstalledRecord.
-    try {
-      fs.unlinkSync(target);
-    } catch {
-      // best-effort
-    }
-    fs.renameSync(tmp, target);
-  }
+  publishAtomically(
+    cacheDir,
+    target,
+    JSON.stringify(record, null, 2),
+    fs,
+    pid,
+    now()
+  );
   return target;
 }
 
@@ -189,37 +226,51 @@ export function claimWarmManifest({
   const { fs, now, isPidAlive, pid } = resolveDeps(deps);
   const source = manifestPath(cacheDir);
   if (!fs.existsSync(source)) return null;
-  let manifest: WarmManifestFile | null;
+  // Rename FIRST, read after: the rename is the atomic claim, and reading
+  // the claimed file guarantees we adopt exactly what we claimed — reading
+  // `source` before renaming would let a concurrent warm swap the file in
+  // between, leaving us stamped over one manifest while holding another's
+  // devices.
+  const target = claimedPath(cacheDir, runId);
   try {
-    manifest = parseManifest(fs.readFileSync(source));
+    fs.renameSync(source, target);
   } catch {
+    // Another runner claimed between our existence check and rename.
     return null;
   }
+  let manifest: WarmManifestFile | null;
+  try {
+    manifest = parseManifest(fs.readFileSync(target));
+  } catch {
+    manifest = null;
+  }
   if (!manifest) {
-    // Corrupt: a half-written or foreign file. Remove it so it stops
-    // shadowing future handoffs; there is nothing safe to adopt.
+    // Corrupt: a half-written or foreign file. We claimed it, so we clean
+    // it up; there is nothing safe to adopt.
     try {
-      fs.unlinkSync(source);
+      fs.unlinkSync(target);
     } catch {
       // best-effort
     }
     return null;
   }
-  const target = claimedPath(cacheDir, runId);
-  try {
-    fs.renameSync(source, target);
-  } catch {
-    // Another runner claimed between our read and rename.
-    return null;
-  }
   // Durable claim record: a later scan can tell whether the adopter is
   // still alive (releaseWarmClaim deletes this after the run-end sweep).
+  // Stamped atomically (temp + rename) — a truncate-then-fail writeFileSync
+  // would corrupt the only durable ownership record.
   const claimed: WarmManifestFile = {
     ...manifest,
     claimedBy: { runId, pid, claimedAt: new Date(now()).toISOString() },
   };
   try {
-    fs.writeFileSync(target, JSON.stringify(claimed, null, 2));
+    publishAtomically(
+      cacheDir,
+      target,
+      JSON.stringify(claimed, null, 2),
+      fs,
+      pid,
+      now()
+    );
   } catch {
     // The rename already succeeded; a failed stamp only degrades the
     // orphan scan (the file falls back to the TTL heuristic).

--- a/src/core/warmManifest.ts
+++ b/src/core/warmManifest.ts
@@ -56,6 +56,7 @@ export interface WarmManifestFs {
   renameSync(from: string, to: string): void;
   unlinkSync(p: string): void;
   readdirSync(p: string): string[];
+  mkdirSync(p: string, opts?: { recursive?: boolean }): unknown;
 }
 
 export type WarmManifestDeps = {
@@ -82,8 +83,12 @@ function defaultIsPidAlive(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch (error: any) {
-    // EPERM means the process exists but isn't ours — alive.
-    return error?.code === "EPERM";
+    // Dead ONLY on ESRCH (no such process). Any other error — EPERM
+    // (exists, different user) or something unexpected — reads as alive:
+    // this check licenses SWEEPING (killing) a recorded device, so
+    // uncertainty must never count as dead. Matches the lock lease's
+    // liveness probe (src/runtime/lock.ts).
+    return error?.code !== "ESRCH";
   }
 }
 /* c8 ignore stop */
@@ -132,6 +137,9 @@ export function writeWarmManifest({
 }): string | null {
   const { fs, now, pid } = resolveDeps(deps);
   if (!devices.length) return null;
+  // A warm on a pristine host can reach here before anything else created
+  // the cache root (getCacheDir only resolves the path).
+  fs.mkdirSync(cacheDir, { recursive: true });
   const target = manifestPath(cacheDir);
   const record: WarmManifestFile = {
     version: 1,

--- a/src/debug/command.ts
+++ b/src/debug/command.ts
@@ -29,27 +29,14 @@ export const debugCommand: CommandModule<{}, DebugArgv> = {
     }) as unknown as import("yargs").Argv<DebugArgv>,
   handler: async (args) => {
     // Lazy-load so the default `runTests` path doesn't pay the import cost.
-    const { setConfig } = await import("../utils.js");
+    const { setConfig, discoverConfigPath } = await import("../utils.js");
     const { printDebug, defaultDebugDir } = await import("./index.js");
     const outDir = defaultDebugDir();
 
-    const configPathJSON = path.resolve(process.cwd(), ".doc-detective.json");
-    const configPathYAML = path.resolve(process.cwd(), ".doc-detective.yaml");
-    const configPathYML = path.resolve(process.cwd(), ".doc-detective.yml");
-    // Treat any non-empty `--config` as authoritative (resolved to an
-    // absolute path) — a mistyped path must surface as a CONFIG INVALID
-    // dump for that path, not silently fall back to auto-discovery.
-    const hasExplicitConfig =
-      typeof args.config === "string" && args.config.trim().length > 0;
-    const configPath = hasExplicitConfig
-      ? path.resolve((args.config as string).trim())
-      : fs.existsSync(configPathJSON)
-      ? configPathJSON
-      : fs.existsSync(configPathYAML)
-      ? configPathYAML
-      : fs.existsSync(configPathYML)
-      ? configPathYML
-      : null;
+    // Shared discovery (utils.ts): an explicit --config is authoritative —
+    // a mistyped path must surface as a CONFIG INVALID dump for that path,
+    // not silently fall back to auto-discovery.
+    const configPath = discoverConfigPath(args);
 
     // `--include-env` lands on argv as both kebab and camel; tolerate either.
     const includeEnv = Boolean(args["include-env"] ?? args.includeEnv);

--- a/src/hints/hints.ts
+++ b/src/hints/hints.ts
@@ -798,5 +798,34 @@ export const HINTS: Hint[] = [
     ].join("\n"),
     when: (ctx) => ctx.failedCount > 0 && ctx.usedSelectorOnlyFinds,
   },
+
+  // ------------------------------------------------------------------
+  // useWarmCommandForDeviceBoots (optimization & advanced)
+  // ------------------------------------------------------------------
+  {
+    id: "useWarmCommandForDeviceBoots",
+    priority: 50,
+    markdown: [
+      "This run spent noticeable time provisioning devices before any test executed (see `warm` in the JSON results). Move that cost out of the run entirely — for example, boot devices while your project builds — with the standalone warm command; the run that follows adopts the ready devices:",
+      "",
+      "```bash",
+      "doc-detective warm --input docs/ &   # then run tests as usual",
+      "```",
+      "",
+      "More: [doc-detective.com/reference/cli/warm](https://doc-detective.com/reference/cli/warm)",
+    ].join("\n"),
+    // Fires when the run's own warm phase demonstrably paid for device
+    // work (a boot or on-device prefetch) and took long enough that
+    // fronting it would matter. A run that adopted a prior warm's devices
+    // has a fast warm phase, so the hint self-gates when the feature is
+    // already in use.
+    when: (ctx) =>
+      (ctx.results?.warm?.tasks ?? []).some(
+        (task: any) =>
+          (task.kind === "device-boot" ||
+            task.kind === "chromedriver-prefetch") &&
+          task.outcome === "warmed"
+      ) && (ctx.results?.warm?.durationMs ?? 0) > 20000,
+  },
 ];
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,31 @@ export {
   reporters,
   registerReporter,
   isDebugRequested,
+  discoverConfigPath,
 };
+
+/**
+ * Resolve which config file a CLI command should load: any non-empty
+ * `--config` is authoritative (resolved to an absolute path, so a mistyped
+ * path fails deterministically in setConfig rather than silently falling
+ * back), otherwise auto-discover the `.doc-detective.(json|yaml|yml)` file
+ * in the cwd. Shared by the runTests, debug, and warm command handlers so
+ * the discovery order can't drift between commands.
+ */
+function discoverConfigPath(args: { config?: unknown }): string | null {
+  const hasExplicitConfig =
+    typeof args.config === "string" && args.config.trim().length > 0;
+  if (hasExplicitConfig) return path.resolve((args.config as string).trim());
+  for (const name of [
+    ".doc-detective.json",
+    ".doc-detective.yaml",
+    ".doc-detective.yml",
+  ]) {
+    const candidate = path.resolve(process.cwd(), name);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
 
 // True when `DOC_DETECTIVE_DEBUG` env var is set to a truthy value.
 // Used by `runTestsHandler` in cli.ts to decide whether to catch

--- a/src/warm/command.ts
+++ b/src/warm/command.ts
@@ -1,6 +1,4 @@
 import type { CommandModule } from "yargs";
-import path from "node:path";
-import fs from "node:fs";
 
 export interface WarmArgv {
   config?: string;
@@ -29,25 +27,8 @@ export const warmCommand: CommandModule<{}, WarmArgv> = {
     }) as unknown as import("yargs").Argv<WarmArgv>,
   handler: async (args) => {
     // Lazy-load so the default `runTests` path doesn't pay the import cost.
-    const { setConfig, log } = await import("../utils.js");
-
-    // Same config discovery as the default command: an explicit --config is
-    // authoritative; otherwise auto-discover the .doc-detective file.
-    const configPathJSON = path.resolve(process.cwd(), ".doc-detective.json");
-    const configPathYAML = path.resolve(process.cwd(), ".doc-detective.yaml");
-    const configPathYML = path.resolve(process.cwd(), ".doc-detective.yml");
-    const hasExplicitConfig =
-      typeof args.config === "string" && args.config.trim().length > 0;
-    const configPath = hasExplicitConfig
-      ? path.resolve((args.config as string).trim())
-      : fs.existsSync(configPathJSON)
-      ? configPathJSON
-      : fs.existsSync(configPathYAML)
-      ? configPathYAML
-      : fs.existsSync(configPathYML)
-      ? configPathYML
-      : null;
-
+    const { setConfig, log, discoverConfigPath } = await import("../utils.js");
+    const configPath = discoverConfigPath(args);
     const config: any = await setConfig({ configPath, args });
 
     if (args.down) {

--- a/src/warm/command.ts
+++ b/src/warm/command.ts
@@ -1,0 +1,86 @@
+import type { CommandModule } from "yargs";
+import path from "node:path";
+import fs from "node:fs";
+
+export interface WarmArgv {
+  config?: string;
+  input?: string;
+  logLevel?: string;
+  down: boolean;
+}
+
+// `doc-detective warm` — the standalone warm phase (docs/design/warm-phase.md,
+// phase B3): resolve the given tests, provision everything they need
+// (browsers, drivers, simulator/emulator boots, the chromedriver prefetch),
+// and exit with the booted devices LEFT UP, handed off to the next run
+// through <cacheDir>/warm-manifest.json. Run it while your CI build compiles
+// so the test run that follows adopts ready devices instead of paying the
+// boots itself. `--down` is the manual teardown for anything handed off.
+export const warmCommand: CommandModule<{}, WarmArgv> = {
+  command: "warm",
+  describe:
+    "Provision what the given tests need (browsers, drivers, device boots) and exit with devices left up, handed off to the next run. Use --down to tear handed-off devices down.",
+  builder: (yargs) =>
+    yargs.option("down", {
+      type: "boolean",
+      default: false,
+      describe:
+        "Tear down every device recorded in warm handoff manifests (including claims left by dead runs) and delete the manifests.",
+    }) as unknown as import("yargs").Argv<WarmArgv>,
+  handler: async (args) => {
+    // Lazy-load so the default `runTests` path doesn't pay the import cost.
+    const { setConfig, log } = await import("../utils.js");
+
+    // Same config discovery as the default command: an explicit --config is
+    // authoritative; otherwise auto-discover the .doc-detective file.
+    const configPathJSON = path.resolve(process.cwd(), ".doc-detective.json");
+    const configPathYAML = path.resolve(process.cwd(), ".doc-detective.yaml");
+    const configPathYML = path.resolve(process.cwd(), ".doc-detective.yml");
+    const hasExplicitConfig =
+      typeof args.config === "string" && args.config.trim().length > 0;
+    const configPath = hasExplicitConfig
+      ? path.resolve((args.config as string).trim())
+      : fs.existsSync(configPathJSON)
+      ? configPathJSON
+      : fs.existsSync(configPathYAML)
+      ? configPathYAML
+      : fs.existsSync(configPathYML)
+      ? configPathYML
+      : null;
+
+    const config: any = await setConfig({ configPath, args });
+
+    if (args.down) {
+      const { warmDown } = await import("../core/tests.js");
+      await warmDown({ config });
+      return;
+    }
+
+    const { runTests } = await import("../core/index.js");
+    const results = await runTests(config, { warmOnly: true });
+    if (!results) return;
+    // Concise terminal summary — warm results aren't test results, so the
+    // reporters don't run; the structured detail is results.warm.
+    const tasks: any[] = results.warm?.tasks ?? [];
+    const counts = tasks.reduce(
+      (acc: Record<string, number>, t: any) => {
+        acc[t.outcome] = (acc[t.outcome] ?? 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+    log(
+      `Warm finished in ${results.warm?.durationMs ?? 0}ms: ${
+        tasks.length
+      } task(s) (${Object.entries(counts)
+        .map(([outcome, n]) => `${n} ${outcome}`)
+        .join(", ") || "none"}).${
+        results.warmManifest
+          ? ` Devices handed off via ${results.warmManifest}.`
+          : ""
+      }`,
+      "info",
+      config
+    );
+  },
+};

--- a/test/hints.test.js
+++ b/test/hints.test.js
@@ -1635,12 +1635,12 @@ describe("hints/index pickByPriority + priorityWeight", function () {
 
 describe("hints/hints (registry)", function () {
   it("every hint has stable id, body, predicate, and a numeric priority when set", function () {
-    // 35 active hints. `useFileTypesForRst` is commented out in the
+    // 36 active hints. `useFileTypesForRst` is commented out in the
     // registry but the `RST_EXTENSIONS` constant, the
     // `detectRstFiles` helper, and the `hasRstFiles` context field
     // are kept in place so the hint can be re-enabled without
     // re-plumbing.
-    expect(HINTS.length).to.equal(35);
+    expect(HINTS.length).to.equal(36);
     const ids = new Set();
     // Ids are camelCase, matching the convention used everywhere else
     // in the project (step names like `goTo`, config fields like
@@ -1680,6 +1680,41 @@ describe("hints/hints (registry)", function () {
     expect(
       h.when(fakeCtx({ ranIosContexts: false, hasManagedWdaProducts: false })),
       "no iOS contexts this run — no nudge"
+    ).to.equal(false);
+  });
+
+  it("useWarmCommandForDeviceBoots: fires when the warm phase paid for device work and took long", function () {
+    const h = findHint("useWarmCommandForDeviceBoots");
+    expect(h.priority).to.equal(50);
+    const warmResults = (tasks, durationMs) =>
+      fakeCtx({ results: { warm: { durationMs, tasks } } });
+    const boot = { kind: "device-boot", outcome: "warmed", durationMs: 90 };
+    const prefetch = {
+      kind: "chromedriver-prefetch",
+      outcome: "warmed",
+      durationMs: 120000,
+    };
+    expect(h.when(warmResults([boot], 125000))).to.equal(true);
+    expect(h.when(warmResults([prefetch], 125000))).to.equal(true);
+    expect(
+      h.when(warmResults([boot], 1500)),
+      "fast warm (e.g. devices adopted from a prior `doc-detective warm`) — no nudge"
+    ).to.equal(false);
+    expect(
+      h.when(
+        warmResults([{ kind: "device-boot", outcome: "skipped" }], 125000)
+      ),
+      "no device was actually warmed — no nudge"
+    ).to.equal(false);
+    expect(
+      h.when(
+        warmResults([{ kind: "browser-install", outcome: "warmed" }], 125000)
+      ),
+      "browser-only warm — a persisted cache already covers it"
+    ).to.equal(false);
+    expect(
+      h.when(fakeCtx({ results: {} })),
+      "no warm block (older results shape) — no nudge, no throw"
     ).to.equal(false);
   });
 

--- a/test/warm-cli.test.js
+++ b/test/warm-cli.test.js
@@ -1,0 +1,115 @@
+// End-to-end coverage for `doc-detective warm` (design phase B3), hermetic
+// on every OS: a shell-only spec provisions nothing, so the command runs the
+// full resolve → warm → handoff path without booting devices, and --down
+// exercises manifest cleanup against a synthetic manifest. Device-bearing
+// warms are CI/dev-box territory (the mobile fixture legs).
+import { spawnSync } from "node:child_process";
+import assert from "node:assert/strict";
+import path from "node:path";
+import fs from "node:fs";
+import { runTests } from "../dist/core/index.js";
+import { WARM_MANIFEST_NAME } from "../dist/core/warmManifest.js";
+
+const CACHE_DIR = path.resolve("./.tmp/warm-cli-cache");
+const SPEC_PATH = path.resolve("./.tmp/warm-cli-spec.json");
+
+function runCli(args, env = {}) {
+  return spawnSync(
+    process.execPath,
+    [path.resolve("bin/doc-detective.js"), ...args],
+    {
+      env: {
+        ...process.env,
+        DOC_DETECTIVE_SKIP_AUTO_UPDATE: "1",
+        DOC_DETECTIVE_CACHE_DIR: CACHE_DIR,
+        ...env,
+      },
+      encoding: "utf8",
+    }
+  );
+}
+
+describe("CLI: doc-detective warm", function () {
+  this.timeout(120000);
+
+  before(function () {
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+    fs.writeFileSync(
+      SPEC_PATH,
+      JSON.stringify({
+        tests: [{ testId: "warm-cli", steps: [{ runShell: "echo warm" }] }],
+      })
+    );
+  });
+
+  after(function () {
+    try {
+      fs.unlinkSync(SPEC_PATH);
+    } catch {}
+    fs.rmSync(CACHE_DIR, { recursive: true, force: true });
+  });
+
+  it("`--help` lists the warm command", function () {
+    const r = runCli(["--help"]);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /warm/);
+    assert.match(r.stdout, /devices left up|handed off/i);
+  });
+
+  it("warms a shell-only input, hands nothing off, and exits 0", function () {
+    const r = runCli(["warm", "--input", SPEC_PATH, "--logLevel", "info"]);
+    assert.equal(r.status, 0, r.stderr + r.stdout);
+    assert.match(r.stdout, /Warm complete: nothing to hand off/);
+    assert.match(r.stdout, /Warm finished in \d+ms/);
+    assert.equal(
+      fs.existsSync(path.join(CACHE_DIR, WARM_MANIFEST_NAME)),
+      false,
+      "a device-less warm must not write a manifest"
+    );
+  });
+
+  it("`warm --down` reports cleanly when there is nothing to tear down", function () {
+    const r = runCli(["warm", "--down", "--logLevel", "info"]);
+    assert.equal(r.status, 0, r.stderr + r.stdout);
+    assert.match(r.stdout, /nothing to tear down/i);
+  });
+
+  it("`warm --down` sweeps a leftover manifest and deletes it", function () {
+    const manifestPath = path.join(CACHE_DIR, WARM_MANIFEST_NAME);
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        version: 1,
+        createdAt: new Date().toISOString(),
+        devices: [
+          {
+            platform: "android",
+            name: "long-gone",
+            udid: "emulator-9998",
+            // A pid that can't be alive (max pid is far below this on
+            // every supported OS) — the sweep is best-effort either way.
+            pid: 2147483646,
+            sdkRoot: CACHE_DIR,
+          },
+        ],
+      })
+    );
+    const r = runCli(["warm", "--down", "--logLevel", "info"]);
+    assert.equal(r.status, 0, r.stderr + r.stdout);
+    assert.match(r.stdout, /Warm teardown complete: 1 device\(s\) swept, 1 manifest file\(s\) removed/);
+    assert.equal(fs.existsSync(manifestPath), false);
+  });
+
+  it("runTests({warmOnly: true}) returns the warm report without running tests", async function () {
+    const results = await runTests({
+      input: SPEC_PATH,
+      cacheDir: CACHE_DIR,
+      logLevel: "silent",
+    }, { warmOnly: true });
+    assert.ok(results);
+    assert.deepEqual(results.specs, []);
+    assert.equal(results.summary.steps.pass, 0, "no step may execute during warm");
+    assert.deepEqual(results.warm, { durationMs: 0, tasks: [] });
+    assert.equal(results.warmManifest, undefined);
+  });
+});

--- a/test/warm-cli.test.js
+++ b/test/warm-cli.test.js
@@ -35,6 +35,9 @@ describe("CLI: doc-detective warm", function () {
   this.timeout(120000);
 
   before(function () {
+    // A previous interrupted run can leave a manifest behind; the assertions
+    // below depend on a pristine cache.
+    fs.rmSync(CACHE_DIR, { recursive: true, force: true });
     fs.mkdirSync(CACHE_DIR, { recursive: true });
     fs.writeFileSync(
       SPEC_PATH,

--- a/test/warm-cli.test.js
+++ b/test/warm-cli.test.js
@@ -9,6 +9,8 @@ import path from "node:path";
 import fs from "node:fs";
 import { runTests } from "../dist/core/index.js";
 import { WARM_MANIFEST_NAME } from "../dist/core/warmManifest.js";
+import { warmCommand } from "../dist/warm/command.js";
+import { discoverConfigPath } from "../dist/utils.js";
 
 const CACHE_DIR = path.resolve("./.tmp/warm-cli-cache");
 const SPEC_PATH = path.resolve("./.tmp/warm-cli-spec.json");
@@ -98,6 +100,73 @@ describe("CLI: doc-detective warm", function () {
     assert.equal(r.status, 0, r.stderr + r.stdout);
     assert.match(r.stdout, /Warm teardown complete: 1 device\(s\) swept, 1 manifest file\(s\) removed/);
     assert.equal(fs.existsSync(manifestPath), false);
+  });
+
+  it("handler: `--down` in-process reports a clean cache (direct-call precedent: debug-remaining-coverage)", async function () {
+    const prev = process.env.DOC_DETECTIVE_CACHE_DIR;
+    process.env.DOC_DETECTIVE_CACHE_DIR = CACHE_DIR;
+    try {
+      // No manifests in the cache — the handler must return cleanly after
+      // warmDown's nothing-to-tear-down path.
+      await warmCommand.handler({ down: true, logLevel: "silent" });
+    } finally {
+      if (prev === undefined) delete process.env.DOC_DETECTIVE_CACHE_DIR;
+      else process.env.DOC_DETECTIVE_CACHE_DIR = prev;
+    }
+  });
+
+  it("handler: returns quietly when nothing resolves (runTests → null)", async function () {
+    const prev = process.env.DOC_DETECTIVE_CACHE_DIR;
+    process.env.DOC_DETECTIVE_CACHE_DIR = CACHE_DIR;
+    try {
+      const emptyDir = path.join(CACHE_DIR, "no-tests-here");
+      fs.mkdirSync(emptyDir, { recursive: true });
+      await warmCommand.handler({
+        down: false,
+        input: emptyDir,
+        logLevel: "silent",
+      });
+    } finally {
+      if (prev === undefined) delete process.env.DOC_DETECTIVE_CACHE_DIR;
+      else process.env.DOC_DETECTIVE_CACHE_DIR = prev;
+    }
+  });
+
+  describe("discoverConfigPath (shared command config discovery)", function () {
+    it("treats a non-empty --config as authoritative, trimmed and resolved", function () {
+      assert.equal(
+        discoverConfigPath({ config: "  ./somewhere/config.json  " }),
+        path.resolve("./somewhere/config.json")
+      );
+    });
+
+    it("returns null when nothing is configured and no .doc-detective file exists in cwd", function () {
+      const emptyDir = path.join(CACHE_DIR, "cfg-empty");
+      fs.mkdirSync(emptyDir, { recursive: true });
+      const prevCwd = process.cwd();
+      process.chdir(emptyDir);
+      try {
+        assert.equal(discoverConfigPath({}), null);
+        assert.equal(discoverConfigPath({ config: "   " }), null);
+        assert.equal(discoverConfigPath({ config: 42 }), null);
+      } finally {
+        process.chdir(prevCwd);
+      }
+    });
+
+    it("auto-discovers a .doc-detective.json in the cwd", function () {
+      const dir = path.join(CACHE_DIR, "cfg-discovery");
+      fs.mkdirSync(dir, { recursive: true });
+      const cfg = path.join(dir, ".doc-detective.json");
+      fs.writeFileSync(cfg, "{}");
+      const prevCwd = process.cwd();
+      process.chdir(dir);
+      try {
+        assert.equal(discoverConfigPath({}), cfg);
+      } finally {
+        process.chdir(prevCwd);
+      }
+    });
   });
 
   it("runTests({warmOnly: true}) returns the warm report without running tests", async function () {

--- a/test/warm-handoff.test.js
+++ b/test/warm-handoff.test.js
@@ -1,0 +1,141 @@
+// Registry ↔ handoff conversion for the warm ownership handoff (phase B3):
+// adopted devices are seeded into the run registries as bootedByUs (so the
+// existing run-end sweep reclaims them), and a warm-only run collects its
+// owned, booted devices back out of the registries into manifest shape.
+import assert from "node:assert/strict";
+import {
+  seedRegistriesFromHandoff,
+  collectHandoffDevices,
+} from "../dist/core/tests.js";
+import {
+  createSimulatorRegistry,
+  teardownSimulatorRegistry,
+} from "../dist/core/tests/iosSimulator.js";
+import {
+  createDeviceRegistry,
+  teardownDeviceRegistry,
+} from "../dist/core/tests/androidEmulator.js";
+
+const androidDevice = {
+  platform: "android",
+  name: "doc-detective",
+  udid: "emulator-5554",
+  pid: 4242,
+  sdkRoot: "C:\\sdk",
+  headless: true,
+};
+const iosDevice = {
+  platform: "ios",
+  name: "doc-detective-iphone",
+  udid: "UDID-1",
+};
+
+describe("warm handoff: registry seeding and collection", function () {
+  it("seeds adopted devices as owned registry entries the run-end sweep reclaims", async function () {
+    const deviceRegistry = createDeviceRegistry();
+    const simulatorRegistry = createSimulatorRegistry();
+    seedRegistriesFromHandoff({
+      devices: [androidDevice, iosDevice],
+      deviceRegistry,
+      simulatorRegistry,
+    });
+
+    const emulator = deviceRegistry.get("doc-detective");
+    assert.ok(emulator);
+    assert.equal(emulator.bootedByUs, true);
+    assert.equal(emulator.udid, "emulator-5554");
+    assert.equal(emulator.process.pid, 4242);
+    assert.equal(emulator.sdkRoot, "C:\\sdk");
+
+    const simulator = simulatorRegistry.get("doc-detective-iphone");
+    assert.ok(simulator);
+    assert.equal(simulator.bootedByUs, true);
+    assert.equal(simulator.udid, "UDID-1");
+
+    // The existing sweeps must reclaim both without any new lifecycle code.
+    const killed = [];
+    await teardownDeviceRegistry(deviceRegistry, async (entry) => {
+      killed.push(entry.process?.pid);
+    });
+    assert.deepEqual(killed, [4242]);
+    const shutdown = [];
+    await teardownSimulatorRegistry(simulatorRegistry, async (entry) => {
+      shutdown.push(entry.udid);
+    });
+    assert.deepEqual(shutdown, ["UDID-1"]);
+  });
+
+  it("ignores malformed handoff entries instead of seeding broken registry state", function () {
+    const deviceRegistry = createDeviceRegistry();
+    const simulatorRegistry = createSimulatorRegistry();
+    seedRegistriesFromHandoff({
+      devices: [
+        { platform: "android", name: "", udid: "emulator-5556" },
+        { platform: "ios", name: "no-udid", udid: "" },
+        { platform: "other", name: "x", udid: "y" },
+      ],
+      deviceRegistry,
+      simulatorRegistry,
+    });
+    assert.equal(deviceRegistry.size, 0);
+    assert.equal(simulatorRegistry.size, 0);
+  });
+
+  it("collects only owned, booted devices back into handoff shape", function () {
+    const deviceRegistry = createDeviceRegistry();
+    const simulatorRegistry = createSimulatorRegistry();
+    deviceRegistry.set("doc-detective", {
+      name: "doc-detective",
+      udid: "emulator-5554",
+      bootedByUs: true,
+      process: { pid: 4242 },
+      sdkRoot: "C:\\sdk",
+      headless: true,
+    });
+    // Reused (not owned) — must not be handed off: this run never booted it.
+    deviceRegistry.set("pre-existing", {
+      name: "pre-existing",
+      udid: "emulator-5556",
+      bootedByUs: false,
+      sdkRoot: "C:\\sdk",
+    });
+    simulatorRegistry.set("doc-detective-iphone", {
+      name: "doc-detective-iphone",
+      udid: "UDID-1",
+      bootedByUs: true,
+    });
+    // Mid-create placeholder without a udid — nothing adoptable to record.
+    simulatorRegistry.set("half-built", {
+      name: "half-built",
+      udid: "",
+      bootedByUs: true,
+    });
+
+    const devices = collectHandoffDevices({ deviceRegistry, simulatorRegistry });
+    assert.deepEqual(devices, [
+      {
+        platform: "android",
+        name: "doc-detective",
+        udid: "emulator-5554",
+        pid: 4242,
+        sdkRoot: "C:\\sdk",
+        headless: true,
+      },
+      { platform: "ios", name: "doc-detective-iphone", udid: "UDID-1" },
+    ]);
+  });
+
+  it("round-trips: seeding then collecting reproduces the handoff", function () {
+    const deviceRegistry = createDeviceRegistry();
+    const simulatorRegistry = createSimulatorRegistry();
+    seedRegistriesFromHandoff({
+      devices: [androidDevice, iosDevice],
+      deviceRegistry,
+      simulatorRegistry,
+    });
+    assert.deepEqual(collectHandoffDevices({ deviceRegistry, simulatorRegistry }), [
+      androidDevice,
+      iosDevice,
+    ]);
+  });
+});

--- a/test/warm-manifest.test.js
+++ b/test/warm-manifest.test.js
@@ -44,7 +44,10 @@ function memFs(initial = {}) {
         throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       files.delete(norm(p));
     },
-    readdirSync: () => [...files.keys()].map((p) => path.basename(p)),
+    readdirSync: (dir) =>
+      [...files.keys()]
+        .filter((p) => path.dirname(p) === norm(dir))
+        .map((p) => path.basename(p)),
     mkdirSync: () => {},
   };
 }
@@ -185,6 +188,48 @@ describe("warm manifest: write / claim / release / sweep", function () {
     assert.equal(fs.files.has(manifestPath), false);
   });
 
+  it("sweeps (never adopts) devices when createdAt is unparseable", function () {
+    // Date.parse("junk") is NaN; `now - NaN > ttl` is false, so without a
+    // finite-date guard a corrupt timestamp would read as "fresh forever"
+    // and every device (with a live-looking pid) would be adopted.
+    const fs = memFs({
+      [manifestPath]: manifestContent({ createdAt: "not-a-date" }),
+    });
+    const claim = claimWarmManifest({
+      cacheDir: CACHE,
+      runId: "run-1",
+      deps: deps({ fs }),
+    });
+    assert.ok(claim);
+    assert.deepEqual(claim.adopt, []);
+    assert.deepEqual(claim.sweep, [androidDevice, iosDevice]);
+  });
+
+  it("drops malformed device entries at parse time instead of adopting them", function () {
+    const fs = memFs({
+      [manifestPath]: JSON.stringify({
+        version: 1,
+        createdAt: "2026-07-14T00:00:00.000Z",
+        devices: [
+          androidDevice,
+          null,
+          "junk",
+          { platform: "toaster", name: "x", udid: "y" },
+          { platform: "android", name: "", udid: "emulator-5560" },
+          { platform: "ios", name: "no-udid" },
+        ],
+      }),
+    });
+    const claim = claimWarmManifest({
+      cacheDir: CACHE,
+      runId: "run-1",
+      deps: deps({ fs }),
+    });
+    assert.ok(claim);
+    assert.deepEqual(claim.adopt, [androidDevice]);
+    assert.deepEqual(claim.sweep, []);
+  });
+
   it("sweeps (never adopts) a manifest older than the TTL", function () {
     const fs = memFs({ [manifestPath]: manifestContent() });
     const claim = claimWarmManifest({
@@ -235,6 +280,23 @@ describe("warm manifest: write / claim / release / sweep", function () {
       orphans[0].devices.map((d) => d.udid).sort(),
       ["UDID-1", "emulator-5554"]
     );
+  });
+
+  it("treats an unstamped claim with an unparseable createdAt as orphaned", function () {
+    // A crash between the claim rename and the claimedBy stamp leaves an
+    // unstamped claimed file; its only staleness signal is createdAt. A
+    // corrupt timestamp must fall on the orphaned side (NaN comparisons
+    // would otherwise keep it "fresh" forever, devices never swept).
+    const fs = memFs({
+      [claimedPath("crashed-run")]: JSON.stringify({
+        version: 1,
+        createdAt: "garbage",
+        devices: [iosDevice],
+      }),
+    });
+    const orphans = listOrphanedClaims({ cacheDir: CACHE, deps: deps({ fs }) });
+    assert.equal(orphans.length, 1);
+    assert.deepEqual(orphans[0].devices, [iosDevice]);
   });
 
   it("does not list a live adopter's claim as orphaned", function () {
@@ -357,7 +419,7 @@ describe("warm manifest: write / claim / release / sweep", function () {
     assert.equal(old[0].path, claimedPath("crashed"));
   });
 
-  it("skips an unreadable claimed file in the orphan scan but --down still lists a corrupt manifest", function () {
+  it("skips an unreadable claimed file in the orphan scan but --down still lists every file", function () {
     const fs = memFs({
       [manifestPath]: "corrupt{{",
       [claimedPath("x")]: manifestContent(),
@@ -369,11 +431,11 @@ describe("warm manifest: write / claim / release / sweep", function () {
       }
       return realRead(p);
     };
+    // Nothing safe to SWEEP from an unreadable claim (no device list) —
+    // but --down must still enumerate both files for deletion.
     assert.deepEqual(listOrphanedClaims({ cacheDir: CACHE, deps: deps({ fs }) }), []);
     const leftovers = collectWarmLeftovers({ cacheDir: CACHE, deps: deps({ fs }) });
-    // The corrupt manifest is still a file --down must delete; it just
-    // contributes no devices.
-    assert.deepEqual(leftovers.files, [manifestPath]);
+    assert.deepEqual(leftovers.files.sort(), [manifestPath, claimedPath("x")].sort());
     assert.deepEqual(leftovers.devices, []);
   });
 
@@ -411,5 +473,14 @@ describe("warm manifest: write / claim / release / sweep", function () {
       leftovers.devices.map((d) => d.udid).sort(),
       ["UDID-1", "emulator-5554"]
     );
+  });
+
+  it("collectWarmLeftovers includes unreadable claimed files so --down can delete them", function () {
+    const fs = memFs({
+      [claimedPath("mangled")]: "not json{{",
+    });
+    const leftovers = collectWarmLeftovers({ cacheDir: CACHE, deps: deps({ fs }) });
+    assert.deepEqual(leftovers.files, [claimedPath("mangled")]);
+    assert.deepEqual(leftovers.devices, []);
   });
 });

--- a/test/warm-manifest.test.js
+++ b/test/warm-manifest.test.js
@@ -45,6 +45,7 @@ function memFs(initial = {}) {
       files.delete(norm(p));
     },
     readdirSync: () => [...files.keys()].map((p) => path.basename(p)),
+    mkdirSync: () => {},
   };
 }
 
@@ -94,6 +95,34 @@ describe("warm manifest: write / claim / release / sweep", function () {
     assert.equal(typeof parsed.createdAt, "string");
     assert.deepEqual(parsed.devices, [androidDevice, iosDevice]);
     assert.equal(fs.files.size, 1, `stray files: ${[...fs.files.keys()]}`);
+  });
+
+  it("creates the cache root before writing (pristine-host warm)", function () {
+    const fs = memFs();
+    const made = [];
+    fs.mkdirSync = (p, opts) => {
+      made.push({ p, recursive: opts?.recursive });
+    };
+    writeWarmManifest({
+      cacheDir: CACHE,
+      devices: [iosDevice],
+      deps: deps({ fs }),
+    });
+    assert.deepEqual(made, [{ p: CACHE, recursive: true }]);
+  });
+
+  it("treats an uncertain pid probe as alive — sweeping requires proof of death", function () {
+    // isPidAlive contract: only a definite "no such process" may route a
+    // device to sweep. The default probe reads EPERM/unknown as alive; the
+    // injected fake here mimics that by only reporting 4242 dead when told.
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    const claim = claimWarmManifest({
+      cacheDir: CACHE,
+      runId: "run-1",
+      deps: { ...deps({ fs }), isPidAlive: () => true },
+    });
+    assert.deepEqual(claim.sweep, []);
+    assert.equal(claim.adopt.length, 2);
   });
 
   it("writes nothing when there are no devices to hand off", function () {

--- a/test/warm-manifest.test.js
+++ b/test/warm-manifest.test.js
@@ -251,6 +251,38 @@ describe("warm manifest: write / claim / release / sweep", function () {
     assert.deepEqual(orphans, []);
   });
 
+  it("merges into an existing unclaimed manifest instead of clobbering it", function () {
+    // Two warms racing: the loser's ownership records must survive the
+    // winner's write, or its devices become undiscoverable orphans.
+    const fs = memFs({
+      [manifestPath]: manifestContent({ devices: [androidDevice] }),
+    });
+    writeWarmManifest({
+      cacheDir: CACHE,
+      devices: [iosDevice],
+      deps: deps({ fs }),
+    });
+    const merged = JSON.parse(fs.files.get(manifestPath));
+    assert.deepEqual(
+      merged.devices.map((d) => d.udid).sort(),
+      ["UDID-1", "emulator-5554"]
+    );
+  });
+
+  it("the newer entry wins a udid collision during the merge", function () {
+    const fs = memFs({
+      [manifestPath]: manifestContent({ devices: [iosDevice] }),
+    });
+    const renamed = { ...iosDevice, name: "renamed-same-sim" };
+    writeWarmManifest({
+      cacheDir: CACHE,
+      devices: [renamed],
+      deps: deps({ fs }),
+    });
+    const merged = JSON.parse(fs.files.get(manifestPath));
+    assert.deepEqual(merged.devices, [renamed]);
+  });
+
   it("falls back to remove-then-rename when the atomic write's rename is refused", function () {
     // Windows can refuse an overwrite-rename with EEXIST/EPERM.
     const fs = memFs({ [manifestPath]: manifestContent() });
@@ -269,7 +301,12 @@ describe("warm manifest: write / claim / release / sweep", function () {
       deps: deps({ fs }),
     });
     assert.equal(written, manifestPath);
-    assert.deepEqual(JSON.parse(fs.files.get(manifestPath)).devices, [iosDevice]);
+    // Merge-on-write: the pre-existing manifest's devices survive alongside
+    // the new entry.
+    assert.deepEqual(
+      JSON.parse(fs.files.get(manifestPath)).devices.map((d) => d.udid).sort(),
+      ["UDID-1", "emulator-5554"]
+    );
   });
 
   it("returns null when the manifest exists but can't be read", function () {

--- a/test/warm-manifest.test.js
+++ b/test/warm-manifest.test.js
@@ -251,6 +251,107 @@ describe("warm manifest: write / claim / release / sweep", function () {
     assert.deepEqual(orphans, []);
   });
 
+  it("falls back to remove-then-rename when the atomic write's rename is refused", function () {
+    // Windows can refuse an overwrite-rename with EEXIST/EPERM.
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    let refused = false;
+    const realRename = fs.renameSync;
+    fs.renameSync = (from, to) => {
+      if (!refused && to === manifestPath) {
+        refused = true;
+        throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+      }
+      realRename(from, to);
+    };
+    const written = writeWarmManifest({
+      cacheDir: CACHE,
+      devices: [iosDevice],
+      deps: deps({ fs }),
+    });
+    assert.equal(written, manifestPath);
+    assert.deepEqual(JSON.parse(fs.files.get(manifestPath)).devices, [iosDevice]);
+  });
+
+  it("returns null when the manifest exists but can't be read", function () {
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    fs.readFileSync = () => {
+      throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+    };
+    assert.equal(
+      claimWarmManifest({ cacheDir: CACHE, runId: "run-1", deps: deps({ fs }) }),
+      null
+    );
+  });
+
+  it("still adopts when the claimed-file stamp write fails", function () {
+    // The rename IS the claim; a failed claimedBy stamp only degrades the
+    // orphan scan to its TTL fallback.
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    const realWrite = fs.writeFileSync;
+    fs.writeFileSync = (p, data) => {
+      if (String(p).includes("claimed-")) {
+        throw Object.assign(new Error("ENOSPC"), { code: "ENOSPC" });
+      }
+      realWrite(p, data);
+    };
+    const claim = claimWarmManifest({
+      cacheDir: CACHE,
+      runId: "run-1",
+      deps: deps({ fs }),
+    });
+    assert.ok(claim);
+    assert.equal(claim.adopt.length, 2);
+  });
+
+  it("treats an unstamped claim (crash between rename and stamp) as orphaned only past the TTL", function () {
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    // Simulate the crash window: rename succeeded, stamp never written.
+    fs.renameSync(manifestPath, claimedPath("crashed"));
+    const fresh = listOrphanedClaims({
+      cacheDir: CACHE,
+      deps: deps({ fs, nowMs: T0 + 60_000 }),
+    });
+    assert.deepEqual(fresh, []);
+    const old = listOrphanedClaims({
+      cacheDir: CACHE,
+      deps: deps({ fs, nowMs: T0 + DEFAULT_WARM_MANIFEST_TTL_MS + 1 }),
+    });
+    assert.equal(old.length, 1);
+    assert.equal(old[0].path, claimedPath("crashed"));
+  });
+
+  it("skips an unreadable claimed file in the orphan scan but --down still lists a corrupt manifest", function () {
+    const fs = memFs({
+      [manifestPath]: "corrupt{{",
+      [claimedPath("x")]: manifestContent(),
+    });
+    const realRead = fs.readFileSync;
+    fs.readFileSync = (p) => {
+      if (String(p).includes("claimed-")) {
+        throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+      }
+      return realRead(p);
+    };
+    assert.deepEqual(listOrphanedClaims({ cacheDir: CACHE, deps: deps({ fs }) }), []);
+    const leftovers = collectWarmLeftovers({ cacheDir: CACHE, deps: deps({ fs }) });
+    // The corrupt manifest is still a file --down must delete; it just
+    // contributes no devices.
+    assert.deepEqual(leftovers.files, [manifestPath]);
+    assert.deepEqual(leftovers.devices, []);
+  });
+
+  it("ignores non-manifest files in the cache root", function () {
+    const fs = memFs({
+      [path.join(CACHE, "installed.json")]: "{}",
+      [path.join(CACHE, "warm-manifest.claimed-x.txt")]: "not json suffix",
+    });
+    assert.deepEqual(listOrphanedClaims({ cacheDir: CACHE, deps: deps({ fs }) }), []);
+    assert.deepEqual(
+      collectWarmLeftovers({ cacheDir: CACHE, deps: deps({ fs }) }).files,
+      []
+    );
+  });
+
   it("collectWarmLeftovers gathers the unclaimed manifest and every claimed file for --down", function () {
     const fs = memFs({ [manifestPath]: manifestContent() });
     claimWarmManifest({

--- a/test/warm-manifest.test.js
+++ b/test/warm-manifest.test.js
@@ -1,0 +1,248 @@
+// The warm ownership-handoff manifest (docs/design/warm-phase.md, phase B3):
+// `doc-detective warm` exits with devices left up and records them in
+// <cacheDir>/warm-manifest.json; the next run claims the manifest atomically
+// (rename to warm-manifest.claimed-<runId>.json in the same directory),
+// adopts live devices as bootedByUs, sweeps stale ones, and deletes the
+// claimed file only after its run-end sweep. Hermetic: fs/clock/pid effects
+// are injected.
+import assert from "node:assert/strict";
+import path from "node:path";
+import {
+  WARM_MANIFEST_NAME,
+  DEFAULT_WARM_MANIFEST_TTL_MS,
+  writeWarmManifest,
+  claimWarmManifest,
+  releaseWarmClaim,
+  listOrphanedClaims,
+  collectWarmLeftovers,
+} from "../dist/core/warmManifest.js";
+
+const CACHE = "C:\\cache";
+
+// Minimal in-memory fs covering exactly the surface the module uses.
+function memFs(initial = {}) {
+  const files = new Map(Object.entries(initial));
+  const norm = (p) => String(p);
+  return {
+    files,
+    existsSync: (p) => files.has(norm(p)),
+    readFileSync: (p) => {
+      if (!files.has(norm(p))) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      return files.get(norm(p));
+    },
+    writeFileSync: (p, data) => {
+      files.set(norm(p), String(data));
+    },
+    renameSync: (from, to) => {
+      if (!files.has(norm(from)))
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      files.set(norm(to), files.get(norm(from)));
+      files.delete(norm(from));
+    },
+    unlinkSync: (p) => {
+      if (!files.has(norm(p)))
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      files.delete(norm(p));
+    },
+    readdirSync: () => [...files.keys()].map((p) => path.basename(p)),
+  };
+}
+
+const manifestPath = path.join(CACHE, WARM_MANIFEST_NAME);
+const claimedPath = (runId) =>
+  path.join(CACHE, `warm-manifest.claimed-${runId}.json`);
+
+const androidDevice = {
+  platform: "android",
+  name: "doc-detective",
+  udid: "emulator-5554",
+  pid: 4242,
+  sdkRoot: "C:\\sdk",
+};
+const iosDevice = {
+  platform: "ios",
+  name: "doc-detective-iphone",
+  udid: "UDID-1",
+};
+
+function manifestContent({ createdAt = "2026-07-14T00:00:00.000Z", devices = [androidDevice, iosDevice] } = {}) {
+  return JSON.stringify({ version: 1, createdAt, devices });
+}
+
+const T0 = Date.parse("2026-07-14T00:00:00.000Z");
+
+function deps({ fs, nowMs = T0 + 60_000, alivePids = [4242, process.pid] } = {}) {
+  return {
+    fs,
+    now: () => nowMs,
+    isPidAlive: (pid) => alivePids.includes(pid),
+    pid: 777,
+  };
+}
+
+describe("warm manifest: write / claim / release / sweep", function () {
+  it("writes the manifest atomically and leaves no temp file behind", function () {
+    const fs = memFs();
+    const written = writeWarmManifest({
+      cacheDir: CACHE,
+      devices: [androidDevice, iosDevice],
+      deps: deps({ fs }),
+    });
+    assert.equal(written, manifestPath);
+    const parsed = JSON.parse(fs.files.get(manifestPath));
+    assert.equal(parsed.version, 1);
+    assert.equal(typeof parsed.createdAt, "string");
+    assert.deepEqual(parsed.devices, [androidDevice, iosDevice]);
+    assert.equal(fs.files.size, 1, `stray files: ${[...fs.files.keys()]}`);
+  });
+
+  it("writes nothing when there are no devices to hand off", function () {
+    const fs = memFs();
+    const written = writeWarmManifest({ cacheDir: CACHE, devices: [], deps: deps({ fs }) });
+    assert.equal(written, null);
+    assert.equal(fs.files.size, 0);
+  });
+
+  it("claims atomically: renames, stamps claimedBy, and adopts live devices", function () {
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    const claim = claimWarmManifest({
+      cacheDir: CACHE,
+      runId: "run-1",
+      deps: deps({ fs }),
+    });
+    assert.ok(claim);
+    assert.deepEqual(claim.adopt, [androidDevice, iosDevice]);
+    assert.deepEqual(claim.sweep, []);
+    assert.equal(fs.files.has(manifestPath), false, "manifest must be renamed away");
+    const claimed = JSON.parse(fs.files.get(claimedPath("run-1")));
+    assert.equal(claimed.claimedBy.runId, "run-1");
+    assert.equal(claimed.claimedBy.pid, 777);
+  });
+
+  it("returns null when there is no manifest", function () {
+    const fs = memFs();
+    assert.equal(
+      claimWarmManifest({ cacheDir: CACHE, runId: "run-1", deps: deps({ fs }) }),
+      null
+    );
+  });
+
+  it("loses the claim race gracefully when another runner renamed first", function () {
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    // Simulate the race: the manifest disappears between read and rename.
+    const racedFs = {
+      ...fs,
+      renameSync: (from, to) => {
+        fs.files.delete(manifestPath);
+        return memFs().renameSync(from, to);
+      },
+    };
+    const claim = claimWarmManifest({
+      cacheDir: CACHE,
+      runId: "run-2",
+      deps: deps({ fs: racedFs }),
+    });
+    assert.equal(claim, null);
+  });
+
+  it("deletes a corrupt manifest instead of adopting it", function () {
+    const fs = memFs({ [manifestPath]: "not json{{" });
+    const claim = claimWarmManifest({
+      cacheDir: CACHE,
+      runId: "run-1",
+      deps: deps({ fs }),
+    });
+    assert.equal(claim, null);
+    assert.equal(fs.files.has(manifestPath), false);
+  });
+
+  it("sweeps (never adopts) a manifest older than the TTL", function () {
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    const claim = claimWarmManifest({
+      cacheDir: CACHE,
+      runId: "run-1",
+      deps: deps({ fs, nowMs: T0 + DEFAULT_WARM_MANIFEST_TTL_MS + 1 }),
+    });
+    assert.ok(claim);
+    assert.deepEqual(claim.adopt, []);
+    assert.deepEqual(claim.sweep, [androidDevice, iosDevice]);
+  });
+
+  it("sweeps a device whose recorded pid is dead and adopts the rest", function () {
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    const claim = claimWarmManifest({
+      cacheDir: CACHE,
+      runId: "run-1",
+      deps: deps({ fs, alivePids: [process.pid] }), // 4242 is dead
+    });
+    assert.ok(claim);
+    assert.deepEqual(claim.adopt, [iosDevice]);
+    assert.deepEqual(claim.sweep, [androidDevice]);
+  });
+
+  it("releaseWarmClaim deletes the claimed file, idempotently", function () {
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    claimWarmManifest({ cacheDir: CACHE, runId: "run-1", deps: deps({ fs }) });
+    releaseWarmClaim({ cacheDir: CACHE, runId: "run-1", deps: deps({ fs }) });
+    assert.equal(fs.files.has(claimedPath("run-1")), false);
+    // Releasing again must not throw.
+    releaseWarmClaim({ cacheDir: CACHE, runId: "run-1", deps: deps({ fs }) });
+  });
+
+  it("lists claimed files whose adopter is dead as orphaned", function () {
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    claimWarmManifest({
+      cacheDir: CACHE,
+      runId: "dead-run",
+      deps: { ...deps({ fs }), pid: 99999 },
+    });
+    const orphans = listOrphanedClaims({
+      cacheDir: CACHE,
+      deps: deps({ fs, alivePids: [process.pid, 4242] }), // 99999 dead
+    });
+    assert.equal(orphans.length, 1);
+    assert.equal(orphans[0].path, claimedPath("dead-run"));
+    assert.deepEqual(
+      orphans[0].devices.map((d) => d.udid).sort(),
+      ["UDID-1", "emulator-5554"]
+    );
+  });
+
+  it("does not list a live adopter's claim as orphaned", function () {
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    claimWarmManifest({
+      cacheDir: CACHE,
+      runId: "live-run",
+      deps: { ...deps({ fs }), pid: 4242 },
+    });
+    const orphans = listOrphanedClaims({
+      cacheDir: CACHE,
+      deps: deps({ fs, alivePids: [4242] }),
+    });
+    assert.deepEqual(orphans, []);
+  });
+
+  it("collectWarmLeftovers gathers the unclaimed manifest and every claimed file for --down", function () {
+    const fs = memFs({ [manifestPath]: manifestContent() });
+    claimWarmManifest({
+      cacheDir: CACHE,
+      runId: "run-x",
+      deps: { ...deps({ fs }), pid: 99999 },
+    });
+    // A fresh, unclaimed manifest appears after the claim (a later warm).
+    writeWarmManifest({
+      cacheDir: CACHE,
+      devices: [iosDevice],
+      deps: deps({ fs }),
+    });
+    const leftovers = collectWarmLeftovers({ cacheDir: CACHE, deps: deps({ fs }) });
+    assert.equal(leftovers.files.length, 2);
+    assert.ok(leftovers.files.includes(manifestPath));
+    assert.ok(leftovers.files.includes(claimedPath("run-x")));
+    // Devices deduped by udid across files.
+    assert.deepEqual(
+      leftovers.devices.map((d) => d.udid).sort(),
+      ["UDID-1", "emulator-5554"]
+    );
+  });
+});


### PR DESCRIPTION
Completes the warm-phase roadmap from [docs/design/warm-phase.md](https://github.com/doc-detective/doc-detective/blob/main/docs/design/warm-phase.md) with **phase B3**: the standalone `doc-detective warm` command and its device ownership handoff. Builds on the inline warm phase that shipped in #628 (ADR 01060).

## What it does

- **`doc-detective warm --input <specs>`** shares a run's whole front half — config discovery, resolve, JIT preflight, the inline warm planner/executor — then awaits its owned boots and exits with the devices **left up**, recorded in `<cacheDir>/warm-manifest.json`. Run it while a CI build compiles; the test run that follows adopts ready devices and its warm phase reports `device ready` in milliseconds.
- **`doc-detective warm --down`** is the operator's "leave nothing running" switch: it tears down every device recorded in handoff manifests (including claims left by dead runs) and deletes the files.

## The ownership handoff (ADR 01061)

- **Atomic same-directory claim.** A run claims the manifest by renaming it to `warm-manifest.claimed-<runId>.json` — exactly one of N concurrent runners wins, and the claimed record (stamped with the adopter's pid) survives an adopter crash. It is deleted only after the adopter's run-end sweep, so the record always outlives the resources it describes.
- **Adoption reuses launch-ownership.** Adopted devices seed the run registries as `bootedByUs: true` (android entries carry `{ pid }` for the tree-kill; simulators shut down by udid); the existing sweeps reclaim them with no new lifecycle machinery, and consuming contexts registry-hit them instantly.
- **Staleness is swept, never adopted.** A manifest past the 60-minute TTL or a device whose recorded pid is provably dead (liveness reads dead only on ESRCH — uncertainty never licenses killing, mirroring the ADR 01059 lock lease's probe) is torn down at claim time; every run also sweeps claims whose adopter died.
- **Crash windows converge.** A crashed warm writes no manifest (its devices fall to `--down` or VM disposal — documented); a crashed adopter's claim is detected and swept by the next run.

## Companions (repo policy)

- **ADR:** [adrs/01061-standalone-warm-command-ownership-handoff.md](../blob/HEAD/adrs/01061-standalone-warm-command-ownership-handoff.md).
- **Docs:** new `reference/cli/warm` page (registered in docs.yml), a cross-link from the CI caching guidance, and the design doc flipped to B1+B2+B3 shipped. Retiring the fixtures.yml iOS pre-boot step in favor of `warm` is tracked as a follow-up CI change.
- **Hint:** `useWarmCommandForDeviceBoots` fires when a run's warm phase demonstrably paid >20s for device work — required by the hints playbook's opt-in-feature criteria; self-gating (adopted runs have fast warm phases).
- **Schema:** `report_v3.warmManifest` added schema-first alongside the existing `warm` block.
- **Fixtures:** no new fixture files — the command's device-bearing path rides the mobile CI legs (an orphaned emulator would fail the next run's boot on a busy port); the precise assertions live in hermetic suites per the CLAUDE.md escape hatch.

## Testing

- Hermetic manifest suite (atomic write, claim races, corrupt manifests, TTL, dead-pid partitioning, release idempotence, orphan scan, `--down` leftovers) — `test/warm-manifest.test.js`.
- Registry seeding/collection round-trip incl. sweep interplay — `test/warm-handoff.test.js`.
- CLI end-to-end on every OS (shell-only warm exits 0 and hands nothing off; `--down` sweeps a synthetic manifest; `runTests({warmOnly})` returns the warm report with zero executed steps) — `test/warm-cli.test.js`.
- Hint predicate positive/negative coverage — `test/hints.test.js`.
- Full local suites green (3501 root + 943 common, Windows). A self-review pass (the multi-agent review harness was temporarily unavailable) found and fixed 7 issues before push — most notably the pid-liveness bias and the pristine-host manifest write — plus a shared `discoverConfigPath` extracted from the three copy-pasted command handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added standalone `doc-detective warm` to provision/boot resources ahead of a later run and keep devices up for handoff.
  - Added concurrent-safe device handoff plus `warm --down` to tear down retained devices and clean up handoff data.
  - Added warm-only reporting in `report_v3` (including `warmManifest` when applicable).
- **Bug Fixes**
  - Improved consistent config discovery behavior across commands, with clearer handling for API-dispatched warm-only execution.
- **Documentation**
  - Updated warm-phase docs and added CLI/CI guidance for using `warm`.
- **Tests**
  - Added coverage for warm manifest ownership handoff, CLI behavior, handoff/regression cases, and schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->