### PR TITLE
perf(core): phase 1 — eliminate per-run/step/file waste

### DIFF
--- a/docs/design/run-performance.md
+++ b/docs/design/run-performance.md
@@ -1,0 +1,205 @@
+# Design: run-performance improvements (five phases)
+
+Status: **proposed** (2026-07-14). Produced from a full-pipeline performance hunt across startup,
+resolution, runner, driver/session, and reporting paths. Every finding below was verified against
+code with file:line evidence; refuted candidates (JIT-install network cost on steady-state runs,
+per-call AJV schema compilation, `recordRuntimeDependencies` on the no-install path) are excluded.
+Companion plan: [warm-phase.md](warm-phase.md) (already shipped) covers provisioning overlap; this
+plan covers everything else a run pays.
+
+## Problem
+
+A run pays large, measurable costs that have nothing to do with executing tests:
+
+- **Fixed startup tax.** `probeBrowserEnvironment` spawns `node <appium> driver list` (~17s by its
+  own comment) to learn what a filesystem lookup already knows
+  ([config.ts:749-801](../../src/core/config.ts)). The self-update registry check (up to 3s) is
+  awaited serially before anything else ([cli.ts:169-197](../../src/cli.ts)).
+- **Per-session tax.** Every `(test × context)` job starts and tears down a full driver session
+  ([tests.ts:4204](../../src/core/tests.ts), `:4928`), ~1–3s each. `appiumIsReady` sleeps 1s
+  *before* its first `/status` check ([tests.ts:5418-5434](../../src/core/tests.ts)), and servers
+  are started with readiness awaited serially ([tests.ts:1766-1776](../../src/core/tests.ts)).
+- **Per-step tax.** Pretty-printed `JSON.stringify` of the full step and result objects is built
+  on every step regardless of log level ([tests.ts:4612](../../src/core/tests.ts), `:4730-4733`);
+  `evaluateExpression` compiles a fresh `new Function` per evaluation
+  ([expressions.ts:487](../../src/core/expressions.ts)); `replaceEnvs` re-walks the step with a
+  fresh regex per string node, per attempt ([utils.ts:1461-1510](../../src/utils.ts)).
+- **Per-file tax.** Spec files are read twice and validated 3–5× each, with a full
+  `JSON.parse(JSON.stringify(...))` deep clone per validation
+  ([validate.ts:143](../../src/common/src/validate.ts), [files.ts:191-211](../../src/core/files.ts));
+  detection regexes are recompiled ~36×/markdown file
+  ([common detectTests.ts:20-31](../../src/common/src/detectTests.ts)); qualify/parse and remote
+  fetches are strictly serial ([detectTests.ts:257](../../src/core/detectTests.ts), `:421`).
+- **Per-screenshot tax.** Captures are written to disk, read back and sync-decoded for compare,
+  re-encoded on size mismatch, and the crop path does write → re-read → extract → rename
+  ([saveScreenshot.ts:519](../../src/core/tests/saveScreenshot.ts), `:592-614`, `:654-655`,
+  `:699-714`) — up to ~5 PNG encode/decode passes + 4 disk ops per step.
+- **Run-end tax.** The whole results tree is walked ≥4× (info-level dump at
+  [core/index.ts:254-256](../../src/core/index.ts), json reporter, runFolder JSON, HTML build),
+  and the PostHog flush ([telem.ts:97-102](../../src/core/telem.ts)) holds the event loop open
+  after everything else finishes.
+
+## Decisions (settled, 2026-07-14)
+
+1. **Driver presence is a filesystem question, not an Appium question.** The `appium driver list`
+   spawn is replaced by direct `resolveHeavyDepPath()`/`npmInstalled()` checks — the mechanism
+   already used at [config.ts:1054-1092](../../src/core/config.ts). This serves *all* platforms
+   (browser drivers and native Windows/macOS/iOS/Android drivers) identically; no gating on
+   "browser runs only."
+2. **Session reuse is default-on where reset is provably complete, and only there.** No opt-in
+   flag. Chromium-family engines get reuse with a deterministic CDP reset protocol; engines
+   without a verifiable global state clear (Firefox, Safari) and native app surfaces keep today's
+   fresh-session behavior. Any reset failure falls back to a fresh session (fail-closed). Users
+   get an escape hatch (`freshSession: true` on a context), not an opt-in.
+3. **Self-update overlaps resolution; it still completes before the first test executes.**
+   The check starts concurrently with input detection/resolution and is joined before test
+   execution, preserving the "update before the run" guarantee. `config.autoUpdate` already gates
+   it from resolved config ([cli.ts:169-173](../../src/cli.ts)) — no new preference plumbing.
+4. **Validation deep clones keep their safety guarantees.** The clone exists because AJV
+   `useDefaults` mutates and candidate-schema probing must not contaminate the caller's object.
+   The improvement is *when* to clone (only for the winning, mutating pass) and *how*
+   (`structuredClone` where JSON-value semantics are guaranteed), never *whether* callers'
+   objects stay unmutated.
+5. **Log arguments are lazy.** No call site builds a string that the level check will discard.
+   `log()` already stringifies objects passed directly ([core/utils.ts:1324](../../src/core/utils.ts));
+   call sites pass objects, not pre-interpolated `JSON.stringify` templates.
+
+## Phase 1 — free latency (no observable behavior change)
+
+Pure waste removal; no ADRs (mechanical), no docs impact. Each item is its own red→green cycle.
+
+| # | Change | Anchor | Win |
+|---|---|---|---|
+| 1.1 | Pass objects to `log()`/level-guard instead of eager `JSON.stringify` templates: per-step STEP/RESULT ([tests.ts:4612](../../src/core/tests.ts), `:4730-4733`), per-context CONTEXT (`:4097`), the resolveTests call sites (`:148-329` incl. the two whole-tree stringifies at `:315`/`:329`), CLI version/config dumps ([cli.ts:146-150](../../src/cli.ts)) | per step / 2× whole tree per run | CPU + allocations on every run at default level |
+| 1.2 | `appiumIsReady`: probe `/status` immediately, then poll at 250ms (drop the leading 1s sleep) ([tests.ts:5427](../../src/core/tests.ts)) | per server (browser pool ≤4, app surface, warm probe) | ≥1s × servers |
+| 1.3 | Overlap server readiness: keep serial spawn (port-rebind race), pre-allocate ports, `Promise.all` the readiness waits ([tests.ts:1766-1776](../../src/core/tests.ts)) | once per run | ~(N−1)×spawn+poll |
+| 1.4 | Memoize compiled expression evaluators in a `Map` keyed by preprocessed source + arg signature ([expressions.ts:487](../../src/core/expressions.ts)) | per conditional/routed step | repeated `new Function` JIT |
+| 1.5 | `replaceEnvs`: hoist the constant regex to module scope; substitute once before the retry loop instead of per attempt ([utils.ts:1461-1510](../../src/utils.ts), call at [tests.ts:5078](../../src/core/tests.ts)) | per step × attempt | allocations + redundant re-walks |
+| 1.6 | Telemetry: call `sendTelemetry` before reporters/hints run, `await client.shutdown(timeoutMs)` after they finish ([telem.ts:97-102](../../src/core/telem.ts), [core/index.ts:262](../../src/core/index.ts)) — flush overlaps reporter I/O, bounded worst case, no dropped events (no `unref`) | once per run | full PostHog round-trip off the exit path |
+| 1.7 | Detection micro-fixes: single `statSync` (or `readdirSync(..., { withFileTypes: true })`) ([detectTests.ts:345-346](../../src/core/detectTests.ts), `:390-391`); hoist `allowedExtensions` to a per-run `Set` (`:79-82`); cache compiled `safeRegExp` per `(pattern, flags)` and drop the no-op `Array.from` rebuild ([common detectTests.ts:20-31](../../src/common/src/detectTests.ts)) | per walked entry / per file | thousands of syscalls; ~36 compiles/file |
+
+1.7's regex cache lives in `src/common` — follow [src/common/AGENTS.md](../../src/common/AGENTS.md)
+and its tdd-coverage skill.
+
+## Phase 2 — startup path (contract-adjacent; ADRs)
+
+| # | Change | Anchor | Win |
+|---|---|---|---|
+| 2.1 | Replace `probeBrowserEnvironment`'s `appium driver list` spawn with direct package-presence checks for every managed driver (browser *and* native platforms) | [config.ts:749-801](../../src/core/config.ts) → mechanism from `:1054-1092` | ~17s fixed, every driver-touching run |
+| 2.2 | JIT preflight patches the app cache with the just-installed descriptors instead of `clearAppCache` — the driver list didn't change, only the browser binary did | [core/index.ts:193](../../src/core/index.ts), cache at [config.ts:670](../../src/core/config.ts), `:820-821` | second ~17s probe on fresh-machine runs |
+| 2.3 | Start `checkForUpdate` concurrently with detection/resolution; join (and `selfUpdate` re-exec if newer) before the first test executes | [cli.ts:169-197](../../src/cli.ts) | up to 3s registry latency hidden behind resolution |
+| 2.4 | Demote the full results-tree `info` dump to `debug` (reporters already render results); serialize the canonical JSON once and share it between the json and runFolder reporters | [core/index.ts:254-256](../../src/core/index.ts), [utils.ts:539](../../src/utils.ts), `:654`, `:664` | ≥2 full-tree serializations; terminal flood |
+| 2.5 | Delete the stray `console.log(payload)` on the orchestration-API report-back path | [utils.ts:1176](../../src/utils.ts) | noise; large inspect on API runs |
+
+ADRs: 2.1 (probe mechanism becomes presence-based — document the "present ≠ functional" trade and
+the retained `verifyDriverBinary` layer), 2.3 (update-check ordering guarantee), 2.4 (terminal
+output contract change). Docs impact: 2.4 touches what users see at default log level.
+
+## Phase 3 — resolution & validation efficiency
+
+| # | Change | Anchor | Win |
+|---|---|---|---|
+| 3.1 | Read + parse each spec file once: thread the parsed object/raw content from `isValidSourceFile` qualification through `parseTests`; pass known `objectType` into `resolvePaths` to skip the config_v3-then-spec_v3 probe | [detectTests.ts:91](../../src/core/detectTests.ts), `:430`; [files.ts:191-211](../../src/core/files.ts), `:530`, `:627` | ~2 reads + ~4-5 validations → 1 read + ~2 validations per file |
+| 3.2 | `validate()` clone strategy: probe candidate schemas with non-mutating check-only validators (no `useDefaults`), clone **once** for the winning mutate-with-defaults pass only (today: one clone per candidate, up to 12 for `step_v3` at [validate.ts:167](../../src/common/src/validate.ts)); use `structuredClone` on the detection path where inputs are guaranteed JSON values (they came from `JSON.parse`/YAML) | [validate.ts:143](../../src/common/src/validate.ts), `:167` | dominant detection CPU on step-heavy specs |
+| 3.3 | Memoize `loadDescription` by resolved description path for the run (specs re-dereference the same OpenAPI doc per test today); reuse the `definition` already attached in `setConfig` | [resolveTests.ts:152-183](../../src/core/resolveTests.ts), `:246`, `:288`; [openapi.ts:14-27](../../src/core/openapi.ts) | T+1 reads + dereferences → 1 per document |
+| 3.4 | Lazy-import `json-schema-faker` / `@apidevtools/json-schema-ref-parser` inside the functions that use them (module-load `createGenerator` runs on every run via the `config.ts:11` static import chain, OpenAPI or not) | [openapi.ts:2-6](../../src/core/openapi.ts) | tens of ms cold start, unconditional today |
+| 3.5 | Concurrent qualify/parse via the existing `runConcurrent` helper (remote `fetchFile`/axios reads benefit most; keep ditamap/heretto splice sequencing) | [detectTests.ts:257](../../src/core/detectTests.ts), `:421`; helper at [core/utils.ts:106](../../src/core/utils.ts) | wall-clock ≈ max instead of sum for file I/O |
+
+3.2 changes `src/common` validation internals — behavior contract (callers' objects never mutated;
+returned object carries defaults) is preserved and pinned by tests before refactoring. ADR for
+3.2's clone-semantics decision; 3.1/3.3–3.5 are mechanical (no ADR) but 3.3 needs a fixture
+asserting OpenAPI-bound runs still resolve identically with multiple tests sharing a description.
+
+## Phase 4 — in-memory screenshot pipeline
+
+Replace the disk round-trip chain with one buffer flow:
+
+1. Capture via `takeScreenshot()` (base64 → `Buffer`) instead of `saveScreenshot(filePath)`
+   ([saveScreenshot.ts:519](../../src/core/tests/saveScreenshot.ts)).
+2. Crop on the buffer (`sharp(buffer).extract(...)`) — eliminates the write → `sharp(filePath)`
+   re-read → `cropped_*.png` temp write → `renameSync` cycle (`:592-614`).
+3. Compare decoded buffers directly — eliminates `PNG.sync.read(fs.readFileSync(...))` read-backs
+   (`:654-655`); on dimension mismatch stay in sharp's raw pipeline instead of re-encoding to PNG
+   and re-decoding (`:699-714`).
+4. Write the final PNG to disk exactly once, at the end.
+
+Same files land on disk with the same names and compare semantics — behavior-preserving, so no
+ADR; the existing capture fixtures in [test/core-artifacts/capture/](../../test/core-artifacts/capture)
+gate it, plus a permutation covering crop + variation-compare together (the worst-case path).
+This also directly cuts the per-step cost of `autoScreenshot` runs (`resolveAutoScreenshot`,
+[tests.ts:3494](../../src/core/tests.ts)), which funnel every driver step through this pipeline.
+
+## Phase 5 — default-on browser session reuse (tiered reset)
+
+The biggest ceiling: today every `(test × context)` job pays a full session start + teardown
+([tests.ts:4204](../../src/core/tests.ts), `:4928`). Design principle (Decision 2): **reuse is the
+default wherever reset is provably complete; everywhere else nothing changes.**
+
+### Reset protocol (Chromium family: Chrome, Edge, chromium engine)
+
+Order matters — WebDriver ends the session when its last window closes, so the fresh window opens
+*first*:
+
+1. `browser.newWindow('about:blank')` → switch to the new handle.
+2. Close every other window handle.
+3. CDP global clears (this is why Chromium qualifies — one call covers all storage classes):
+   - `Storage.clearDataForOrigin(origin: "*", storageTypes: "all")` — cookies, local/session
+     storage, IndexedDB, WebSQL, service workers, cache storage.
+   - `Network.clearBrowserCookies` + `Network.clearBrowserCache` (belt-and-suspenders for the
+     network stack).
+   - `Browser.resetPermissions` — granted permission grants.
+   - `Emulation.clearDeviceMetricsOverride` + `Emulation.clearGeolocationOverride` — any
+     emulation state a test set.
+4. Reapply the incoming context's window size/viewport and navigate `about:blank`.
+5. **Fail-closed:** if any step throws or times out, discard the session and start fresh — the
+   reset is an accelerator, never a new failure mode (same posture as the warm phase).
+
+### Why cookie-clear + new window alone isn't enough
+
+`deleteAllCookies` (WebDriver classic) is scoped to the *current document's domain*, and window
+close doesn't touch localStorage/IndexedDB/service workers/permissions. That's exactly why:
+
+- **Firefox (gecko):** no CDP-equivalent global clear on modern releases → keeps fresh sessions.
+- **Safari:** no reliable programmatic clear → keeps fresh sessions.
+- **Native app surfaces (Windows/macOS/iOS/Android):** a session *is* the app instance; relaunch
+  is the isolation model → out of scope, unchanged.
+
+### Pool mechanics
+
+- Reuse pool keyed by the full capability signature (engine, headless, args, proxy — everything
+  except resettable state like window size), scoped per Appium server/runner worker, so the
+  existing ChromeDriver-contention design ([tests.ts:1720](../../src/core/tests.ts)) is untouched.
+- A context only draws from the pool on an exact signature match; otherwise fresh session.
+- `freshSession: true` on a context (schema addition, `context_v3`) forces today's behavior.
+- Run-end teardown unchanged: pooled sessions are owned by the run and swept in the existing
+  `finally` block.
+
+### Confidence mechanism (gates the phase)
+
+Per the feature-fixture rule, a `sessions/` leakage fixture suite asserts **non-leakage across the
+reuse boundary for every state class**, per engine: cookie, localStorage, sessionStorage,
+IndexedDB, cache storage, service worker registration, granted permission, viewport override,
+window count. Each fixture is a pair of tests in one spec — test A plants the state, test B (same
+context signature, therefore a reused session) asserts absence. A companion fixture asserts
+`freshSession: true` still yields a cold session. These run on every Chromium platform leg; the
+phase does not ship until every leg passes. ADR records the tiering decision and the fail-closed
+rule; docs impact: contexts/session reference page (new `freshSession` field + which engines pool).
+
+### Expected win
+
+For a spec with N Chromium tests: N×(1–3s) session cycles → 1 session start + (N−1) resets
+(~100–300ms each). On small-test-heavy suites this is the largest single wall-clock reduction in
+the plan.
+
+## Sequencing rationale
+
+Phase 1 is risk-free and immediately measurable, and 1.2 makes Phase 5's per-reset economics
+better. Phase 2 removes the dominant *fixed* costs (17s probe) before per-test costs matter.
+Phase 3 scales with suite size and is contained in detection/validation. Phase 4 is contained in
+one action. Phase 5 is last because it carries the only real semantic risk and depends on its
+fixture suite existing first.
+
+Every phase lands with the repo's standard trio where applicable: ADR (noted per phase) +
+fixtures + docs-impact assessment. Measurement: reuse the `report.warm`-style timing block to add
+coarse phase timings (startup, resolution, execution, reporting) so each phase's win is visible in
+run output rather than asserted.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import { runTests } from "./core/index.js";
+import { runTests, awaitTelemetryFlush } from "./core/index.js";
 import {
   buildYargs,
   setConfig,
@@ -6,6 +6,7 @@ import {
   setMeta,
   getVersionData,
   log,
+  logLevelEnabled,
   getResolvedTestsFromEnv,
   reportResults,
   isDebugRequested,
@@ -142,12 +143,16 @@ async function runTestsHandler(args: any) {
     return;
   }
 
-  log(
-    `CLI:VERSION INFO:\n${JSON.stringify(getVersionData(), null, 2)}`,
-    "debug",
-    config
-  );
-  log(`CLI:CONFIG:\n${JSON.stringify(config, null, 2)}`, "debug", config);
+  // Guard the pretty-print dumps behind a cheap level check so the (large)
+  // JSON.stringify only runs when the debug message would actually print.
+  if (logLevelEnabled("debug", config)) {
+    log(
+      `CLI:VERSION INFO:\n${JSON.stringify(getVersionData(), null, 2)}`,
+      "debug",
+      config
+    );
+    log(`CLI:CONFIG:\n${JSON.stringify(config, null, 2)}`, "debug", config);
+  }
 
   // Self-update on startup. Honors config.autoUpdate (schema default true),
   // DOC_DETECTIVE_SKIP_AUTO_UPDATE=1 (set by the re-execed child to prevent
@@ -238,4 +243,10 @@ async function runTestsHandler(args: any) {
     // Wrapped in its own try/catch internally — never throws.
     await maybeShowHint(config, results);
   }
+
+  // Join the telemetry flush started inside runTests. Awaited only NOW — after
+  // reporters + hint — so the PostHog round-trip overlaps that I/O instead of
+  // hanging off the tail of the process. Bounded + non-throwing; a no-op when
+  // telemetry is disabled or already flushed.
+  await awaitTelemetryFlush();
 }

--- a/src/common/src/detectTests.ts
+++ b/src/common/src/detectTests.ts
@@ -9,25 +9,38 @@ import { validate, transformToSchemaKey } from "./validate.js";
 import { SchemaKey } from "./schemas/index.js";
 import { defaultFileTypes, detectFileTypeFromContent, FileType } from "./fileTypes.js";
 
+// Cache of compiled patterns, keyed by `pattern + ' ' + flags`. parseContent
+// re-derives the same handful of file-type regexes for EVERY file it scans
+// (~36 per markdown file), so compiling each pattern once and reusing it
+// removes almost all of that RegExp construction. Both the compiled RegExp and
+// the `null` (invalid/unsafe) outcome are cached. Safe to share the returned
+// instance: callers only use it via `String.prototype.matchAll`, which clones
+// the regexp internally and so never mutates the cached object's `lastIndex`.
+const compiledRegExpCache = new Map<string, RegExp | null>();
+
 /**
  * Creates a RegExp from a pattern string with safety checks against ReDoS.
- * Returns null if the pattern is invalid or potentially unsafe.
+ * Returns null if the pattern is invalid or potentially unsafe. Results are
+ * memoized per `(pattern, flags)` for the lifetime of the process.
  *
- * The pattern is reconstructed character-by-character to establish a
- * sanitization boundary, since these patterns come from trusted file type
- * configuration rather than arbitrary user input.
+ * These patterns come from trusted file type configuration rather than
+ * arbitrary user input.
  */
-function safeRegExp(pattern: string, flags: string): RegExp | null {
+export function safeRegExp(pattern: string, flags: string): RegExp | null {
   if (typeof pattern !== 'string' || pattern.length === 0) return null;
   // Reject excessively long patterns
   if (pattern.length > 1500) return null;
-  // Reconstruct pattern to establish sanitization boundary
-  const sanitized = Array.from(pattern, c => String.fromCharCode(c.charCodeAt(0))).join('');
+  const cacheKey = pattern + ' ' + flags;
+  const cached = compiledRegExpCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+  let compiled: RegExp | null;
   try {
-    return new RegExp(sanitized, flags);
+    compiled = new RegExp(pattern, flags);
   } catch {
-    return null;
+    compiled = null;
   }
+  compiledRegExpCache.set(cacheKey, compiled);
+  return compiled;
 }
 
 // Keys excluded when hashing a test/step definition for an ID: IDs are what

--- a/src/common/test/detectTests.test.js
+++ b/src/common/test/detectTests.test.js
@@ -12,6 +12,7 @@ import {
   getLineNumber,
   getLineStarts,
   contentHash,
+  safeRegExp,
 } from "../dist/detectTests.js";
 import { detectFileTypeFromContent, defaultFileTypes } from "../dist/fileTypes.js";
 
@@ -3184,3 +3185,53 @@ function readFixture(filename) {
       });
     });
   });
+
+// Phase 1.7: safeRegExp compiles each (pattern, flags) once and reuses it —
+// parseContent re-derives the same file-type regexes for every scanned file
+// (~36 per markdown file), so caching removes almost all RegExp construction.
+describe("safeRegExp (compiled-pattern cache)", function () {
+  it("returns a working RegExp for a valid pattern", function () {
+    const re = safeRegExp("\\d+", "g");
+    expect(re).to.be.instanceOf(RegExp);
+    expect(re.source).to.equal("\\d+");
+    expect(re.flags).to.equal("g");
+    expect([..."a12b34".matchAll(re)].length).to.equal(2);
+  });
+
+  it("returns the SAME instance on a cache hit (same pattern + flags)", function () {
+    const first = safeRegExp("\\w+foo", "g");
+    const second = safeRegExp("\\w+foo", "g");
+    expect(first).to.equal(second);
+  });
+
+  it("keys the cache on flags too (different flags → different instance)", function () {
+    const g = safeRegExp("abc", "g");
+    const gi = safeRegExp("abc", "gi");
+    expect(g).to.not.equal(gi);
+    expect(gi.flags).to.equal("gi");
+  });
+
+  it("reusing a cached /g regex via matchAll stays correct (no lastIndex leak)", function () {
+    const re = safeRegExp("x", "g");
+    expect([..."xxx".matchAll(re)].length).to.equal(3);
+    // Second use of the SAME cached instance must still find all matches.
+    expect([..."xx".matchAll(re)].length).to.equal(2);
+  });
+
+  it("returns null for empty or non-string patterns", function () {
+    expect(safeRegExp("", "g")).to.equal(null);
+    expect(safeRegExp(undefined, "g")).to.equal(null);
+    expect(safeRegExp(123, "g")).to.equal(null);
+  });
+
+  it("returns null for an excessively long pattern (ReDoS guard)", function () {
+    expect(safeRegExp("a".repeat(1501), "g")).to.equal(null);
+  });
+
+  it("caches the null outcome for an invalid pattern", function () {
+    const first = safeRegExp("(", "g"); // unbalanced group → invalid
+    const second = safeRegExp("(", "g");
+    expect(first).to.equal(null);
+    expect(second).to.equal(null);
+  });
+});

--- a/src/core/detectTests.ts
+++ b/src/core/detectTests.ts
@@ -74,12 +74,26 @@ function generateSpecId(filePath: string) {
  * @param {string} options.source - File path to check
  * @returns {Promise<boolean>}
  */
-async function isValidSourceFile({ config, files, source }: { config: any; files: any[]; source: string }) {
-  log(config, "debug", `validation: ${source}`);
-  let allowedExtensions = ["json", "yaml", "yml"];
-  config.fileTypes.forEach((fileType: any) => {
-    allowedExtensions = allowedExtensions.concat(fileType.extensions);
+// Build the set of allowed source-file extensions from config.fileTypes.
+// Computed ONCE per run by the caller (detectTests) and threaded into every
+// isValidSourceFile call, rather than rebuilt on each call. Mirrors the
+// original concat-based construction (same inputs, same assumptions), just
+// into a Set for O(1) membership.
+function buildAllowedExtensions(config: any): Set<string> {
+  const allowed = new Set<string>(["json", "yaml", "yml"]);
+  // `|| []` because this now runs ONCE up front, before any source is known to
+  // be a real file — a config with no fileTypes (e.g. inputs that are all URLs
+  // or ditamaps) must not throw. The original built this lazily inside
+  // isValidSourceFile, so it was only reached once a file needed validating.
+  (config.fileTypes || []).forEach((fileType: any) => {
+    fileType.extensions.forEach((ext: string) => allowed.add(ext));
   });
+  return allowed;
+}
+
+async function isValidSourceFile({ config, files, source, allowedExtensions }: { config: any; files: any[]; source: string; allowedExtensions: Set<string> }) {
+  log(config, "debug", `validation: ${source}`);
+  const allowed = allowedExtensions;
   // Already in files array
   if (files.indexOf(source) >= 0) return false;
   // Is JSON or YAML but isn't a valid spec-formatted object
@@ -148,7 +162,7 @@ async function isValidSourceFile({ config, files, source }: { config: any; files
   }
   // Extension not in allowed list
   const extension = path.extname(source).substring(1);
-  if (!allowedExtensions.includes(extension)) {
+  if (!allowed.has(extension)) {
     log(
       config,
       "debug",
@@ -249,6 +263,11 @@ async function qualifyFiles({ config }: { config: any }) {
 
   const ignoredDitaMaps: string[] = [];
 
+  // Set of allowed source-file extensions, computed ONCE per run rather than
+  // rebuilt (concat over every fileType) on every isValidSourceFile call. A
+  // Set gives O(1) membership at the check site.
+  const allowedExtensions = buildAllowedExtensions(config);
+
   // Track Heretto output paths for sourceIntegration metadata
   if (!config._herettoPathMapping) {
     config._herettoPathMapping = {};
@@ -338,12 +357,15 @@ async function qualifyFiles({ config }: { config: any }) {
       /* c8 ignore next */
       source = fetch.path;
     }
-    // Check if source is a file or directory
+    // Check if source is a file or directory. One statSync, reused for both
+    // predicates (the value is the same for a given path — no reason to pay two
+    // syscalls).
     let isFile = false;
     let isDir = false;
     try {
-      isFile = fs.statSync(source).isFile();
-      isDir = fs.statSync(source).isDirectory();
+      const stat = fs.statSync(source);
+      isFile = stat.isFile();
+      isDir = stat.isDirectory();
     } catch {
       log(config, "warning", `Cannot access path: ${source}. Skipping.`);
       continue;
@@ -376,7 +398,7 @@ async function qualifyFiles({ config }: { config: any }) {
     // referenced once relative and once absolute could slip through twice with a
     // mismatched phase.
     const resolved = path.resolve(source);
-    if (isFile && (await isValidSourceFile({ config, files, source: resolved }))) {
+    if (isFile && (await isValidSourceFile({ config, files, allowedExtensions, source: resolved }))) {
       files.push(resolved);
       if (!phaseByFile.has(resolved)) phaseByFile.set(resolved, phase);
     } else if (isDir) {
@@ -387,11 +409,15 @@ async function qualifyFiles({ config }: { config: any }) {
         for (const object of objects) {
           const content = path.resolve(dir + "/" + object);
           if (content.includes("node_modules")) continue;
-          const isFile = fs.statSync(content).isFile();
-          const isDir = fs.statSync(content).isDirectory();
+          // One statSync, reused for both predicates (same value per path).
+          // statSync (not the Dirent from readdirSync withFileTypes) is kept
+          // deliberately so symlink following is unchanged from before.
+          const stat = fs.statSync(content);
+          const isFile = stat.isFile();
+          const isDir = stat.isDirectory();
           if (
             isFile &&
-            (await isValidSourceFile({ config, files, source: content }))
+            (await isValidSourceFile({ config, files, allowedExtensions, source: content }))
           ) {
             const resolved = path.resolve(content);
             files.push(resolved);

--- a/src/core/expressions.ts
+++ b/src/core/expressions.ts
@@ -391,6 +391,13 @@ function containsOperators(expression: string, allowOperators: boolean = false):
   return false;
 }
 
+// Compiled-evaluator cache for evaluateExpression. `new Function(...)` is a
+// full parse + JIT compile; the same (argNames, preprocessed-source) pair
+// always yields an identical function body, so caching it removes the
+// per-evaluation compile cost for conditional/routed steps that re-evaluate
+// the same expressions. See the keying rationale at the construction site.
+const compiledEvaluatorCache = new Map<string, Function>();
+
 /**
  * Evaluates an expression containing operators.
  * @param {string} expression - The expression to evaluate.
@@ -484,10 +491,24 @@ async function evaluateExpression(expression: string, context: any): Promise<any
     // escapes its own backslashes/quotes. A previous blunt global
     // `\\` -> `\\\\` doubling here corrupted intentional escapes (e.g. \" inside
     // a literal, or a regex containing a double-quote), so it has been removed.
-    const evaluator = new Function(
-      ...Object.keys(evalContext),
-      `return ${expression};`
-    );
+    //
+    // Memoize the compiled evaluator: `new Function(...)` re-parses + re-JITs
+    // the body on every call, but the compiled function depends ONLY on the
+    // preprocessed expression source and the argument-name list (the helper
+    // names plus this call's context keys, in order). The context VALUES are
+    // passed in per call, so a cached function is reused safely across calls
+    // with the same key. Keyed by comma-joined argNames + space + source (arg
+    // names are identifiers with no spaces, so the first space is an
+    // unambiguous delimiter). Encoding arg ORDER means a different
+    // key order (which changes the positional arg binding) never reuses a
+    // function compiled for a different order.
+    const argNames = Object.keys(evalContext);
+    const cacheKey = `${argNames.join(",")} ${expression}`;
+    let evaluator = compiledEvaluatorCache.get(cacheKey);
+    if (!evaluator) {
+      evaluator = new Function(...argNames, `return ${expression};`);
+      compiledEvaluatorCache.set(cacheKey, evaluator);
+    }
     return evaluator(...Object.values(evalContext));
   } catch (error: any) {
     log(

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,10 +3,10 @@ import { detectTests } from "./detectTests.js";
 import { resolveTests } from "./resolveTests.js";
 import { log, cleanTemp } from "./utils.js";
 import { runSpecs, runViaApi, getRunner } from "./tests.js";
-import { telemetryNotice, sendTelemetry } from "./telem.js";
+import { telemetryNotice, sendTelemetry, awaitTelemetryFlush } from "./telem.js";
 import { readFile, resolvePaths } from "./files.js";
 
-export { runTests, getRunner, detectTests, detectAndResolveTests, resolveTests, readFile, resolvePaths };
+export { runTests, getRunner, detectTests, detectAndResolveTests, resolveTests, readFile, resolvePaths, awaitTelemetryFlush };
 
 const supportMessage = `
 ##########################################################################

--- a/src/core/resolveTests.ts
+++ b/src/core/resolveTests.ts
@@ -5,7 +5,7 @@
  */
 
 import crypto from "node:crypto";
-import { log } from "./utils.js";
+import { log, logLevelEnabled } from "./utils.js";
 import { generateSpecId } from "./detectTests.js";
 import { contentHash } from "../common/src/detectTests.js";
 import { loadDescription } from "./openapi.js";
@@ -145,12 +145,12 @@ function resolveContexts({ contexts, test, config }: { contexts: any[]; test: an
     resolvedContexts.push({});
   }
 
-  log(config, "debug", `Resolved contexts for test ${test.testId}:\n${JSON.stringify(resolvedContexts, null, 2)}`);
+  if (logLevelEnabled(config, "debug")) log(config, "debug", `Resolved contexts for test ${test.testId}:\n${JSON.stringify(resolvedContexts, null, 2)}`);
   return resolvedContexts;
 }
 
 async function fetchOpenApiDocuments({ config, documentArray }: { config: any; documentArray: any[] }) {
-  log(config, "debug", `Fetching OpenAPI documents:\n${JSON.stringify(documentArray, null, 2)}`);
+  if (logLevelEnabled(config, "debug")) log(config, "debug", `Fetching OpenAPI documents:\n${JSON.stringify(documentArray, null, 2)}`);
   const openApiDocuments: any[] = [];
   if (config?.integrations?.openApi?.length > 0)
     openApiDocuments.push(...config.integrations.openApi);
@@ -178,7 +178,7 @@ async function fetchOpenApiDocuments({ config, documentArray }: { config: any; d
       openApiDocuments.push(definition);
     }
   }
-  log(config, "debug", `Fetched OpenAPI documents:\n${JSON.stringify(openApiDocuments, null, 2)}`);
+  if (logLevelEnabled(config, "debug")) log(config, "debug", `Fetched OpenAPI documents:\n${JSON.stringify(openApiDocuments, null, 2)}`);
   return openApiDocuments;
 }
 
@@ -217,7 +217,7 @@ async function resolveContext({ config, test, context, usedContextIds, openApi }
     : deriveContextId({ context, usedIds: usedContextIds });
   const contextId = context.contextId;
   usedContextIds.add(contextId);
-  log(config, "debug", `RESOLVING CONTEXT ID ${contextId}:\n${JSON.stringify(context, null, 2)}`);
+  if (logLevelEnabled(config, "debug")) log(config, "debug", `RESOLVING CONTEXT ID ${contextId}:\n${JSON.stringify(context, null, 2)}`);
   const resolvedContext = {
     ...context,
     unsafe: test.unsafe || false,
@@ -229,7 +229,7 @@ async function resolveContext({ config, test, context, usedContextIds, openApi }
     steps: [...test.steps],
     contextId: contextId,
   };
-  log(config, "debug", `RESOLVED CONTEXT ${contextId}:\n${JSON.stringify(resolvedContext, null, 2)}`);
+  if (logLevelEnabled(config, "debug")) log(config, "debug", `RESOLVED CONTEXT ${contextId}:\n${JSON.stringify(resolvedContext, null, 2)}`);
   return resolvedContext;
 }
 
@@ -238,7 +238,7 @@ async function resolveTest({ config, spec, test }: { config: any; spec: any; tes
   // `<specId>~<hash>` IDs for both inline and JSON/YAML tests); covers
   // programmatic callers that hand resolveTests raw specs.
   const testId = test.testId || `${spec.specId}~${contentHash(test)}`;
-  log(config, "debug", `RESOLVING TEST ID ${testId}:\n${JSON.stringify(test, null, 2)}`);
+  if (logLevelEnabled(config, "debug")) log(config, "debug", `RESOLVING TEST ID ${testId}:\n${JSON.stringify(test, null, 2)}`);
   const resolvedTest = {
     ...test,
     testId: testId,
@@ -269,7 +269,7 @@ async function resolveTest({ config, spec, test }: { config: any; spec: any; tes
     });
     resolvedTest.contexts.push(resolvedContext);
   }
-  log(config, "debug", `RESOLVED TEST ${testId}:\n${JSON.stringify(resolvedTest, null, 2)}`);
+  if (logLevelEnabled(config, "debug")) log(config, "debug", `RESOLVED TEST ${testId}:\n${JSON.stringify(resolvedTest, null, 2)}`);
   return resolvedTest;
 }
 
@@ -280,7 +280,7 @@ async function resolveSpec({ config, spec }: { config: any; spec: any }) {
   const specId =
     spec.specId ||
     (spec.contentPath ? generateSpecId(spec.contentPath) : crypto.randomUUID());
-  log(config, "debug", `RESOLVING SPEC ID ${specId}:\n${JSON.stringify(spec, null, 2)}`);
+  if (logLevelEnabled(config, "debug")) log(config, "debug", `RESOLVING SPEC ID ${specId}:\n${JSON.stringify(spec, null, 2)}`);
   const resolvedSpec = {
     ...spec,
     specId: specId,
@@ -299,7 +299,7 @@ async function resolveSpec({ config, spec }: { config: any; spec: any }) {
     });
     resolvedSpec.tests.push(resolvedTest);
   }
-  log(config, "debug", `RESOLVED SPEC ${specId}:\n${JSON.stringify(resolvedSpec, null, 2)}`);
+  if (logLevelEnabled(config, "debug")) log(config, "debug", `RESOLVED SPEC ${specId}:\n${JSON.stringify(resolvedSpec, null, 2)}`);
   return resolvedSpec;
 }
 
@@ -312,7 +312,7 @@ async function resolveSpec({ config, spec }: { config: any; spec: any }) {
  * @returns {Promise<Object>} Resolved tests object with config and specs
  */
 async function resolveTests({ config, detectedTests }: { config: any; detectedTests: any[] }) {
-  log(config, "debug", `RESOLVING DETECTED TEST SPECS:\n${JSON.stringify(detectedTests, null, 2)}`);
+  if (logLevelEnabled(config, "debug")) log(config, "debug", `RESOLVING DETECTED TEST SPECS:\n${JSON.stringify(detectedTests, null, 2)}`);
 
   const resolvedTests = {
     resolvedTestsId: crypto.randomUUID(),
@@ -326,7 +326,7 @@ async function resolveTests({ config, detectedTests }: { config: any; detectedTe
     resolvedTests.specs.push(resolvedSpec);
   }
 
-  log(config, "debug", `RESOLVED TEST SPECS:\n${JSON.stringify(resolvedTests, null, 2)}`);
+  if (logLevelEnabled(config, "debug")) log(config, "debug", `RESOLVED TEST SPECS:\n${JSON.stringify(resolvedTests, null, 2)}`);
   return resolvedTests;
 }
 

--- a/src/core/telem.ts
+++ b/src/core/telem.ts
@@ -43,6 +43,14 @@ function telemetryNotice(config: any) {
 //   core_deployment: "node", // node, electron, docker, github-action, lambda, vscode-extension, browser-extension
 // };
 
+// Bounded worst case for the telemetry flush that overlaps reporter/hint I/O.
+const TELEMETRY_FLUSH_TIMEOUT_MS = 2000;
+
+// The in-flight flush kicked off by the most recent sendTelemetry call, or null
+// when none is pending. Module-scoped so awaitTelemetryFlush (called at the end
+// of the run path) can join the flush that sendTelemetry started earlier.
+let pendingTelemetryFlush: Promise<void> | null = null;
+
 // Send telemetry data to PostHog
 function sendTelemetry(config: any, command: string, results: any) {
   // Exit early if telemetry is disabled
@@ -99,7 +107,25 @@ function sendTelemetry(config: any, command: string, results: any) {
     { host: "https://app.posthog.com" }
   );
   client.capture(event);
-  client.shutdown();
+  // Kick off the flush NOW (as soon as results are final) but DON'T await it
+  // here — store the promise so the run path can await it AFTER the reporters
+  // and hint run, letting the network round-trip overlap that I/O instead of
+  // adding a full round-trip to the tail of the run. `shutdown(timeoutMs)`
+  // flushes queued events and bounds the wait; never `unref()` (that would
+  // drop events). Errors are swallowed — telemetry must never fail a run.
+  pendingTelemetryFlush = Promise.resolve(client.shutdown(TELEMETRY_FLUSH_TIMEOUT_MS))
+    .then(() => undefined)
+    .catch(() => undefined);
 }
 
-export { telemetryNotice, sendTelemetry };
+// Await any in-flight telemetry flush started by sendTelemetry. Call at the
+// very end of the run path (after reporters + hint) so the flush overlaps that
+// work. Bounded by the shutdown timeout above; resolves immediately when no
+// flush is pending. Never throws.
+async function awaitTelemetryFlush(): Promise<void> {
+  const pending = pendingTelemetryFlush;
+  pendingTelemetryFlush = null;
+  if (pending) await pending;
+}
+
+export { telemetryNotice, sendTelemetry, awaitTelemetryFlush };

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -24,6 +24,7 @@ import {
 import os from "node:os";
 import {
   log,
+  logLevelEnabled,
   replaceEnvs,
   selectSpecsForRun,
   findFreePort,
@@ -196,9 +197,8 @@ export {
   buildWarmPlanDeps,
   warmBrowserInstall,
   prefetchMobileChromedriver,
+  appiumIsReady,
 };
-// exports.appiumStart = appiumStart;
-// exports.appiumIsReady = appiumIsReady;
 // exports.driverStart = driverStart;
 
 // Browser names getDriverCapabilities knows how to build caps for. `safari` is
@@ -1763,6 +1763,11 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     // that removes the port race and fails fast on the first server that can't
     // come up, tearing down any already started so they don't leak.
     try {
+      // Spawn servers one at a time (serial spawn keeps the findFreePort race
+      // protection + avoids a CPU spike), but collect their readiness polls and
+      // await them together so the waits OVERLAP — total ≈ max(readiness)
+      // instead of the sum of serial waits.
+      const readinessWaits: Promise<boolean>[] = [];
       for (let i = 0; i < serverCount; i++) {
         let display: string | undefined;
         if (useXvfbDisplays) {
@@ -1770,9 +1775,20 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
           xvfbProcesses.push(await startXvfb(display));
           log(config, "debug", `Started Xvfb on ${display} for recording.`);
         }
-        appiumServers.push(
-          await startAppiumServer(appiumEntry, config, display)
-        );
+        const server = await spawnAppiumServer(appiumEntry, config, display);
+        appiumServers.push(server);
+        const wait = appiumIsReady(server.port);
+        // Attach a no-op catch so that once Promise.all rejects on the FIRST
+        // failing server, the other still-pending readiness rejections don't
+        // surface as unhandled promise rejections. Promise.all still sees the
+        // original `wait`, so it fails fast on the first error; the catch
+        // block below tears down every spawned server (ready or not).
+        wait.catch(() => {});
+        readinessWaits.push(wait);
+      }
+      await Promise.all(readinessWaits);
+      for (const server of appiumServers) {
+        log(config, "debug", `Appium is ready on port ${server.port}.`);
       }
     } catch (error) {
       await Promise.all(
@@ -4094,7 +4110,7 @@ async function runContext({
     contextReport.resultDescription = errorMessage;
     return contextReport;
   }
-  clog("debug", `CONTEXT:\n${JSON.stringify(context, null, 2)}`);
+  if (logLevelEnabled(config, "debug")) clog("debug", `CONTEXT:\n${JSON.stringify(context, null, 2)}`);
 
   let driver: any;
   let appiumPort: number | undefined;
@@ -4609,7 +4625,7 @@ async function runContext({
         break;
       }
 
-      clog("debug", `STEP:\n${JSON.stringify(step, null, 2)}`);
+      if (logLevelEnabled(config, "debug")) clog("debug", `STEP:\n${JSON.stringify(step, null, 2)}`);
 
       if (step.unsafe && runnerDetails.allowUnsafeSteps === false) {
         clog(
@@ -4727,7 +4743,7 @@ async function runContext({
           processRegistry: processRegistry,
           appSession: appSession,
         });
-        clog(
+        if (logLevelEnabled(config, "debug")) clog(
           "debug",
           `RESULT: ${r.status}\n${JSON.stringify(r, null, 2)}`
         );
@@ -5357,7 +5373,12 @@ async function runStep({
 // Start one Appium server on a free port and resolve once it answers /status.
 // Each concurrent runner gets its own server (own port) so parallel contexts
 // never create sessions on the same Appium instance.
-async function startAppiumServer(
+// Spawn an Appium server process WITHOUT waiting for readiness. Split out from
+// startAppiumServer so the browser-pool startup (below) can spawn servers
+// SERIALLY — preserving the findFreePort close-to-rebind race protection and
+// avoiding a startup CPU spike — while OVERLAPPING their readiness polls. A
+// single-server caller uses startAppiumServer, which spawns then awaits.
+async function spawnAppiumServer(
   appiumEntry: string,
   config: any,
   display?: string,
@@ -5399,38 +5420,76 @@ async function startAppiumServer(
   });
   proc.stdout.on("data", () => {});
   proc.stderr.on("data", () => {});
+  return { port, process: proc, display };
+}
+
+async function startAppiumServer(
+  appiumEntry: string,
+  config: any,
+  display?: string,
+  extraEnv?: Record<string, string>,
+  // Extra CLI args for the server, e.g. the scoped `--allow-insecure`
+  // chromedriver-autodownload opt-in for android mobile-web sessions.
+  extraArgs?: string[]
+): Promise<{ port: number; process: any; display?: string }> {
+  const server = await spawnAppiumServer(
+    appiumEntry,
+    config,
+    display,
+    extraEnv,
+    extraArgs
+  );
   try {
-    await appiumIsReady(port);
+    await appiumIsReady(server.port);
   } catch (error) {
     // appiumIsReady threw or timed out — the spawned child is still alive and
     // would leak (orphan process, port still bound). Tear it down before
     // propagating so subsequent runs don't trip on the stale state. Awaited
     // so the process is confirmed gone before this function returns control
     // to the caller.
-    await killTree(proc?.pid);
+    await killTree(server.process?.pid);
     throw error;
   }
-  log(config, "debug", `Appium is ready on port ${port}.`);
-  return { port, process: proc, display };
+  log(config, "debug", `Appium is ready on port ${server.port}.`);
+  return server;
 }
 
-// Delay execution until Appium server is available.
-async function appiumIsReady(port: number, timeoutMs: number = 120000) {
-  let isReady = false;
+// Delay execution until Appium server is available. Probe `/status`
+// IMMEDIATELY, then poll on a short 250ms interval until ready or the overall
+// timeout — a server that is already up returns in ~one round-trip instead of
+// paying a fixed leading 1s sleep (the old loop slept before its first probe).
+// `probe`/`sleep` are injectable for hermetic unit tests; the overall timeout
+// cap (default 120s) is unchanged.
+async function appiumIsReady(
+  port: number,
+  timeoutMs: number = 120000,
+  deps: {
+    probe?: (port: number) => Promise<boolean>;
+    sleep?: (ms: number) => Promise<void>;
+  } = {}
+) {
+  const probe =
+    deps.probe ??
+    (async (p: number) => {
+      try {
+        const resp = await axios.get(`http://127.0.0.1:${p}/status`);
+        return resp.status === 200;
+      } catch {
+        return false;
+      }
+    });
+  const sleep =
+    deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   const start = Date.now();
-  while (!isReady) {
+  while (true) {
+    if (await probe(port)) return true;
     if (Date.now() - start > timeoutMs) {
       throw new Error(
         `Appium server on port ${port} failed to start within ${timeoutMs / 1000} seconds`
       );
     }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    try {
-      let resp = await axios.get(`http://127.0.0.1:${port}/status`);
-      if (resp.status === 200) isReady = true;
-    } catch {}
+    await sleep(250);
   }
-  return isReady;
 }
 
 // Start the Appium driver specified in `capabilities`.

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -5454,6 +5454,11 @@ async function startAppiumServer(
   return server;
 }
 
+// Per-probe HTTP timeout for the Appium `/status` check. Bounds a single
+// hung request so the overall readiness timeout can still fire; a healthy
+// server answers in milliseconds.
+const STATUS_PROBE_TIMEOUT_MS = 10000;
+
 // Delay execution until Appium server is available. Probe `/status`
 // IMMEDIATELY, then poll on a short 250ms interval until ready or the overall
 // timeout — a server that is already up returns in ~one round-trip instead of
@@ -5472,7 +5477,12 @@ async function appiumIsReady(
     deps.probe ??
     (async (p: number) => {
       try {
-        const resp = await axios.get(`http://127.0.0.1:${p}/status`);
+        // Bound each probe: without a per-request timeout a hung /status
+        // response would block this await indefinitely, and the overall
+        // `timeoutMs` guard (checked only between probes) could never fire.
+        const resp = await axios.get(`http://127.0.0.1:${p}/status`, {
+          timeout: STATUS_PROBE_TIMEOUT_MS,
+        });
         return resp.status === 200;
       } catch {
         return false;

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -21,6 +21,7 @@ export {
   outputResults,
   loadEnvs,
   log,
+  logLevelEnabled,
   timestamp,
   getOrInitRunTimestamp,
   getRunOutputDir,
@@ -1288,34 +1289,42 @@ async function loadEnvs(envsFile: string) {
   }
 }
 
+// Pure predicate: would `log(config, level, ...)` actually print at this
+// config.logLevel? Exported so hot call sites can GUARD expensive message
+// construction (e.g. `JSON.stringify(bigObject, null, 2)`) behind a cheap
+// check — the stringify then only runs when the message would be printed.
+// `log` itself delegates to this so the level policy has a single source of
+// truth and can never drift from the guard.
+function logLevelEnabled(config: any, level: string): boolean {
+  if (config.logLevel === "error" && level === "error") return true;
+  if (
+    config.logLevel === "warning" &&
+    (level === "error" || level === "warning")
+  )
+    return true;
+  if (
+    config.logLevel === "info" &&
+    (level === "error" || level === "warning" || level === "info")
+  )
+    return true;
+  if (
+    config.logLevel === "debug" &&
+    (level === "error" ||
+      level === "warning" ||
+      level === "info" ||
+      level === "debug")
+  )
+    return true;
+  return false;
+}
+
 async function log(config: any, level: string, message?: any) {
   if (message === undefined) {
     // 2-arg form: log(message, level)
     message = config;
     config = {};
   }
-  let logLevelMatch = false;
-  if (config.logLevel === "error" && level === "error") {
-    logLevelMatch = true;
-  } else if (
-    config.logLevel === "warning" &&
-    (level === "error" || level === "warning")
-  ) {
-    logLevelMatch = true;
-  } else if (
-    config.logLevel === "info" &&
-    (level === "error" || level === "warning" || level === "info")
-  ) {
-    logLevelMatch = true;
-  } else if (
-    config.logLevel === "debug" &&
-    (level === "error" ||
-      level === "warning" ||
-      level === "info" ||
-      level === "debug")
-  ) {
-    logLevelMatch = true;
-  }
+  const logLevelMatch = logLevelEnabled(config, level);
 
   if (logLevelMatch) {
     if (typeof message === "string") {
@@ -1458,6 +1467,18 @@ function evaluateContextRequirements({
   return { met: missing.length === 0, missing };
 }
 
+// Env-var reference matcher for replaceEnvs, hoisted to module scope so it is
+// compiled ONCE rather than per string node on every recursive walk. The
+// trailing `(?![a-zA-Z0-9_$])` guard means a `$NAME$` token (a dollar on BOTH
+// sides — the `$KEY$` special-key / device-key sentinel vocabulary, e.g.
+// `$HOME$`, `$ENTER$`) is never treated as an env-var reference. Without it,
+// `$HOME$` matched the `$HOME` prefix and — on any host where $HOME is set
+// (every Unix box) — got rewritten to the home path, corrupting the sentinel.
+// A real env ref is `$NAME` NOT followed by another `$` (or word char).
+// Safe to share: used only via `String.prototype.match`, which does not rely
+// on or leave mutated `lastIndex` state.
+const ENV_VAR_REGEX = /\$[a-zA-Z0-9_]+(?![a-zA-Z0-9_$])/g;
+
 function replaceEnvs(stringOrObject: any): any {
   if (!stringOrObject) return stringOrObject;
   if (typeof stringOrObject === "object") {
@@ -1468,15 +1489,7 @@ function replaceEnvs(stringOrObject: any): any {
       stringOrObject[key] = replaceEnvs(stringOrObject[key]);
     });
   } else if (typeof stringOrObject === "string") {
-    // Load variable from string. The trailing `(?![a-zA-Z0-9_$])` guard means
-    // a `$NAME$` token (a dollar on BOTH sides — the `$KEY$` special-key /
-    // device-key sentinel vocabulary, e.g. `$HOME$`, `$ENTER$`) is never
-    // treated as an env-var reference. Without it, `$HOME$` matched the
-    // `$HOME` prefix and — on any host where $HOME is set (every Unix box) —
-    // got rewritten to the home path, corrupting the sentinel. A real env ref
-    // is `$NAME` NOT followed by another `$` (or word char).
-    const variableRegex = new RegExp(/\$[a-zA-Z0-9_]+(?![a-zA-Z0-9_$])/, "g");
-    const matches = stringOrObject.match(variableRegex);
+    const matches = stringOrObject.match(ENV_VAR_REGEX);
     // If no matches, return string
     if (!matches) return stringOrObject;
     // Iterate matches

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,6 +21,7 @@ export {
   setMeta,
   getVersionData,
   log,
+  logLevelEnabled,
   getResolvedTestsFromEnv,
   reportResults,
   reporters,
@@ -43,14 +44,22 @@ function isDebugRequested(): boolean {
 }
 
 // Log function that respects logLevel
-function log(message: any, level: string = "info", config: any = {}) {
+// Pure predicate: would `log(message, level, config)` actually print at this
+// config.logLevel? Exported so CLI call sites can GUARD expensive message
+// construction (e.g. `JSON.stringify(config, null, 2)`) behind a cheap check —
+// the stringify then only runs when the message would be printed. `log`
+// delegates to this so the level policy has a single source of truth.
+function logLevelEnabled(level: string, config: any = {}): boolean {
   const logLevels = ["silent", "error", "warning", "info", "debug"];
   const currentLevel = config.logLevel || "info";
   const currentLevelIndex = logLevels.indexOf(currentLevel);
   const messageLevelIndex = logLevels.indexOf(level);
+  return currentLevelIndex >= messageLevelIndex && messageLevelIndex > 0;
+}
 
+function log(message: any, level: string = "info", config: any = {}) {
   // Only log if the message level is at or above the current log level
-  if (currentLevelIndex >= messageLevelIndex && messageLevelIndex > 0) {
+  if (logLevelEnabled(level, config)) {
     if (level === "error") {
       console.error(message);
     } else {

--- a/test/appium-ready.test.js
+++ b/test/appium-ready.test.js
@@ -1,0 +1,62 @@
+// Unit tests for appiumIsReady (src/core/tests.ts, compiled dist/core/tests.js).
+//
+// Phase 1.2: the readiness loop must probe /status IMMEDIATELY and then poll on
+// a short 250ms interval, instead of sleeping a fixed ~1s BEFORE its first
+// probe. Hermetic: the network probe and the sleep are injected, so no real
+// Appium server or timer delay is involved.
+import assert from "node:assert/strict";
+import { appiumIsReady } from "../dist/core/tests.js";
+
+describe("appiumIsReady (immediate probe + 250ms poll)", function () {
+  it("probes immediately and returns without ever sleeping when already up", async function () {
+    const sleeps = [];
+    let probes = 0;
+    const ready = await appiumIsReady(4723, 120000, {
+      probe: async () => {
+        probes += 1;
+        return true; // up on the very first probe
+      },
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    assert.equal(ready, true);
+    assert.equal(probes, 1, "should probe exactly once when immediately ready");
+    assert.deepEqual(sleeps, [], "must NOT sleep before the first successful probe");
+  });
+
+  it("polls on a 250ms interval until ready", async function () {
+    const sleeps = [];
+    let probes = 0;
+    const ready = await appiumIsReady(4723, 120000, {
+      probe: async () => {
+        probes += 1;
+        return probes >= 3; // fails twice, then succeeds
+      },
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    assert.equal(ready, true);
+    assert.equal(probes, 3);
+    // Two failed probes → two 250ms sleeps between them; none after success.
+    assert.deepEqual(sleeps, [250, 250]);
+  });
+
+  it("throws after the overall timeout, having probed at least once", async function () {
+    let probes = 0;
+    await assert.rejects(
+      appiumIsReady(4723, -1, {
+        // timeoutMs = -1 → the elapsed check trips after the first failed probe,
+        // proving the probe runs BEFORE the timeout is enforced.
+        probe: async () => {
+          probes += 1;
+          return false;
+        },
+        sleep: async () => {},
+      }),
+      /failed to start within/
+    );
+    assert.equal(probes, 1, "must probe before giving up on timeout");
+  });
+});

--- a/test/core-utils-coverage.test.js
+++ b/test/core-utils-coverage.test.js
@@ -13,6 +13,7 @@ import sinon from "sinon";
 import dnsPromises from "node:dns/promises";
 import {
   log,
+  logLevelEnabled,
   outputResults,
   replaceEnvs,
   timestamp,
@@ -371,6 +372,59 @@ describe("core/utils coverage", function () {
     });
   });
 
+  describe("logLevelEnabled (lazy-log gate, mirrors log's level policy)", function () {
+    let logged;
+    beforeEach(function () {
+      sandbox = sinon.createSandbox();
+      logged = [];
+      sandbox.stub(console, "log").callsFake((m) => logged.push(m));
+    });
+    afterEach(function () {
+      sandbox.restore();
+      sandbox = undefined;
+    });
+    it("error level: only error is enabled", function () {
+      const c = { logLevel: "error" };
+      assert.equal(logLevelEnabled(c, "error"), true);
+      assert.equal(logLevelEnabled(c, "warning"), false);
+      assert.equal(logLevelEnabled(c, "info"), false);
+      assert.equal(logLevelEnabled(c, "debug"), false);
+    });
+    it("warning level: error + warning enabled", function () {
+      const c = { logLevel: "warning" };
+      assert.equal(logLevelEnabled(c, "error"), true);
+      assert.equal(logLevelEnabled(c, "warning"), true);
+      assert.equal(logLevelEnabled(c, "info"), false);
+      assert.equal(logLevelEnabled(c, "debug"), false);
+    });
+    it("info level: error/warning/info enabled, debug not", function () {
+      const c = { logLevel: "info" };
+      assert.equal(logLevelEnabled(c, "info"), true);
+      assert.equal(logLevelEnabled(c, "debug"), false);
+    });
+    it("debug level: everything enabled", function () {
+      const c = { logLevel: "debug" };
+      assert.equal(logLevelEnabled(c, "error"), true);
+      assert.equal(logLevelEnabled(c, "warning"), true);
+      assert.equal(logLevelEnabled(c, "info"), true);
+      assert.equal(logLevelEnabled(c, "debug"), true);
+    });
+    it("undefined/silent logLevel: nothing enabled (matches log's no-match behavior)", function () {
+      assert.equal(logLevelEnabled({}, "error"), false);
+      assert.equal(logLevelEnabled({ logLevel: "silent" }, "error"), false);
+    });
+    it("agrees with log(): guarding a debug dump prints iff enabled", async function () {
+      // At info level the guard is false, so the expensive message is never
+      // built or printed; at debug it prints exactly once.
+      const infoCfg = { logLevel: "info" };
+      if (logLevelEnabled(infoCfg, "debug")) await log(infoCfg, "debug", "X");
+      assert.equal(logged.length, 0);
+      const dbgCfg = { logLevel: "debug" };
+      if (logLevelEnabled(dbgCfg, "debug")) await log(dbgCfg, "debug", "X");
+      assert.deepEqual(logged, ["(DEBUG) X"]);
+    });
+  });
+
   describe("outputResults", function () {
     let tmpDir;
     beforeEach(function () {
@@ -461,6 +515,23 @@ describe("core/utils coverage", function () {
     });
     it("leaves an undefined env var reference in place", function () {
       assert.equal(replaceEnvs("$DD_DOES_NOT_EXIST_123"), "$DD_DOES_NOT_EXIST_123");
+    });
+    it("module-hoisted regex is safe across multiple matches and repeated calls (1.5)", function () {
+      // The matcher is now a single module-scoped /g RegExp reused on every
+      // string node. `String.prototype.match` with /g does not depend on or
+      // leave mutated lastIndex, so multiple matches in one string and repeated
+      // calls must all resolve correctly (a shared stateful regex would drop
+      // matches on alternate calls).
+      process.env.DD_TEST_VAL = "X";
+      // Two references in one string → both replaced in a single call.
+      assert.equal(
+        replaceEnvs("$DD_TEST_VAL-$DD_TEST_VAL"),
+        "X-X"
+      );
+      // Repeated invocations stay correct (no lastIndex carry-over).
+      for (let i = 0; i < 3; i++) {
+        assert.equal(replaceEnvs("a $DD_TEST_VAL b"), "a X b");
+      }
     });
   });
 

--- a/test/core-utils-coverage.test.js
+++ b/test/core-utils-coverage.test.js
@@ -522,15 +522,23 @@ describe("core/utils coverage", function () {
       // leave mutated lastIndex, so multiple matches in one string and repeated
       // calls must all resolve correctly (a shared stateful regex would drop
       // matches on alternate calls).
+      const prev = process.env.DD_TEST_VAL;
       process.env.DD_TEST_VAL = "X";
-      // Two references in one string → both replaced in a single call.
-      assert.equal(
-        replaceEnvs("$DD_TEST_VAL-$DD_TEST_VAL"),
-        "X-X"
-      );
-      // Repeated invocations stay correct (no lastIndex carry-over).
-      for (let i = 0; i < 3; i++) {
-        assert.equal(replaceEnvs("a $DD_TEST_VAL b"), "a X b");
+      try {
+        // Two references in one string → both replaced in a single call.
+        assert.equal(
+          replaceEnvs("$DD_TEST_VAL-$DD_TEST_VAL"),
+          "X-X"
+        );
+        // Repeated invocations stay correct (no lastIndex carry-over).
+        for (let i = 0; i < 3; i++) {
+          assert.equal(replaceEnvs("a $DD_TEST_VAL b"), "a X b");
+        }
+      } finally {
+        // Restore so this mutation can't make later env-sensitive tests
+        // order-dependent.
+        if (prev === undefined) delete process.env.DD_TEST_VAL;
+        else process.env.DD_TEST_VAL = prev;
       }
     });
   });

--- a/test/expressions-unit.test.js
+++ b/test/expressions-unit.test.js
@@ -534,3 +534,37 @@ describe("expressions: literal-scan regexes are ReDoS-safe (finding 1)", functio
     );
   });
 });
+
+// Phase 1.4: evaluateExpression memoizes its compiled `new Function(...)` by
+// (argNames, preprocessed-source). The compiled body is reused, but the CONTEXT
+// VALUES are passed per call — so re-evaluating a cached expression against
+// fresh values must never reuse stale values baked into the function.
+describe("expressions: compiled-evaluator cache correctness (1.4)", function () {
+  it("re-evaluates the same expression against fresh values, not baked-in ones", async function () {
+    const expr = "$$outputs.exitCode == 0";
+    const pass = { platform: "windows", outputs: { exitCode: 0 } };
+    const fail = { platform: "windows", outputs: { exitCode: 1 } };
+    // First call compiles + caches; subsequent calls hit the cache but must
+    // still read the per-call context values.
+    assert.equal(await evaluateAssertion(expr, pass), true);
+    assert.equal(await evaluateAssertion(expr, fail), false);
+    assert.equal(await evaluateAssertion(expr, pass), true);
+    assert.equal(await evaluateAssertion(expr, fail), false);
+  });
+
+  it("keeps operator helpers working across cache hits", async function () {
+    const expr = "$$outputs.text contains world";
+    const hit = { outputs: { text: "hello world" } };
+    const miss = { outputs: { text: "hello there" } };
+    assert.equal(await evaluateAssertion(expr, hit), true);
+    assert.equal(await evaluateAssertion(expr, miss), false);
+    assert.equal(await evaluateAssertion(expr, hit), true);
+  });
+
+  it("evaluates distinct expressions independently (no key collision)", async function () {
+    const ctx = { outputs: { a: 1, b: 2 } };
+    assert.equal(await evaluateAssertion("$$outputs.a == 1", ctx), true);
+    assert.equal(await evaluateAssertion("$$outputs.b == 1", ctx), false);
+    assert.equal(await evaluateAssertion("$$outputs.a == 1", ctx), true);
+  });
+});

--- a/test/telem-coverage.test.js
+++ b/test/telem-coverage.test.js
@@ -10,7 +10,11 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import sinon from "sinon";
 import { PostHog } from "posthog-node";
-import { telemetryNotice, sendTelemetry } from "../dist/core/telem.js";
+import {
+  telemetryNotice,
+  sendTelemetry,
+  awaitTelemetryFlush,
+} from "../dist/core/telem.js";
 
 const config = { logLevel: "silent" };
 
@@ -26,11 +30,16 @@ describe("telem coverage: telemetryNotice", function () {
 
 describe("telem coverage: sendTelemetry", function () {
   let captureStub;
+  let shutdownStub;
   beforeEach(function () {
     captureStub = sinon.stub(PostHog.prototype, "capture").callsFake(() => {});
-    sinon.stub(PostHog.prototype, "shutdown").callsFake(async () => {});
+    shutdownStub = sinon
+      .stub(PostHog.prototype, "shutdown")
+      .callsFake(async () => {});
   });
-  afterEach(function () {
+  afterEach(async function () {
+    // Drain any flush this test kicked off before restoring the stubs.
+    await awaitTelemetryFlush();
     sinon.restore();
     delete process.env.DOC_DETECTIVE_META;
   });
@@ -84,5 +93,47 @@ describe("telem coverage: sendTelemetry", function () {
     sendTelemetry({ ...config }, "someCommand", {});
     const event = captureStub.firstCall.args[0];
     assert.equal(event.properties.core_platform, "freebsd");
+  });
+
+  // Phase 1.6: the flush is kicked off inside sendTelemetry (bounded, not
+  // awaited there) and joined later via awaitTelemetryFlush, so the PostHog
+  // round-trip overlaps reporter/hint I/O instead of hanging off the tail.
+  it("kicks off a BOUNDED shutdown flush (2000ms), not an unbounded one", function () {
+    sendTelemetry({ ...config }, "someCommand", {});
+    assert.equal(shutdownStub.calledOnce, true);
+    assert.equal(shutdownStub.firstCall.args[0], 2000);
+  });
+
+  it("awaitTelemetryFlush joins the in-flight flush kicked off by sendTelemetry", async function () {
+    let flushResolved = false;
+    shutdownStub.callsFake(
+      () =>
+        new Promise((resolve) =>
+          setImmediate(() => {
+            flushResolved = true;
+            resolve();
+          })
+        )
+    );
+    sendTelemetry({ ...config }, "someCommand", {});
+    // Flush hasn't completed synchronously — awaitTelemetryFlush must wait.
+    assert.equal(flushResolved, false);
+    await awaitTelemetryFlush();
+    assert.equal(flushResolved, true);
+  });
+
+  it("awaitTelemetryFlush is a no-op when telemetry is disabled (no flush pending)", async function () {
+    await awaitTelemetryFlush(); // drain anything prior
+    sendTelemetry({ ...config, telemetry: { send: false } }, "runTests", {});
+    assert.equal(shutdownStub.called, false);
+    await awaitTelemetryFlush(); // resolves immediately, does not throw
+  });
+
+  it("awaitTelemetryFlush swallows a shutdown rejection (telemetry never fails a run)", async function () {
+    shutdownStub.callsFake(async () => {
+      throw new Error("network down");
+    });
+    sendTelemetry({ ...config }, "someCommand", {});
+    await awaitTelemetryFlush(); // must not throw
   });
 });

--- a/test/temp-screenshot-url-tests/seed-spec.json
+++ b/test/temp-screenshot-url-tests/seed-spec.json
@@ -1,1 +1,0 @@
-{"tests":[{"steps":[{"goTo":"http://localhost:8092"},{"screenshot":{"path":"C:\\Users\\hawkeyexl\\Documents\\Workspaces\\doc-detective\\.claude\\worktrees\\perf-optimization-opportunities-eff6e9\\test\\temp-screenshot-url-tests\\seed-screenshot.png","overwrite":"true"}}]}]}

--- a/test/temp-screenshot-url-tests/seed-spec.json
+++ b/test/temp-screenshot-url-tests/seed-spec.json
@@ -1,0 +1,1 @@
+{"tests":[{"steps":[{"goTo":"http://localhost:8092"},{"screenshot":{"path":"C:\\Users\\hawkeyexl\\Documents\\Workspaces\\doc-detective\\.claude\\worktrees\\perf-optimization-opportunities-eff6e9\\test\\temp-screenshot-url-tests\\seed-screenshot.png","overwrite":"true"}}]}]}

--- a/test/utils-coverage.test.js
+++ b/test/utils-coverage.test.js
@@ -20,6 +20,7 @@ import sinon from "sinon";
 import axios from "axios";
 import {
   log,
+  logLevelEnabled,
   setConfig,
   outputResults,
   reporters,
@@ -156,6 +157,33 @@ describe("utils.ts coverage", function () {
       const cap = captureConsole(sandbox);
       log("detail", "debug", { logLevel: "debug" });
       assert.ok(cap.log.includes("detail"));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // logLevelEnabled (lazy-log gate for CLI dumps) — signature is
+  // logLevelEnabled(level, config), mirroring log(message, level, config)
+  // ---------------------------------------------------------------------------
+  describe("logLevelEnabled", function () {
+    it("defaults to 'info' when config.logLevel is absent", function () {
+      assert.equal(logLevelEnabled("info"), true);
+      assert.equal(logLevelEnabled("debug"), false);
+    });
+    it("gates debug output on logLevel === 'debug'", function () {
+      assert.equal(logLevelEnabled("debug", { logLevel: "info" }), false);
+      assert.equal(logLevelEnabled("debug", { logLevel: "debug" }), true);
+    });
+    it("never enables the 'silent' level (index must be > 0)", function () {
+      assert.equal(logLevelEnabled("silent", { logLevel: "debug" }), false);
+    });
+    it("agrees with log(): guarding a dump prints iff enabled", function () {
+      const cap = captureConsole(sandbox);
+      const cfg = { logLevel: "info" };
+      if (logLevelEnabled("debug", cfg)) log("DUMP", "debug", cfg);
+      assert.equal(cap.log, "");
+      const dbg = { logLevel: "debug" };
+      if (logLevelEnabled("debug", dbg)) log("DUMP", "debug", dbg);
+      assert.ok(cap.log.includes("DUMP"));
     });
   });
 


### PR DESCRIPTION
## Phase 1 of the run-performance plan

Companion design: `docs/design/run-performance.md` (included in this PR). This is the first of five stacked PRs. **Phase 1 is behavior-preserving latency removal** — no observable behavior change, so per the design it carries **no ADR and no feature fixtures**; each change ships with unit coverage instead.

### Changes
- **Lazy log stringification** — a new `logLevelEnabled` predicate (mirrors each `log()`'s existing level policy) guards the per-step / per-context / per-spec and two whole-tree `JSON.stringify(..., null, 2)` debug dumps so the stringify only runs when debug would actually print. Sites: `src/core/tests.ts`, `src/core/resolveTests.ts`, `src/cli.ts`.
- **`appiumIsReady`** — probe `/status` immediately, then poll at 250ms, instead of a fixed ~1s sleep before the first probe. Readiness/​sleep are injectable for hermetic unit tests; the 120s overall cap is unchanged.
- **Overlapped Appium server readiness** — `spawnAppiumServer` splits spawn from readiness so servers still spawn **serially** (preserving the `findFreePort` rebind-race protection) while their readiness polls **overlap** via `Promise.all`. Single-server callers keep using `startAppiumServer` (spawn + await, unchanged contract).
- **Expression-evaluator cache** — memoize the compiled `new Function(...)` by `argNames + source`; context values are still passed per call.
- **`replaceEnvs`** — hoist the env-var regex to module scope (was constructed per string node per walk).
- **Bounded telemetry flush** — `sendTelemetry` kicks off `client.shutdown(2000)`; `awaitTelemetryFlush` joins it **after** reporters + hint, so the PostHog round-trip overlaps that I/O instead of hanging off process exit. No `unref` (events aren't dropped).
- **Detection micro-fixes** — single `statSync` per path (was two), `allowedExtensions` computed once as a `Set`, and `safeRegExp` compiles each `(pattern, flags)` once (was ~36 recompiles per markdown file).

### Validation
Local unit suites green: expressions/telemetry/utils/appium-ready **265 passing**, detection/resolution **68 passing**, full `src/common` package **949 passing**, 0 failing. Full browser e2e/fixtures run in CI.

### Docs impact
None user-facing (internal performance only). The design doc is added under `docs/design/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved test-run startup and execution efficiency, including faster service readiness checks and reduced repeated processing.
  * Reduced unnecessary work when debug logging is disabled.
  * Improved expression evaluation and file detection performance.

* **Reliability**
  * Telemetry now completes more consistently without delaying or interrupting test runs.
  * Appium readiness failures provide clearer timeout handling and cleanup.

* **Documentation**
  * Added a comprehensive design document outlining planned run-performance improvements and measurement guidance.

* **Tests**
  * Expanded coverage for logging, telemetry, readiness checks, expression evaluation, and pattern handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->