### PR TITLE
fix(core): surface swallowed 2-arg log() calls (default level to info)

### DIFF
--- a/adrs/01061-default-core-log-level-to-info.md
+++ b/adrs/01061-default-core-log-level-to-info.md
@@ -1,0 +1,108 @@
+---
+status: accepted
+date: 2026-07-14
+decision-makers: [hawkeyexl]
+---
+
+# Default the core `log` level to `info` so 2-arg calls stop silently dropping messages
+
+## Context and Problem Statement
+
+The core logger `log(config, level, message)` in [src/core/utils.ts](../src/core/utils.ts) supports a
+convenience 2-argument form, `log(message, level)`. When invoked with two arguments it resets
+`config = {}`, so `config.logLevel` is `undefined`. The level-gating logic — extracted by the Phase-1
+performance work (PR #632) into the pure predicate `logLevelEnabled(config, level)`, which `log`
+delegates to — is a chain of `if (config.logLevel === "error" && …)` branches with **no branch for an
+undefined `logLevel`**, so the predicate evaluates to `false` and nothing is printed.
+
+Every 2-arg call therefore emitted **nothing**. The seven active 2-arg call sites all live in
+[src/core/expressions.ts](../src/core/expressions.ts) — expression/assertion evaluation:
+
+- line 45 — `"warning"`: could not resolve a standalone expression
+- line 238 — `"error"`: error applying a JSON pointer to a value
+- line 305 — `"warning"`: could not evaluate an embedded `{{…}}` expression
+- line 449 — `"error"`: regex extraction error
+- line 493 — `"error"`: error evaluating an expression (`new Function` failure)
+- line 779 — `"debug"`: condition has an unresolved meta value; treated as false
+- line 804 — `"error"`: error evaluating an assertion
+
+Several are `"error"`-level diagnostics that should surface to help users debug broken conditions and
+expressions. Instead they were swallowed. This was confirmed by CodeRabbit on PR #632.
+
+## Decision Drivers
+
+- Error and warning diagnostics from expression/assertion evaluation should reach the user.
+- The fix should be small, low-risk, and not require restructuring the expression engine.
+- Level semantics should stay consistent with the other logger in the codebase.
+- Explicit silencing (`logLevel: "silent"`) must keep suppressing all output.
+
+## Considered Options
+
+- **(a) Default an undefined `logLevel` to `"info"`** inside the `logLevelEnabled` predicate that the
+  core `log` delegates to (parity with [src/utils.ts](../src/utils.ts)'s `log`, which already does
+  `config.logLevel || "info"`).
+- **(b) Convert the seven `expressions.ts` sites to the 3-arg `log(config, level, message)` form** by
+  threading a `config` object into the expression engine so each log respects the user's configured
+  `logLevel`.
+
+## Decision Outcome
+
+Chosen option: **(a)**, because `config` is **not in scope** at any `expressions.ts` log site and does
+not thread cleanly. The seven functions involved (`resolveExpression`, `resolveExpressionOrThrow`,
+`replaceMetaValues`, `getMetaValue`, `resolveEmbeddedExpressions`, `evaluateExpression`,
+`evaluateAssertion`) all pass a `context` object, never a `config`. Threading `config` would require
+changing all seven signatures **plus** the routing-layer callers
+(`evaluateImplicitAssertions`, `evaluateGuard`, `evaluateCustomAssertions`, and their entire call
+chains through [src/core/routing.ts](../src/core/routing.ts) and
+[src/core/tests.ts](../src/core/tests.ts)) — a broad, invasive change spread across several files for
+a one-line defect. Option (a) is a single, well-contained fix that also aligns the core logger's
+default with the existing CLI logger.
+
+The change: inside `logLevelEnabled`, compute `const currentLevel = config.logLevel || "info"` and
+branch on `currentLevel`. Because `log` delegates to `logLevelEnabled`, the guard predicate (used by
+hot call sites to skip expensive message construction) and `log`'s own gating share one source of
+truth for the level policy and cannot drift.
+
+### Consequences
+
+- Good, because previously-silent `error`/`warning` diagnostics from expression and assertion
+  evaluation now surface for users at the default `info` verbosity.
+- Good, because core `log` now matches [src/utils.ts](../src/utils.ts)'s `info` default, removing a
+  latent inconsistency between the two loggers.
+- Good, because `logLevel: "silent"` (and any explicit level) is preserved — the default only applies
+  to an undefined/empty level, so explicit silencing still suppresses everything.
+- Neutral/known trade-off: all 2-arg core `log` calls now print at the `info` default regardless of
+  the user's configured level (a 2-arg call carries no `config`, so it never could respect the
+  configured level). This is bounded — only the seven `expressions.ts` sites use the 2-arg form, the
+  `"debug"` one (line 779) still stays suppressed under the `info` default, and every other core
+  `log` call already uses the 3-arg form or a correctly-wrapped injected logger that forwards
+  `config`. If a future need arises to make these respect configured verbosity, option (b) remains
+  available as a follow-up.
+
+### Confirmation
+
+Covered by unit tests in
+[test/core-utils-coverage.test.js](../test/core-utils-coverage.test.js). In the
+`log (level filtering + 2-arg form)` block, the 2-arg form now emits `info`/`warning`/`error`,
+still suppresses `debug` under the `info` default, and the 3-arg form with an explicit `logLevel` is
+unaffected. In the `logLevelEnabled` block, the predicate now reports `true` for an undefined/empty
+`logLevel` at `error`/`warning`/`info` and `false` at `debug`, while an explicit `silent` still
+suppresses everything. The pre-existing tests that asserted the buggy "2-arg form logs nothing" and
+"undefined `logLevel` returns `false`" behaviors were updated to assert the corrected behavior.
+
+## Pros and Cons of the Options
+
+### (a) Default undefined `logLevel` to `info`
+
+- Good, because it is a one-line, self-contained change with no ripple across the expression engine.
+- Good, because it makes the core logger consistent with the CLI logger's existing `info` default.
+- Good, because it preserves explicit `silent`/level settings.
+- Bad, because 2-arg calls print at `info` regardless of configured verbosity (bounded to the seven
+  `expressions.ts` sites, and `debug` stays suppressed).
+
+### (b) Thread `config` into the expression engine and use the 3-arg form
+
+- Good, because those logs would respect the user's configured `logLevel`.
+- Bad, because `config` is not in scope anywhere in the expression engine; it would require changing
+  seven `expressions.ts` signatures plus the routing/tests call chains — a large, invasive change for
+  a one-line defect, with correspondingly higher regression risk.

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1296,19 +1296,28 @@ async function loadEnvs(envsFile: string) {
 // `log` itself delegates to this so the level policy has a single source of
 // truth and can never drift from the guard.
 function logLevelEnabled(config: any, level: string): boolean {
-  if (config.logLevel === "error" && level === "error") return true;
+  // Default an undefined/empty logLevel to "info" (parity with src/utils.ts#log,
+  // which already defaults to info). Without this fallback none of the branches
+  // below match an undefined logLevel, so the 2-arg `log(message, level)` form —
+  // which resets config to {} — silently dropped EVERY message, swallowing the
+  // error/warning logs emitted at 2-arg call sites in expressions.ts. An explicit
+  // level such as "silent" is preserved, so intentional silencing still
+  // suppresses all output. Defaulting here (rather than in `log`) keeps the guard
+  // predicate and `log` as a single source of truth for the level policy.
+  const currentLevel = config.logLevel || "info";
+  if (currentLevel === "error" && level === "error") return true;
   if (
-    config.logLevel === "warning" &&
+    currentLevel === "warning" &&
     (level === "error" || level === "warning")
   )
     return true;
   if (
-    config.logLevel === "info" &&
+    currentLevel === "info" &&
     (level === "error" || level === "warning" || level === "info")
   )
     return true;
   if (
-    config.logLevel === "debug" &&
+    currentLevel === "debug" &&
     (level === "error" ||
       level === "warning" ||
       level === "info" ||

--- a/test/core-utils-coverage.test.js
+++ b/test/core-utils-coverage.test.js
@@ -365,9 +365,25 @@ describe("core/utils coverage", function () {
       assert.equal(logged[0], "(INFO)");
       assert.equal(logged[1], JSON.stringify({ a: 1 }, null, 2));
     });
-    it("supports the 2-arg form log(message, level) with empty config (no match)", async function () {
-      // config defaults to {} so logLevel is undefined → no match → nothing logged
+    it("2-arg form log(message, level) defaults an undefined logLevel to info and emits", async function () {
+      // config defaults to {} so logLevel is undefined → treated as "info" (parity
+      // with src/utils.ts#log). error/warning/info messages must surface rather
+      // than being silently dropped (regression: 2-arg expressions.ts log sites).
       await log("just a message", "info");
+      await log("an error", "error");
+      await log("a warning", "warning");
+      assert.deepEqual(logged, ["(INFO) just a message", "(ERROR) an error", "(WARNING) a warning"]);
+    });
+    it("2-arg form still suppresses debug under the info default", async function () {
+      // The info default surfaces error/warning/info but NOT debug — matching the
+      // configured-info semantics, so 2-arg calls don't force debug spam.
+      await log("a debug line", "debug");
+      assert.equal(logged.length, 0);
+    });
+    it("3-arg form with explicit logLevel is unaffected by the default", async function () {
+      // A caller that DOES supply logLevel keeps exact configured semantics: an
+      // explicit "error" level still suppresses info.
+      await log({ logLevel: "error" }, "info", "quiet");
       assert.equal(logged.length, 0);
     });
   });
@@ -409,9 +425,22 @@ describe("core/utils coverage", function () {
       assert.equal(logLevelEnabled(c, "info"), true);
       assert.equal(logLevelEnabled(c, "debug"), true);
     });
-    it("undefined/silent logLevel: nothing enabled (matches log's no-match behavior)", function () {
-      assert.equal(logLevelEnabled({}, "error"), false);
+    it("undefined/empty logLevel defaults to info (parity with log's 2-arg default)", function () {
+      // Undefined/empty logLevel is treated as "info": error/warning/info enabled,
+      // debug not. This mirrors log()'s default so the guard never drifts from the
+      // emit — the fix that stopped 2-arg calls being silently dropped.
+      assert.equal(logLevelEnabled({}, "error"), true);
+      assert.equal(logLevelEnabled({}, "warning"), true);
+      assert.equal(logLevelEnabled({}, "info"), true);
+      assert.equal(logLevelEnabled({}, "debug"), false);
+      assert.equal(logLevelEnabled({ logLevel: "" }, "error"), true);
+      assert.equal(logLevelEnabled({ logLevel: "" }, "debug"), false);
+    });
+    it("explicit silent logLevel suppresses everything", function () {
       assert.equal(logLevelEnabled({ logLevel: "silent" }, "error"), false);
+      assert.equal(logLevelEnabled({ logLevel: "silent" }, "warning"), false);
+      assert.equal(logLevelEnabled({ logLevel: "silent" }, "info"), false);
+      assert.equal(logLevelEnabled({ logLevel: "silent" }, "debug"), false);
     });
     it("agrees with log(): guarding a debug dump prints iff enabled", async function () {
       // At info level the guard is false, so the expensive message is never


### PR DESCRIPTION
## Bug
The core `log(config, level, message)` in `src/core/utils.ts` silently dropped **every** call made in its 2-argument `log(message, level)` convenience form: that form resets `config = {}`, and the level-gating chain had no branch for an undefined `logLevel`, so nothing matched and the message was discarded. This swallowed the error/warning diagnostics emitted at **seven** 2-arg call sites in `src/core/expressions.ts` (expression + assertion evaluation failures — e.g. "Error evaluating assertion …", regex/JSON-pointer errors). Confirmed by CodeRabbit while reviewing #632.

Pre-existing bug — **not** introduced by the perf work in #632.

## Fix
Default an undefined/empty `config.logLevel` to `"info"` (parity with `src/utils.ts`'s `log`, which already does this). Explicit levels — including `"silent"` — are preserved, so intentional silencing still suppresses everything.

### Why (a) default-to-info, not (b) thread `config` through expressions.ts
`config` is **not in scope** at any of the seven sites; all expression-engine functions thread a `context`, never a `config`. Option (b) would require changing seven signatures plus the routing/`tests.ts` call chains — a broad change for a one-line defect. See `adrs/01061-default-core-log-level-to-info.md`.

## Behavior change / docs impact
User-visible: users running expressions/conditions may now see expression- and assertion-evaluation **error/warning** logs that were previously swallowed. The documented `logLevel` contract is unchanged (`info` remains the default). No dedicated docs page covers this; the reasoning is captured in the ADR.

## Validation
`npm run compile` clean. Affected suites (core-utils, utils, expressions, routing, guard-if, custom-assertions): **501 passing, 0 failing**. The one pre-existing test that asserted the buggy "2-arg logs nothing" behavior was intentionally updated; no test asserts on the now-surfaced message strings.

## ⚠️ Concurrent-PR interaction with #632
Both this PR and #632 (perf phase 1) edit the same `log()` machinery in `src/core/utils.ts`. #632 extracts a `logLevelEnabled(config, level)` predicate (preserving today's no-default behavior) and has `log()` delegate to it; this PR adds the `"info"` default to the original if/else chain. **They will conflict.** Intended reconciliation, whichever merges second: apply the `|| "info"` default **inside `logLevelEnabled`** so the predicate and `log()` stay consistent (single source of truth). I'll rebase the second one.

## ADR number
`01061` (next after `01060`). This repo has known concurrent-PR ADR-number collisions; may need renumbering at merge if another in-flight PR claims it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Core logging now defaults to `info` when no log level is configured, so two-argument log calls no longer drop `info`/`warning`/`error` output.
  * `debug` remains suppressed by default, and explicit log-level settings (including `silent`) continue to control output.
* **Documentation**
  * Added an architectural decision record describing the new default logging behavior.
* **Tests**
  * Updated log-level filtering and coverage expectations for default and explicitly configured cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->