### PR TITLE
perf(core): phase 2 — startup-path latency removal

### DIFF
--- a/adrs/01062-driver-presence-is-a-filesystem-question.md
+++ b/adrs/01062-driver-presence-is-a-filesystem-question.md
@@ -1,0 +1,139 @@
+---
+status: accepted
+date: 2026-07-14
+decision-makers: doc-detective maintainers
+---
+
+# Driver presence is a filesystem question, not an `appium driver list` question
+
+## Context and Problem Statement
+
+`getAvailableApps` (`src/core/config.ts`) is the runtime gate that decides which browsers a run can
+launch. To learn which Appium browser drivers are installed, `probeBrowserEnvironment` spawned
+`node <appium> driver list` and regex-parsed its formatted text table:
+
+```
+appiumDriverOutput.match(/\n.*chromium.*installed \(npm\).*\n/)  // chrome gate
+appiumDriverOutput.match(/\n.*gecko.*installed \(npm\).*\n/)     // firefox gate
+appiumDriverOutput.match(/\n.*safari.*installed \(npm\).*\n/)    // safari gate
+```
+
+That spawn is **~17 s by its own comment** and runs on every driver-touching run, inside `setConfig`
+— a fixed startup tax paid before any test executes. Yet the answer it computes ("is this
+appium-\*-driver installed?") is a pure filesystem question: the drivers are npm packages, and the
+**same module already resolves package presence directly** for the diagnostic dump
+(`getBrowserDiagnostics`'s `npmInstalled` → `resolveHeavyDepPath(name, { cacheDir })`) and for the
+JIT installer's already-up-to-date check (`ensureRuntimeInstalled`). Spawning a whole Node process +
+Appium's CLI + parsing a human-formatted table to discover what a `require.resolve`-style lookup
+answers instantly and offline is the single largest avoidable fixed cost in the startup path
+(design doc `docs/design/run-performance.md`, item 2.1).
+
+The tension: presence-on-disk is *cheaper information* than what a spawn learns, but is it
+*equivalent enough*? `appium driver list` in principle reflects Appium's own view of a driver home;
+a package being resolvable on disk is a necessary condition for that, but not identical.
+
+## Decision Drivers
+
+* Eliminate the ~17 s fixed spawn on every driver-touching run without changing which browsers are
+  reported available.
+* Preserve the existing two-layer resilience strategy: presence (Layer 1) is necessary-but-not-
+  sufficient; the functional `verifyDriverBinary` execution check (Layer 2, ADR 01008) is what
+  actually proves a driver can start a session. Only the *presence-discovery mechanism* should
+  change — never the functional gate.
+* Coverage parity: the presence check must recognize *exactly* the drivers the old table-regex
+  recognized (chromium, gecko, safari), mapped to their npm package names, so no browser silently
+  drops out of detection.
+* Consistency: use the same presence mechanism the rest of the module already uses
+  (`resolveHeavyDepPath` via `getBrowserDiagnostics`'s `npmInstalled`).
+
+## Considered Options
+
+* **A. Direct package-presence checks** (chosen) — replace the spawn + table parse with
+  `detectInstalledBrowserDrivers(config)`, which resolves each `appium-*-driver` package on disk via
+  `resolveHeavyDepPath`. Keep `verifyDriverBinary` (Layer 2) exactly as-is.
+* **B. Keep the spawn but cache/parallelize it** — memoize the `driver list` output more
+  aggressively, or move it off the critical path.
+* **C. Parse Appium's manifest cache** (`extensions.yaml`) instead of spawning — read the file
+  Appium itself writes.
+
+## Decision Outcome
+
+Chosen option: **A**. The drivers are npm packages; their presence is a filesystem fact, and the
+codebase already answers it that way in `getBrowserDiagnostics` and the installer. `detectInstalled
+BrowserDrivers` returns `{ chromium, gecko, safari }` booleans, each mapped to exactly the package
+the old regex recognized:
+
+| old table regex | npm package |
+|---|---|
+| `/chromium.*installed \(npm\)/` | `appium-chromium-driver` |
+| `/gecko.*installed \(npm\)/` | `appium-geckodriver` |
+| `/safari.*installed \(npm\)/` | `appium-safari-driver` |
+
+`probeBrowserEnvironment` now returns `installedDrivers` (that boolean set) instead of the raw
+`appiumDriverOutput` string; `getAvailableApps` reads `installedDrivers.chromium/gecko/safari` in
+place of the three `.match(...)` calls. **No child process, no table parse, no ~17 s wait.**
+
+Crucially, the **Layer 2 functional gate is untouched**: every candidate browser still passes
+through `verifyAppDrivers` → `verifyDriverBinary`, which executes `<driver> --version` before the
+browser is reported available. A partially-downloaded or broken driver that is *present on disk* but
+can't run is still excluded exactly as before — presence changed how we *discover* candidates, not
+how we *validate* them.
+
+B was rejected: caching a 17 s spawn still pays it once per process and keeps a whole Node+Appium
+subprocess and brittle human-table parsing on the critical path for information a package lookup
+already has. C was rejected: the manifest cache is an Appium implementation detail that is
+deliberately deleted by the driver-install preflight (see `src/runtime/AGENTS.md` — "Appium
+extension manifest cache"), so reading it would race the very code that invalidates it; the
+package-on-disk check has no such coupling.
+
+### Consequences
+
+* Good: the dominant fixed startup cost (~17 s/run) is removed for every browser/driver-touching
+  run, including native-platform runs that also went through this probe.
+* Good: presence discovery now uses the identical mechanism as the diagnostic dump and the
+  installer, so the three views of "is this driver installed?" can no longer disagree.
+* Neutral (accepted trade): "present on disk" and "Appium reports installed (npm)" are not
+  *definitionally* identical. In practice the driver being a resolvable npm package is precisely what
+  makes `appium driver list` report it, and the ESM-driver resolution fallback
+  (`resolveHeavyDepPath`, ADR 01006) already handles the exports-map edge cases. The residual risk —
+  a package resolvable on disk that Appium nonetheless refuses to load — is caught downstream: it
+  surfaces at session start, where ADR 01008's cross-engine fallback takes over, the same safety net
+  that always guarded a driver that passes presence but fails at runtime.
+* Neutral: `verifyDriverBinary` (Layer 2) is retained verbatim; the "present ≠ functional"
+  distinction the old code relied on is preserved.
+
+### Confirmation
+
+* Red→green hermetic unit tests in `test/config-coverage.test.js`
+  (`detectInstalledBrowserDrivers (2.1)`): assert the name→package mapping (chromium →
+  `appium-chromium-driver`, gecko → `appium-geckodriver`, safari → `appium-safari-driver`) via an
+  injected presence checker, so coverage parity with the old regexes is pinned.
+* The existing `getAvailableApps` tests (empty cache dir → `[]`, the macOS Safari branch, the
+  pre-resolved-API-config path) continue to pass unchanged, confirming behavior equivalence.
+* End-to-end, the `apps`/browser fixtures in `test/core-artifacts/` exercise the discovery path
+  through the real runner on every browser CI leg.
+
+## Pros and Cons of the Options
+
+### A. Direct package-presence checks
+* Good: removes the ~17 s spawn; reuses the module's existing presence mechanism; preserves Layer 2.
+* Bad: presence-on-disk is a slightly weaker signal than a live Appium query (mitigated by the
+  retained functional gate + runtime fallback).
+
+### B. Keep but cache/parallelize the spawn
+* Good: no change to the information source.
+* Bad: still spawns a Node+Appium subprocess and parses a human table for a filesystem fact; still
+  pays the cost once per process.
+
+### C. Parse Appium's manifest cache
+* Good: reflects Appium's own view without spawning.
+* Bad: reads an implementation-detail file the install preflight deliberately deletes — a direct
+  race with existing behavior documented in `src/runtime/AGENTS.md`.
+
+## More Information
+
+Design: `docs/design/run-performance.md` (Phase 2, item 2.1, and Decision 1). Related:
+[ADR 01008](01008-resilient-any-browser-driver-fallback.md) (the retained runtime driver
+fallback / Layer 2 rationale), [ADR 01006](01006-appium-v3-drivers-esm-heavy-dep-resolution.md) (ESM-driver
+`resolveHeavyDepPath` fallback), and `src/runtime/AGENTS.md` (JIT-install architecture, the Appium
+manifest-cache hazard).

--- a/adrs/01063-overlap-self-update-check-with-resolution.md
+++ b/adrs/01063-overlap-self-update-check-with-resolution.md
@@ -1,0 +1,116 @@
+---
+status: accepted
+date: 2026-07-14
+decision-makers: doc-detective maintainers
+---
+
+# Overlap the self-update check with detection/resolution, join before the first test
+
+## Context and Problem Statement
+
+On the default `doc-detective` run, `runTestsHandler` (`src/cli.ts`) performs a startup self-update:
+it calls `checkForUpdate(currentVersion)` (an npm-registry GET, bounded at 3 s) and, if a newer
+version exists, `selfUpdate(...)` — which `npm install -g`s the new version and re-execs the process.
+This ran **serially, awaited before any other startup work**, so a run paid up to ~3 s of registry
+latency up front, doing nothing else, before it even began detecting and resolving tests
+(`docs/design/run-performance.md`, item 2.3).
+
+Detection and resolution (`detectAndResolveTests` inside `runTests`) execute **no tests** — they read
+and validate spec files and resolve contexts. That is exactly the kind of unavoidable work the
+registry round-trip could hide behind. The question is how to overlap the check with resolution
+**without weakening the guarantee that an available update is applied before the run executes** —
+the whole point of a startup self-update is that you don't run the old version's tests when a new
+version is one command away.
+
+## Decision Drivers
+
+* Hide the up-to-3 s registry latency behind work that has to happen anyway (detection/resolution).
+* Preserve the ordering guarantee exactly: if a newer version is found, `selfUpdate` still re-execs
+  **before the first test runs** (and before any dry-run output is emitted).
+* No new configuration surface: `config.autoUpdate` (and `DOC_DETECTIVE_SKIP_AUTO_UPDATE`, `CI`)
+  already gate the check from resolved config; don't add a flag.
+* Correctness of concurrency: the network check may overlap resolution, but the *re-exec decision*
+  must be a synchronous barrier before execution — never run tests in the parent while a child
+  re-exec also runs them.
+
+## Considered Options
+
+* **A. Start `checkForUpdate` concurrently; join (and conditionally `selfUpdate`) inside `runTests`
+  before the first test** (chosen). The CLI kicks off the registry check without awaiting it and
+  hands `runTests` an `updateJoin` closure; `runTests` awaits `updateJoin` after resolution and
+  before the dry-run/preflight/execution.
+* **B. Run the whole check *and* `selfUpdate` concurrently** with resolution, without a join barrier.
+* **C. Leave it serial** — accept the latency.
+
+## Decision Outcome
+
+Chosen option: **A**. The CLI starts only the **registry check** concurrently (`updateCheck`
+promise), so its latency overlaps `getResolvedTestsFromEnv` and the detection/resolution `runTests`
+does. The **decision to re-exec is deferred** into an `updateJoin` closure that `runTests` awaits at
+a single barrier: immediately after `detectAndResolveTests` resolves and **before** the dry-run JSON
+print, the JIT preflight, and `runSpecs`. On a newer version, `selfUpdate` re-execs (`process.exit`)
+at that barrier — so no test (and no dry-run output) is ever produced by the parent when an update is
+pending. When auto-update is gated off, `updateJoin` is `undefined` and the barrier is a no-op.
+
+Option **B** was rejected as **incorrect**: `selfUpdate`'s re-exec path (`runChild` in
+`src/runtime/selfUpdate.ts`) spawns the new version with inherited stdio and **awaits the child
+running the entire command to completion** before `process.exit`. Running that concurrently with the
+parent's own detection→execution would double-execute the run (child *and* parent both run tests) and
+race on `process.exit`. Only the *check* is safe to overlap; the *re-exec* must be a barrier.
+
+Option **C** keeps today's cost for no benefit.
+
+### The ordering guarantee (what is preserved)
+
+* The registry check *starts* earlier (concurrent with resolution) but its result is *joined* before
+  execution.
+* If `newer && latest`, `selfUpdate` runs at the join and re-execs before the first test — identical
+  observable outcome to the old serial code, minus the latency.
+* Because the re-exec's child sets `DOC_DETECTIVE_SKIP_AUTO_UPDATE=1`, no update loop is possible
+  (unchanged from before).
+* One deliberate ordering shift: `getResolvedTestsFromEnv` (the DOC_DETECTIVE_API fetch) now runs in
+  the parent *before* the join, where previously the whole update ran first. If an update is pending,
+  the parent may perform that fetch and then re-exec — harmless (the child re-fetches); the "update
+  before any test executes" guarantee is unaffected because that fetch executes no tests.
+
+### Consequences
+
+* Good: up to ~3 s of registry latency is hidden behind resolution on every auto-updating run.
+* Good: no new config/preference plumbing — the existing `autoUpdate`/`SKIP`/`CI` gate is unchanged.
+* Neutral: the update's *effect* (re-exec on newer) is unchanged and still precedes the run; only its
+  *latency* moved.
+* Bad (accepted, negligible): on a pending-update run the parent may do slightly more work before
+  re-execing (the API fetch above) than the old serial path did. The child re-does it; no test runs
+  twice.
+
+### Confirmation
+
+* Red→green unit test in `test/cli-index-adapters-coverage.test.js`
+  (`awaits options.updateJoin before dry-run output / test execution`): a stub `updateJoin` records
+  that it was awaited exactly once and that no dry-run stdout had yet been emitted at join time —
+  proving the barrier precedes both dry-run output and execution. On the pre-change code the option
+  was ignored (never called), so the test fails.
+* The `runTestsHandler` guard combinations (`autoUpdate`/`SKIP`/`CI`) remain covered offline by the
+  existing `cli.ts — runTestsHandler branches` describe. The network/`process.exit` bodies of
+  `checkForUpdate`/`selfUpdate` remain covered by `runtime/selfUpdate.ts`'s own module tests.
+
+## Pros and Cons of the Options
+
+### A. Concurrent check, deferred re-exec barrier inside runTests
+* Good: hides latency; preserves the guarantee exactly; correct under concurrency.
+* Bad: threads one `updateJoin` option from CLI into `runTests` (small surface addition).
+
+### B. Fully concurrent check + selfUpdate, no barrier
+* Good: maximal overlap.
+* Bad: incorrect — `selfUpdate` runs the child to completion, so parent+child double-execute the run
+  and race on exit.
+
+### C. Leave serial
+* Good: simplest; no change.
+* Bad: keeps the up-to-3 s fixed startup latency for no reason.
+
+## More Information
+
+Design: `docs/design/run-performance.md` (Phase 2, item 2.3, and Decision 3). The re-exec mechanics
+this decision depends on live in `src/runtime/selfUpdate.ts` (`selfUpdate` → `runChild` →
+`process.exit`).

--- a/adrs/01064-demote-results-tree-dump-to-debug.md
+++ b/adrs/01064-demote-results-tree-dump-to-debug.md
@@ -1,0 +1,99 @@
+---
+status: accepted
+date: 2026-07-14
+decision-makers: doc-detective maintainers
+---
+
+# Demote the full results-tree terminal dump from info to debug
+
+## Context and Problem Statement
+
+At the end of a run, `runTests` (`src/core/index.ts`) logged the entire results tree at **info**
+level:
+
+```ts
+log(config, "info", "RESULTS:");
+log(config, "info", results);   // pretty-printed JSON.stringify of the whole tree
+```
+
+`info` is the **default** log level, so every default run printed the complete, pretty-printed
+results object to the terminal — a tree that, on a real suite, is hundreds to thousands of lines.
+This duplicates what the reporters already render for the user: the terminal reporter prints a
+human summary, and the json/runFolder reporters write the full tree to files with a "See results
+at …" pointer. The raw info-level dump is therefore both **redundant** and a **terminal flood** that
+buries the reporter summary the user actually reads (`docs/design/run-performance.md`, item 2.4a).
+
+Because the default log level is `info`, changing where this dump appears is an **observable
+terminal-output contract change**, so it warrants an ADR even though the code change is a one-word
+level swap.
+
+## Decision Drivers
+
+* Stop flooding the default terminal with a duplicate of what the reporters already present.
+* Keep the raw tree available for debugging — it is genuinely useful when diagnosing a run, just not
+  at the default level.
+* Don't touch the reporters' output or the file artifacts; the summary and the written JSON/HTML are
+  the user-facing surfaces and must be unchanged.
+
+## Considered Options
+
+* **A. Demote the dump (label + tree) to `debug`** (chosen) — it prints under `--logLevel debug`
+  (or `DOC_DETECTIVE_RUNTIME`/config equivalents), and is silent at the default `info`.
+* **B. Delete the dump entirely** — the reporters already cover results; drop the raw tree.
+* **C. Keep it at `info`** — status quo.
+
+## Decision Outcome
+
+Chosen option: **A**. Both `log(config, "info", "RESULTS:")` and `log(config, "info", results)`
+become `log(config, "debug", …)`. At the default `info` level the terminal now shows the reporter
+summary and the "See results at …" pointers without the raw-tree flood; the full tree remains one
+`--logLevel debug` away for anyone diagnosing a run. The surrounding
+`"Cleaning up and finishing post-processing."` and the support message stay at `info` (they are
+short status lines, not the flood).
+
+B was rejected: the raw tree is a real debugging aid (it shows the exact in-memory result shape,
+including fields a reporter may summarize away), and moving it to `debug` keeps that value at zero
+default-output cost — strictly better than deleting it.
+
+### Consequences
+
+* Good: the default terminal is no longer flooded by a full JSON dump duplicating the reporters; the
+  human summary is what the user sees.
+* Good: the raw tree is still available at `debug` for diagnosis.
+* Observable change (the reason for this ADR): users who ran at the default level and *relied on*
+  the `RESULTS:` + JSON block appearing in stdout will no longer see it there. The same data is in
+  the json/runFolder report files (default reporters) and re-appears in the terminal at
+  `--logLevel debug`. This is called out in the docs-impact assessment (see below).
+* Neutral: this is independent of, and complementary to, item 2.4b (serializing the results JSON once
+  and sharing it between the json and runFolder reporters), which does not change any output.
+
+### Confirmation
+
+Red→green unit test in `test/cli-index-adapters-coverage.test.js`
+(`does not dump the full results tree at info level, but does at debug`): runs a `wait`-only spec
+(fully offline, no browser) through `runTests` at `info` and asserts the captured stdout does **not**
+contain `RESULTS:`, then at `debug` asserts it **does**. On the pre-change code the info run contained
+`RESULTS:`, so the test fails.
+
+## Pros and Cons of the Options
+
+### A. Demote to debug
+* Good: removes the default-level flood; keeps the tree for debugging; minimal change.
+* Bad: a behavior change for anyone parsing the info-level dump from stdout (mitigated: the data is
+  in the report files and at `debug`).
+
+### B. Delete entirely
+* Good: simplest; smallest output.
+* Bad: loses a genuine debugging aid (exact in-memory result shape) that costs nothing to keep at
+  `debug`.
+
+### C. Keep at info
+* Good: no change.
+* Bad: keeps flooding the default terminal with a duplicate of the reporters' output.
+
+## More Information
+
+Design: `docs/design/run-performance.md` (Phase 2, item 2.4, and Decision 5 on lazy log arguments).
+Docs-impact: the default-terminal-output change is noted for the CLI/logging reference; users who
+scripted against the info-level `RESULTS:` dump should read the report files or use `--logLevel
+debug`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -159,48 +159,68 @@ async function runTestsHandler(args: any) {
   // loops, and by Docker images), and process.env.CI (CI environments
   // should pin their version explicitly — surprise updates in CI are bad).
   //
-  // The `if` condition itself is exercised offline (every combination of the
-  // three guards short-circuiting false — see the "cli.ts — runTestsHandler
-  // branches" describe in test/cli-index-adapters-coverage.test.js, including
-  // a dedicated case that reaches the third (`!process.env.CI`) term). Only
-  // the block BODY needs a real network/exec dependency: `checkForUpdate`
-  // hits a real npm/GitHub registry, and `selfUpdate` re-execs the process via
-  // `process.exit` on a newer version. Neither has an injectable seam at this
-  // call site (the seam is one level down, in runtime/selfUpdate.ts's own
-  // exported functions, which are network/exec bound themselves) — forcing it
-  // here would either hit a real registry or replace the body with a no-op
-  // stub that proves nothing beyond "the dynamic import resolved". See
-  // runtime/selfUpdate.ts for that module's own (separately covered) tests.
+  // The registry check (`checkForUpdate`, up to a 3s round-trip) is STARTED
+  // here but not awaited: it runs concurrently with input detection /
+  // resolution (which execute no tests) so its latency is hidden behind work
+  // that has to happen anyway. `updateJoin` is handed to runTests, which awaits
+  // it AFTER resolution but BEFORE the first test (or any dry-run output) — so
+  // `selfUpdate` still re-execs the process before the run, preserving the
+  // "update before the run" guarantee (ADR 01063). Only the deferred decision
+  // (re-exec on a newer version) is joined; the check itself already overlapped.
+  //
+  // The `if` condition is exercised offline (every combination of the three
+  // guards short-circuiting false — see the "cli.ts — runTestsHandler branches"
+  // describe in test/cli-index-adapters-coverage.test.js). Only the block BODY
+  // needs a real network/exec dependency: `checkForUpdate` hits a real npm
+  // registry and `selfUpdate` re-execs the process via `process.exit` on a
+  // newer version. Neither has an injectable seam at this call site (the seam
+  // is one level down, in runtime/selfUpdate.ts's own exported functions, which
+  // are network/exec bound themselves). See runtime/selfUpdate.ts for that
+  // module's own (separately covered) tests. The join-inside-runTests seam is
+  // covered directly in test/cli-index-adapters-coverage.test.js.
+  let updateJoin: (() => Promise<void>) | undefined;
   if (
     config.autoUpdate !== false &&
     !process.env.DOC_DETECTIVE_SKIP_AUTO_UPDATE &&
     !process.env.CI
   ) {
     /* c8 ignore start - self-update: real registry HTTP + real process re-exec via process.exit; no injectable seam at this call site (see comment above) */
-    try {
-      const { checkForUpdate, detectInstallMode, selfUpdate } = await import(
-        "./runtime/selfUpdate.js"
-      );
-      const currentVersion: string = cliRequire("../package.json").version;
-      // Route the self-update module's logs through the CLI's existing
-      // log() helper so config.logLevel is respected (transient registry
-      // failures should not flood stdout at the default level). Map
-      // "warn" → "warning" since core/utils.ts uses the latter.
-      const cliLogger = (msg: string, level: string = "info") => {
-        const mapped = level === "warn" ? "warning" : level;
-        log(msg, mapped, config);
-      };
-      const { latest, newer } = await checkForUpdate(currentVersion, {
-        logger: cliLogger,
-      });
-      if (newer && latest) {
-        await selfUpdate(latest, detectInstallMode(), { logger: cliLogger });
+    // Route the self-update module's logs through the CLI's existing log()
+    // helper so config.logLevel is respected. Map "warn" → "warning".
+    const cliLogger = (msg: string, level: string = "info") => {
+      const mapped = level === "warn" ? "warning" : level;
+      log(msg, mapped, config);
+    };
+    const currentVersion: string = cliRequire("../package.json").version;
+    // Kick off the registry check now, concurrently with the detection /
+    // resolution work that runTests is about to do. Self-contained error
+    // handling so a rejected promise never becomes an unhandled rejection.
+    const updateCheck = (async () => {
+      try {
+        const { checkForUpdate } = await import("./runtime/selfUpdate.js");
+        return await checkForUpdate(currentVersion, { logger: cliLogger });
+      } catch (err) {
+        log(`Self-update check skipped: ${String(err)}`, "debug", config);
+        return { latest: null as string | null, newer: false };
       }
-    } catch (err) {
-      log(`Self-update check skipped: ${String(err)}`, "debug", config);
-    }
+    })();
+    // Deferred join: awaited by runTests once resolution is done and before the
+    // first test. On a newer version, selfUpdate re-execs (process.exit) here.
+    updateJoin = async () => {
+      try {
+        const { latest, newer } = await updateCheck;
+        if (newer && latest) {
+          const { detectInstallMode, selfUpdate } = await import(
+            "./runtime/selfUpdate.js"
+          );
+          await selfUpdate(latest, detectInstallMode(), { logger: cliLogger });
+        }
+      } catch (err) {
+        log(`Self-update check skipped: ${String(err)}`, "debug", config);
+      }
+    };
+    /* c8 ignore stop */
   }
-  /* c8 ignore stop */
 
   // Check for DOC_DETECTIVE_API environment variable
   const api = await getResolvedTestsFromEnv(config);
@@ -210,8 +230,8 @@ async function runTestsHandler(args: any) {
   // Run tests
   const output = config.output;
   const results = resolvedTests
-    ? await runTests(config, { resolvedTests })
-    : await runTests(config);
+    ? await runTests(config, { resolvedTests, updateJoin })
+    : await runTests(config, { updateJoin });
 
   // Dry-run already emitted the resolved-tests JSON inside runTests().
   // Skip both reporters (which assume executed-result shape) and the

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export { setConfig, getAvailableApps, getBrowserDiagnostics, getEnvironment, resolveConcurrentRunners, clearAppCache, verifyAppDrivers };
+export { setConfig, getAvailableApps, getBrowserDiagnostics, getEnvironment, resolveConcurrentRunners, clearAppCache, patchAppCache, verifyAppDrivers, detectInstalledBrowserDrivers };
 
 /**
  * A candidate browser app plus the driver binary that must be functional for
@@ -572,9 +572,9 @@ async function setConfig({ config }: any) {
   // the runner paths in tests.ts re-discover apps themselves via
   // getAvailableApps rather than reading this field back — so skipping the
   // detection on a dry run avoids the @puppeteer/browsers load, the
-  // browser-cache scan, and the unbounded `appium driver list` spawn (the work
-  // that pushes dryRun.test.js past its mocha timeout on a starved
-  // windows+node22 runner) with no effect on resolved output or execution.
+  // browser-cache scan, and the driver-presence probing (the work that pushes
+  // dryRun.test.js past its mocha timeout on a starved windows+node22 runner)
+  // with no effect on resolved output or execution.
   config.environment.apps = config.dryRun ? [] : await getAvailableApps({ config });
 
   // Resolve concurrent runners configuration
@@ -664,9 +664,10 @@ function getEnvironment() {
 // config.cacheDir or DOC_DETECTIVE_CACHE_DIR), and lazy-install can
 // materialize new browsers between calls — so a single process-global
 // slot would (a) cross-contaminate different cacheDir values and (b)
-// return stale "no browsers" results after a JIT pre-flight install.
-// Avoids redundant `appium driver list` calls (~17s each) and browser
-// scanning for repeat lookups against the same cache dir.
+// return stale "no browsers" results after a JIT pre-flight install (which now
+// patches this cache in place — see patchAppCache — rather than clearing it).
+// Avoids redundant browser-cache scans and driver-presence probing for repeat
+// lookups against the same cache dir.
 const cachedAppsByDir: Map<string, any[]> = new Map();
 
 function cacheKeyFor(config: any): string {
@@ -684,14 +685,142 @@ function clearAppCache(config?: any) {
   cachedAppsByDir.delete(cacheKeyFor(config));
 }
 
+/**
+ * A browser the JIT preflight just installed, described by the paths/versions
+ * `ensureBrowserInstalled` already resolved. Enough to rebuild the same app
+ * descriptor `getAvailableApps` would, without re-scanning the browsers cache.
+ */
+interface InstalledBrowserDescriptor {
+  name: string; // "chrome" | "firefox"
+  version?: string;
+  path?: string;
+  driverPath?: string; // chromedriver / geckodriver binary
+}
+
+/**
+ * Patch the module-level available-apps cache for `config`'s cache dir with the
+ * browsers a JIT preflight just installed, so the *next* `getAvailableApps`
+ * call is a cache HIT and skips a full re-probe (browser scan + driver-presence
+ * + `verifyDriverBinary`) — replacing the previous `clearAppCache` +
+ * lazy-re-probe.
+ *
+ * Correctness: driver *presence* discovery (which appium-*-driver packages are
+ * on disk) did not change across the install — only the browser binary arrived
+ * — so each descriptor is rebuilt from the install results and gated on the
+ * SAME two checks `getAvailableApps` uses: the matching appium-*-driver package
+ * present (presence) AND `verifyDriverBinary` (Layer 2, functional). A browser
+ * that fails either gate is left out — matching `getAvailableApps`, which would
+ * also exclude it — so a later cache hit reports exactly what a fresh probe
+ * would.
+ *
+ * Fail-open: on any error, or when there is nothing to add, we DELETE the cache
+ * entry so the next `getAvailableApps` re-probes from scratch — never a stale
+ * or partial hit. `verify`/`detectDrivers` are injectable for hermetic tests.
+ */
+async function patchAppCache(
+  config: any,
+  installed: InstalledBrowserDescriptor[],
+  deps: {
+    verify?: (
+      driverName: string,
+      driverPath: string
+    ) => Promise<{ ok: boolean; error?: string }>;
+    detectDrivers?: (config: any) => {
+      chromium: boolean;
+      gecko: boolean;
+      safari: boolean;
+    };
+  } = {}
+): Promise<void> {
+  const key = cacheKeyFor(config);
+  try {
+    const verify = deps.verify ?? verifyDriverBinary;
+    const drivers = (deps.detectDrivers ?? detectInstalledBrowserDrivers)(
+      config
+    );
+    const descriptors: AppDriverDescriptor[] = [];
+    for (const b of installed ?? []) {
+      if (b.name === "chrome" && b.path && b.driverPath && drivers.chromium) {
+        descriptors.push({
+          app: {
+            name: "chrome",
+            version: b.version,
+            path: b.path,
+            driver: b.driverPath,
+          },
+          driverName: "chromedriver",
+          driverPath: b.driverPath,
+        });
+      } else if (b.name === "firefox" && b.path && drivers.gecko) {
+        // Mirror getAvailableApps: firefox passes through even without a
+        // resolvable driver path (Layer 4 runtime fallback), but verifies it
+        // when present.
+        descriptors.push({
+          app: { name: "firefox", version: b.version, path: b.path },
+          driverName: b.driverPath ? "geckodriver" : undefined,
+          driverPath: b.driverPath,
+        });
+      }
+    }
+    if (descriptors.length === 0) {
+      // Nothing rebuildable — invalidate so the next call re-probes.
+      cachedAppsByDir.delete(key);
+      return;
+    }
+    const verifiedApps = await verifyAppDrivers(descriptors, {
+      verify: (driverName, driverPath) => verify(driverName, driverPath),
+      logger: (msg, level) => log(config, level ?? "warning", msg),
+    });
+    const existing = cachedAppsByDir.get(key) ?? [];
+    const existingNames = new Set(existing.map((a: any) => a?.name));
+    const additions = verifiedApps.filter(
+      (a: any) => !existingNames.has(a?.name)
+    );
+    cachedAppsByDir.set(key, [...existing, ...additions]);
+  } catch {
+    // Fail-open: never leave a stale/incorrect hit behind.
+    cachedAppsByDir.delete(key);
+  }
+}
+
+/**
+ * Which managed Appium browser drivers are present on disk, by package name.
+ *
+ * Presence discovery is a filesystem question — the same `resolveHeavyDepPath`
+ * check `getBrowserDiagnostics` (and `ensureRuntimeInstalled`) already use — so
+ * we no longer spawn `node <appium> driver list` (~17s by its own comment) to
+ * learn what a package lookup answers instantly. Each key maps to exactly the
+ * driver the old `appium driver list` table-regex recognized:
+ *   chromium → appium-chromium-driver  (was /chromium.*installed \(npm\)/)
+ *   gecko    → appium-geckodriver      (was /gecko.*installed \(npm\)/)
+ *   safari   → appium-safari-driver    (was /safari.*installed \(npm\)/)
+ *
+ * IMPORTANT: presence (package on disk) is necessary but NOT sufficient. The
+ * functional Layer 2 gate (`verifyDriverBinary`, run inside `verifyAppDrivers`)
+ * still executes each driver's binary before a browser is reported available —
+ * only the *presence-discovery* mechanism changed here, never the functional
+ * check. `isInstalled` is injectable so this maps hermetically in unit tests.
+ */
+function detectInstalledBrowserDrivers(
+  config: any,
+  isInstalled: (name: string) => boolean = (name) =>
+    Boolean(resolveHeavyDepPath(name, { cacheDir: config?.cacheDir }))
+): { chromium: boolean; gecko: boolean; safari: boolean } {
+  return {
+    chromium: isInstalled("appium-chromium-driver"),
+    gecko: isInstalled("appium-geckodriver"),
+    safari: isInstalled("appium-safari-driver"),
+  };
+}
+
 // Live browser/driver probing for `getAvailableApps` — the runtime gate
 // that decides whether a real run can launch a browser right now.
 //
-// Returns the raw `@puppeteer/browsers` install list and the combined
-// `appium driver list` output, plus a `browserDetectionFailed` flag set
-// only on an *unexpected* failure (the dep is present but fails to
-// load/scan) so callers can skip caching. A simply-absent dep (lean
-// install) is the normal "nothing installed" case, not a failure.
+// Returns the raw `@puppeteer/browsers` install list and the set of managed
+// Appium browser drivers present on disk (chromium/gecko/safari), plus a
+// `browserDetectionFailed` flag set only on an *unexpected* failure (the dep is
+// present but fails to load/scan) so callers can skip caching. A simply-absent
+// dep (lean install) is the normal "nothing installed" case, not a failure.
 //
 // Note: the diagnostic dump uses `getBrowserDiagnostics` instead, which
 // reads doc-detective's `installed.json` record so it reports the same
@@ -701,7 +830,7 @@ async function probeBrowserEnvironment({
   browsersDir,
 }: any): Promise<{
   installedBrowsers: any[];
-  appiumDriverOutput: string;
+  installedDrivers: { chromium: boolean; gecko: boolean; safari: boolean };
   browserDetectionFailed: boolean;
 }> {
   setAppiumHome({ cacheDir: config?.cacheDir });
@@ -709,7 +838,7 @@ async function probeBrowserEnvironment({
   process.chdir(path.join(__dirname, "../.."));
   let installedBrowsers: any[] = [];
   let browserDetectionFailed = false;
-  let appiumDriverOutput = "";
+  let installedDrivers = { chromium: false, gecko: false, safari: false };
   try {
     // Detect installed browsers read-only: autoInstall=false so config
     // resolution never triggers a heavy @puppeteer/browsers install (which
@@ -742,69 +871,17 @@ async function probeBrowserEnvironment({
         installedBrowsers = [];
       }
     }
-    // Resolve appium's JS entry directly (shim first, then cache)
-    // and spawn `node <entry> driver list`. Bypasses `.cmd` shims,
-    // `npm exec`, and shell:true — the same pattern as the Appium
-    // spawns in src/core/tests.ts.
-    const appiumEntry = resolveHeavyDepPath("appium", {
-      cacheDir: config?.cacheDir,
-    });
-    const installedAppiumDrivers = await new Promise<{
-      stdout: string;
-      stderr: string;
-      exitCode: number;
-    }>((resolve) => {
-      if (!appiumEntry) {
-        resolve({
-          stdout: "",
-          stderr: "appium is not installed; driver list unavailable",
-          exitCode: 1,
-        });
-        return;
-      }
-      const child = spawnChild(
-        process.execPath,
-        [appiumEntry, "driver", "list"],
-        { env: process.env }
-      );
-      let stdout = "";
-      let stderr = "";
-      child.stdout?.on("data", (c: Buffer | string) => {
-        stdout += typeof c === "string" ? c : c.toString("utf8");
-      });
-      child.stderr?.on("data", (c: Buffer | string) => {
-        stderr += typeof c === "string" ? c : c.toString("utf8");
-      });
-      // Treat a spawn error (ENOENT, EACCES) as exitCode 1 with the
-      // message in stderr so the downstream driver-presence regex
-      // checks degrade to "no drivers detected" rather than aborting
-      // the run.
-      child.on("error", (err) => {
-        resolve({
-          stdout: stdout.replace(/\n$/, ""),
-          stderr: (stderr + String(err)).replace(/\n$/, ""),
-          exitCode: 1,
-        });
-      });
-      child.on("close", (code: number | null) => {
-        resolve({
-          stdout: stdout.replace(/\n$/, ""),
-          stderr: stderr.replace(/\n$/, ""),
-          exitCode: code ?? 1,
-        });
-      });
-    });
-
-    // `appium driver list` writes its formatted table to stdout; combine both
-    // streams so detection works regardless of which version uses which stream.
-    appiumDriverOutput =
-      installedAppiumDrivers.stdout + "\n" + installedAppiumDrivers.stderr;
+    // Managed Appium browser-driver presence, resolved directly from disk
+    // (no child process). This replaces the old `node <appium> driver list`
+    // spawn + table-regex parse: the drivers are npm packages, so a
+    // `resolveHeavyDepPath` lookup answers "installed?" instantly and offline.
+    installedDrivers = detectInstalledBrowserDrivers(config);
   } finally {
     // Always restore the original working directory
     process.chdir(cwd);
   }
 
-  return { installedBrowsers, appiumDriverOutput, browserDetectionFailed };
+  return { installedBrowsers, installedDrivers, browserDetectionFailed };
 }
 
 async function getAvailableApps({ config }: any) {
@@ -820,7 +897,7 @@ async function getAvailableApps({ config }: any) {
   const hit = cachedAppsByDir.get(key);
   if (hit) return hit;
 
-  const { installedBrowsers, appiumDriverOutput, browserDetectionFailed } =
+  const { installedBrowsers, installedDrivers, browserDetectionFailed } =
     await probeBrowserEnvironment({ config, browsersDir });
 
   // Note: Edge/Microsoft Edge detection is intentionally excluded
@@ -828,8 +905,9 @@ async function getAvailableApps({ config }: any) {
   //
   // Build candidate apps with the driver binary each needs, then gate them on
   // the driver actually executing (Layer 2). Presence in `installed.json` /
-  // `appium driver list` is necessary but not sufficient — a partially
-  // downloaded driver passes presence checks yet can't start a session.
+  // the appium-*-driver package on disk is necessary but not sufficient — a
+  // partially downloaded driver passes presence checks yet can't start a
+  // session.
   const descriptors: AppDriverDescriptor[] = [];
 
   // Detect Chrome
@@ -840,9 +918,7 @@ async function getAvailableApps({ config }: any) {
   const chromedriver = installedBrowsers.find(
     (browser: any) => browser.browser === "chromedriver"
   );
-  const appiumChromium = appiumDriverOutput.match(
-    /\n.*chromium.*installed \(npm\).*\n/
-  );
+  const appiumChromium = installedDrivers.chromium;
 
   if (chrome && chromedriver && appiumChromium) {
     descriptors.push({
@@ -861,9 +937,7 @@ async function getAvailableApps({ config }: any) {
   const firefox = installedBrowsers.find(
     (browser: any) => browser.browser === "firefox"
   );
-  const appiumFirefox = appiumDriverOutput.match(
-    /\n.*gecko.*installed \(npm\).*\n/
-  );
+  const appiumFirefox = installedDrivers.gecko;
 
   if (firefox && appiumFirefox) {
     // Resolve the geckodriver binary so Layer 2 can execute it. Best-effort:
@@ -889,9 +963,7 @@ async function getAvailableApps({ config }: any) {
     const safariVersion = await spawnCommand(
       "defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString"
     );
-    const appiumSafari = appiumDriverOutput.match(
-      /\n.*safari.*installed \(npm\).*\n/
-    );
+    const appiumSafari = installedDrivers.safari;
 
     if (safariVersion.exitCode === 0 && appiumSafari) {
       // safaridriver ships with macOS at a fixed path; verifying it executes

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -84,6 +84,16 @@ async function runTests(config: any, options: any = {}) {
     }
   }
 
+  // Join the self-update check the CLI started concurrently with detection /
+  // resolution (which execute no tests). If a newer version was found,
+  // `options.updateJoin` re-execs the process here — BEFORE any test runs or
+  // any dry-run output is emitted — preserving the "update before the run"
+  // guarantee while the registry latency was hidden behind resolution. A no-op
+  // (undefined) for the programmatic API and whenever auto-update is gated off.
+  if (typeof options.updateJoin === "function") {
+    await options.updateJoin();
+  }
+
   if (config.dryRun) {
     console.log(JSON.stringify(resolvedTests, null, 2));
     cleanTemp();
@@ -168,29 +178,61 @@ async function runTests(config: any, options: any = {}) {
     }
     if (needs.browsers.size > 0) {
       try {
-        const { getAvailableApps, clearAppCache } = await import("./config.js");
+        const { getAvailableApps, patchAppCache } = await import("./config.js");
         const { ensureBrowserInstalled, requiredBrowserAssets } = await import(
           "../runtime/browsers.js"
         );
         const available = await getAvailableApps({ config });
         const availableNames = new Set(available.map((a: any) => a.name));
-        let installedAnything = false;
+        const installedDescriptors: {
+          name: string;
+          version?: string;
+          path?: string;
+          driverPath?: string;
+        }[] = [];
         for (const browser of needs.browsers) {
           if (availableNames.has(browser)) continue;
           // requiredBrowserAssets returns [] for safari (ships with the OS)
           // and any unknown name, so the loop body simply no-ops for those.
           const assets = requiredBrowserAssets(browser);
+          const assetResults: Record<string, { path: string; version: string }> =
+            {};
           for (const asset of assets) {
-            await ensureBrowserInstalled(asset, { ctx, deps: { logger: preflightLogger } });
+            assetResults[asset] = await ensureBrowserInstalled(asset, {
+              ctx,
+              deps: { logger: preflightLogger },
+            });
           }
-          if (assets.length > 0) installedAnything = true;
+          if (assets.length === 0) continue;
+          // Capture the paths/versions ensureBrowserInstalled just resolved so
+          // patchAppCache can rebuild this browser's descriptor without a
+          // second full probe.
+          if (browser === "chrome") {
+            installedDescriptors.push({
+              name: "chrome",
+              version: assetResults.chrome?.version,
+              path: assetResults.chrome?.path,
+              driverPath: assetResults.chromedriver?.path,
+            });
+          } else if (browser === "firefox") {
+            installedDescriptors.push({
+              name: "firefox",
+              version: assetResults.firefox?.version,
+              path: assetResults.firefox?.path,
+              driverPath: assetResults.geckodriver?.path,
+            });
+          }
         }
-        // Invalidate the available-apps cache for this cacheDir so a
-        // subsequent runSpecs/getRunner call re-detects what the
-        // pre-flight just materialized. Without this, the empty
-        // `available` snapshot above would stick and downstream
-        // browser-presence checks would still see "not installed."
-        if (installedAnything) clearAppCache(config);
+        // Patch the available-apps cache with what the preflight just
+        // materialized so a subsequent runSpecs/getRunner call is a cache HIT
+        // and skips a redundant full re-probe. Driver *presence* did not change
+        // across the install — only the browser binary arrived — so patchAppCache
+        // rebuilds each descriptor from the install results and still runs the
+        // functional verifyDriverBinary gate. Fail-open: it invalidates the
+        // entry on any error, so a downstream re-probe is still the safety net.
+        if (installedDescriptors.length > 0) {
+          await patchAppCache(config, installedDescriptors);
+        }
       } catch (browserErr: any) {
         log(
           config,
@@ -251,8 +293,12 @@ async function runTests(config: any, options: any = {}) {
     // Run test specs locally
     results = await runSpecs({ resolvedTests });
   }
-  log(config, "info", "RESULTS:");
-  log(config, "info", results);
+  // The full results tree is a debug-only dump — the reporters (terminal
+  // summary, json/runFolder files) already render results for the user, and at
+  // the default `info` level this pretty-printed tree floods the terminal with
+  // a duplicate of what the reporters write. Keep it available under `debug`.
+  log(config, "debug", "RESULTS:");
+  log(config, "debug", results);
   log(config, "info", "Cleaning up and finishing post-processing.");
 
   // Clean up

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -545,7 +545,13 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
     // Normalize output path
     outputPath = path.resolve(outputPath);
 
-    const data = JSON.stringify(results, null, 2);
+    // Reuse the results JSON serialized once by outputResults when present
+    // (byte-identical to serializing `results` here); fall back for direct
+    // callers that don't pass it.
+    const data =
+      typeof options.resultsJson === "string"
+        ? options.resultsJson
+        : JSON.stringify(results, null, 2);
     let outputFile = "";
     let outputDir = "";
     let reportType = "doc-detective-results";
@@ -656,11 +662,19 @@ const reporters: Record<string, (config: any, outputPath: any, results: any, opt
           // The run folder name IS the runId under the `runs/<id>` layout.
           runId: path.basename(runDir),
         };
+    // When we archive the unmodified `results` (stamped-runDir case), reuse the
+    // JSON outputResults already serialized. When we rewrote runId/runDir into a
+    // fresh copy, that object differs from `results`, so serialize it directly —
+    // keeping the written file byte-identical to before this optimization.
+    const persistedJson =
+      useStampedRunDir && typeof options.resultsJson === "string"
+        ? options.resultsJson
+        : JSON.stringify(persistedResults, null, 2);
     const outputFile = path.resolve(runDir, `${reportType}.json`);
 
     try {
       fs.mkdirSync(runDir, { recursive: true });
-      fs.writeFileSync(outputFile, JSON.stringify(persistedResults, null, 2));
+      fs.writeFileSync(outputFile, persistedJson);
 
       // Archive a human-readable HTML report beside the JSON, so the run folder
       // is a complete shareable artifact without the standalone `html` reporter.
@@ -1182,8 +1196,6 @@ async function reportResults({ apiConfig, results }: { apiConfig: any; results: 
     const url = `${apiConfig.url}/contexts`;
     const payload = { contexts };
 
-    console.log(payload);
-
     const response = await axios.post(url, payload, {
       headers: {
         "x-runner-token": apiConfig.token,
@@ -1232,14 +1244,30 @@ async function outputResults(config: any = {}, outputPath: any, results: any, op
     });
   }
 
+  // Serialize the canonical results tree ONCE and share the string with the
+  // JSON-writing reporters (json + runFolder) instead of each calling
+  // JSON.stringify on the full tree independently. Only computed when a
+  // JSON-writing reporter is actually active, so a terminal-only run pays
+  // nothing. Each reporter still falls back to serializing itself when the
+  // shared string is absent (so they stay correct if called directly), and
+  // runFolder only reuses it when it archives the unmodified `results` (the
+  // stamped-runDir case) — a rewritten runId/runDir copy is serialized fresh,
+  // keeping every written file byte-identical to before.
+  const writesJson =
+    activeReporters.includes("jsonReporter") ||
+    activeReporters.includes("runFolderReporter");
+  const reporterOptions = writesJson
+    ? { ...options, resultsJson: JSON.stringify(results, null, 2) }
+    : options;
+
   // Execute each reporter
   const reporterPromises = activeReporters.map((reporter: any) => {
     if (typeof reporter === "function") {
       // Direct function reference
-      return reporter(config, outputPath, results, options);
+      return reporter(config, outputPath, results, reporterOptions);
     } else if (typeof reporter === "string" && reporters[reporter]) {
       // String reference to built-in or registered reporter
-      return reporters[reporter](config, outputPath, results, options);
+      return reporters[reporter](config, outputPath, results, reporterOptions);
     } else if (typeof reporter === "string" && !reporters[reporter]) {
       console.error(
         `Reporter "${reporter}" not found. Available reporters: ${Object.keys(

--- a/test/cli-index-adapters-coverage.test.js
+++ b/test/cli-index-adapters-coverage.test.js
@@ -435,6 +435,77 @@ describe("core/index.ts — runTests offline branches", function () {
       }
     }
   });
+
+  // 2.3: the CLI starts the self-update registry check concurrently with
+  // detection/resolution and hands runTests an `updateJoin` that runTests must
+  // await BEFORE any test runs or any dry-run output is emitted — preserving
+  // the "update before the run" guarantee while hiding the registry latency.
+  it("awaits options.updateJoin before dry-run output / test execution", async function () {
+    const spec = path.join(tmpDir, "u.spec.json");
+    fs.writeFileSync(spec, JSON.stringify({ tests: [{ steps: [{ wait: 5 }] }] }));
+    const seed = await runTests({
+      input: [spec],
+      output: tmpDir,
+      logLevel: "silent",
+      dryRun: true,
+      telemetry: { send: false },
+    });
+    captured.length = 0;
+
+    let calls = 0;
+    let capturedLenAtJoin = -1;
+    const updateJoin = async () => {
+      calls += 1;
+      // At join time no dry-run stdout has been emitted yet (join precedes the
+      // dry-run JSON print, and thus any test execution).
+      capturedLenAtJoin = captured.length;
+    };
+
+    const result = await runTests(
+      { dryRun: true, logLevel: "silent", telemetry: { send: false } },
+      { resolvedTests: JSON.parse(JSON.stringify(seed)), updateJoin }
+    );
+    assert.equal(calls, 1, "updateJoin must be awaited exactly once");
+    assert.equal(
+      capturedLenAtJoin,
+      0,
+      "updateJoin must run before the dry-run stdout (and before execution)"
+    );
+    assert.ok(result.resolvedTestsId, "dry-run still returns the resolved tests");
+  });
+
+  // 2.4(a): the full results tree is demoted from info to debug. At the default
+  // info level the reporters render results; the raw tree dump must not flood
+  // the terminal. A wait-only spec executes fully offline (no browser/driver).
+  it("does not dump the full results tree at info level, but does at debug", async function () {
+    const spec = path.join(tmpDir, "r.spec.json");
+    fs.writeFileSync(spec, JSON.stringify({ tests: [{ steps: [{ wait: 5 }] }] }));
+
+    const runAt = async (logLevel) => {
+      captured.length = 0;
+      const res = await runTests({
+        input: [spec],
+        output: tmpDir,
+        logLevel,
+        telemetry: { send: false },
+        reporters: [],
+      });
+      assert.ok(res && res.summary, `expected the wait spec to execute at ${logLevel}`);
+      return captured.join("\n");
+    };
+
+    const infoOut = await runAt("info");
+    assert.ok(
+      !infoOut.includes("RESULTS:"),
+      "the results-tree dump must be absent at info level"
+    );
+
+    const debugOut = await runAt("debug");
+    assert.ok(
+      debugOut.includes("RESULTS:"),
+      "the results-tree dump must still be available at debug level"
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/config-coverage.test.js
+++ b/test/config-coverage.test.js
@@ -20,7 +20,9 @@ import {
   getEnvironment,
   resolveConcurrentRunners,
   clearAppCache,
+  patchAppCache,
   verifyAppDrivers,
+  detectInstalledBrowserDrivers,
 } from "../dist/core/config.js";
 
 // A throwaway cache dir per test keeps getAvailableApps / getBrowserDiagnostics
@@ -169,6 +171,121 @@ describe("config.ts — clearAppCache", function () {
     clearAppCache(config);
     const afterClear = await getAvailableApps({ config });
     assert.notStrictEqual(afterClear, first);
+  });
+});
+
+// 2.1: driver presence is a filesystem question, not an `appium driver list`
+// spawn. detectInstalledBrowserDrivers maps each managed browser driver to its
+// npm package name — the coverage the old table-regex parsing recognized.
+describe("config.ts — detectInstalledBrowserDrivers (2.1)", function () {
+  it("maps chromium/gecko/safari to their appium-*-driver packages", function () {
+    const probed = [];
+    const drivers = detectInstalledBrowserDrivers({ cacheDir: "/nonexistent" }, (name) => {
+      probed.push(name);
+      return name === "appium-chromium-driver";
+    });
+    assert.deepEqual(drivers, { chromium: true, gecko: false, safari: false });
+    assert.deepEqual(
+      probed.slice().sort(),
+      ["appium-chromium-driver", "appium-geckodriver", "appium-safari-driver"]
+    );
+  });
+
+  it("reports gecko and safari present when their packages resolve", function () {
+    const drivers = detectInstalledBrowserDrivers({}, (name) => name !== "appium-chromium-driver");
+    assert.deepEqual(drivers, { chromium: false, gecko: true, safari: true });
+  });
+
+  it("reports all absent when nothing resolves", function () {
+    const drivers = detectInstalledBrowserDrivers({}, () => false);
+    assert.deepEqual(drivers, { chromium: false, gecko: false, safari: false });
+  });
+});
+
+// 2.2: after a JIT preflight install, patch the app cache with the just-installed
+// descriptors so the next getAvailableApps() is a cache HIT (no re-probe). The
+// functional verifyDriverBinary (Layer 2) gate is preserved; fail-open on error.
+describe("config.ts — patchAppCache (2.2)", function () {
+  this.timeout(30000);
+
+  const chromeDesc = {
+    name: "chrome",
+    version: "123",
+    path: "/fake/chrome",
+    driverPath: "/fake/chromedriver",
+  };
+
+  it("adds a verified just-installed chrome so getAvailableApps hits the patched cache", async function () {
+    const cacheDir = trackedTmpDir();
+    const config = { cacheDir, environment: { platform: "windows" } };
+    // Pre-install probe result (empty) is cached first.
+    assert.deepEqual(await getAvailableApps({ config }), []);
+    await patchAppCache(config, [chromeDesc], {
+      verify: async () => ({ ok: true }),
+      detectDrivers: () => ({ chromium: true, gecko: false, safari: false }),
+    });
+    const after = await getAvailableApps({ config });
+    assert.equal(after.length, 1);
+    assert.equal(after[0].name, "chrome");
+    assert.equal(after[0].version, "123");
+    assert.equal(after[0].driver, "/fake/chromedriver");
+  });
+
+  it("excludes a browser whose driver fails the functional gate (Layer 2 preserved)", async function () {
+    const cacheDir = trackedTmpDir();
+    const config = { cacheDir, environment: { platform: "windows" } };
+    await getAvailableApps({ config });
+    await patchAppCache(config, [chromeDesc], {
+      verify: async () => ({ ok: false, error: "did not validate" }),
+      detectDrivers: () => ({ chromium: true, gecko: false, safari: false }),
+    });
+    assert.deepEqual(await getAvailableApps({ config }), []);
+  });
+
+  it("skips a browser whose appium driver package is absent (presence gate)", async function () {
+    const cacheDir = trackedTmpDir();
+    const config = { cacheDir, environment: { platform: "windows" } };
+    await getAvailableApps({ config });
+    await patchAppCache(config, [chromeDesc], {
+      verify: async () => ({ ok: true }),
+      detectDrivers: () => ({ chromium: false, gecko: false, safari: false }),
+    });
+    assert.deepEqual(await getAvailableApps({ config }), []);
+  });
+
+  it("fails open (invalidates the cache) when verification throws", async function () {
+    const cacheDir = trackedTmpDir();
+    const config = { cacheDir, environment: { platform: "windows" } };
+    const primed = await getAvailableApps({ config });
+    // Confirm the entry is cached (same reference on a hit).
+    assert.strictEqual(await getAvailableApps({ config }), primed);
+    await patchAppCache(config, [chromeDesc], {
+      verify: async () => {
+        throw new Error("boom");
+      },
+      detectDrivers: () => ({ chromium: true, gecko: false, safari: false }),
+    });
+    // The entry was deleted → next call re-probes into a NEW array.
+    const after = await getAvailableApps({ config });
+    assert.notStrictEqual(after, primed);
+    assert.deepEqual(after, []);
+  });
+
+  it("merges into the existing cache entry without duplicating browsers", async function () {
+    const cacheDir = trackedTmpDir();
+    const config = { cacheDir, environment: { platform: "windows" } };
+    await getAvailableApps({ config });
+    await patchAppCache(config, [chromeDesc], {
+      verify: async () => ({ ok: true }),
+      detectDrivers: () => ({ chromium: true, gecko: false, safari: false }),
+    });
+    // A second patch for the same browser must not add a duplicate entry.
+    await patchAppCache(config, [chromeDesc], {
+      verify: async () => ({ ok: true }),
+      detectDrivers: () => ({ chromium: true, gecko: false, safari: false }),
+    });
+    const after = await getAvailableApps({ config });
+    assert.equal(after.filter((a) => a.name === "chrome").length, 1);
   });
 });
 

--- a/test/resolvedTests.test.js
+++ b/test/resolvedTests.test.js
@@ -4,11 +4,13 @@ import assert from "node:assert/strict";
 // A DOC_DETECTIVE_API run never writes to `-o`/config.output — cli.ts routes
 // its results through reportResults() (a POST back to the orchestration
 // API's /contexts endpoint) instead of outputResults(). The results object is
-// still logged to stdout as a "(INFO) RESULTS:" marker followed by pretty
-// JSON, so tests recover it from there rather than waiting on a file that
-// this run mode never produces.
+// logged to stdout as a "(DEBUG) RESULTS:" marker followed by pretty JSON, so
+// tests recover it from there rather than waiting on a file that this run mode
+// never produces. The dump is debug-level (ADR 01064 demoted it from info so it
+// no longer floods the default-level terminal), so these tests run the CLI at
+// logLevel "debug" via DOC_DETECTIVE_CONFIG to surface it.
 function extractResultsJson(stdout) {
-  const marker = "(INFO) RESULTS:";
+  const marker = "(DEBUG) RESULTS:";
   const markerIndex = stdout.indexOf(marker);
   assert.ok(
     markerIndex !== -1,
@@ -60,9 +62,13 @@ describe("DOC_DETECTIVE_API environment variable", function () {
       contextIds: "test-context",
     };
 
-    // Set environment variable
+    // Set environment variables. logLevel "debug" surfaces the "(DEBUG)
+    // RESULTS:" dump that extractResultsJson parses (ADR 01064 demoted it from
+    // info); the API path writes no results file, so stdout is the only source.
     const originalEnv = process.env.DOC_DETECTIVE_API;
+    const originalConfigEnv = process.env.DOC_DETECTIVE_CONFIG;
     process.env.DOC_DETECTIVE_API = JSON.stringify(apiConfig);
+    process.env.DOC_DETECTIVE_CONFIG = JSON.stringify({ logLevel: "debug" });
 
     try {
       const result = await spawnCommand("node ./bin/doc-detective.js");
@@ -87,6 +93,11 @@ describe("DOC_DETECTIVE_API environment variable", function () {
         process.env.DOC_DETECTIVE_API = originalEnv;
       } else {
         delete process.env.DOC_DETECTIVE_API;
+      }
+      if (originalConfigEnv !== undefined) {
+        process.env.DOC_DETECTIVE_CONFIG = originalConfigEnv;
+      } else {
+        delete process.env.DOC_DETECTIVE_CONFIG;
       }
     }
   });

--- a/test/utils-coverage.test.js
+++ b/test/utils-coverage.test.js
@@ -445,6 +445,31 @@ describe("utils.ts coverage", function () {
       assert.equal(out, null);
       assert.ok(cap.error.includes("Error writing results"));
     });
+
+    // 2.4(b): reuse the results JSON serialized once by outputResults instead
+    // of re-stringifying the tree in every JSON-writing reporter.
+    it("writes options.resultsJson verbatim when provided (shared serialization)", async function () {
+      captureConsole(sandbox);
+      const dir = makeTmpDir();
+      const file = path.join(dir, "shared.json");
+      const marker = '{"shared":"MARKER"}';
+      const out = await reporters.jsonReporter({}, file, { a: 1 }, {
+        resultsJson: marker,
+      });
+      assert.equal(fs.readFileSync(out, "utf8"), marker);
+    });
+
+    it("falls back to serializing results when no shared string is passed", async function () {
+      captureConsole(sandbox);
+      const dir = makeTmpDir();
+      const file = path.join(dir, "fallback.json");
+      const results = { a: 1, nested: { b: 2 } };
+      const out = await reporters.jsonReporter({}, file, results, {});
+      assert.equal(
+        fs.readFileSync(out, "utf8"),
+        JSON.stringify(results, null, 2)
+      );
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -508,6 +533,44 @@ describe("utils.ts coverage", function () {
       const dir = makeTmpDir();
       const outPath = await reporters.runFolderReporter({}, dir, { specs: [] }, {});
       assert.ok(outPath.endsWith("doc-detective-results.json"));
+    });
+
+    // 2.4(b): the shared JSON string is reused ONLY when the reporter archives
+    // the unmodified `results` (stamped-runDir case). A rewritten runId/runDir
+    // copy differs from `results`, so it must be serialized fresh — never the
+    // shared string — keeping the written file byte-identical to before.
+    it("reuses options.resultsJson only for the stamped runDir it archives verbatim", async function () {
+      captureConsole(sandbox);
+      const dir = makeTmpDir();
+      const runDir = path.join(dir, ".doc-detective", "runs", "run-123");
+      fs.mkdirSync(runDir, { recursive: true });
+      const results = { runDir, specs: [], summary: {} };
+      const marker = '{"shared":"STAMPED_MARKER"}';
+      const outPath = await reporters.runFolderReporter({}, dir, results, {
+        command: "runTests",
+        resultsJson: marker,
+      });
+      assert.equal(path.dirname(outPath), runDir, "should archive in the stamped runDir");
+      assert.equal(fs.readFileSync(outPath, "utf8"), marker);
+    });
+
+    it("ignores the shared string when it rewrites runId/runDir (fresh serialization)", async function () {
+      captureConsole(sandbox);
+      const dir = makeTmpDir();
+      // No stamped runDir → the reporter derives a fresh folder and rewrites
+      // runId/runDir, so the persisted object differs from `results` and the
+      // shared marker must NOT be used.
+      const results = { specs: [], summary: {} };
+      const marker = '{"shared":"SHOULD_NOT_APPEAR"}';
+      const outPath = await reporters.runFolderReporter({}, dir, results, {
+        command: "runTests",
+        resultsJson: marker,
+      });
+      const written = fs.readFileSync(outPath, "utf8");
+      assert.notEqual(written, marker);
+      const parsed = JSON.parse(written);
+      assert.equal(parsed.runDir, path.dirname(outPath));
+      assert.equal(typeof parsed.runId, "string");
     });
 
     it("returns null and logs an error when the JSON write fails", async function () {
@@ -630,6 +693,28 @@ describe("utils.ts coverage", function () {
       const cap = captureConsole(sandbox);
       await outputResults({ reporters: [42] }, "out", { x: 1 }, {});
       assert.ok(cap.error.includes("Invalid reporter"));
+    });
+
+    // 2.4(b): outputResults serializes the results tree ONCE and hands the
+    // shared string to the JSON-writing reporters via options.resultsJson.
+    it("serializes results once and shares it with JSON-writing reporters", async function () {
+      captureConsole(sandbox);
+      const results = { summary: {}, specs: [{ specId: "s1" }] };
+      const jsonStub = sandbox.stub(reporters, "jsonReporter").resolves();
+      await outputResults({ reporters: ["json"] }, "out", results, {});
+      assert.ok(jsonStub.calledOnce);
+      const passedOptions = jsonStub.firstCall.args[3];
+      assert.equal(passedOptions.resultsJson, JSON.stringify(results, null, 2));
+    });
+
+    it("does not serialize the tree for a terminal-only run", async function () {
+      captureConsole(sandbox);
+      const results = { summary: {}, specs: [] };
+      const terminalStub = sandbox.stub(reporters, "terminalReporter").resolves();
+      await outputResults({ reporters: ["terminal"] }, "out", results, {});
+      assert.ok(terminalStub.calledOnce);
+      const passedOptions = terminalStub.firstCall.args[3];
+      assert.equal(passedOptions.resultsJson, undefined);
     });
   });
 


### PR DESCRIPTION
## Phase 2 of the run-performance plan

Design: `docs/design/run-performance.md` (Phase 2 table). Follows #632 (phase 1, merged). Base `main`.

### Changes
- **2.1 — Replace the `appium driver list` spawn with package-presence checks** *(the headline win, ~17s/run)*. `probeBrowserEnvironment` no longer spawns `node <appium> driver list` and regex-parses its table; `detectInstalledBrowserDrivers` resolves `appium-chromium-driver`/`-geckodriver`/`-safari-driver` on disk via `resolveHeavyDepPath` — the **same mechanism `getBrowserDiagnostics` already uses** (these are npm-managed heavy deps, not APPIUM_HOME installs), so the result is equivalent. The functional `verifyDriverBinary` (Layer 2) gate is retained unchanged. ADR 01062.
- **2.2 — Patch the app cache after a JIT preflight install** instead of `clearAppCache` + full re-probe (`patchAppCache`, fail-open). ADR-free. ⚠️ **Note for review:** now that 2.1 removed the spawn from *all* probes, this saves a cheap re-scan + `verifyDriverBinary`, not ~17s — the win is structural (guaranteed cache hit), not the originally-estimated 17s. Kept because it's correct and matches design intent; happy to drop it for `clearAppCache` if you'd prefer less surface.
- **2.3 — Overlap the self-update check with detection/resolution.** The CLI starts `checkForUpdate` concurrently and hands `runTests` an `updateJoin` closure, joined after resolution but before the first test / dry-run output; `selfUpdate` still re-execs before the run. ADR 01063. **Behavior note:** self-update no longer runs on the *no-tests-resolved* early return (no run happens, so "update before the run" holds) — a minor, arguably-better change from the old always-check-on-invocation.
- **2.4 — Reporter/output cleanup.** (a) Demote the full results-tree dump from `info` to `debug` (reporters already render results; it flooded the terminal) — ADR 01064, minor user-visible default-level change. (b) Serialize the results JSON once in `outputResults`, shared between the json + runFolder reporters (**written files byte-identical**).
- **2.5 — Remove a stray `console.log(payload)`** on the orchestration-API report-back path.

### Validation
Affected unit suites: **482 passing, 0 failing**; `npm run compile` clean. Browser/appium fixture legs (which gate 2.1/2.2 discovery end-to-end) run in CI.

### Docs impact
2.4(a) is observable at default `info` level (results tree now at `--logLevel debug`); assessed against `docs/content-strategy/` — the `logLevel` reference row stays accurate, contract change recorded in ADR 01064. Others internal-only.

### ADR numbers
01062–01064 (01061 is claimed by the concurrent fix #633); may need renumbering at merge if another in-flight PR collides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced startup delays by detecting installed browser drivers directly.
  * Overlapped self-update checks with test discovery while preserving execution order.

* **User Experience**
  * Results-tree details now appear only at debug logging level, reducing default terminal output.
  * Improved browser availability updates after on-demand installation.

* **Reporting**
  * Reduced redundant results serialization for JSON-based reporters.

* **Documentation**
  * Added decision records documenting driver detection, startup updates, and logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->