### PR TITLE
feat(record): report recording metadata outputs from stopRecord

### DIFF
--- a/adrs/01071-stoprecord-reports-recording-metadata-outputs.md
+++ b/adrs/01071-stoprecord-reports-recording-metadata-outputs.md
@@ -1,0 +1,81 @@
+---
+status: accepted
+date: 2026-07-16
+decision-makers: [hawkeyexl]
+---
+
+# stopRecord reports recording metadata outputs
+
+## Context and Problem Statement
+
+A `stopRecord` step currently returns only `{ status, description }`. The produced video's path, duration, resolution, frame rate, and format are invisible in the results JSON, so nothing downstream — reporters, integrations, assertions, or the planned recording visual-regression layers — can reason about what was actually produced. Screenshots set rich `outputs` (`screenshotPath`, `variation`, …); recordings set none. How should `stopRecord` report what it produced, and where should the metadata come from given that ffprobe is not bundled?
+
+## Decision Drivers
+
+- All three engines (browser/MediaRecorder, ffmpeg capture, Appium device) must report the same output shape.
+- The metadata must describe the **final artifact** — post-crop, post-transcode, post-gif-scale — not the raw capture.
+- No new heavy dependency: `@ffmpeg-installer/ffmpeg` ships only the `ffmpeg` binary, not `ffprobe`.
+- A metadata failure must never change the step's PASS/FAIL status; reporting is best-effort.
+- Later layers (checkpoint comparison, structural `verify` guards) will consume these outputs via the shared implicit-assertion engine.
+
+## Considered Options
+
+1. **Probe the final file with `ffmpeg -i <target>` and parse stderr.**
+2. **Parse the transcode invocation's stderr** (already captured with a bounded tail).
+3. **Derive metadata analytically** from capture info + crop rect + requested fps.
+4. **Bundle ffprobe** (e.g. `@ffprobe-installer/ffprobe`) and parse its JSON output.
+
+## Decision Outcome
+
+Chosen option: **1 — probe the final artifact with `ffmpeg -i` and parse stderr**, because it is the only option that measures the file users actually get, works identically for all three engines (including the device engine's native-mp4 path that never transcodes), and needs no new dependency. `ffmpeg -i` with no output file exits non-zero by design; the probe captures stderr with the same bounded-tail pattern the transcode step uses and parses it regardless of exit code.
+
+`stopRecord` gains `outputs`:
+
+| Field | Type | Source |
+|---|---|---|
+| `recordingPath` | string | absolute target path |
+| `duration` | number (seconds) | `Duration: HH:MM:SS.ss` stderr line |
+| `width`, `height` | integers | `Video: … WxH` stderr line |
+| `fps` | number | `N fps`, falling back to `N tbr` (gif often reports only tbr) |
+| `format` | string | target extension |
+
+On probe failure (missing binary, unreadable file, unparsable stderr) the affected fields are omitted, a debug log records why, and the step status is untouched. `recordingPath` and `format` are always set when a file was produced. Skipped recordings (`overwrite: "false"`, headless guard, stop-without-start) report no outputs.
+
+### Consequences
+
+- Good, because results JSON finally records what recording a run produced, enabling downstream assertions and the later visual-regression layers.
+- Good, because one probe path serves all engines and formats, and reflects crops/scales applied during transcode.
+- Neutral, because one extra short-lived ffmpeg process runs per `stopRecord` (milliseconds; the binary is already resolved/cached by `getFfmpegPath`).
+- Bad, because stderr parsing is a contract with ffmpeg's human-readable output; regexes are kept deliberately loose and unit-tested against canned stderr for mp4/webm/gif.
+
+### Confirmation
+
+- Unit tests for the pure stderr parser (`parseMediaProbeStderr`) in `test/ffmpeg-recorder.test.js` cover mp4, webm, and gif (tbr-only) stderr blobs, `N/A` durations, and garbage input yielding `{}`.
+- `stopRecording` integration tests in `test/app-recording.test.js` run the real probe against a real generated mp4 (asserting the full outputs shape) and against a non-video payload (asserting the step stays PASS with probe-derived fields omitted).
+- `test/core-core.test.js` asserts the skip-path contract end-to-end through `runTests`: a skipped `stopRecord` reports no `outputs`.
+- The feature fixture `test/core-artifacts/recording/recording-outputs.spec.json` exercises the outputs end-to-end through the real runner on headed Windows/macOS: it captures `$$recordingPath`/`$$format`/`$$duration`/`$$width`/`$$height`/`$$fps` via step `variables` and fails the spec if any is missing or non-positive, for both mp4 (fps token) and gif (tbr fallback).
+
+## Pros and Cons of the Options
+
+### 1. Probe final file with `ffmpeg -i`
+
+- Good, because it measures the true artifact for every engine and format.
+- Good, because zero new dependencies and an established stderr-parsing precedent (`parseCaptureFrameSize`).
+- Bad, because it parses human-readable output rather than a stable machine format.
+
+### 2. Parse transcode stderr
+
+- Good, because zero extra processes.
+- Bad, because transcode stderr describes the *input* stream (pre-crop, pre-scale), not the output.
+- Bad, because the device engine's native-mp4 path never transcodes, so there is no stderr to parse.
+
+### 3. Derive analytically
+
+- Good, because no process at all.
+- Bad, because it reports intent, not reality — a truncated or corrupt output file would still "report" full metadata, defeating the point.
+- Bad, because duration is not reliably derivable (graceful-stop timing varies).
+
+### 4. Bundle ffprobe
+
+- Good, because `ffprobe -print_format json` is a stable machine-readable contract.
+- Bad, because it adds a second ~70 MB heavy dependency and installer surface for metadata we can already extract.

--- a/docs/fern/pages/docs/actions/stopRecord.mdx
+++ b/docs/fern/pages/docs/actions/stopRecord.mdx
@@ -20,6 +20,16 @@ The same untargeted and named forms stop recordings of every kind—browser, des
 >
 > For comprehensive options, see the [`stopRecord`](/reference/schemas/stoprecord) reference.
 
+**Outputs:** when a recording saves, the action exposes the following values in its `outputs` object. To capture any of them for later steps, use the step-level `variables` object with the matching expression. Metadata fields are best-effort—if Doc Detective can't read the saved file's metadata, it omits those fields without failing the step:
+
+- `$$recordingPath`: the absolute path of the saved video file.
+- `$$format`: the saved file's format (`mp4`, `webm`, or `gif`).
+- `$$duration`: the video's duration in seconds.
+- `$$width` and `$$height`: the video's dimensions in pixels, after any window or viewport crop.
+- `$$fps`: the video's frame rate.
+
+A skipped `stopRecord` (no active recording, or a recording that never started) reports no outputs.
+
 ## Examples
 
 This example starts recording, performs an action, and then stops the recording.

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -23,6 +23,8 @@ export {
   resolveCropGeometry,
   ffmpegPathEnv,
   parseCaptureFrameSize,
+  parseMediaProbeStderr,
+  probeVideoMetadata,
   deriveCropScale,
   detectDisplayPointSize,
   jobIsFfmpegRecording,
@@ -464,6 +466,105 @@ function parseCaptureFrameSize(
   return { w: Number(m[1]), h: Number(m[2]) };
 }
 
+// The metadata a probe of a produced recording can yield. Every field is
+// best-effort — absent when the file (or its stderr dump) doesn't carry it.
+type RecordingProbeMetadata = {
+  duration?: number;
+  width?: number;
+  height?: number;
+  fps?: number;
+};
+
+// Parse recording metadata out of `ffmpeg -i <file>` stderr. Only the input
+// Video stream line is trusted for dimensions/fps (the same guard as
+// parseCaptureFrameSize, but with a 2-digit lower bound — produced recordings
+// can legitimately be tiny, unlike display captures). fps falls back to tbr
+// because gif streams report no fps token. Missing or `N/A` fields are simply
+// omitted — callers treat every field as best-effort.
+function parseMediaProbeStderr(stderr: string): RecordingProbeMetadata {
+  const meta: RecordingProbeMetadata = {};
+  const text = stderr ?? "";
+  const duration = /\bDuration:\s*(\d+):(\d{2}):(\d{2}(?:\.\d+)?)/.exec(text);
+  if (duration) {
+    meta.duration =
+      Number(duration[1]) * 3600 +
+      Number(duration[2]) * 60 +
+      Number(duration[3]);
+  }
+  const videoLine = /Stream #\d+:\d+.*?Video:.*/.exec(text)?.[0];
+  if (videoLine) {
+    const size = /\b(\d{2,5})x(\d{2,5})\b/.exec(videoLine);
+    if (size) {
+      meta.width = Number(size[1]);
+      meta.height = Number(size[2]);
+    }
+    const fps =
+      /([\d.]+)\s+fps\b/.exec(videoLine) ?? /([\d.]+)\s+tbr\b/.exec(videoLine);
+    if (fps && Number.isFinite(Number(fps[1]))) {
+      meta.fps = Number(fps[1]);
+    }
+  }
+  return meta;
+}
+
+// Probe a produced recording's metadata by running `ffmpeg -i <file>` and
+// parsing its stderr. ffmpeg exits non-zero without an output file by design,
+// so the exit code is ignored — the stderr dump is the product. Returns null
+// when no stderr was obtained (missing binary, spawn error); an unparsable
+// file yields {}. Callers report whatever fields they can and never fail the
+// step over metadata. Deliberately bounded on both axes:
+// - autoInstall: false — metadata is never worth a JIT npm install (the
+//   device .mp4 path reaches here on hosts that never needed ffmpeg).
+// - 5s kill timer — a wedged probe must not stall an already-passed stop
+//   (same bound as the detectMacScreenIndex probe).
+// The buffer keeps the HEAD of stderr: ffmpeg prints Duration/Stream metadata
+// first, and trailing demux warnings must not evict it.
+async function probeVideoMetadata({
+  cacheDir,
+  filePath,
+}: {
+  cacheDir?: string;
+  filePath: string;
+}): Promise<RecordingProbeMetadata | null> {
+  try {
+    const ffmpegPath = await getFfmpegPath({ cacheDir, autoInstall: false });
+    const stderr = await new Promise<string | null>((resolve) => {
+      let head = "";
+      let settled = false;
+      let proc: any = null;
+      const done = (v: string | null) => {
+        if (settled) return;
+        settled = true;
+        try {
+          proc?.kill();
+        } catch {
+          /* ignore */
+        }
+        resolve(v);
+      };
+      try {
+        proc = spawn(ffmpegPath, ["-hide_banner", "-i", filePath], {
+          stdio: ["ignore", "ignore", "pipe"],
+        });
+        proc.stderr?.on("data", (chunk: Buffer) => {
+          if (head.length < 4000) {
+            head = (head + chunk.toString()).slice(0, 4000);
+          }
+        });
+        proc.on("error", () => done(null));
+        proc.on("close", () => done(head));
+        setTimeout(() => done(head.length > 0 ? head : null), 5000);
+      } catch {
+        done(null);
+      }
+    });
+    if (stderr === null) return null;
+    return parseMediaProbeStderr(stderr);
+  } catch {
+    return null;
+  }
+}
+
 // The physical-pixels-per-point scale for an app-window crop, derived from
 // measurements instead of a DOM probe (native drivers can't answer
 // devicePixelRatio — the A2-discovered scaling gap, fixed in A7):
@@ -723,8 +824,16 @@ function jobExclusiveResources(
 // Resolve the ffmpeg binary path lazily — @ffmpeg-installer/ffmpeg is a heavy
 // runtime dep that should only load when a recording step actually runs. The
 // ctx threads a user-overridden cacheDir through, matching the JIT installer.
-async function getFfmpegPath(ctx: { cacheDir?: string } = {}): Promise<string> {
-  const mod = await loadHeavyDep<any>("@ffmpeg-installer/ffmpeg", { ctx });
+// autoInstall: false makes a missing install throw instead of JIT-installing —
+// for best-effort callers (the metadata probe) that must never spawn npm.
+async function getFfmpegPath({
+  cacheDir,
+  autoInstall = true,
+}: { cacheDir?: string; autoInstall?: boolean } = {}): Promise<string> {
+  const mod = await loadHeavyDep<any>("@ffmpeg-installer/ffmpeg", {
+    ctx: { cacheDir },
+    autoInstall,
+  });
   // The package's CJS entry exports an object with a .path field; under an
   // ESM dynamic import we may get { default: { path }, path? }. Try both, then
   // guard before handing it to a child process so a malformed install fails

--- a/src/core/tests/ffmpegRecorder.ts
+++ b/src/core/tests/ffmpegRecorder.ts
@@ -532,9 +532,11 @@ async function probeVideoMetadata({
       let head = "";
       let settled = false;
       let proc: any = null;
+      let timer: any;
       const done = (v: string | null) => {
         if (settled) return;
         settled = true;
+        clearTimeout(timer);
         try {
           proc?.kill();
         } catch {
@@ -553,7 +555,7 @@ async function probeVideoMetadata({
         });
         proc.on("error", () => done(null));
         proc.on("close", () => done(head));
-        setTimeout(() => done(head.length > 0 ? head : null), 5000);
+        timer = setTimeout(() => done(head.length > 0 ? head : null), 5000);
       } catch {
         done(null);
       }

--- a/src/core/tests/stopRecording.ts
+++ b/src/core/tests/stopRecording.ts
@@ -12,6 +12,7 @@ import {
   stopRecordTargetName,
   deriveCropScale,
   detectDisplayPointSize,
+  probeVideoMetadata,
 } from "./ffmpegRecorder.js";
 
 export { stopRecording };
@@ -359,7 +360,29 @@ async function stopRecording({
     return result;
   }
 
-  // PASS
+  // PASS — report what was produced. Metadata is best-effort: a probe
+  // failure omits fields and logs debug; it never changes the step's status.
+  // The field list is copied explicitly — the outputs object is a documented
+  // user-facing contract ($$duration etc.), so parser additions must opt in.
+  result.outputs = {
+    recordingPath: path.resolve(recording.targetPath),
+    format: path.extname(recording.targetPath).slice(1),
+  };
+  const meta = await probeVideoMetadata({
+    cacheDir: config?.cacheDir,
+    filePath: recording.targetPath,
+  });
+  if (meta?.duration !== undefined) result.outputs.duration = meta.duration;
+  if (meta?.width !== undefined) result.outputs.width = meta.width;
+  if (meta?.height !== undefined) result.outputs.height = meta.height;
+  if (meta?.fps !== undefined) result.outputs.fps = meta.fps;
+  if (!meta || Object.keys(meta).length === 0) {
+    log(
+      config,
+      "debug",
+      `Couldn't probe recording metadata for ${recording.targetPath}.`
+    );
+  }
   return result;
 }
 

--- a/src/reporters/htmlReporter.ts
+++ b/src/reporters/htmlReporter.ts
@@ -1052,7 +1052,9 @@ function collectMedia(step) {
   if (step.record && (step.record.path || outs.recordingPath)) {
     media.push({ kind: "video", path: outs.recordingPath || step.record.path });
   }
-  if (step.stopRecord && outs.recordingPath) {
+  // Match the runner's dispatch (presence, not truthiness): stopRecord null
+  // is a valid untargeted stop that still saves a video.
+  if (typeof step.stopRecord !== "undefined" && outs.recordingPath) {
     media.push({ kind: "video", path: outs.recordingPath });
   }
   return media;

--- a/test/app-recording.test.js
+++ b/test/app-recording.test.js
@@ -822,6 +822,55 @@ describe("stopRecording: device (appium) handles", function () {
     assert.equal(host.state.recordings.length, 0);
   });
 
+  it("reports probe-derived metadata outputs for a real mp4 target", async function () {
+    const samplePath = path.join(tmpDir, "sample.mp4");
+    await generateSampleMp4(samplePath);
+    const b64 = fs.readFileSync(samplePath).toString("base64");
+    const target = path.join(tmpDir, "out.mp4");
+    const handle = {
+      type: "appium",
+      driver: { stopRecordingScreen: async () => b64 },
+      targetPath: target,
+    };
+    const host = hostWith([handle]);
+    const result = await stopRecording({
+      config,
+      step: { stepId: "x", stopRecord: true },
+      driver: host,
+    });
+    assert.equal(result.status, "PASS");
+    assert.equal(result.outputs.recordingPath, target);
+    assert.equal(result.outputs.format, "mp4");
+    assert.ok(result.outputs.duration > 0, "duration > 0");
+    assert.equal(result.outputs.width, 64);
+    assert.equal(result.outputs.height, 64);
+    assert.ok(result.outputs.fps > 0, "fps > 0");
+  });
+
+  it("keeps PASS and path/format outputs when the file can't be probed", async function () {
+    // A payload that is not real video: the write succeeds, the metadata
+    // probe fails, and the step must stay PASS with only the probe-derived
+    // fields omitted.
+    const payload = Buffer.from("fake-device-video");
+    const target = path.join(tmpDir, "out.mp4");
+    const handle = {
+      type: "appium",
+      driver: { stopRecordingScreen: async () => payload.toString("base64") },
+      targetPath: target,
+    };
+    const host = hostWith([handle]);
+    const result = await stopRecording({
+      config,
+      step: { stepId: "x", stopRecord: true },
+      driver: host,
+    });
+    assert.equal(result.status, "PASS");
+    assert.equal(result.outputs.recordingPath, target);
+    assert.equal(result.outputs.format, "mp4");
+    assert.equal(result.outputs.duration, undefined);
+    assert.equal(result.outputs.width, undefined);
+  });
+
   it("transcodes the device payload for non-mp4 targets (.gif)", async function () {
     const samplePath = path.join(tmpDir, "sample.mp4");
     await generateSampleMp4(samplePath);

--- a/test/core-artifacts/recording/recording-outputs.spec.json
+++ b/test/core-artifacts/recording/recording-outputs.spec.json
@@ -1,0 +1,102 @@
+{
+  "specId": "recording-outputs",
+  "description": "stopRecord metadata outputs: after a recording saves, the stopRecord step exposes recordingPath/format/duration/width/height/fps in outputs, capturable via step variables. One test per output-bearing format family: mp4 (fps token in ffmpeg stderr) and gif (fps derived from the tbr fallback). Headed-only like all real recordings; the skip path (no outputs on a skipped stopRecord) is asserted programmatically in test/core-core.test.js.",
+  "tests": [
+    {
+      "testId": "recording-outputs-mp4",
+      "description": "An mp4 recording reports probe-derived metadata outputs.",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "recording-outputs.mp4",
+            "engine": {
+              "name": "ffmpeg",
+              "target": "display"
+            },
+            "overwrite": "true"
+          }
+        },
+        {
+          "wait": 1500
+        },
+        {
+          "stopRecord": true,
+          "variables": {
+            "REC_MP4_PATH": "$$recordingPath",
+            "REC_MP4_FORMAT": "$$format",
+            "REC_MP4_DURATION": "$$duration",
+            "REC_MP4_WIDTH": "$$width",
+            "REC_MP4_HEIGHT": "$$height",
+            "REC_MP4_FPS": "$$fps"
+          }
+        },
+        {
+          "description": "Assert the captured outputs: format matches, path non-empty, and every probed metric is a positive number.",
+          "runShell": "node -e \"const ok = '$REC_MP4_FORMAT' === 'mp4' && '$REC_MP4_PATH'.length > 0 && Number('$REC_MP4_DURATION') > 0 && Number('$REC_MP4_WIDTH') > 0 && Number('$REC_MP4_HEIGHT') > 0 && Number('$REC_MP4_FPS') > 0; process.exit(ok ? 0 : 1)\""
+        }
+      ]
+    },
+    {
+      "testId": "recording-outputs-gif",
+      "description": "A gif recording reports metadata outputs, exercising the tbr fps fallback (gif streams carry no fps token in ffmpeg stderr).",
+      "runOn": [
+        {
+          "platforms": [
+            "windows",
+            "mac"
+          ],
+          "browsers": {
+            "name": "chrome",
+            "headless": false
+          }
+        }
+      ],
+      "steps": [
+        {
+          "goTo": "http://localhost:8092"
+        },
+        {
+          "record": {
+            "path": "recording-outputs.gif",
+            "engine": {
+              "name": "ffmpeg",
+              "target": "display",
+              "fps": 10
+            },
+            "overwrite": "true"
+          }
+        },
+        {
+          "wait": 1500
+        },
+        {
+          "stopRecord": true,
+          "variables": {
+            "REC_GIF_FORMAT": "$$format",
+            "REC_GIF_DURATION": "$$duration",
+            "REC_GIF_FPS": "$$fps"
+          }
+        },
+        {
+          "description": "Assert the gif outputs: format matches and duration/fps are positive (fps comes from the tbr fallback).",
+          "runShell": "node -e \"const ok = '$REC_GIF_FORMAT' === 'gif' && Number('$REC_GIF_DURATION') > 0 && Number('$REC_GIF_FPS') > 0; process.exit(ok ? 0 : 1)\""
+        }
+      ]
+    }
+  ]
+}

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -821,6 +821,39 @@ describe("Run tests successfully", function () {
     }
   });
 
+  it("a skipped stopRecord reports no recording outputs", async function () {
+    // stopRecord with no active recording SKIPs deterministically on every
+    // platform, headed or headless. Skip paths must not report `outputs` —
+    // recording metadata (recordingPath, duration, ...) is only set when a
+    // file was actually produced.
+    const spec = {
+      tests: [
+        {
+          testId: "skipped-recording-outputs",
+          steps: [{ goTo: "http://localhost:8092" }, { stopRecord: true }],
+        },
+      ],
+    };
+    const tempFilePath = path.resolve("./test/temp-skipped-record-outputs.json");
+    fs.writeFileSync(tempFilePath, JSON.stringify(spec, null, 2));
+    const config = { input: tempFilePath, logLevel: "silent" };
+    try {
+      const result = await runTests(config);
+      assert.equal(result.summary.specs.fail, 0);
+      const steps = result.specs[0].tests[0].contexts[0].steps;
+      const stopStep = steps.find((s) => typeof s.stopRecord !== "undefined");
+      assert.ok(stopStep, "stopRecord step should be reported");
+      assert.equal(stopStep.result, "SKIPPED");
+      assert.equal(
+        stopStep.outputs,
+        undefined,
+        "a skipped stopRecord must not report recording outputs"
+      );
+    } finally {
+      fs.unlinkSync(tempFilePath);
+    }
+  });
+
   it("autoRecord/record name conflict skips the whole test before any step runs", async function () {
     // A `record` step that reuses a recording `name` while one with that name
     // is still active is caught by the static Phase-1 preflight, which skips

--- a/test/ffmpeg-recorder.test.js
+++ b/test/ffmpeg-recorder.test.js
@@ -5,6 +5,7 @@ import {
   resolveRecordPlan,
   coerceRecordContextBrowser,
   parseCaptureFrameSize,
+  parseMediaProbeStderr,
   deriveCropScale,
   ffmpegPathEnv,
   safeContextId,
@@ -1158,5 +1159,92 @@ describe("ffmpegRecorder", function () {
       expect(threw).to.not.equal(null);
       expect(threw.message).to.match(/ENOENT|spawn/i);
     });
+  });
+});
+
+// parseMediaProbeStderr parses the human-readable `ffmpeg -i <file>` stderr
+// into recording metadata. Canned blobs below are trimmed from real ffmpeg
+// output for each supported container.
+describe("parseMediaProbeStderr", function () {
+  const MP4_STDERR = [
+    "ffmpeg version 6.1.1-full_build Copyright (c) 2000-2023 the FFmpeg developers",
+    "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'demo.mp4':",
+    "  Metadata:",
+    "    major_brand     : isom",
+    "    encoder         : Lavf60.16.100",
+    "  Duration: 00:00:05.43, start: 0.000000, bitrate: 1092 kb/s",
+    "  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637634), yuv420p(progressive), 1280x720 [SAR 1:1 DAR 16:9], 1090 kb/s, 30 fps, 30 tbr, 15360 tbn (default)",
+    "At least one output file must be specified",
+  ].join("\n");
+
+  const WEBM_STDERR = [
+    "Input #0, matroska,webm, from 'demo.webm':",
+    "  Metadata:",
+    "    ENCODER         : Lavf60.3.100",
+    "  Duration: 00:01:02.07, start: 0.000000, bitrate: 723 kb/s",
+    "  Stream #0:0: Video: vp9 (Profile 0), yuv420p(tv, bt709), 1920x1080, SAR 1:1 DAR 16:9, 29.97 fps, 29.97 tbr, 1k tbn (default)",
+    "At least one output file must be specified",
+  ].join("\n");
+
+  // gif reports no `fps` token -- only `tbr`.
+  const GIF_STDERR = [
+    "Input #0, gif, from 'demo.gif':",
+    "  Duration: 00:00:03.90, start: 0.000000, bitrate: 1832 kb/s",
+    "  Stream #0:0: Video: gif, bgra, 800x600, 10.42 tbr, 100 tbn",
+    "At least one output file must be specified",
+  ].join("\n");
+
+  it("parses duration, dimensions, and fps from mp4 stderr", function () {
+    const meta = parseMediaProbeStderr(MP4_STDERR);
+    expect(meta.duration).to.be.closeTo(5.43, 0.001);
+    expect(meta.width).to.equal(1280);
+    expect(meta.height).to.equal(720);
+    expect(meta.fps).to.be.closeTo(30, 0.001);
+  });
+
+  it("parses minutes-bearing duration and fractional fps from webm stderr", function () {
+    const meta = parseMediaProbeStderr(WEBM_STDERR);
+    expect(meta.duration).to.be.closeTo(62.07, 0.001);
+    expect(meta.width).to.equal(1920);
+    expect(meta.height).to.equal(1080);
+    expect(meta.fps).to.be.closeTo(29.97, 0.001);
+  });
+
+  it("falls back to tbr when the stream reports no fps (gif)", function () {
+    const meta = parseMediaProbeStderr(GIF_STDERR);
+    expect(meta.duration).to.be.closeTo(3.9, 0.001);
+    expect(meta.width).to.equal(800);
+    expect(meta.height).to.equal(600);
+    expect(meta.fps).to.be.closeTo(10.42, 0.001);
+  });
+
+  it("omits duration when ffmpeg reports N/A", function () {
+    const meta = parseMediaProbeStderr(
+      [
+        "Input #0, matroska,webm, from 'x.webm':",
+        "  Duration: N/A, start: 0.000000, bitrate: N/A",
+        "  Stream #0:0: Video: vp9, yuv420p, 640x480, 25 fps, 25 tbr, 1k tbn",
+      ].join("\n")
+    );
+    expect(meta.duration).to.equal(undefined);
+    expect(meta.width).to.equal(640);
+    expect(meta.height).to.equal(480);
+  });
+
+  it("returns an empty object for unparsable input", function () {
+    expect(parseMediaProbeStderr("")).to.deep.equal({});
+    expect(parseMediaProbeStderr("no such file or directory")).to.deep.equal({});
+  });
+
+  it("ignores dimension-like tokens outside the Video stream line", function () {
+    const meta = parseMediaProbeStderr(
+      [
+        "Input #0, mov, from 'weird 99x99 name.mp4':",
+        "  Duration: 00:00:01.00, start: 0.000000, bitrate: 100 kb/s",
+        "  Stream #0:0: Video: h264, yuv420p, 320x240, 15 fps, 15 tbr",
+      ].join("\n")
+    );
+    expect(meta.width).to.equal(320);
+    expect(meta.height).to.equal(240);
   });
 });


### PR DESCRIPTION
## Summary

Layer 1 of the recording visual-regression plan: a successful `stopRecord` now reports what it produced.

- `outputs.recordingPath` (absolute) and `outputs.format` are always set when a file saves.
- `outputs.duration`, `width`, `height`, `fps` are probed from the **final artifact** via the bundled ffmpeg (`-i` stderr parse) — post-crop, post-transcode, identical across all three engines including the device native-mp4 path.
- The probe is strictly best-effort: head-bounded stderr capture, 5s kill timer, `autoInstall: false` (never triggers a JIT npm install), omits fields and logs debug on failure, never changes step status. Skipped stops report no outputs.
- Also fixes the HTML reporter to attach the saved video for the `stopRecord: null` form (presence check, matching runner dispatch).

## ADR

[adrs/01071-stoprecord-reports-recording-metadata-outputs.md](https://github.com/doc-detective/doc-detective/blob/claude/visual-regression-recordings-9e090f/adrs/01071-stoprecord-reports-recording-metadata-outputs.md) — probe-the-final-file decision, rejected alternatives (transcode stderr, analytic derivation, bundling ffprobe).

## Fixtures

New `test/core-artifacts/recording/recording-outputs.spec.json` (runs in the existing recording bundle): captures every output via step `variables` and fails the spec if any is missing/non-positive, for mp4 (fps token) and gif (tbr fallback). Headed Windows/macOS; lands SKIPPED elsewhere. Skip-path contract (no outputs on skipped stop) is asserted programmatically in `test/core-core.test.js`.

## Docs impact

Yes — user-facing outputs. `docs/fern/pages/docs/actions/stopRecord.mdx` gains an Outputs section (matches the screenshot action's pattern).

## Verification

- 182 recording-related unit tests + full suite green locally (the one observed failure was an orphaned local test server colliding on port 8092, not this change).
- End-to-end through the real CLI headed on Windows: mp4 display recording reported `{duration: 2.53, width: 3840, height: 2160, fps: 30}`; viewport-cropped gif at fps 10 reported post-crop dimensions and tbr-derived fps; skip path reported no outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `stopRecord` now returns an `outputs` object with best-effort recording metadata (recording path, format, and, when available, duration, width/height, and fps) derived from the produced file.
  * Skipped `stopRecord` steps (no active/never-started recording) report no outputs.
* **Bug Fixes**
  * HTML reports now include recorded video media even when the stop-recording result is empty or `null`.
* **Documentation**
  * Updated `stopRecord` docs to describe the `outputs` fields and corresponding step variables.  
* **Tests**
  * Added coverage for metadata extraction and skip/output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->