### PR TITLE
test(dryrun): remove the real browser from the executed-shape control test

### DIFF
--- a/test/dryRun.test.js
+++ b/test/dryRun.test.js
@@ -82,12 +82,26 @@ describe("--dry-run short-circuits before execution", function () {
   });
 
   it("without dryRun, runTests returns an executed-results shape", async function () {
-    // Sanity control: the same spec, run normally, returns an object with
-    // `summary` and `specs[].tests[].contexts[].steps[]` carrying step
-    // results (a `result` field). This proves the dry-run case above is
-    // returning a *different* shape, not just an empty execution.
+    // Sanity control: a real (non-dry) run returns an object with `summary`,
+    // proving the dry-run case above returns a *different* shape, not just an
+    // empty execution.
+    //
+    // Uses a browserless `wait` step rather than the shared `goTo` spec. This
+    // is the only test in the file that actually EXECUTES, and driving a real
+    // browser to a live URL made it the shard's flakiest test: a dead
+    // WebDriver session (ECONNREFUSED on the Windows runner) hung it to the
+    // 30s mocha timeout and failed the whole shard — repeatedly, including on
+    // release runs. The shape assertion doesn't need a browser or the network,
+    // only a real execution, and `wait` provides one with neither. (The
+    // sibling dry-run tests never execute, so their `goTo` spec is fine.)
+    const execSpecPath = path.join(tmpDir, "exec.spec.json");
+    fs.writeFileSync(
+      execSpecPath,
+      JSON.stringify({ tests: [{ steps: [{ wait: 1 }] }] })
+    );
+
     const result = await runTests({
-      input: [specPath],
+      input: [execSpecPath],
       output: tmpDir,
       logLevel: "silent",
       telemetry: { send: false },


### PR DESCRIPTION
Fixes the flaky test that failed `windows shard-1` on #666 and, more importantly, **blocked a release run** (the shard is part of the release gate).

## The flake

`test/dryRun.test.js` has one test — `"without dryRun, runTests returns an executed-results shape"` — that runs the shared `{ goTo: "https://example.com" }` spec **normally**, so it's the only test in the file that actually executes. That means it launches a **real browser** and hits a **live external URL** inside a unit test.

On the Windows CI runner the WebDriver session intermittently died mid-run:

```
ERROR webdriver: WebDriverError: ECONNREFUSED when running "title" with method "GET"
...
Error: Timeout of 30000ms exceeded ... (test/dryRun.test.js)
  1997 passing, 1 failing
```

`runTests` then hung waiting on the dead driver until the 30s mocha timeout, failing the whole shard. (The file's own comment at lines 71–73 already flagged this file as a Windows flake source; that earlier fix covered the dry-run probe path, not this executing control.)

## The fix

The test only proves a real run returns a *different shape* (with `summary`) than a dry run — it never asserts the navigation succeeded. So it doesn't need a browser at all. Swapped the shared `goTo` spec for a browserless `wait` step:

- Still a genuine execution that produces a `summary` (proving the shape difference).
- No driver, no network → the `ECONNREFUSED` hang is impossible.
- Runs in **~130ms** instead of launching Chrome.

The sibling dry-run tests never execute, so their `goTo` spec is untouched. Verified locally: all 4 dryRun tests pass in ~4s.

`test:` change — no release of its own. Worth landing so this flake stops blocking releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved execution-mode validation by using a browserless test scenario.
  * Reduced test flakiness by avoiding live URL navigation during execution checks.
  * Continued verifying the distinction between dry-run results and executed test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->