### PR TITLE
test(recording): guard every annotate target with a preceding find

### DIFF
--- a/test/core-artifacts/recording/annotate.spec.json
+++ b/test/core-artifacts/recording/annotate.spec.json
@@ -22,9 +22,10 @@
           "goTo": "http://localhost:8092/enhanced-elements.html"
         },
         {
-          "description": "Guard every annotation target with a preceding `find`. `annotate` resolves its target once with no polling, so on a slow headed browser (notably Windows CI) a bare goTo/navigation can hand off before the element is queryable and the annotate FAILs; `find` waits for the element, closing that race. Every element-targeting `annotate` in this spec (including `update` and each transition, which re-target new elements) is paired with a matching `find` for the same target.",
+          "description": "Guard every annotation target with a preceding `find`. `annotate` resolves its target once with no polling, so on a slow headed browser (notably Windows CI) a bare goTo/navigation can hand off before the element is queryable and the annotate FAILs; `find` waits for the element, closing that race. Every element-targeting `annotate` in this spec (including `update` and each transition, which re-target new elements) is paired with a matching `find` for the same target. The first find after each navigation carries a generous `timeout` because later tests reuse a browser context that recording has made slow — the default 5s can lapse before the page is queryable on a cold CI runner.",
           "find": {
-            "selector": "#username-input"
+            "selector": "#username-input",
+            "timeout": 20000
           }
         },
         {
@@ -120,7 +121,8 @@
         },
         {
           "find": {
-            "selector": "#submit-button"
+            "selector": "#submit-button",
+            "timeout": 20000
           }
         },
         {
@@ -220,7 +222,8 @@
         },
         {
           "find": {
-            "selector": "#username-input"
+            "selector": "#username-input",
+            "timeout": 20000
           }
         },
         {
@@ -358,7 +361,8 @@
         },
         {
           "find": {
-            "selector": "#submit-button"
+            "selector": "#submit-button",
+            "timeout": 20000
           }
         },
         {
@@ -409,7 +413,8 @@
         },
         {
           "find": {
-            "selector": ".form-control"
+            "selector": ".form-control",
+            "timeout": 20000
           }
         },
         {

--- a/test/core-artifacts/recording/annotate.spec.json
+++ b/test/core-artifacts/recording/annotate.spec.json
@@ -4,7 +4,7 @@
   "tests": [
     {
       "testId": "annotate-lifecycle-in-recording",
-      "description": "The core choreography: add annotations, interact, update one by id, clear one, clear the rest \u2014 all inside a recording, so every state lands in the video.",
+      "description": "The core choreography: add annotations, interact, update one by id, clear one, clear the rest — all inside a recording, so every state lands in the video.",
       "runOn": [
         {
           "platforms": [
@@ -20,6 +20,12 @@
       "steps": [
         {
           "goTo": "http://localhost:8092/enhanced-elements.html"
+        },
+        {
+          "description": "Guard every annotation target with a preceding `find`. `annotate` resolves its target once with no polling, so on a slow headed browser (notably Windows CI) a bare goTo/navigation can hand off before the element is queryable and the annotate FAILs; `find` waits for the element, closing that race. Every element-targeting `annotate` in this spec (including `update` and each transition, which re-target new elements) is paired with a matching `find` for the same target.",
+          "find": {
+            "selector": "#username-input"
+          }
         },
         {
           "record": {
@@ -48,6 +54,11 @@
         },
         {
           "click": "#username-input"
+        },
+        {
+          "find": {
+            "selector": "#submit-button"
+          }
         },
         {
           "stepId": "annotate-update",
@@ -106,6 +117,11 @@
       "steps": [
         {
           "goTo": "http://localhost:8092/enhanced-elements.html"
+        },
+        {
+          "find": {
+            "selector": "#submit-button"
+          }
         },
         {
           "annotate": {
@@ -185,7 +201,7 @@
     },
     {
       "testId": "annotate-transitions-and-duration",
-      "description": "Recording-only semantics: each enter transition, and a duration that clears the annotation without a paired clear step. No recording here \u2014 the browser engine allows one recording per context and four in a spec contend; the lifecycle test covers the in-recording path, and these exercise the same rendering.",
+      "description": "Recording-only semantics: each enter transition, and a duration that clears the annotation without a paired clear step. No recording here — the browser engine allows one recording per context and four in a spec contend; the lifecycle test covers the in-recording path, and these exercise the same rendering.",
       "runOn": [
         {
           "platforms": [
@@ -203,6 +219,11 @@
           "goTo": "http://localhost:8092/enhanced-elements.html"
         },
         {
+          "find": {
+            "selector": "#username-input"
+          }
+        },
+        {
           "stepId": "annotate-transition-fade",
           "annotate": {
             "add": [
@@ -215,6 +236,11 @@
                 }
               }
             ]
+          }
+        },
+        {
+          "find": {
+            "selector": "#submit-button"
           }
         },
         {
@@ -231,6 +257,11 @@
                 }
               }
             ]
+          }
+        },
+        {
+          "find": {
+            "elementTestId": "password-field"
           }
         },
         {
@@ -251,8 +282,13 @@
           }
         },
         {
+          "find": {
+            "selector": "#contact-email"
+          }
+        },
+        {
           "stepId": "annotate-transition-none",
-          "description": "A blur must never fade in \u2014 that would show the sensitive content while it animates.",
+          "description": "A blur must never fade in — that would show the sensitive content while it animates.",
           "annotate": {
             "add": [
               {
@@ -263,6 +299,11 @@
                 }
               }
             ]
+          }
+        },
+        {
+          "find": {
+            "selector": "#primary-action"
           }
         },
         {
@@ -316,6 +357,11 @@
           "goTo": "http://localhost:8092/enhanced-elements.html"
         },
         {
+          "find": {
+            "selector": "#submit-button"
+          }
+        },
+        {
           "stepId": "annotate-tracked",
           "annotate": {
             "add": [
@@ -360,6 +406,11 @@
       "steps": [
         {
           "goTo": "http://localhost:8092/enhanced-elements.html"
+        },
+        {
+          "find": {
+            "selector": ".form-control"
+          }
         },
         {
           "stepId": "annotate-redact-all",


### PR DESCRIPTION
## Problem

`fixtures / recording (windows-latest)` fails intermittently on the `annotate` recording fixture. The failing test **rotates run to run** — `annotate-lifecycle-in-recording`, `annotate-tracks-through-scroll`, etc. — always with:

```
Couldn't resolve every annotation target. Couldn't find the element to annotate: #submit-button
```

(Surfaced on #675, which is unrelated — that PR only adds a CLI flag. The fixture was introduced by #666.)

## Root cause

The `annotate` step resolves its target element **once, with no polling**, unlike `find`, which waits/retries for its target. Every affected test does `goTo` (or navigate) → `annotate <selector>` immediately. On a **cold, slow headed Windows CI runner** there's a brief post-load window where the (static) element isn't yet queryable, so the immediate `annotate` misses and FAILs. Whichever `annotate` loses that race is the one that fails — hence the rotating failure. The elements are static HTML (verified), so this is purely a resolution-timing gap, not a bad selector.

## Fix

Pair **every element-targeting `annotate`** in `annotate.spec.json` with a matching **`find`** for the same target (`selector` or `elementTestId`) immediately before it — including the `update` step and each transition step that re-targets a **new** element (`#submit-button`, `password-field`, `#contact-email`, `#primary-action`). `find` waits for the element, closing the race deterministically. Position-anchored `text` annotations (no element target) are intentionally left unguarded.

Guards are placed so recording content is unaffected (e.g. the lifecycle guard sits before the `record` step).

## Verification

- **6/6 tests, 45/45 steps PASS** running `annotate.spec.json` **headed on Windows** locally.
- `--dry-run` resolves all six tests with no validation errors.
- A programmatic audit confirms **every** annotate element-target has a matching preceding `find` (0 unguarded).
- The authoritative check is this PR's `fixtures / recording (windows-latest)` gate.

## Scope

Fixture-only; no runtime/behavior change (so no ADR needed). Fixtures resolve PASS/SKIPPED only, per repo rules.

Refs #666, #675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of recording and annotation workflows by explicitly locating target elements before applying annotation add/update operations.
  * Enhanced coverage for annotation persistence, transition/duration handling, scroll tracking, and blur-based redaction scenarios.
  * Updated test descriptions to reflect the target-resolution behavior and reduced timing-related failures in slower browser environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->