### PR TITLE
test(core): retry the browser-session getRunner suite to de-flake CI

### DIFF
--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -1516,6 +1516,16 @@ describe("getRunner() function", function () {
   // 5 minutes per test
   this.timeout(300000);
 
+  // Every test here drives a real Appium + Chromium session (or a runTests
+  // browser flow). On constrained CI runners — notably windows-latest — that
+  // session can crash shortly after launch, surfacing as an empty getTitle()
+  // ("first runner should work" assertion) or an ECONNREFUSED on teardown: a
+  // transient infra flake, not a getRunner defect. Retry like the sibling
+  // browser suites above (this.retries(2) on the runTests cases). Retries only
+  // re-run on failure, so a deterministic bug still fails all attempts — this
+  // heals a one-off session death without masking a real regression.
+  this.retries(2);
+
   let getRunner;
 
   before(async function () {


### PR DESCRIPTION
## Problem

`test / Test (windows-latest, node 24, shard 1)` intermittently fails on the `getRunner() function` suite — e.g. `should handle multiple sequential runners` failing the `assert.ok(title1, "first runner should work")` check, with `WebDriverError: ECONNREFUSED` on session teardown in the log.

## Diagnosis

Each test in that describe drives a **real Appium + Chromium session** (or a `runTests` browser flow). The failure signature — an **empty** `getTitle()` (the assertion fails; it doesn't throw) plus **ECONNREFUSED on teardown** — is a Chrome/ChromeDriver session **crashing shortly after launch** on a constrained runner, not a `getRunner` bug:

- `driverStart` already retries session *creation* (4 attempts, fresh chromedriver port each — ADR 01039). This is a *mid-session* crash, which that retry doesn't cover.
- It's intermittent: passes on reruns, on sibling matrix legs, and it **passed on #675**.
- The Linux-only stability flags (`--no-sandbox`, `--disable-dev-shm-usage`) are correctly Linux-scoped; the Windows crash is transient resource contention.

## Fix

Add `this.retries(2)` at the `getRunner()` describe level — the **same pattern the sibling `runTests` browser suites in this file already use** (`this.retries(2); // browser startup … can be flaky`). The whole describe is browser-session-heavy, so one describe-level retry covers it.

**Why this doesn't mask real bugs:** mocha retries only re-run a test *on failure*, so a deterministic bug fails all attempts and still surfaces. Retries only heal a *non-deterministic* one-off session death.

## Verification

- `should handle multiple sequential runners` passes locally with the change (real Appium+Chromium session, 45s).
- `mocha --dry-run` confirms the suite loads and the retries config is valid.
- Test-only change; no runtime behavior change, no ADR needed.

Refs #675, #677 (where this flake blocked the windows-latest test shard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added limited retries for intermittent test-session failures on constrained environments.
  * Deterministic test failures continue to be reported normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->