### PR TITLE
feat(core): record durationMs on every report node

### DIFF
--- a/adrs/01083-record-durationms-on-report-nodes.md
+++ b/adrs/01083-record-durationms-on-report-nodes.md
@@ -49,7 +49,7 @@ Three consequences:
 Chosen: **option A**. Every run, spec, test, context, and step report node carries `durationMs` —
 integer milliseconds, `readOnly`, system-populated, never authored.
 
-```
+```text
 step.durationMs    = measured wall clock of the FINAL attempt
 context.durationMs = measured wall clock of the FINAL attempt
 test.durationMs    = sum(context.durationMs)
@@ -88,8 +88,22 @@ For a step re-run by `onFail: retry` routing, or a context re-run by the `retrie
 (ADR 01082), `durationMs` is the **final attempt's** elapsed time — not the sum across attempts,
 and not including the backoff waits between them. The final attempt is the one the reported
 `result` describes, so its timing is the one that matches the verdict. The surrounding `attempts`
-and `retries` fields already tell a consumer that earlier attempts happened; a context's
-`durationMs` still spans every attempt of its *steps*, so retry cost remains visible one level up.
+and `retries` fields already tell a consumer that earlier attempts happened.
+
+The two retry levels differ in whether that discarded time is recoverable from the report, and the
+distinction is easy to state imprecisely:
+
+- **Step retries stay visible one level up.** The context clock spans every attempt of its steps
+  plus the backoff waits, so `context.durationMs - sum(step.durationMs)` is a lower bound on what
+  the retries cost.
+- **Context retries do not.** A re-run context reports only its final attempt, and because the test
+  level is a sum of those final-attempt values, no node absorbs the abandoned attempts. Time spent
+  on a context attempt that was thrown away appears nowhere in the totals; `retries` is the only
+  signal it happened.
+
+Accepted as a consequence of choosing final-attempt semantics. Summing context attempts instead
+would make `context.durationMs` describe work the reported `result` does not, which is the
+ambiguity this rule exists to avoid.
 
 ### Why `durationMs`, not `duration`
 

--- a/adrs/01083-record-durationms-on-report-nodes.md
+++ b/adrs/01083-record-durationms-on-report-nodes.md
@@ -94,8 +94,11 @@ The two retry levels differ in whether that discarded time is recoverable from t
 distinction is easy to state imprecisely:
 
 - **Step retries stay visible one level up.** The context clock spans every attempt of its steps
-  plus the backoff waits, so `context.durationMs - sum(step.durationMs)` is a lower bound on what
-  the retries cost.
+  plus the backoff waits between them, so a retried step's discarded time is still counted in
+  `context.durationMs` even though the step itself reports only its final attempt. It is *counted*,
+  not *isolated*: `context.durationMs - sum(step.durationMs)` is an **upper** bound on retry cost,
+  because that same gap also holds ordinary context overhead — preflight, driver startup, teardown —
+  which is there whether or not anything retried. Read `attempts` to know a retry happened at all.
 - **Context retries do not.** A re-run context reports only its final attempt, and because the test
   level is a sum of those final-attempt values, no node absorbs the abandoned attempts. Time spent
   on a context attempt that was thrown away appears nowhere in the totals; `retries` is the only

--- a/adrs/01083-record-durationms-on-report-nodes.md
+++ b/adrs/01083-record-durationms-on-report-nodes.md
@@ -1,0 +1,193 @@
+---
+status: accepted
+date: 2026-07-24
+decision-makers: doc-detective maintainers
+---
+
+# Record `durationMs` on every report node
+
+## Context and Problem Statement
+
+Nothing in a results report records how long anything took. Grepping `src/core/tests.ts`,
+`src/core/index.ts`, and `src/core/utils.ts` for `duration|startTime|elapsed` turns up only an
+unrelated poll loop and `warm.durationMs` — no timing was captured around `runStep` or
+`runContext`.
+
+Three consequences:
+
+- A **`junit` reporter** (#683) would have to emit `time="0"` on every `<testcase>`, so the GitLab
+  MR test-summary widget (and GitHub's test reporting) would show `0s` everywhere. The timing
+  columns become dead weight.
+- **Slow-test triage is impossible from the report.** There is no way to answer "which spec is
+  making CI slow?" without instrumenting by hand.
+- The HTML reporter already *tried* to render a run duration: `src/reporters/htmlReporter.ts`
+  read `results.meta.startedAt` / `results.meta.finishedAt` — fields **nothing in `src/` ever
+  wrote** (`setMeta()` only populates the `DOC_DETECTIVE_META` env var for telemetry). Step rows
+  rendered `step.duration`, which is an *authored action input*, not a timing. Both chips rendered
+  an em-dash on every real run.
+
+## Decision Drivers
+
+* Unblock a `junit` reporter with real per-testcase times (#683, the first-class GitLab CI
+  initiative — `docs/design/gitlab-ci-first-class-support.md`).
+* Make slow-test triage answerable from the report alone.
+* Do not collide with the authored `duration` action input.
+* Honest numbers under `concurrentRunners` — never report a figure whose meaning silently changes
+  with the concurrency setting.
+* Minimal risk to `runContext`, the largest function in the runner.
+
+## Considered Options
+
+* **A. `durationMs` on every node; wall clock where a contiguous interval exists, sum-of-children
+  at test and spec** (chosen).
+* **B. `durationMs` as a sum at every level above the context**, including the run.
+* **C. Wall-clock span at every level**, tracking min-start / max-end per test and spec.
+* **D. Reuse the name `duration`** rather than introducing `durationMs`.
+
+## Decision Outcome
+
+Chosen: **option A**. Every run, spec, test, context, and step report node carries `durationMs` —
+integer milliseconds, `readOnly`, system-populated, never authored.
+
+```
+step.durationMs    = measured wall clock of the FINAL attempt
+context.durationMs = measured wall clock of the FINAL attempt
+test.durationMs    = sum(context.durationMs)
+spec.durationMs    = sum(test.durationMs)
+run.durationMs     = measured wall clock of the execution phase
+```
+
+The run clock starts inside `runSpecs`, so it spans the warm phase, every spec, and teardown, but
+**excludes test detection, resolution, and just-in-time dependency installs**, which `runTests`
+performs before calling it. On a cold runner the process therefore takes measurably longer than
+`run.durationMs` reports. This boundary is deliberate: the excluded work is one-time environment
+setup that isn't attributable to any test, and the field's consumers — a `junit` reporter and
+slow-test triage — are asking about test execution. The schema description states the exclusion so
+the number is not mistaken for total process time.
+
+### Why sums at test and spec
+
+Contexts from every test and every spec are flattened into **one concurrent job pool**. A
+wall-clock *span* for a test would therefore include idle time during which unrelated specs were
+running — a test whose two contexts got pool slots at t=0 and t=45s would report 47s for 2s of
+actual work. The sum is total work: the right answer for "which spec is making CI slow", and the
+conventional meaning of JUnit's `<testsuite time>`. This rules out **option C**.
+
+### The concurrency caveat, stated explicitly
+
+`run.durationMs` is measured elapsed time, while `spec.durationMs` is a sum. **Under
+`concurrentRunners > 1`, `run.durationMs` can be LESS than the sum of the per-spec durations.**
+This is intended: the run figure answers "how long did I wait?" and the spec figures answer "where
+did the work go?" Making the run a sum too (**option B**) would give a tidier invariant at the cost
+of a headline number that overstates elapsed time — a 4-way-concurrent 60s run would report ~200s,
+and the HTML duration chip could not honestly use it.
+
+### Retry semantics
+
+For a step re-run by `onFail: retry` routing, or a context re-run by the `retries` policy
+(ADR 01082), `durationMs` is the **final attempt's** elapsed time — not the sum across attempts,
+and not including the backoff waits between them. The final attempt is the one the reported
+`result` describes, so its timing is the one that matches the verdict. The surrounding `attempts`
+and `retries` fields already tell a consumer that earlier attempts happened; a context's
+`durationMs` still spans every attempt of its *steps*, so retry cost remains visible one level up.
+
+### Why `durationMs`, not `duration`
+
+Step reports are built as `{ ...step, ...result }`, so an authored action input named `duration` —
+`click` press-duration, `annotation` display-duration, `dragAndDrop`, `moveTo` — already spreads
+into the step report. Reusing that name (**option D**) would produce a field that sometimes means
+"how long to hold the mouse button" and sometimes "how long the step took." `warm.durationMs`
+already establishes the name and the unit in `report_v3`, so this is consistent with the existing
+report contract rather than novel.
+
+### Presence, deliberately unlike `attempts` / `visit`
+
+`attempts` and `visit` are *additive-only-when-nontrivial*, so an un-retried, once-visited step
+report stays byte-identical. `durationMs` deliberately **does not** follow that convention: it is
+present on every node of a completed run, and a step or context that never executed (skipped,
+unsafe, guard-`if` false, routing-error marker, crash-isolated) reports `0`. A reporter that has to
+branch on presence cannot emit a complete `<testsuite>`, which is the whole point of the field.
+
+That guarantee is enforced in **one place**: the Phase 3 roll-up pass in `runSpecs` defaults any
+node still missing the field (`??= 0`) as it walks the tree. Phase 3 is the only code that sees
+every node from both execution paths — the flat concurrent pool and the routed sequencer — and both
+kinds of node, measured and synthetic. Synthetic context reports are built at seven scattered sites
+(`prepareContextSlot`'s spec-guard / test-guard / recording-name-conflict skips, the two
+crash-isolation handlers, the routed `stopRest` skip, and the runaway-`goToTest` marker), so
+stamping `0` at each construction site would be a standing invitation for the next one to forget —
+and because the report is not runtime-validated (ADR 01060), a forgotten site would surface only as
+`undefined` in a downstream reporter. One default in the pass that already traverses everything is
+the durable form.
+
+Two consequences worth noting: the `runContext` step loop's `pushStepReport` funnel needs no default
+of its own, and the recording-teardown sweep (`stopAllRecordings`) — which pushes step reports
+directly, bypassing that funnel — is given a **real clock** rather than being left to the `0`
+default, because those steps genuinely execute.
+
+### Consequences
+
+* Good: a `junit` reporter can emit real times; slow-test triage works from the report; the HTML
+  reporter's duration chip and per-step durations render real values for the first time.
+* Good: `runContext` is untouched — the clock lives in `runContextWithRetries`, its sole caller,
+  which covers all twelve of `runContext`'s exits (eleven early SKIPPED returns plus the normal
+  one) with one measurement.
+* Bad: `run.durationMs < sum(spec.durationMs)` under concurrency will surprise anyone who assumes
+  a uniform roll-up. Mitigated by saying so in the schema descriptions, the docs, and here.
+* Neutral: reports grow by one small integer field per node.
+* Neutral: `Date.now()` (not `performance.now()`) matches the `warmPhase.ts` precedent and is
+  wall-clock, so a suspended/throttled CI runner's stalls are counted — which is what a user
+  waiting on CI actually experiences.
+
+### Confirmation
+
+* `src/common/test/validate.test.js` — `report_v3 durationMs`: positive case with the field on all
+  five node levels, back-compat case without it, and negatives (negative value, fractional value)
+  at each level. The negatives assert the failure comes from the `minimum`/`integer` constraint and
+  **not** from `additionalProperties`, so they cannot pass against a schema that never declared the
+  field.
+* `test/core-core.test.js` — `durationMs on report nodes`: present, integer and non-negative on
+  every node of a completed run; `test == sum(contexts)`, `spec == sum(tests)`,
+  `context >= sum(steps)`; a step re-run by `onFail: retry` reports well under the accumulated
+  backoff; a never-executed step reports `0`; a context skipped by a false test guard — one of the
+  synthetic sites that never reaches a clock — still carries the field; a filtered-to-zero run does
+  not throw.
+* `test/concurrency.test.js` — the 1-runner vs 2-runner byte-identical-report assertion now asserts
+  `durationMs` is present at every level, then strips it before comparing. It is measured time, so
+  it can never match across runs, and the run-level value is *expected* to differ: that test
+  observed ~3985 ms serial against ~1969 ms with two runners, while the spec-level sums held at
+  ~2770 ms either way — a direct demonstration of both the concurrency caveat and the stability of
+  the sum-based levels.
+* `test/browser-fallback.test.js` — `runContextWithRetries`: the retries-disabled fast path is
+  still stamped, and a retried context reports the final attempt rather than the sum.
+
+Feature fixtures under `test/core-artifacts/` are **not** used here: a spec cannot read its own run
+report, so this behavior is not expressible through the PASS/SKIPPED gate. Per `CLAUDE.md`, the
+precise assertions live in `test/core-core.test.js` instead.
+
+## Pros and Cons of the Options
+
+### A. Wall clock where measurable, sums at test and spec (chosen)
+
+* Good, run figure is honest elapsed time — usable for the HTML duration chip.
+* Good, spec/test figures are total work — stable under any `concurrentRunners` value.
+* Good, matches JUnit's conventional `<testsuite time>`.
+* Bad, the roll-up invariant is not uniform across all five levels.
+
+### B. Sum all the way up
+
+* Good, uniform invariant: `parent == sum(children)` above the context.
+* Bad, `run.durationMs` overstates elapsed time under concurrency, sometimes by several multiples.
+* Bad, leaves the HTML duration chip with no honest source.
+
+### C. Wall-clock span at every level
+
+* Good, "duration" means one thing everywhere.
+* Bad, a test's span includes idle gaps while unrelated specs ran, so slow-test triage is actively
+  misleading — the failure mode that motivated the issue.
+* Bad, requires threading min-start / max-end through the concurrent pool.
+
+### D. Reuse the name `duration`
+
+* Good, no new vocabulary.
+* Bad, collides with authored action inputs through the `{ ...step, ...result }` spread; the field
+  would mean two different things depending on the action.

--- a/docs/fern/pages/docs/ci/reporters-and-artifacts.mdx
+++ b/docs/fern/pages/docs/ci/reporters-and-artifacts.mdx
@@ -87,7 +87,12 @@ To find the specs slowing your CI down, sort the specs by `durationMs`:
 jq '.specs | sort_by(-.durationMs) | .[:5] | .[] | {specId, durationMs}' testResults-*.json
 ```
 
-When a step or context runs more than once—a step re-run by [`onFail` retry routing](/reference/schemas/routing), or a context re-run by the [`retries`](/reference/schemas/config) policy—`durationMs` reports the **final attempt**, the one the reported result describes. The `attempts` and `retries` fields tell you that earlier attempts happened, and the enclosing context's duration still includes them, so the cost of retrying stays visible. A step that never ran—skipped, guarded off, or downstream of a failure—reports `0`.
+Anything that runs more than once reports the **final attempt** in `durationMs`—the attempt the reported result describes. What that costs you depends on which kind of retry happened:
+
+- A step re-run by [`onFail` retry routing](/reference/schemas/routing) reports only its last attempt, but the enclosing context's duration covers every attempt and the waits between them. Compare the two to see what the retries cost, and read `attempts` for the count.
+- A context re-run by the [`retries`](/reference/schemas/config) policy reports only its last attempt, and no other field absorbs the earlier ones—so the time spent on abandoned context attempts appears nowhere in the totals. The `retries` count is your signal that it happened.
+
+A step that never ran—skipped, guarded off, or downstream of a failure—reports `0`.
 
 ### Read the warm-phase timings
 

--- a/docs/fern/pages/docs/ci/reporters-and-artifacts.mdx
+++ b/docs/fern/pages/docs/ci/reporters-and-artifacts.mdx
@@ -50,6 +50,45 @@ The `json` reporter writes the full results to a file:
 
 The results file carries a `summary` object with the pass, fail, warning, and skipped counts, followed by the per-spec, per-test, per-context, and per-step detail. For an example of the results structure, see [Create your first test](/docs/get-started/create-your-first-test#outcome). To act on results programmatically, parse this file (see [Fail CI when tests fail](#step-6-fail-ci-when-tests-fail)).
 
+### Find slow specs with `durationMs`
+
+Every node in the results—the run, each spec, each test, each context, and each step—carries a `durationMs` field in whole milliseconds. Doc Detective populates it; you never set it yourself.
+
+```json
+{
+  "durationMs": 61840,
+  "specs": [
+    {
+      "specId": "api.spec.json",
+      "durationMs": 48200,
+      "tests": [{ "testId": "create-a-widget", "durationMs": 48200 }]
+    }
+  ]
+}
+```
+
+The meaning shifts slightly by level, and the difference matters when you run tests concurrently:
+
+| Level | `durationMs` is |
+|---|---|
+| Run | Elapsed time for the execution phase: the warm phase, every spec, and teardown. It excludes test detection, resolution, and any just-in-time dependency install, so a cold runner spends longer than this value reports. |
+| Spec | The sum of its tests' durations. |
+| Test | The sum of its contexts' durations. |
+| Context | Elapsed time for the context, covering setup, every step, and teardown. |
+| Step | Elapsed time for the step. |
+
+Spec and test durations are **sums of work**, not elapsed spans. Contexts from every test share one concurrent pool, so an elapsed span for a spec would count time while unrelated specs were running. Summing keeps the number stable no matter what you set [`concurrentRunners`](/reference/schemas/config) to, which is what you want when comparing specs to each other.
+
+The consequence: when `concurrentRunners` is greater than 1, the run's `durationMs` is *less* than the sum of its specs' durations, because specs overlapped. That's expected. Read the run value as elapsed wall-clock time, and the spec values as where the work went.
+
+To find the specs slowing your CI down, sort the specs by `durationMs`:
+
+```bash
+jq '.specs | sort_by(-.durationMs) | .[:5] | .[] | {specId, durationMs}' testResults-*.json
+```
+
+When a step or context runs more than once—a step re-run by [`onFail` retry routing](/reference/schemas/routing), or a context re-run by the [`retries`](/reference/schemas/config) policy—`durationMs` reports the **final attempt**, the one the reported result describes. The `attempts` and `retries` fields tell you that earlier attempts happened, and the enclosing context's duration still includes them, so the cost of retrying stays visible. A step that never ran—skipped, guarded off, or downstream of a failure—reports `0`.
+
 ### Read the warm-phase timings
 
 The results also carry a `warm` object that records what the run provisioned before executing tests. At the start of every run, Doc Detective front-loads the setup its tests would otherwise pay one at a time—browser and driver installs, simulator and emulator boots, and related downloads—and runs those tasks concurrently. Each entry lists the task, its outcome, and how long it took:

--- a/docs/fern/pages/docs/ci/reporters-and-artifacts.mdx
+++ b/docs/fern/pages/docs/ci/reporters-and-artifacts.mdx
@@ -52,7 +52,7 @@ The results file carries a `summary` object with the pass, fail, warning, and sk
 
 ### Find slow specs with `durationMs`
 
-Every node in the results—the run, each spec, each test, each context, and each step—carries a `durationMs` field in whole milliseconds. Doc Detective populates it; you never set it yourself.
+Every node in the results—the run, each spec, each test, each context, and each step—carries a `durationMs` field in whole milliseconds. Doc Detective populates it. You never set it yourself.
 
 ```json
 {
@@ -71,13 +71,13 @@ The meaning shifts slightly by level, and the difference matters when you run te
 
 | Level | `durationMs` is |
 |---|---|
-| Run | Elapsed time for the execution phase: the warm phase, every spec, and teardown. It excludes test detection, resolution, and any just-in-time dependency install, so a cold runner spends longer than this value reports. |
+| Run | Elapsed time for the execution phase: the warm phase, every spec, and cleanup. It excludes test detection, resolution, and any just-in-time dependency install, so a cold runner spends longer than this value reports. |
 | Spec | The sum of its tests' durations. |
 | Test | The sum of its contexts' durations. |
-| Context | Elapsed time for the context, covering setup, every step, and teardown. |
+| Context | Elapsed time for the context, covering setup, every step, and cleanup. |
 | Step | Elapsed time for the step. |
 
-Spec and test durations are **sums of work**, not elapsed spans. Contexts from every test share one concurrent pool, so an elapsed span for a spec would count time while unrelated specs were running. Summing keeps the number stable no matter what you set [`concurrentRunners`](/reference/schemas/config) to, which is what you want when comparing specs to each other.
+Spec and test durations are **sums of work**, not elapsed spans. Contexts from every test run through the same set of concurrent runners, so an elapsed span for a spec would count time while unrelated specs were running. Summing keeps the number stable no matter what you set [`concurrentRunners`](/reference/schemas/config) to, which is what you want when comparing specs to each other.
 
 The consequence: when `concurrentRunners` is greater than 1, the run's `durationMs` is *less* than the sum of its specs' durations, because specs overlapped. That's expected. Read the run value as elapsed wall-clock time, and the spec values as where the work went.
 

--- a/docs/fern/pages/docs/ci/reporters-and-artifacts.mdx
+++ b/docs/fern/pages/docs/ci/reporters-and-artifacts.mdx
@@ -89,7 +89,7 @@ jq '.specs | sort_by(-.durationMs) | .[:5] | .[] | {specId, durationMs}' testRes
 
 Anything that runs more than once reports the **final attempt** in `durationMs`—the attempt the reported result describes. What that costs you depends on which kind of retry happened:
 
-- A step re-run by [`onFail` retry routing](/reference/schemas/routing) reports only its last attempt, but the enclosing context's duration covers every attempt and the waits between them. Compare the two to see what the retries cost, and read `attempts` for the count.
+- A step re-run by [`onFail` retry routing](/reference/schemas/routing) reports only its last attempt, but the enclosing context's duration still covers every attempt and the waits between them, so the time isn't lost from the totals. It isn't separable, though: the difference between a context and the sum of its steps also includes ordinary setup and cleanup, so read it as an upper limit on what retrying cost, not a measurement of it. Use `attempts` to tell whether a step retried at all.
 - A context re-run by the [`retries`](/reference/schemas/config) policy reports only its last attempt, and no other field absorbs the earlier ones—so the time spent on abandoned context attempts appears nowhere in the totals. The `retries` count is your signal that it happened.
 
 A step that never ran—skipped, guarded off, or downstream of a failure—reports `0`.

--- a/docs/fern/pages/reference/schemas/common.mdx
+++ b/docs/fern/pages/reference/schemas/common.mdx
@@ -33,6 +33,7 @@ location | object([Source Location](/reference/schemas/source-location)) | ReadO
 autoScreenshot | string | ReadOnly. Path, relative to the run's artifact directory (the report's `runDir`), of the screenshot captured automatically after this step. Always a non-empty, forward-slash, relative path. Present only in test results, when `autoScreenshot` is enabled and the capture succeeded. This is system-populated metadata and should not be set manually.<br/><br/>Minimum length: 1. Pattern: `^(?![A-Za-z]:|[\\/])[^\\]+$` | —
 attempts | integer | ReadOnly. Total number of times this step ran (the initial attempt plus retries) when a routing `retry` action re-ran it. Present only in test results, and only when the step was retried at least once (so the value is always >= 2). This is system-populated metadata and should not be set manually.<br/><br/>Minimum: 2 | —
 visit | integer | ReadOnly. Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.<br/><br/>Minimum: 2 | —
+durationMs | integer | ReadOnly. Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.<br/><br/>Minimum: 0 | —
 
 ## Examples
 

--- a/docs/fern/pages/reference/schemas/resolved-context.mdx
+++ b/docs/fern/pages/reference/schemas/resolved-context.mdx
@@ -14,6 +14,7 @@ description: "Reference for the `Resolved context` schema."
 
 Field | Type | Description | Default
 :-- | :-- | :-- | :--
+durationMs | integer | ReadOnly. Wall-clock duration of this context in milliseconds, covering preflight, driver startup, every step, and teardown. When the `retries` policy re-ran the context, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. Present only in test results. System-populated.<br/><br/>Minimum: 0 | —
 platform | string | Optional. Platform to run the test on. This is a resolved version of the `platforms` property. | —
 browser | object([Browser](/reference/schemas/browser)) | Optional. Browser configuration. | —
 openApi | array of unknown | Optional. No description provided. | —

--- a/docs/fern/pages/reference/schemas/specification.mdx
+++ b/docs/fern/pages/reference/schemas/specification.mdx
@@ -21,6 +21,7 @@ openApi | array of unknown | Optional. No description provided. | —
 autoScreenshot | boolean | Optional. If `true`, captures a screenshot after every step in this spec's tests that runs in a browser. Overrides the config-level `autoScreenshot`; individual tests can override this value with their own `autoScreenshot`. When unset, defers to the config level. | —
 autoRecord | boolean | Optional. If `true`, records a video of every browser context in this spec's tests. Overrides the config-level `autoRecord`; individual tests can override this value with their own `autoRecord`. When unset, defers to the config level. | —
 annotationDefaults | object([Annotation defaults](/reference/schemas/annotation-defaults)) | Optional. Default visual theme for annotations in this spec's tests. Overrides the config-level `annotationDefaults`; individual tests can override this value with their own `annotationDefaults`. When unset, defers to the config level. | —
+durationMs | integer | ReadOnly. Total time this specification's tests took, in milliseconds: the sum of the per-test durations. A sum rather than a wall-clock span, because this spec's contexts share a concurrent pool with every other spec's. Present only in test results. System-populated.<br/><br/>Minimum: 0 | —
 tests | array of object([test](/reference/schemas/test)) | Required. [Tests](test) to perform. | —
 
 ## Examples

--- a/docs/fern/pages/reference/schemas/test.mdx
+++ b/docs/fern/pages/reference/schemas/test.mdx
@@ -33,6 +33,7 @@ onSkip | array of object([routing](/reference/schemas/routing)) | Optional. Rout
 before | string | Optional. Path to a test specification to perform before this test, while maintaining this test's context. Useful for setting up testing environments. Only the `steps` property is used from the first test in the setup spec. | —
 after | string | Optional. Path to a test specification to perform after this test, while maintaining this test's context. Useful for cleaning up testing environments. Only the `steps` property is used from the first test in the cleanup spec. | —
 steps | array of object | Optional. Steps to perform as part of the test. Performed in the sequence defined. If one or more actions fail, the test fails. By default, if a step fails, the test stops and the remaining steps are not executed. | —
+durationMs | integer | ReadOnly. Total time this test took, in milliseconds: the sum of the per-context durations. A sum rather than a wall-clock span, because this test's contexts share a concurrent pool with every other test's. Present only in test results. System-populated.<br/><br/>Minimum: 0 | —
 contexts | array of object([Resolved context](/reference/schemas/resolved-context)) | ReadOnly. Resolved contexts to run the test in. This is a resolved version of the `runOn` property. It is not user-defined and should not be used in test specifications. | —
 
 ## Examples

--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -2022,6 +2022,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -2922,6 +2928,12 @@
                                           "type": "integer",
                                           "minimum": 2,
                                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                          "readOnly": true
+                                        },
+                                        "durationMs": {
+                                          "type": "integer",
+                                          "minimum": 0,
+                                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                           "readOnly": true
                                         },
                                         "location": {
@@ -3889,6 +3901,12 @@
                                                 "type": "integer",
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                 "readOnly": true
                                               }
                                             },
@@ -5046,6 +5064,12 @@
                                                 "type": "integer",
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                 "readOnly": true
                                               }
                                             },
@@ -6702,6 +6726,12 @@
                                                 "type": "integer",
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                 "readOnly": true
                                               }
                                             },
@@ -15995,6 +16025,12 @@
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                 "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                "readOnly": true
                                               }
                                             },
                                             "title": "Common"
@@ -18112,6 +18148,12 @@
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                 "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                "readOnly": true
                                               }
                                             },
                                             "title": "Common"
@@ -20055,6 +20097,12 @@
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                 "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                "readOnly": true
                                               }
                                             },
                                             "title": "Common"
@@ -21392,6 +21440,12 @@
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                 "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                "readOnly": true
                                               }
                                             },
                                             "title": "Common"
@@ -22677,6 +22731,12 @@
                                                 "type": "integer",
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                 "readOnly": true
                                               }
                                             },
@@ -24105,6 +24165,12 @@
                                                 "type": "integer",
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                 "readOnly": true
                                               }
                                             },
@@ -28115,6 +28181,12 @@
                                                 "type": "integer",
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                 "readOnly": true
                                               }
                                             },
@@ -36889,6 +36961,12 @@
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                 "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                "readOnly": true
                                               }
                                             },
                                             "title": "Common"
@@ -38082,6 +38160,12 @@
                                                 "type": "integer",
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                 "readOnly": true
                                               }
                                             },
@@ -39938,6 +40022,12 @@
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                 "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                "readOnly": true
                                               }
                                             },
                                             "title": "Common"
@@ -40937,6 +41027,12 @@
                                                 "type": "integer",
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                 "readOnly": true
                                               }
                                             },
@@ -43175,6 +43271,12 @@
                                                 "type": "integer",
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                 "readOnly": true
                                               }
                                             },
@@ -45542,6 +45644,12 @@
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                 "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                "readOnly": true
                                               }
                                             },
                                             "title": "Common"
@@ -46499,6 +46607,12 @@
                                                 "type": "integer",
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                 "readOnly": true
                                               }
                                             },
@@ -48099,6 +48213,12 @@
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                 "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                "readOnly": true
                                               }
                                             },
                                             "title": "Common"
@@ -49275,6 +49395,12 @@
                                                 "type": "integer",
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                 "readOnly": true
                                               }
                                             },
@@ -51597,6 +51723,12 @@
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                 "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                "readOnly": true
                                               }
                                             },
                                             "title": "Common"
@@ -52586,6 +52718,12 @@
                                                 "type": "integer",
                                                 "minimum": 2,
                                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                "readOnly": true
+                                              },
+                                              "durationMs": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                 "readOnly": true
                                               }
                                             },
@@ -59802,6 +59940,12 @@
                                 "minimum": 2,
                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                 "readOnly": true
+                              },
+                              "durationMs": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                "readOnly": true
                               }
                             },
                             "title": "Common"
@@ -60702,6 +60846,12 @@
                             "type": "integer",
                             "minimum": 2,
                             "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                            "readOnly": true
+                          },
+                          "durationMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                             "readOnly": true
                           },
                           "location": {
@@ -61669,6 +61819,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 }
                               },
@@ -62826,6 +62982,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 }
                               },
@@ -64482,6 +64644,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 }
                               },
@@ -73775,6 +73943,12 @@
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                   "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                  "readOnly": true
                                 }
                               },
                               "title": "Common"
@@ -75892,6 +76066,12 @@
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                   "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                  "readOnly": true
                                 }
                               },
                               "title": "Common"
@@ -77835,6 +78015,12 @@
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                   "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                  "readOnly": true
                                 }
                               },
                               "title": "Common"
@@ -79172,6 +79358,12 @@
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                   "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                  "readOnly": true
                                 }
                               },
                               "title": "Common"
@@ -80457,6 +80649,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 }
                               },
@@ -81885,6 +82083,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 }
                               },
@@ -85895,6 +86099,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 }
                               },
@@ -94669,6 +94879,12 @@
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                   "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                  "readOnly": true
                                 }
                               },
                               "title": "Common"
@@ -95862,6 +96078,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 }
                               },
@@ -97718,6 +97940,12 @@
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                   "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                  "readOnly": true
                                 }
                               },
                               "title": "Common"
@@ -98717,6 +98945,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 }
                               },
@@ -100955,6 +101189,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 }
                               },
@@ -103322,6 +103562,12 @@
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                   "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                  "readOnly": true
                                 }
                               },
                               "title": "Common"
@@ -104279,6 +104525,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 }
                               },
@@ -105879,6 +106131,12 @@
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                   "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                  "readOnly": true
                                 }
                               },
                               "title": "Common"
@@ -107055,6 +107313,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 }
                               },
@@ -109377,6 +109641,12 @@
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                   "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                  "readOnly": true
                                 }
                               },
                               "title": "Common"
@@ -110366,6 +110636,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 }
                               },

--- a/src/common/src/schemas/output_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/report_v3.schema.json
@@ -20,6 +20,12 @@
       "description": "Absolute path to the run's artifact folder (`<output>/.doc-detective/runs/<runId>/`), where the `runFolder` reporter archives results and `autoScreenshot` images are saved (nested under `specs/<specId>/tests/<testId>/contexts/<contextId>/`). Step-level `autoScreenshot` paths in the report are relative to this folder. System-populated.",
       "readOnly": true
     },
+    "durationMs": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Wall-clock duration of the run's execution phase in milliseconds, spanning the warm phase, every spec, and teardown. Excludes what happens before execution starts — test detection, resolution, and any just-in-time dependency install — so on a cold runner the process takes longer than this. Because contexts run concurrently, this can be LESS than the sum of the per-spec durations. Present only in test results. System-populated.",
+      "readOnly": true
+    },
     "specs": {
       "description": "Test specifications that were performed.",
       "type": "array",
@@ -1452,6 +1458,12 @@
                     }
                   }
                 ]
+              },
+              "durationMs": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Total time this specification's tests took, in milliseconds: the sum of the per-test durations. A sum rather than a wall-clock span, because this spec's contexts share a concurrent pool with every other spec's. Present only in test results. System-populated.",
+                "readOnly": true
               },
               "tests": {
                 "description": "[Tests](test) to perform.",
@@ -4513,6 +4525,12 @@
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                       "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                      "readOnly": true
                                     }
                                   },
                                   "title": "Common"
@@ -5413,6 +5431,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 },
                                 "location": {
@@ -6380,6 +6404,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -7537,6 +7567,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -9193,6 +9229,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -18486,6 +18528,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -20603,6 +20651,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -22546,6 +22600,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -23883,6 +23943,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -25168,6 +25234,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -26596,6 +26668,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -30606,6 +30684,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -39380,6 +39464,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -40573,6 +40663,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -42429,6 +42525,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -43428,6 +43530,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -45666,6 +45774,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -48033,6 +48147,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -48990,6 +49110,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -50590,6 +50716,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -51766,6 +51898,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -54088,6 +54226,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -55077,6 +55221,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -59795,6 +59945,12 @@
                             ]
                           }
                         },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Total time this test took, in milliseconds: the sum of the per-context durations. A sum rather than a wall-clock span, because this test's contexts share a concurrent pool with every other test's. Present only in test results. System-populated.",
+                          "readOnly": true
+                        },
                         "contexts": {
                           "title": "Resolved contexts",
                           "type": "array",
@@ -59803,6 +59959,12 @@
                           "items": {
                             "type": "object",
                             "properties": {
+                              "durationMs": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "description": "Wall-clock duration of this context in milliseconds, covering preflight, driver startup, every step, and teardown. When the `retries` policy re-ran the context, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. Present only in test results. System-populated.",
+                                "readOnly": true
+                              },
                               "platform": {
                                 "type": "string",
                                 "description": "Platform to run the test on. This is a resolved version of the `platforms` property."
@@ -60996,6 +61158,12 @@
                                             "minimum": 2,
                                             "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                             "readOnly": true
+                                          },
+                                          "durationMs": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                            "readOnly": true
                                           }
                                         },
                                         "title": "Common"
@@ -61896,6 +62064,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       },
                                       "location": {
@@ -62863,6 +63037,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -64020,6 +64200,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -65676,6 +65862,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -74969,6 +75161,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -77086,6 +77284,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -79029,6 +79233,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -80366,6 +80576,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -81651,6 +81867,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -83079,6 +83301,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -87089,6 +87317,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -95863,6 +96097,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -97056,6 +97296,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -98912,6 +99158,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -99911,6 +100163,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -102149,6 +102407,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -104516,6 +104780,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -105473,6 +105743,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -107073,6 +107349,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -108249,6 +108531,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -110571,6 +110859,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -111560,6 +111854,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -2035,6 +2035,12 @@
                                                   "minimum": 2,
                                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                   "readOnly": true
+                                                },
+                                                "durationMs": {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                  "readOnly": true
                                                 }
                                               },
                                               "title": "Common"
@@ -2935,6 +2941,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             },
                                             "location": {
@@ -3902,6 +3914,12 @@
                                                     "type": "integer",
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                    "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                     "readOnly": true
                                                   }
                                                 },
@@ -5059,6 +5077,12 @@
                                                     "type": "integer",
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                    "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                     "readOnly": true
                                                   }
                                                 },
@@ -6715,6 +6739,12 @@
                                                     "type": "integer",
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                    "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                     "readOnly": true
                                                   }
                                                 },
@@ -16008,6 +16038,12 @@
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                     "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                    "readOnly": true
                                                   }
                                                 },
                                                 "title": "Common"
@@ -18125,6 +18161,12 @@
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                     "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                    "readOnly": true
                                                   }
                                                 },
                                                 "title": "Common"
@@ -20068,6 +20110,12 @@
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                     "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                    "readOnly": true
                                                   }
                                                 },
                                                 "title": "Common"
@@ -21405,6 +21453,12 @@
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                     "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                    "readOnly": true
                                                   }
                                                 },
                                                 "title": "Common"
@@ -22690,6 +22744,12 @@
                                                     "type": "integer",
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                    "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                     "readOnly": true
                                                   }
                                                 },
@@ -24118,6 +24178,12 @@
                                                     "type": "integer",
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                    "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                     "readOnly": true
                                                   }
                                                 },
@@ -28128,6 +28194,12 @@
                                                     "type": "integer",
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                    "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                     "readOnly": true
                                                   }
                                                 },
@@ -36902,6 +36974,12 @@
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                     "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                    "readOnly": true
                                                   }
                                                 },
                                                 "title": "Common"
@@ -38095,6 +38173,12 @@
                                                     "type": "integer",
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                    "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                     "readOnly": true
                                                   }
                                                 },
@@ -39951,6 +40035,12 @@
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                     "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                    "readOnly": true
                                                   }
                                                 },
                                                 "title": "Common"
@@ -40950,6 +41040,12 @@
                                                     "type": "integer",
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                    "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                     "readOnly": true
                                                   }
                                                 },
@@ -43188,6 +43284,12 @@
                                                     "type": "integer",
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                    "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                     "readOnly": true
                                                   }
                                                 },
@@ -45555,6 +45657,12 @@
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                     "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                    "readOnly": true
                                                   }
                                                 },
                                                 "title": "Common"
@@ -46512,6 +46620,12 @@
                                                     "type": "integer",
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                    "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                     "readOnly": true
                                                   }
                                                 },
@@ -48112,6 +48226,12 @@
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                     "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                    "readOnly": true
                                                   }
                                                 },
                                                 "title": "Common"
@@ -49288,6 +49408,12 @@
                                                     "type": "integer",
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                    "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                     "readOnly": true
                                                   }
                                                 },
@@ -51610,6 +51736,12 @@
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                                     "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                                    "readOnly": true
                                                   }
                                                 },
                                                 "title": "Common"
@@ -52599,6 +52731,12 @@
                                                     "type": "integer",
                                                     "minimum": 2,
                                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                                    "readOnly": true
+                                                  },
+                                                  "durationMs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                                     "readOnly": true
                                                   }
                                                 },
@@ -59815,6 +59953,12 @@
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                     "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                    "readOnly": true
                                   }
                                 },
                                 "title": "Common"
@@ -60715,6 +60859,12 @@
                                 "type": "integer",
                                 "minimum": 2,
                                 "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                "readOnly": true
+                              },
+                              "durationMs": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                 "readOnly": true
                               },
                               "location": {
@@ -61682,6 +61832,12 @@
                                       "type": "integer",
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                      "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                       "readOnly": true
                                     }
                                   },
@@ -62839,6 +62995,12 @@
                                       "type": "integer",
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                      "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                       "readOnly": true
                                     }
                                   },
@@ -64495,6 +64657,12 @@
                                       "type": "integer",
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                      "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                       "readOnly": true
                                     }
                                   },
@@ -73788,6 +73956,12 @@
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                       "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                      "readOnly": true
                                     }
                                   },
                                   "title": "Common"
@@ -75905,6 +76079,12 @@
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                       "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                      "readOnly": true
                                     }
                                   },
                                   "title": "Common"
@@ -77848,6 +78028,12 @@
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                       "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                      "readOnly": true
                                     }
                                   },
                                   "title": "Common"
@@ -79185,6 +79371,12 @@
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                       "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                      "readOnly": true
                                     }
                                   },
                                   "title": "Common"
@@ -80470,6 +80662,12 @@
                                       "type": "integer",
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                      "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                       "readOnly": true
                                     }
                                   },
@@ -81898,6 +82096,12 @@
                                       "type": "integer",
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                      "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                       "readOnly": true
                                     }
                                   },
@@ -85908,6 +86112,12 @@
                                       "type": "integer",
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                      "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                       "readOnly": true
                                     }
                                   },
@@ -94682,6 +94892,12 @@
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                       "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                      "readOnly": true
                                     }
                                   },
                                   "title": "Common"
@@ -95875,6 +96091,12 @@
                                       "type": "integer",
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                      "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                       "readOnly": true
                                     }
                                   },
@@ -97731,6 +97953,12 @@
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                       "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                      "readOnly": true
                                     }
                                   },
                                   "title": "Common"
@@ -98730,6 +98958,12 @@
                                       "type": "integer",
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                      "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                       "readOnly": true
                                     }
                                   },
@@ -100968,6 +101202,12 @@
                                       "type": "integer",
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                      "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                       "readOnly": true
                                     }
                                   },
@@ -103335,6 +103575,12 @@
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                       "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                      "readOnly": true
                                     }
                                   },
                                   "title": "Common"
@@ -104292,6 +104538,12 @@
                                       "type": "integer",
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                      "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                       "readOnly": true
                                     }
                                   },
@@ -105892,6 +106144,12 @@
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                       "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                      "readOnly": true
                                     }
                                   },
                                   "title": "Common"
@@ -107068,6 +107326,12 @@
                                       "type": "integer",
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                      "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                       "readOnly": true
                                     }
                                   },
@@ -109390,6 +109654,12 @@
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                       "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                      "readOnly": true
                                     }
                                   },
                                   "title": "Common"
@@ -110379,6 +110649,12 @@
                                       "type": "integer",
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                      "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                       "readOnly": true
                                     }
                                   },
@@ -116829,6 +117105,12 @@
                   }
                 ]
               },
+              "durationMs": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Total time this specification's tests took, in milliseconds: the sum of the per-test durations. A sum rather than a wall-clock span, because this spec's contexts share a concurrent pool with every other spec's. Present only in test results. System-populated.",
+                "readOnly": true
+              },
               "tests": {
                 "description": "[Tests](test) to perform.",
                 "type": "array",
@@ -119889,6 +120171,12 @@
                                       "minimum": 2,
                                       "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                       "readOnly": true
+                                    },
+                                    "durationMs": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                      "readOnly": true
                                     }
                                   },
                                   "title": "Common"
@@ -120789,6 +121077,12 @@
                                   "type": "integer",
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                  "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                   "readOnly": true
                                 },
                                 "location": {
@@ -121756,6 +122050,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -122913,6 +123213,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -124569,6 +124875,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -133862,6 +134174,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -135979,6 +136297,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -137922,6 +138246,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -139259,6 +139589,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -140544,6 +140880,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -141972,6 +142314,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -145982,6 +146330,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -154756,6 +155110,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -155949,6 +156309,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -157805,6 +158171,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -158804,6 +159176,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -161042,6 +161420,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -163409,6 +163793,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -164366,6 +164756,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -165966,6 +166362,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -167142,6 +167544,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -169464,6 +169872,12 @@
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                         "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                        "readOnly": true
                                       }
                                     },
                                     "title": "Common"
@@ -170453,6 +170867,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       }
                                     },
@@ -175171,6 +175591,12 @@
                             ]
                           }
                         },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Total time this test took, in milliseconds: the sum of the per-context durations. A sum rather than a wall-clock span, because this test's contexts share a concurrent pool with every other test's. Present only in test results. System-populated.",
+                          "readOnly": true
+                        },
                         "contexts": {
                           "title": "Resolved contexts",
                           "type": "array",
@@ -175179,6 +175605,12 @@
                           "items": {
                             "type": "object",
                             "properties": {
+                              "durationMs": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "description": "Wall-clock duration of this context in milliseconds, covering preflight, driver startup, every step, and teardown. When the `retries` policy re-ran the context, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. Present only in test results. System-populated.",
+                                "readOnly": true
+                              },
                               "platform": {
                                 "type": "string",
                                 "description": "Platform to run the test on. This is a resolved version of the `platforms` property."
@@ -176372,6 +176804,12 @@
                                             "minimum": 2,
                                             "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                             "readOnly": true
+                                          },
+                                          "durationMs": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                            "readOnly": true
                                           }
                                         },
                                         "title": "Common"
@@ -177272,6 +177710,12 @@
                                         "type": "integer",
                                         "minimum": 2,
                                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                        "readOnly": true
+                                      },
+                                      "durationMs": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                         "readOnly": true
                                       },
                                       "location": {
@@ -178239,6 +178683,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -179396,6 +179846,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -181052,6 +181508,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -190345,6 +190807,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -192462,6 +192930,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -194405,6 +194879,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -195742,6 +196222,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -197027,6 +197513,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -198455,6 +198947,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -202465,6 +202963,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -211239,6 +211743,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -212432,6 +212942,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -214288,6 +214804,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -215287,6 +215809,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -217525,6 +218053,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -219892,6 +220426,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -220849,6 +221389,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -222449,6 +222995,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -223625,6 +224177,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },
@@ -225947,6 +226505,12 @@
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                               "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                              "readOnly": true
                                             }
                                           },
                                           "title": "Common"
@@ -226936,6 +227500,12 @@
                                               "type": "integer",
                                               "minimum": 2,
                                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                              "readOnly": true
+                                            },
+                                            "durationMs": {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                               "readOnly": true
                                             }
                                           },

--- a/src/common/src/schemas/output_schemas/spec_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/spec_v3.schema.json
@@ -1425,6 +1425,12 @@
         }
       ]
     },
+    "durationMs": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total time this specification's tests took, in milliseconds: the sum of the per-test durations. A sum rather than a wall-clock span, because this spec's contexts share a concurrent pool with every other spec's. Present only in test results. System-populated.",
+      "readOnly": true
+    },
     "tests": {
       "description": "[Tests](test) to perform.",
       "type": "array",
@@ -4485,6 +4491,12 @@
                             "minimum": 2,
                             "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                             "readOnly": true
+                          },
+                          "durationMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                            "readOnly": true
                           }
                         },
                         "title": "Common"
@@ -5385,6 +5397,12 @@
                         "type": "integer",
                         "minimum": 2,
                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                        "readOnly": true
+                      },
+                      "durationMs": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                         "readOnly": true
                       },
                       "location": {
@@ -6352,6 +6370,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             }
                           },
@@ -7509,6 +7533,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             }
                           },
@@ -9165,6 +9195,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             }
                           },
@@ -18458,6 +18494,12 @@
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                               "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                              "readOnly": true
                             }
                           },
                           "title": "Common"
@@ -20575,6 +20617,12 @@
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                               "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                              "readOnly": true
                             }
                           },
                           "title": "Common"
@@ -22518,6 +22566,12 @@
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                               "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                              "readOnly": true
                             }
                           },
                           "title": "Common"
@@ -23855,6 +23909,12 @@
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                               "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                              "readOnly": true
                             }
                           },
                           "title": "Common"
@@ -25140,6 +25200,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             }
                           },
@@ -26568,6 +26634,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             }
                           },
@@ -30578,6 +30650,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             }
                           },
@@ -39352,6 +39430,12 @@
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                               "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                              "readOnly": true
                             }
                           },
                           "title": "Common"
@@ -40545,6 +40629,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             }
                           },
@@ -42401,6 +42491,12 @@
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                               "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                              "readOnly": true
                             }
                           },
                           "title": "Common"
@@ -43400,6 +43496,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             }
                           },
@@ -45638,6 +45740,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             }
                           },
@@ -48005,6 +48113,12 @@
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                               "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                              "readOnly": true
                             }
                           },
                           "title": "Common"
@@ -48962,6 +49076,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             }
                           },
@@ -50562,6 +50682,12 @@
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                               "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                              "readOnly": true
                             }
                           },
                           "title": "Common"
@@ -51738,6 +51864,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             }
                           },
@@ -54060,6 +54192,12 @@
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                               "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                              "readOnly": true
                             }
                           },
                           "title": "Common"
@@ -55049,6 +55187,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             }
                           },
@@ -59767,6 +59911,12 @@
                   ]
                 }
               },
+              "durationMs": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Total time this test took, in milliseconds: the sum of the per-context durations. A sum rather than a wall-clock span, because this test's contexts share a concurrent pool with every other test's. Present only in test results. System-populated.",
+                "readOnly": true
+              },
               "contexts": {
                 "title": "Resolved contexts",
                 "type": "array",
@@ -59775,6 +59925,12 @@
                 "items": {
                   "type": "object",
                   "properties": {
+                    "durationMs": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "description": "Wall-clock duration of this context in milliseconds, covering preflight, driver startup, every step, and teardown. When the `retries` policy re-ran the context, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. Present only in test results. System-populated.",
+                      "readOnly": true
+                    },
                     "platform": {
                       "type": "string",
                       "description": "Platform to run the test on. This is a resolved version of the `platforms` property."
@@ -60968,6 +61124,12 @@
                                   "minimum": 2,
                                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                   "readOnly": true
+                                },
+                                "durationMs": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                  "readOnly": true
                                 }
                               },
                               "title": "Common"
@@ -61868,6 +62030,12 @@
                               "type": "integer",
                               "minimum": 2,
                               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                              "readOnly": true
+                            },
+                            "durationMs": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                               "readOnly": true
                             },
                             "location": {
@@ -62835,6 +63003,12 @@
                                     "type": "integer",
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                    "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                     "readOnly": true
                                   }
                                 },
@@ -63992,6 +64166,12 @@
                                     "type": "integer",
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                    "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                     "readOnly": true
                                   }
                                 },
@@ -65648,6 +65828,12 @@
                                     "type": "integer",
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                    "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                     "readOnly": true
                                   }
                                 },
@@ -74941,6 +75127,12 @@
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                     "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                    "readOnly": true
                                   }
                                 },
                                 "title": "Common"
@@ -77058,6 +77250,12 @@
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                     "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                    "readOnly": true
                                   }
                                 },
                                 "title": "Common"
@@ -79001,6 +79199,12 @@
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                     "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                    "readOnly": true
                                   }
                                 },
                                 "title": "Common"
@@ -80338,6 +80542,12 @@
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                     "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                    "readOnly": true
                                   }
                                 },
                                 "title": "Common"
@@ -81623,6 +81833,12 @@
                                     "type": "integer",
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                    "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                     "readOnly": true
                                   }
                                 },
@@ -83051,6 +83267,12 @@
                                     "type": "integer",
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                    "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                     "readOnly": true
                                   }
                                 },
@@ -87061,6 +87283,12 @@
                                     "type": "integer",
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                    "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                     "readOnly": true
                                   }
                                 },
@@ -95835,6 +96063,12 @@
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                     "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                    "readOnly": true
                                   }
                                 },
                                 "title": "Common"
@@ -97028,6 +97262,12 @@
                                     "type": "integer",
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                    "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                     "readOnly": true
                                   }
                                 },
@@ -98884,6 +99124,12 @@
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                     "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                    "readOnly": true
                                   }
                                 },
                                 "title": "Common"
@@ -99883,6 +100129,12 @@
                                     "type": "integer",
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                    "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                     "readOnly": true
                                   }
                                 },
@@ -102121,6 +102373,12 @@
                                     "type": "integer",
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                    "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                     "readOnly": true
                                   }
                                 },
@@ -104488,6 +104746,12 @@
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                     "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                    "readOnly": true
                                   }
                                 },
                                 "title": "Common"
@@ -105445,6 +105709,12 @@
                                     "type": "integer",
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                    "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                     "readOnly": true
                                   }
                                 },
@@ -107045,6 +107315,12 @@
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                     "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                    "readOnly": true
                                   }
                                 },
                                 "title": "Common"
@@ -108221,6 +108497,12 @@
                                     "type": "integer",
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                    "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                     "readOnly": true
                                   }
                                 },
@@ -110543,6 +110825,12 @@
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                                     "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                                    "readOnly": true
                                   }
                                 },
                                 "title": "Common"
@@ -111532,6 +111820,12 @@
                                     "type": "integer",
                                     "minimum": 2,
                                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                                    "readOnly": true
+                                  },
+                                  "durationMs": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                                     "readOnly": true
                                   }
                                 },

--- a/src/common/src/schemas/output_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/step_v3.schema.json
@@ -937,6 +937,12 @@
             "minimum": 2,
             "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
             "readOnly": true
+          },
+          "durationMs": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+            "readOnly": true
           }
         },
         "title": "Common"
@@ -1837,6 +1843,12 @@
         "type": "integer",
         "minimum": 2,
         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+        "readOnly": true
+      },
+      "durationMs": {
+        "type": "integer",
+        "minimum": 0,
+        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
         "readOnly": true
       },
       "location": {
@@ -2804,6 +2816,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             }
           },
@@ -3961,6 +3979,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             }
           },
@@ -5617,6 +5641,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             }
           },
@@ -14910,6 +14940,12 @@
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
               "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+              "readOnly": true
             }
           },
           "title": "Common"
@@ -17027,6 +17063,12 @@
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
               "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+              "readOnly": true
             }
           },
           "title": "Common"
@@ -18970,6 +19012,12 @@
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
               "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+              "readOnly": true
             }
           },
           "title": "Common"
@@ -20307,6 +20355,12 @@
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
               "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+              "readOnly": true
             }
           },
           "title": "Common"
@@ -21592,6 +21646,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             }
           },
@@ -23020,6 +23080,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             }
           },
@@ -27030,6 +27096,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             }
           },
@@ -35804,6 +35876,12 @@
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
               "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+              "readOnly": true
             }
           },
           "title": "Common"
@@ -36997,6 +37075,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             }
           },
@@ -38853,6 +38937,12 @@
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
               "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+              "readOnly": true
             }
           },
           "title": "Common"
@@ -39852,6 +39942,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             }
           },
@@ -42090,6 +42186,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             }
           },
@@ -44457,6 +44559,12 @@
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
               "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+              "readOnly": true
             }
           },
           "title": "Common"
@@ -45414,6 +45522,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             }
           },
@@ -47014,6 +47128,12 @@
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
               "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+              "readOnly": true
             }
           },
           "title": "Common"
@@ -48190,6 +48310,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             }
           },
@@ -50512,6 +50638,12 @@
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
               "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+              "readOnly": true
             }
           },
           "title": "Common"
@@ -51501,6 +51633,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             }
           },

--- a/src/common/src/schemas/output_schemas/test_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/test_v3.schema.json
@@ -3052,6 +3052,12 @@
                   "minimum": 2,
                   "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                   "readOnly": true
+                },
+                "durationMs": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                  "readOnly": true
                 }
               },
               "title": "Common"
@@ -3952,6 +3958,12 @@
               "type": "integer",
               "minimum": 2,
               "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+              "readOnly": true
+            },
+            "durationMs": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
               "readOnly": true
             },
             "location": {
@@ -4919,6 +4931,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   }
                 },
@@ -6076,6 +6094,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   }
                 },
@@ -7732,6 +7756,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   }
                 },
@@ -17025,6 +17055,12 @@
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                     "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                    "readOnly": true
                   }
                 },
                 "title": "Common"
@@ -19142,6 +19178,12 @@
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                     "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                    "readOnly": true
                   }
                 },
                 "title": "Common"
@@ -21085,6 +21127,12 @@
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                     "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                    "readOnly": true
                   }
                 },
                 "title": "Common"
@@ -22422,6 +22470,12 @@
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                     "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                    "readOnly": true
                   }
                 },
                 "title": "Common"
@@ -23707,6 +23761,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   }
                 },
@@ -25135,6 +25195,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   }
                 },
@@ -29145,6 +29211,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   }
                 },
@@ -37919,6 +37991,12 @@
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                     "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                    "readOnly": true
                   }
                 },
                 "title": "Common"
@@ -39112,6 +39190,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   }
                 },
@@ -40968,6 +41052,12 @@
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                     "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                    "readOnly": true
                   }
                 },
                 "title": "Common"
@@ -41967,6 +42057,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   }
                 },
@@ -44205,6 +44301,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   }
                 },
@@ -46572,6 +46674,12 @@
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                     "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                    "readOnly": true
                   }
                 },
                 "title": "Common"
@@ -47529,6 +47637,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   }
                 },
@@ -49129,6 +49243,12 @@
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                     "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                    "readOnly": true
                   }
                 },
                 "title": "Common"
@@ -50305,6 +50425,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   }
                 },
@@ -52627,6 +52753,12 @@
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                     "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                    "readOnly": true
                   }
                 },
                 "title": "Common"
@@ -53616,6 +53748,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   }
                 },
@@ -58334,6 +58472,12 @@
         ]
       }
     },
+    "durationMs": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total time this test took, in milliseconds: the sum of the per-context durations. A sum rather than a wall-clock span, because this test's contexts share a concurrent pool with every other test's. Present only in test results. System-populated.",
+      "readOnly": true
+    },
     "contexts": {
       "title": "Resolved contexts",
       "type": "array",
@@ -58342,6 +58486,12 @@
       "items": {
         "type": "object",
         "properties": {
+          "durationMs": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Wall-clock duration of this context in milliseconds, covering preflight, driver startup, every step, and teardown. When the `retries` policy re-ran the context, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. Present only in test results. System-populated.",
+            "readOnly": true
+          },
           "platform": {
             "type": "string",
             "description": "Platform to run the test on. This is a resolved version of the `platforms` property."
@@ -59535,6 +59685,12 @@
                         "minimum": 2,
                         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                         "readOnly": true
+                      },
+                      "durationMs": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                        "readOnly": true
                       }
                     },
                     "title": "Common"
@@ -60435,6 +60591,12 @@
                     "type": "integer",
                     "minimum": 2,
                     "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                    "readOnly": true
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                     "readOnly": true
                   },
                   "location": {
@@ -61402,6 +61564,12 @@
                           "type": "integer",
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                          "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                           "readOnly": true
                         }
                       },
@@ -62559,6 +62727,12 @@
                           "type": "integer",
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                          "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                           "readOnly": true
                         }
                       },
@@ -64215,6 +64389,12 @@
                           "type": "integer",
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                          "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                           "readOnly": true
                         }
                       },
@@ -73508,6 +73688,12 @@
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                           "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                          "readOnly": true
                         }
                       },
                       "title": "Common"
@@ -75625,6 +75811,12 @@
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                           "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                          "readOnly": true
                         }
                       },
                       "title": "Common"
@@ -77568,6 +77760,12 @@
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                           "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                          "readOnly": true
                         }
                       },
                       "title": "Common"
@@ -78905,6 +79103,12 @@
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                           "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                          "readOnly": true
                         }
                       },
                       "title": "Common"
@@ -80190,6 +80394,12 @@
                           "type": "integer",
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                          "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                           "readOnly": true
                         }
                       },
@@ -81618,6 +81828,12 @@
                           "type": "integer",
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                          "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                           "readOnly": true
                         }
                       },
@@ -85628,6 +85844,12 @@
                           "type": "integer",
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                          "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                           "readOnly": true
                         }
                       },
@@ -94402,6 +94624,12 @@
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                           "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                          "readOnly": true
                         }
                       },
                       "title": "Common"
@@ -95595,6 +95823,12 @@
                           "type": "integer",
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                          "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                           "readOnly": true
                         }
                       },
@@ -97451,6 +97685,12 @@
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                           "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                          "readOnly": true
                         }
                       },
                       "title": "Common"
@@ -98450,6 +98690,12 @@
                           "type": "integer",
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                          "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                           "readOnly": true
                         }
                       },
@@ -100688,6 +100934,12 @@
                           "type": "integer",
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                          "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                           "readOnly": true
                         }
                       },
@@ -103055,6 +103307,12 @@
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                           "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                          "readOnly": true
                         }
                       },
                       "title": "Common"
@@ -104012,6 +104270,12 @@
                           "type": "integer",
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                          "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                           "readOnly": true
                         }
                       },
@@ -105612,6 +105876,12 @@
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                           "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                          "readOnly": true
                         }
                       },
                       "title": "Common"
@@ -106788,6 +107058,12 @@
                           "type": "integer",
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                          "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                           "readOnly": true
                         }
                       },
@@ -109110,6 +109386,12 @@
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
                           "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+                          "readOnly": true
                         }
                       },
                       "title": "Common"
@@ -110099,6 +110381,12 @@
                           "type": "integer",
                           "minimum": 2,
                           "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+                          "readOnly": true
+                        },
+                        "durationMs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
                           "readOnly": true
                         }
                       },

--- a/src/common/src/schemas/src_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/report_v3.schema.json
@@ -20,6 +20,12 @@
       "description": "Absolute path to the run's artifact folder (`<output>/.doc-detective/runs/<runId>/`), where the `runFolder` reporter archives results and `autoScreenshot` images are saved (nested under `specs/<specId>/tests/<testId>/contexts/<contextId>/`). Step-level `autoScreenshot` paths in the report are relative to this folder. System-populated.",
       "readOnly": true
     },
+    "durationMs": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Wall-clock duration of the run's execution phase in milliseconds, spanning the warm phase, every spec, and teardown. Excludes what happens before execution starts — test detection, resolution, and any just-in-time dependency install — so on a cold runner the process takes longer than this. Because contexts run concurrently, this can be LESS than the sum of the per-spec durations. Present only in test results. System-populated.",
+      "readOnly": true
+    },
     "specs": {
       "description": "Test specifications that were performed.",
       "type": "array",

--- a/src/common/src/schemas/src_schemas/spec_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/spec_v3.schema.json
@@ -50,6 +50,12 @@
       "description": "Default visual theme for annotations in this spec's tests. Overrides the config-level `annotationDefaults`; individual tests can override this value with their own `annotationDefaults`. When unset, defers to the config level.",
       "$ref": "annotationDefaults_v3.schema.json#"
     },
+    "durationMs": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total time this specification's tests took, in milliseconds: the sum of the per-test durations. A sum rather than a wall-clock span, because this spec's contexts share a concurrent pool with every other spec's. Present only in test results. System-populated.",
+      "readOnly": true
+    },
     "tests": {
       "description": "[Tests](test) to perform.",
       "type": "array",

--- a/src/common/src/schemas/src_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/step_v3.schema.json
@@ -67,6 +67,12 @@
             "minimum": 2,
             "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
             "readOnly": true
+          },
+          "durationMs": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
+            "readOnly": true
           }
         },
         "title": "Common"
@@ -182,6 +188,12 @@
         "type": "integer",
         "minimum": 2,
         "description": "Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.",
+        "readOnly": true
+      },
+      "durationMs": {
+        "type": "integer",
+        "minimum": 0,
+        "description": "Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.",
         "readOnly": true
       },
       "location": {

--- a/src/common/src/schemas/src_schemas/test_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/test_v3.schema.json
@@ -94,6 +94,12 @@
         "$ref": "step_v3.schema.json#"
       }
     },
+    "durationMs": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total time this test took, in milliseconds: the sum of the per-context durations. A sum rather than a wall-clock span, because this test's contexts share a concurrent pool with every other test's. Present only in test results. System-populated.",
+      "readOnly": true
+    },
     "contexts": {
       "title": "Resolved contexts",
       "type": "array",
@@ -102,6 +108,12 @@
       "items": {
         "type": "object",
         "properties": {
+          "durationMs": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Wall-clock duration of this context in milliseconds, covering preflight, driver startup, every step, and teardown. When the `retries` policy re-ran the context, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. Present only in test results. System-populated.",
+            "readOnly": true
+          },
           "platform": {
             "type": "string",
             "description": "Platform to run the test on. This is a resolved version of the `platforms` property."

--- a/src/common/src/types/generated/report_v3.ts
+++ b/src/common/src/types/generated/report_v3.ts
@@ -44,6 +44,10 @@ export interface Report {
    */
   runDir?: string;
   /**
+   * Wall-clock duration of the run's execution phase in milliseconds, spanning the warm phase, every spec, and teardown. Excludes what happens before execution starts — test detection, resolution, and any just-in-time dependency install — so on a cold runner the process takes longer than this. Because contexts run concurrently, this can be LESS than the sum of the per-spec durations. Present only in test results. System-populated.
+   */
+  durationMs?: number;
+  /**
    * Test specifications that were performed.
    *
    * @minItems 1
@@ -127,6 +131,10 @@ export interface Specification {
    */
   autoRecord?: boolean;
   annotationDefaults?: AnnotationDefaults;
+  /**
+   * Total time this specification's tests took, in milliseconds: the sum of the per-test durations. A sum rather than a wall-clock span, because this spec's contexts share a concurrent pool with every other spec's. Present only in test results. System-populated.
+   */
+  durationMs?: number;
   /**
    * [Tests](test) to perform.
    *

--- a/src/common/src/types/generated/resolvedTests_v3.ts
+++ b/src/common/src/types/generated/resolvedTests_v3.ts
@@ -1006,6 +1006,10 @@ export interface Specification {
   autoRecord?: boolean;
   annotationDefaults?: AnnotationDefaults1;
   /**
+   * Total time this specification's tests took, in milliseconds: the sum of the per-test durations. A sum rather than a wall-clock span, because this spec's contexts share a concurrent pool with every other spec's. Present only in test results. System-populated.
+   */
+  durationMs?: number;
+  /**
    * [Tests](test) to perform.
    *
    * @minItems 1

--- a/src/common/src/types/generated/spec_v3.ts
+++ b/src/common/src/types/generated/spec_v3.ts
@@ -63,6 +63,10 @@ export interface Specification {
   autoRecord?: boolean;
   annotationDefaults?: AnnotationDefaults;
   /**
+   * Total time this specification's tests took, in milliseconds: the sum of the per-test durations. A sum rather than a wall-clock span, because this spec's contexts share a concurrent pool with every other spec's. Present only in test results. System-populated.
+   */
+  durationMs?: number;
+  /**
    * [Tests](test) to perform.
    *
    * @minItems 1

--- a/src/common/src/types/generated/step_v3.ts
+++ b/src/common/src/types/generated/step_v3.ts
@@ -2046,6 +2046,10 @@ export interface Common {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -2228,6 +2232,10 @@ export interface Common1 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -2377,6 +2385,10 @@ export interface Common2 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -2526,6 +2538,10 @@ export interface Common3 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -2732,6 +2748,10 @@ export interface Common4 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -2881,6 +2901,10 @@ export interface Common5 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -3111,6 +3135,10 @@ export interface Common6 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -3342,6 +3370,10 @@ export interface Common7 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -3578,6 +3610,10 @@ export interface Common8 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -3848,6 +3884,10 @@ export interface Common9 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -4571,6 +4611,10 @@ export interface Common10 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -4720,6 +4764,10 @@ export interface Common11 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -5013,6 +5061,10 @@ export interface Common12 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -5168,6 +5220,10 @@ export interface Common13 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -5467,6 +5523,10 @@ export interface Common14 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -6000,6 +6060,10 @@ export interface Common15 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -6149,6 +6213,10 @@ export interface Common16 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -6368,6 +6436,10 @@ export interface Common17 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -6517,6 +6589,10 @@ export interface Common18 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -6857,6 +6933,10 @@ export interface Common19 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -7006,6 +7086,10 @@ export interface Common20 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**

--- a/src/common/src/types/generated/test_v3.ts
+++ b/src/common/src/types/generated/test_v3.ts
@@ -71,6 +71,10 @@ export type Test = {
    * @minItems 1
    */
   steps?: [Step, ...Step[]];
+  /**
+   * Total time this test took, in milliseconds: the sum of the per-context durations. A sum rather than a wall-clock span, because this test's contexts share a concurrent pool with every other test's. Present only in test results. System-populated.
+   */
+  durationMs?: number;
   contexts?: ResolvedContexts;
 };
 export type DeviceByName = string;
@@ -8016,6 +8020,10 @@ export interface Common {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -8200,6 +8208,10 @@ export interface Common1 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -8351,6 +8363,10 @@ export interface Common2 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -8502,6 +8518,10 @@ export interface Common3 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -8710,6 +8730,10 @@ export interface Common4 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -8861,6 +8885,10 @@ export interface Common5 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -9093,6 +9121,10 @@ export interface Common6 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -9326,6 +9358,10 @@ export interface Common7 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -9564,6 +9600,10 @@ export interface Common8 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -9836,6 +9876,10 @@ export interface Common9 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -10561,6 +10605,10 @@ export interface Common10 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -10712,6 +10760,10 @@ export interface Common11 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -11007,6 +11059,10 @@ export interface Common12 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -11164,6 +11220,10 @@ export interface Common13 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -11465,6 +11525,10 @@ export interface Common14 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -12000,6 +12064,10 @@ export interface Common15 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -12151,6 +12219,10 @@ export interface Common16 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -12372,6 +12444,10 @@ export interface Common17 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -12523,6 +12599,10 @@ export interface Common18 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -12865,6 +12945,10 @@ export interface Common19 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -13016,6 +13100,10 @@ export interface Common20 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -14031,6 +14119,10 @@ export interface IdIsRequiredForUpdates {
 }
 export interface ResolvedContext {
   /**
+   * Wall-clock duration of this context in milliseconds, covering preflight, driver startup, every step, and teardown. When the `retries` policy re-ran the context, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. Present only in test results. System-populated.
+   */
+  durationMs?: number;
+  /**
    * Platform to run the test on. This is a resolved version of the `platforms` property.
    */
   platform?: string;
@@ -14149,6 +14241,10 @@ export interface Common21 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -14333,6 +14429,10 @@ export interface Common22 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -14484,6 +14584,10 @@ export interface Common23 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -14635,6 +14739,10 @@ export interface Common24 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -14843,6 +14951,10 @@ export interface Common25 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -14994,6 +15106,10 @@ export interface Common26 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -15226,6 +15342,10 @@ export interface Common27 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -15459,6 +15579,10 @@ export interface Common28 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -15697,6 +15821,10 @@ export interface Common29 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -15969,6 +16097,10 @@ export interface Common30 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -16694,6 +16826,10 @@ export interface Common31 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -16845,6 +16981,10 @@ export interface Common32 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -17140,6 +17280,10 @@ export interface Common33 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -17297,6 +17441,10 @@ export interface Common34 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -17598,6 +17746,10 @@ export interface Common35 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -18133,6 +18285,10 @@ export interface Common36 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -18284,6 +18440,10 @@ export interface Common37 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -18505,6 +18665,10 @@ export interface Common38 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -18656,6 +18820,10 @@ export interface Common39 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -18998,6 +19166,10 @@ export interface Common40 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**
@@ -19149,6 +19321,10 @@ export interface Common41 {
    * Which visit of this step produced this report, when a routing goToStep re-ran it (the first visit omits this field). Present only in test results; system-populated.
    */
   visit?: number;
+  /**
+   * Wall-clock duration of this step in milliseconds. When a routing `retry` action re-ran the step, this is the FINAL attempt's elapsed time — the attempt the reported `result` describes — not the sum across attempts. A step that was skipped or never executed reports `0`. Distinct from the `duration` input that some actions accept (for example a `click`'s press duration). Present only in test results; system-populated.
+   */
+  durationMs?: number;
   [k: string]: unknown;
 }
 /**

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -2046,6 +2046,117 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.errors).to.be.a("string");
       });
     });
+
+    describe("report_v3 durationMs", function () {
+      const minimalSpecs = [
+        { tests: [{ steps: [{ goTo: { url: "https://example.com" } }] }] },
+      ];
+      // Negative cases must fail on the `minimum`/`integer` constraint, not on
+      // `additionalProperties` — otherwise they'd pass identically against a
+      // schema that never declared `durationMs` at all.
+      const expectConstraintError = (errors) => {
+        expect(errors).to.be.a("string");
+        expect(errors).to.include("durationMs");
+        expect(errors).to.not.include("additional properties");
+      };
+      // A fully timed report: `durationMs` on the run, spec, test, resolved
+      // context, and step nodes. System-populated output, never authored.
+      const timedReport = {
+        durationMs: 5000,
+        specs: [
+          {
+            durationMs: 4000,
+            tests: [
+              {
+                durationMs: 4000,
+                contexts: [
+                  {
+                    durationMs: 4000,
+                    steps: [
+                      { goTo: { url: "https://example.com" }, durationMs: 900 },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      it("should validate durationMs on every report node", function () {
+        const result = validate({
+          schemaKey: "report_v3",
+          object: structuredClone(timedReport),
+        });
+        expect(result.valid, result.errors).to.be.true;
+        expect(result.errors).to.equal("");
+        expect(result.object.durationMs).to.equal(5000);
+        expect(result.object.specs[0].durationMs).to.equal(4000);
+        expect(result.object.specs[0].tests[0].durationMs).to.equal(4000);
+        expect(
+          result.object.specs[0].tests[0].contexts[0].durationMs
+        ).to.equal(4000);
+        expect(
+          result.object.specs[0].tests[0].contexts[0].steps[0].durationMs
+        ).to.equal(900);
+      });
+
+      it("should validate a report_v3 object without durationMs (back-compat)", function () {
+        const result = validate({
+          schemaKey: "report_v3",
+          object: { specs: minimalSpecs },
+        });
+        expect(result.valid, result.errors).to.be.true;
+        expect(result.object.durationMs).to.equal(undefined);
+      });
+
+      it("should accept a zero durationMs", function () {
+        const object = structuredClone(timedReport);
+        object.specs[0].tests[0].contexts[0].steps[0].durationMs = 0;
+        const result = validate({ schemaKey: "report_v3", object });
+        expect(result.valid, result.errors).to.be.true;
+      });
+
+      it("should reject a negative run durationMs", function () {
+        const object = structuredClone(timedReport);
+        object.durationMs = -1;
+        const result = validate({ schemaKey: "report_v3", object });
+        expect(result.valid).to.be.false;
+        expectConstraintError(result.errors);
+      });
+
+      it("should reject a fractional step durationMs", function () {
+        const object = structuredClone(timedReport);
+        object.specs[0].tests[0].contexts[0].steps[0].durationMs = 12.5;
+        const result = validate({ schemaKey: "report_v3", object });
+        expect(result.valid).to.be.false;
+        expectConstraintError(result.errors);
+      });
+
+      it("should reject a negative test durationMs", function () {
+        const object = structuredClone(timedReport);
+        object.specs[0].tests[0].durationMs = -5;
+        const result = validate({ schemaKey: "report_v3", object });
+        expect(result.valid).to.be.false;
+        expectConstraintError(result.errors);
+      });
+
+      it("should reject a negative context durationMs", function () {
+        const object = structuredClone(timedReport);
+        object.specs[0].tests[0].contexts[0].durationMs = -5;
+        const result = validate({ schemaKey: "report_v3", object });
+        expect(result.valid).to.be.false;
+        expectConstraintError(result.errors);
+      });
+
+      it("should reject a negative spec durationMs", function () {
+        const object = structuredClone(timedReport);
+        object.specs[0].durationMs = -5;
+        const result = validate({ schemaKey: "report_v3", object });
+        expect(result.valid).to.be.false;
+        expectConstraintError(result.errors);
+      });
+    });
   });
 
   describe("transformToSchemaKey", function () {

--- a/src/core/tests.ts
+++ b/src/core/tests.ts
@@ -1278,6 +1278,8 @@ async function runViaApi({ resolvedTests, apiKey, config = {} }: { resolvedTests
           contexts: { pass: 0, fail: 0, warning: 0, skipped: 0 },
           steps: { pass: 0, fail: 0, warning: 0, skipped: 0 },
         },
+        // Nothing ran, but the shape stays parity with runSpecs' short-circuit.
+        durationMs: 0,
         specs: [],
       };
     }
@@ -1413,6 +1415,14 @@ async function runViaApi({ resolvedTests, apiKey, config = {} }: { resolvedTests
  */
 async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
   const config: any = resolvedTests.config;
+  // Run-level wall clock, scoped to the EXECUTION phase — detection,
+  // resolution, and JIT dependency installs happen in runTests before this
+  // point and are deliberately excluded (see ADR 01083). Started before the
+  // filter short-circuit so a zero-spec run reports a real (tiny) duration
+  // rather than omitting the field. Unlike the spec/test sums, this IS elapsed
+  // time — so under concurrency it can be LESS than the sum of the per-spec
+  // durations.
+  const runStart = Date.now();
   // Narrow the spec set to what specFilter / testFilter allow before running.
   // Filtered-out specs / tests do not appear in the report (true filter, not
   // skip). Pass-through when neither filter is set.
@@ -1438,6 +1448,7 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
         contexts: { pass: 0, fail: 0, warning: 0, skipped: 0 },
         steps: { pass: 0, fail: 0, warning: 0, skipped: 0 },
       },
+      durationMs: Date.now() - runStart,
       specs: [],
     };
   }
@@ -2138,7 +2149,9 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     // Phase 3: roll results up the tree and count the summary in one
     // deterministic pass after all contexts have finished.
     for (const specReport of report.specs) {
+      let specDurationMs = 0;
       for (const testReport of specReport.tests) {
+        let testDurationMs = 0;
         for (const contextReport of testReport.contexts) {
           // Every slot is assigned by the pool callback (even on crash), so
           // this guard should never fire — it documents the invariant and
@@ -2146,13 +2159,30 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
           if (!contextReport) continue;
           for (const stepReport of contextReport.steps) {
             report.summary.steps[stepReport.result.toLowerCase()]++;
+            // Default here rather than at each construction site: this pass is
+            // the only place that sees EVERY node from both execution paths
+            // (flat pool and routed sequencer), real and synthetic alike. A
+            // node that never ran — a guard-skipped context, a routing marker
+            // — has no clock, and a future synthetic site can't forget the
+            // field. Nodes that ran keep their measured value (ADR 01083).
+            stepReport.durationMs ??= 0;
           }
           report.summary.contexts[contextReport.result.toLowerCase()]++;
+          contextReport.durationMs ??= 0;
+          testDurationMs += contextReport.durationMs;
         }
         testReport.result = rollUpResults(testReport.contexts.filter(Boolean));
+        // Test and spec durations are SUMS of their children, not wall-clock
+        // spans: contexts from every test and spec share one concurrent pool,
+        // so a span would count idle time while unrelated specs ran. The sum
+        // is total work — what slow-test triage and JUnit's `<testsuite time>`
+        // both want. See ADR 01083.
+        testReport.durationMs = testDurationMs;
+        specDurationMs += testDurationMs;
         report.summary.tests[testReport.result.toLowerCase()]++;
       }
       specReport.result = rollUpResults(specReport.tests);
+      specReport.durationMs = specDurationMs;
       report.summary.specs[specReport.result.toLowerCase()]++;
     }
   } finally {
@@ -2231,6 +2261,9 @@ async function runSpecs({ resolvedTests }: { resolvedTests: any }) {
     }
   }
 
+  // Stamped last, after teardown and any Heretto upload, so the number matches
+  // the elapsed time a user actually observes.
+  report.durationMs = Date.now() - runStart;
   return report;
 }
 
@@ -4786,6 +4819,7 @@ async function runContext({
       // it. Surface-less browser steps in that (pathological) state fail on the
       // dead session — acceptable; the run closed its own browser mid-test.
       const runStepOnce = async () => {
+        const stepStart = Date.now();
         const r = await runStep({
           config: config,
           context: context,
@@ -4808,7 +4842,12 @@ async function runContext({
         r.resultDescription = r.description;
         delete r.status;
         delete r.description;
-        return { ...step, ...r } as any;
+        // Stamp AFTER the spread: `step` may carry an authored `duration`
+        // input (a click's press duration, an annotation's display duration),
+        // and `r` is the runStep result — neither may clobber the timing.
+        // On retry the loop below discards this report wholesale, so the
+        // surviving value is the FINAL attempt's, per ADR 01083.
+        return { ...step, ...r, durationMs: Date.now() - stepStart } as any;
       };
 
       // Run the step, then resolve routing. A `retry` decision re-runs the step
@@ -5190,8 +5229,21 @@ async function runContextWithRetries(
   delayMs: (attempt: number) => number = (attempt) => 500 * (attempt + 1)
 ): Promise<any> {
   const { context, config } = args;
+  // Time each attempt here rather than inside runContext: runContext has a
+  // dozen exits (eleven early `requires`/preflight SKIPPED returns plus the
+  // normal one), and this wrapper is its only caller, so one clock here stamps
+  // every one of them. A retried context keeps the FINAL attempt's elapsed
+  // time — the attempt the reported `result` describes (ADR 01083).
+  const timedRunContext = async (a: any) => {
+    const start = Date.now();
+    const report = await runContextFn(a);
+    if (report && typeof report === "object") {
+      report.durationMs = Date.now() - start;
+    }
+    return report;
+  };
   const retries = resolveRetryPolicy({ context, config });
-  if (!(retries > 0)) return runContextFn(args);
+  if (!(retries > 0)) return timedRunContext(args);
 
   // Snapshot the non-idempotent context fields so each retry starts from the
   // originally-requested state instead of the prior attempt's narrowed one.
@@ -5211,7 +5263,7 @@ async function runContextWithRetries(
   let report: any;
   let attempt = 0;
   for (; ; attempt++) {
-    report = await runContextFn(args);
+    report = await timedRunContext(args);
     const retryable = report?.result === "FAIL" && report?._sessionDied === true;
     if (!retryable || attempt >= retries) break;
     log(
@@ -5281,6 +5333,10 @@ async function stopAllRecordings({
       description: "Stopping recording",
       stepId: randomUUID(),
     };
+    // These sweep steps really execute, so they carry a measured duration
+    // rather than the Phase-3 zero default. Timed in both the success and the
+    // failure path, so a stop that hangs before throwing still shows its cost.
+    const stopStart = Date.now();
     try {
       const stepResult = await runStep({
         config,
@@ -5295,7 +5351,11 @@ async function stopAllRecordings({
       delete stepResult.description;
       // Don't leak the internal routing marker into the report.
       delete stopRecordStep.__stopAny;
-      contextReport.steps.push({ ...stopRecordStep, ...stepResult });
+      contextReport.steps.push({
+        ...stopRecordStep,
+        ...stepResult,
+        durationMs: Date.now() - stopStart,
+      });
     } catch (error: any) {
       // A throw from runStep would otherwise strand the remaining handles.
       // Drop the top handle so the loop can't spin, and record the failure.
@@ -5305,6 +5365,7 @@ async function stopAllRecordings({
         ...stopRecordStep,
         result: "FAIL",
         resultDescription: `Couldn't stop recording. ${error?.message ?? error}`,
+        durationMs: Date.now() - stopStart,
       });
     }
   }

--- a/src/reporters/htmlReporter.ts
+++ b/src/reporters/htmlReporter.ts
@@ -1136,7 +1136,7 @@ function buildHeader() {
     ["runtime", (meta.platform || "\\u2014") + " \\u00B7 node " + (meta.node || "\\u2014")],
     ["branch", meta.branch || meta.commit ? (meta.branch || "\\u2014") + (meta.commit ? "@" + meta.commit.slice(0, 7) : "") : "\\u2014"],
     ["actor", meta.actor || "\\u2014"],
-    ["duration", fmtDuration(meta.startedAt && meta.finishedAt ? new Date(meta.finishedAt) - new Date(meta.startedAt) : null)],
+    ["duration", fmtDuration(report.durationMs)],
     ["cwd", meta.cwd || "\\u2014"]
   ];
   fields.forEach(function(f) {
@@ -1232,7 +1232,7 @@ function buildStepDetail(step) {
 
   // Input/output panels
   var rest = Object.assign({}, step);
-  delete rest.result; delete rest.resultDescription; delete rest.stepId; delete rest.outputs; delete rest.description; delete rest.duration;
+  delete rest.result; delete rest.resultDescription; delete rest.stepId; delete rest.outputs; delete rest.description; delete rest.duration; delete rest.durationMs;
   var inputJson = JSON.stringify(rest, null, 2);
   var outputJson = step.outputs && Object.keys(step.outputs).length ? JSON.stringify(step.outputs, null, 2) : null;
 
@@ -1266,7 +1266,7 @@ function buildStep(step, idx, ctxId, keyIdx) {
   row.innerHTML = '<span class="chev">' + ICON.chevron + '</span>' +
     badge(step.result) + tag(ak) +
     '<span class="desc" title="' + escAttr(primary) + '"><span style="color:var(--fg3);font-family:var(--font-mono);font-size:11px;margin-right:8px">' + String(idx + 1).padStart(2, "0") + '</span>' + esc(primary) + '</span>' +
-    '<span class="dur">' + fmtDuration(step.duration) + '</span>';
+    '<span class="dur">' + fmtDuration(step.durationMs) + '</span>';
 
   if (isOpen) {
     row.appendChild(buildStepDetail(step));

--- a/test/browser-fallback.test.js
+++ b/test/browser-fallback.test.js
@@ -286,14 +286,18 @@ describe("runContextWithRetries (mid-run session-death retry)", function () {
   });
 
   it("reports the FINAL attempt's durationMs, not the sum across attempts", async function () {
-    // Attempt 1 burns ~120ms then dies; attempt 2 is near-instant and passes.
-    // A summed duration would be >= 120ms; the final-attempt value is well
-    // under that.
+    // Attempt 1 burns SLOW_ATTEMPT_MS then dies; attempt 2 is a near-instant
+    // PASS. So the correct (final-attempt) value is ~0ms and the regression
+    // (summed) value is >= SLOW_ATTEMPT_MS. Asserting at the midpoint keeps a
+    // wide margin on BOTH sides: ~150ms of headroom before a loaded CI node
+    // could push the near-zero final attempt over the line, and ~150ms of
+    // clearance below the smallest possible summed value.
+    const SLOW_ATTEMPT_MS = 300;
     let calls = 0;
     const fn = async (args) => {
       calls++;
       if (calls === 1) {
-        await new Promise((resolve) => setTimeout(resolve, 120));
+        await new Promise((resolve) => setTimeout(resolve, SLOW_ATTEMPT_MS));
         const report = { result: "FAIL", contextId: args.context.contextId, steps: [] };
         Object.defineProperty(report, "_sessionDied", {
           value: true,
@@ -312,8 +316,8 @@ describe("runContextWithRetries (mid-run session-death retry)", function () {
     assert.equal(report.result, "PASS");
     assert.equal(calls, 2, "should have retried once");
     assert.ok(
-      report.durationMs < 100,
-      `durationMs ${report.durationMs}ms looks like a sum across attempts, not the final attempt`
+      report.durationMs < SLOW_ATTEMPT_MS / 2,
+      `durationMs ${report.durationMs}ms looks like a sum across attempts (>= ${SLOW_ATTEMPT_MS}ms), not the final attempt`
     );
   });
 

--- a/test/browser-fallback.test.js
+++ b/test/browser-fallback.test.js
@@ -271,6 +271,52 @@ describe("runContextWithRetries (mid-run session-death retry)", function () {
     assert.equal(fn.calls(), 1);
   });
 
+  it("stamps durationMs even on the retries-disabled fast path", async function () {
+    // The `retries === 0` bypass returns without entering the retry loop, so
+    // it needs its own clock — otherwise a run with retries off would emit
+    // contexts with no timing at all (ADR 01083).
+    const fn = fakeRunContext({ failTimes: 0 });
+    const report = await runContextWithRetries(
+      { context: { contextId: "c1" }, config: { retries: 0 } },
+      fn,
+      noDelay
+    );
+    assert.equal(typeof report.durationMs, "number");
+    assert.ok(report.durationMs >= 0);
+  });
+
+  it("reports the FINAL attempt's durationMs, not the sum across attempts", async function () {
+    // Attempt 1 burns ~120ms then dies; attempt 2 is near-instant and passes.
+    // A summed duration would be >= 120ms; the final-attempt value is well
+    // under that.
+    let calls = 0;
+    const fn = async (args) => {
+      calls++;
+      if (calls === 1) {
+        await new Promise((resolve) => setTimeout(resolve, 120));
+        const report = { result: "FAIL", contextId: args.context.contextId, steps: [] };
+        Object.defineProperty(report, "_sessionDied", {
+          value: true,
+          enumerable: false,
+          configurable: true,
+        });
+        return report;
+      }
+      return { result: "PASS", contextId: args.context.contextId, steps: [] };
+    };
+    const report = await runContextWithRetries(
+      { context: { contextId: "c1" }, config: { retries: 1 } },
+      fn,
+      noDelay
+    );
+    assert.equal(report.result, "PASS");
+    assert.equal(calls, 2, "should have retried once");
+    assert.ok(
+      report.durationMs < 100,
+      `durationMs ${report.durationMs}ms looks like a sum across attempts, not the final attempt`
+    );
+  });
+
   it("restores the non-idempotent context fields (openApi/browser) before each retry", async function () {
     // The fake mutates context the way runContext does — appends openApi and
     // narrows browser to a fallback — so the wrapper must restore before the

--- a/test/concurrency.test.js
+++ b/test/concurrency.test.js
@@ -884,6 +884,29 @@ describe("runSpecs concurrency", function () {
       delete report.runId;
       delete report.runDir;
     }
+    // durationMs is measured wall-clock time, so it can never be identical
+    // across two runs — and the run-level value is EXPECTED to differ by
+    // design: it's elapsed time, so 2 runners finish the same work sooner
+    // (ADR 01083). Assert the field is present at every level, then strip it
+    // so the comparison stays about execution results.
+    const stripDurations = (node) => {
+      // Mirrors the runner's own `if (!contextReport) continue` guard: a
+      // crash-isolated context can leave an unassigned slot.
+      if (!node) return;
+      expect(node.durationMs, "durationMs missing from a report node").to.be.a(
+        "number"
+      );
+      delete node.durationMs;
+      for (const child of node.specs ??
+        node.tests ??
+        node.contexts ??
+        node.steps ??
+        []) {
+        stripDurations(child);
+      }
+    };
+    stripDurations(sequential);
+    stripDurations(concurrent);
     expect(concurrent).to.deep.equal(sequential);
   });
 

--- a/test/core-core.test.js
+++ b/test/core-core.test.js
@@ -128,6 +128,183 @@ describe("Run tests successfully", function () {
     }
   });
 
+  describe("durationMs on report nodes", function () {
+    // Timing is a report *output*, so it can't be asserted through the
+    // fixture gate (a spec can't read its own report). These run the real
+    // pipeline over hermetic shell-only specs and assert the emitted shape.
+    // See adrs/01083-record-durationms-on-report-nodes.md.
+    this.timeout(300000);
+
+    async function runSpecObject(spec, name, configOverrides = {}) {
+      fs.mkdirSync(path.resolve("./.tmp"), { recursive: true });
+      const tempFilePath = path.resolve(`./.tmp/temp-${name}.json`);
+      fs.writeFileSync(tempFilePath, JSON.stringify(spec, null, 2));
+      try {
+        return await runTests({ input: tempFilePath, ...configOverrides });
+      } finally {
+        fs.unlinkSync(tempFilePath);
+      }
+    }
+
+    const isDuration = (value, label) => {
+      assert.equal(typeof value, "number", `${label} durationMs is not a number`);
+      assert.ok(
+        Number.isInteger(value),
+        `${label} durationMs ${value} is not an integer`
+      );
+      assert.ok(value >= 0, `${label} durationMs ${value} is negative`);
+    };
+
+    it("records durationMs on every node of a completed run, and rolls up", async () => {
+      const spec = {
+        tests: [
+          {
+            testId: "dur-a",
+            steps: [{ runShell: "echo a1" }, { runShell: "echo a2" }],
+          },
+          { testId: "dur-b", steps: [{ runShell: "echo b1" }] },
+        ],
+      };
+      const result = await runSpecObject(spec, "durations-rollup");
+
+      isDuration(result.durationMs, "run");
+      assert.ok(result.specs.length > 0, "run produced no specs");
+      for (const specReport of result.specs) {
+        isDuration(specReport.durationMs, "spec");
+        assert.ok(specReport.tests.length > 0, "spec produced no tests");
+        let testSum = 0;
+        for (const testReport of specReport.tests) {
+          isDuration(testReport.durationMs, "test");
+          assert.ok(
+            testReport.contexts.length > 0,
+            "test resolved no contexts"
+          );
+          let contextSum = 0;
+          for (const contextReport of testReport.contexts) {
+            isDuration(contextReport.durationMs, "context");
+            assert.ok(contextReport.steps.length > 0, "context ran no steps");
+            let stepSum = 0;
+            for (const stepReport of contextReport.steps) {
+              isDuration(stepReport.durationMs, "step");
+              stepSum += stepReport.durationMs;
+            }
+            // Steps are serial within a context, and the context clock also
+            // covers preflight and teardown, so this is a true lower bound.
+            assert.ok(
+              contextReport.durationMs >= stepSum,
+              `context ${contextReport.durationMs}ms < sum of steps ${stepSum}ms`
+            );
+            contextSum += contextReport.durationMs;
+          }
+          assert.equal(
+            testReport.durationMs,
+            contextSum,
+            "test durationMs is not the sum of its contexts"
+          );
+          testSum += testReport.durationMs;
+        }
+        assert.equal(
+          specReport.durationMs,
+          testSum,
+          "spec durationMs is not the sum of its tests"
+        );
+      }
+    });
+
+    it("reports the final attempt's time for a step re-run by onFail retry", async () => {
+      // Always fails, so it burns all 3 attempts with a 400ms wait between
+      // them. The step itself is near-instant, so a final-attempt duration is
+      // far below the ~800ms of accumulated backoff a summed duration would
+      // have to exceed.
+      const spec = {
+        tests: [
+          {
+            testId: "dur-retry",
+            steps: [
+              {
+                runShell: "node -e \"process.exit(1)\"",
+                onFail: [{ retry: { limit: 2, delay: 400 } }, { continue: true }],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runSpecObject(spec, "durations-retry");
+      const context = result.specs[0].tests[0].contexts[0];
+      const step = context.steps[0];
+
+      assert.equal(step.attempts, 3, "expected the step to run 3 times");
+      isDuration(step.durationMs, "retried step");
+      assert.ok(
+        step.durationMs < 800,
+        `step durationMs ${step.durationMs}ms looks like a sum across attempts, not the final attempt`
+      );
+      // The context clock DOES span every attempt plus the backoff waits.
+      assert.ok(
+        context.durationMs >= 800,
+        `context durationMs ${context.durationMs}ms should span both 400ms backoff waits`
+      );
+    });
+
+    it("records durationMs on steps that never executed", async () => {
+      // The second step is unreachable: the first fails and stops the test, so
+      // step 2 lands SKIPPED without ever running. It still carries the field.
+      const spec = {
+        tests: [
+          {
+            testId: "dur-skipped",
+            steps: [
+              { runShell: "node -e \"process.exit(1)\"" },
+              { runShell: "echo unreachable" },
+            ],
+          },
+        ],
+      };
+      const result = await runSpecObject(spec, "durations-skipped");
+      const steps = result.specs[0].tests[0].contexts[0].steps;
+      assert.equal(steps.length, 2, "expected both steps to be reported");
+      assert.equal(steps[1].result, "SKIPPED");
+      assert.equal(steps[1].durationMs, 0);
+    });
+
+    it("records durationMs on contexts that were skipped before running", async () => {
+      // A false test guard makes prepareContextSlot synthesize a SKIPPED
+      // context report that never reaches the runner's clock — one of several
+      // such sites. The Phase 3 pass is what guarantees it still carries the
+      // field, so a reporter never sees `undefined`.
+      const spec = {
+        tests: [
+          {
+            testId: "dur-guard-skip",
+            if: "$$env.DOC_DETECTIVE_NO_SUCH_VAR === 'never'",
+            steps: [{ runShell: "echo should-not-run" }],
+          },
+          { testId: "dur-guard-run", steps: [{ runShell: "echo ran" }] },
+        ],
+      };
+      const result = await runSpecObject(spec, "durations-guard-skip");
+      const tests = result.specs[0].tests;
+      const skipped = tests.find((t) => t.testId === "dur-guard-skip");
+      assert.ok(skipped.contexts.length > 0, "guard-skipped test had no contexts");
+      for (const context of skipped.contexts) {
+        assert.equal(context.result, "SKIPPED");
+        isDuration(context.durationMs, "guard-skipped context");
+      }
+      isDuration(skipped.durationMs, "guard-skipped test");
+    });
+
+    it("does not throw on a run where filters match no specs", async () => {
+      const spec = {
+        tests: [{ testId: "dur-filtered", steps: [{ runShell: "echo hi" }] }],
+      };
+      const result = await runSpecObject(spec, "durations-zero-spec", {
+        testFilter: ["no-such-test-matches-this"],
+      });
+      assert.deepEqual(result.specs, []);
+      isDuration(result.durationMs, "zero-spec run");
+    });
+  });
+
   describe("runShell shell selection", function () {
     // Shell steps run through real spawns; give slow Windows JIT paths room.
     this.timeout(300000);


### PR DESCRIPTION
Closes #682. Blocks #683 (the `junit` reporter).

## What

Records elapsed wall-clock time as **`durationMs`** (integer milliseconds) on the run, spec, test, context, and step report nodes, as a read-only system-populated output. Follows the existing `warm.durationMs` precedent in `report_v3`.

```
step    = measured wall clock of the FINAL attempt
context = measured wall clock of the FINAL attempt
test    = sum(context.durationMs)
spec    = sum(test.durationMs)
run     = measured wall clock of the execution phase
```

**Test and spec are sums, not wall-clock spans.** Contexts from every test and spec share one concurrent job pool, so a span for a test would count idle time while unrelated specs ran — a test whose two contexts got slots at t=0 and t=45s would report 47s for 2s of work. The sum is total work: stable under any `concurrentRunners` value, and the conventional meaning of JUnit's `<testsuite time>`.

**The run figure is elapsed time, so under concurrency it can be LESS than the sum of the per-spec durations.** `test/concurrency.test.js` demonstrates both halves of this directly: ~3985 ms serial vs ~1969 ms with two runners, while the spec-level sums held at ~2770 ms either way.

**Named `durationMs`, not `duration`** — step reports are built as `{ ...step, ...result }`, so an authored `duration` action input (`click` press-duration, `annotation` display-duration, `dragAndDrop`, `moveTo`) already spreads into the step report. Reusing the name would produce a field that sometimes means "how long to hold the mouse button."

**Retries record the final attempt**, not the sum — it's the attempt the reported `result` describes. `attempts`/`retries` already signal that earlier attempts happened, and the enclosing context's duration still spans them, so retry cost stays visible one level up.

## Where the clocks live

- **Step** — inside `runStepOnce`, stamped *after* the `{ ...step, ...r }` spread so neither the authored input nor the result can clobber it. The retry loop discards the report wholesale each attempt, so the final attempt's value survives with no extra bookkeeping.
- **Context** — in `runContextWithRetries`, `runContext`'s sole caller. `runContext` has twelve exits (eleven early `requires`/preflight SKIPPED returns plus the normal one); one clock in the wrapper covers all of them.
- **Presence guarantee** — the Phase 3 roll-up pass defaults any node still missing the field. Phase 3 is the only code that sees every node from both execution paths (flat pool and routed sequencer) and both kinds of node. Synthetic context reports are built at **seven** scattered sites, so stamping at each construction site would be a standing invitation for the next one to forget — and since the report is not runtime-validated (ADR 01060), a miss would surface only as `undefined` in a downstream reporter.
- **Recording teardown** — `stopAllRecordings` pushes step reports directly, bypassing the `pushStepReport` funnel. Those steps genuinely execute, so they get a real clock rather than the `0` default.

## Also fixed

The HTML reporter's duration chip read `results.meta.startedAt`/`finishedAt` and its step rows read `step.duration` — none of which anything in `src/` ever wrote, so both rendered an em-dash on every real run. `finishedAt` appears nowhere else in the repo, and the one test fixture supplying `meta` sets only `startedAt`, so the `startedAt && finishedAt` guard could never fire. Both now read the new field; the dead fallback is removed.

## Two judgment calls worth reviewing

1. **The run clock excludes pre-execution work.** It starts inside `runSpecs`, so test detection, resolution, and just-in-time dependency installs (done by `runTests` beforehand) aren't counted — on a cold runner the process takes measurably longer than the reported figure. I kept the boundary because that setup is one-time environment cost not attributable to any test, and the field's consumers are asking about test execution. The exclusion is stated in the schema description, the ADR, the docs, and the code comment so the number isn't mistaken for total process time.

2. **`durationMs` is present on every node, deliberately unlike `attempts`/`visit`.** Those are additive-only-when-nontrivial to keep reports byte-identical; this one is always present, and a node that never executed reports `0`. A reporter that has to branch on presence can't emit a complete `<testsuite>`.

## Definition of done

- **ADR**: [`adrs/01083-record-durationms-on-report-nodes.md`](adrs/01083-record-durationms-on-report-nodes.md) — MADR 4.0.0, four options considered. (Note `01078`/`01079` are already duplicated across concurrent PRs; happy to renumber at merge time.)
- **Docs impact — yes, user-facing.** New read-only report field. `report_v3` isn't in the generated schema reference, so report fields are documented narratively: added a "Find slow specs with `durationMs`" section to [`docs/fern/pages/docs/ci/reporters-and-artifacts.mdx`](docs/fern/pages/docs/ci/reporters-and-artifacts.mdx), same treatment as the `warm` block. Persona **Priya** (CI/platform engineer). Vale clean — 0 errors.
- **Feature fixtures — deliberately not used.** A spec cannot read its own run report, so `durationMs` isn't assertable through the PASS/SKIPPED gate. Per CLAUDE.md's escape hatch, the precise assertions live in `test/core-core.test.js` instead. Called out explicitly rather than silently skipped.

## Verification

- `src/common/test/validate.test.js` — positive case with the field at all five levels, back-compat case without it, and negatives at each level. The negatives assert the failure comes from the `minimum`/`integer` constraint and **not** `additionalProperties`, so they can't pass against a schema that never declared the field.
- `test/core-core.test.js` — present/integer/non-negative on every node; `test == sum(contexts)`, `spec == sum(tests)`, `context >= sum(steps)`; a step re-run by `onFail: retry` reports well under the accumulated backoff; a never-executed step reports `0`; a context skipped by a false test guard (one of the synthetic sites that never reaches a clock) still carries the field; a filtered-to-zero run doesn't throw.
- `test/browser-fallback.test.js` — the retries-disabled fast path is stamped, and a retried context reports the final attempt rather than the sum.
- Full suite: **3979 passing, 0 failing**. `src/common` coverage ratchet holds at 100% on all four metrics.
- End-to-end against a real report (`runTests --input test/core-artifacts/http`): all roll-up invariants hold, HTML chip and per-step durations render real values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only `durationMs` (non-negative integer, always present) across all v3 report nodes: run/spec/test/context/step; reports `0` for skipped/never-executed steps.
  * Retry timing now reflects final-attempt duration (with clarified roll-up behavior) and `run.durationMs` may be less than summed spec durations under concurrent execution.
  * HTML reports now display `durationMs`; step input dumps omit `durationMs`.

* **Documentation**
  * Documented how to interpret `durationMs` by node level, including retries and concurrency, plus a “Find slow specs with `durationMs`” guide.

* **Tests**
  * Expanded schema and integration/browser coverage for constraints, presence, roll-ups, retries, and empty test matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->