### PR TITLE
feat(annotate): configurable timeout on annotation element targets

### DIFF
--- a/adrs/01085-configurable-timeout-for-annotation-targets.md
+++ b/adrs/01085-configurable-timeout-for-annotation-targets.md
@@ -122,10 +122,21 @@ single field. The finding fields have already drifted across four schemas — `c
   paid again on each re-render, not only the first. Applying it uniformly was chosen over
   first-resolve-only because the alternative is a hidden special case: the same annotation would
   wait differently depending on whether a navigation had happened since.
-* Bad/limit: `timeout: 0` is inconsistent across surfaces, because `findElement` uses `|| 5000` on
-  its browser path and `?? 5000` on its app path. So `0` means "check once" on an app surface and
-  "wait 5000 ms" in a browser. This is pre-existing `find` behavior that annotations now inherit
-  rather than anything introduced here; fixing it changes `find` and belongs in its own ADR.
+* Bad/limit: `timeout: 0` is inconsistent, and the split is **per resolution path, not per
+  surface**:
+
+  | Path | How 0 is treated | Why |
+  |---|---|---|
+  | Browser, single element | waits 5000 ms | `findElement` does `step.find.timeout \|\| 5000`, which rewrites 0 |
+  | Browser, `all: true` | checks once | goes straight to `findElementByCriteria`, whose `timeout = 5000` default parameter only fires on `undefined` |
+  | App surface | checks once | `findElement`'s app branch does `findSpec.timeout ?? 5000` |
+
+  So `{"blur": {"selector": ".x", "timeout": 0}, "all": true}` and
+  `{"outline": {"selector": ".x", "timeout": 0}}` behave differently in the *same* browser. The
+  `||` is pre-existing `find` behavior that annotations now inherit; "check once" is arguably the
+  correct reading of 0, so the fix is to change `find`'s `||` to `??` rather than to propagate the
+  clobbering — which changes `find` and belongs in its own ADR. Not papered over here, because
+  making `all` match the `||` path would entrench the wrong behavior in a second place.
 * Bad/limit: the `{"outline": "#foo"}` string shorthand still cannot carry a timeout. Authors who
   need one expand to the object form, as they already do for `find`.
 

--- a/adrs/01085-configurable-timeout-for-annotation-targets.md
+++ b/adrs/01085-configurable-timeout-for-annotation-targets.md
@@ -1,0 +1,182 @@
+---
+status: accepted
+date: 2026-07-26
+decision-makers: doc-detective maintainers
+---
+
+# Configurable `timeout` on annotation element targets
+
+## Context and Problem Statement
+
+Annotation targets already resolve through the same `findElement()` that `find`, `click`,
+`dragAndDrop`, and `goTo` use. `resolveAnnotationRects` in
+[src/core/annotations/geometry.ts](../src/core/annotations/geometry.ts) hands it a criteria object
+built by `criteriaFromTarget`, which whitelists exactly seven fields:
+
+```ts
+return {
+  selector: target?.selector,
+  elementText: target?.elementText,
+  elementId: target?.elementId,
+  elementTestId: target?.elementTestId,
+  elementClass: target?.elementClass,
+  elementAttribute: target?.elementAttribute,
+  elementAria: target?.elementAria,
+};
+```
+
+`timeout` is not in that list, so it was dropped even when an author wrote it, and
+`findElementByCriteria` fell back to its hardcoded 5000 ms parameter default. `find` could ask for
+longer; an annotation pointing at the *same element* could not. Nothing about annotations justifies
+that — it was an omission in a field list, not a decision.
+
+The cost was real and already being paid inside this repo.
+[test/core-artifacts/recording/annotate.spec.json](../test/core-artifacts/recording/annotate.spec.json)
+pairs **every** element-targeting `annotate` with a guard `find` at `timeout: 20000`, and carries a
+paragraph of prose explaining why:
+
+> Guard every annotation target with a preceding `find`. […] on a slow headed browser (notably
+> Windows CI) a bare goTo/navigation can hand off before the element is queryable and the annotate
+> FAILs; `find` waits for the element, closing that race.
+
+[PR #679](https://github.com/doc-detective/doc-detective/pull/679) proposed responding to this by
+*documenting* the gap — a find-vs-annotate comparison table plus a troubleshooting entry teaching
+authors the guard-`find` workaround. That codifies the asymmetry into the contract rather than
+closing it, and leaves every author to rediscover the workaround.
+
+## Decision Drivers
+
+* An author who knows `find`'s `timeout` should not have to learn that annotations are different.
+* The runtime is already a single code path; the fix should not add a second one.
+* Screenshot `annotations` and `annotate` steps share `annotation_v3` — closing the gap on one and
+  not the other would trade one asymmetry for another.
+* Schema size and generated-type quality are live constraints in this package (see the `$comment`s
+  on `annotation_v3` and `annotate_v3`).
+
+## Considered Options
+
+1. **`timeout` on the annotation's element target**, inline in `annotation_v3`'s
+   `target_element_shape`.
+2. **`timeout` on the `annotate` step**, alongside `add` / `update` / `clear`.
+3. **Share `find_v3`'s schema by `$ref`** so there is literally one definition.
+4. **Document the asymmetry** (PR #679's approach) and keep the guard-`find` workaround.
+
+## Decision Outcome
+
+Chosen option: **1, `timeout` on the annotation's element target**, because it is the same field, in
+the same shape, with the same name, unit, and default as `find` — which is what makes the asymmetry
+disappear rather than merely become documented. Because `annotation_v3` is shared, screenshot
+`annotations` get it in the same change.
+
+The runtime change is one field in `criteriaFromTarget`. Every consumer already honors it:
+`findElement` reads `step.find.timeout` on both its browser and app paths, and
+`findElementByCriteria` takes it as a parameter. No new resolution path exists.
+
+`timeout` is deliberately **not** listed in `target_element_guard`, so `{"outline": {"timeout":
+8000}}` stays invalid — a deadline cannot be the only thing identifying an element.
+
+### Why not the alternatives
+
+**Option 2 (step-level `annotate.timeout`)** works with the `{"outline": "#foo"}` string shorthand,
+which option 1 does not. But screenshot `annotations` have no `annotate` step to hang it on, so
+they would keep the fixed 5000 ms — trading the find-vs-annotate asymmetry for an
+annotate-vs-screenshot one. It also gives one deadline to a payload that may target several
+elements with very different readiness. Option 1's shorthand limitation is not a new rule to learn:
+`find`'s string form can't carry a timeout either.
+
+**Option 3 (`$ref` into `find_v3`)** is the most appealing on principle and fails on three concrete
+points:
+
+* `find_v3`'s detailed object bundles *action* fields with finding fields — `moveTo`, `click`,
+  `type`, `surface`. `{"outline": {"selector": "#x", "click": true}}` would validate. An annotation
+  that clicks is not a thing.
+* Draft-07's `additionalProperties: false` does not compose through `allOf`. Both `find_v3`'s object
+  and `annotation_v3`'s `target_element_shape` set it, so they cannot be intersected — the same
+  constraint already documented in [annotationDefaults_v3](../src/common/src/schemas/src_schemas/annotationDefaults_v3.schema.json)'s
+  `$comment`.
+* Dereferenced `find_v3` is 452 KB (it pulls in `click_v3` and `type_v3`). `annotate_v3` is 230 KB
+  and already carries two copies of `annotation_v3`; six target keys x two copies would inline it
+  repeatedly. And `FindElementDetailed` currently generates as `{[k: string]: unknown}` — the
+  index-signature collapse `annotation_v3`'s `$comment` warns about. Annotation targets generate
+  real types today; this would erase them.
+
+Field-level `$ref` into a shared components block (the pattern `click_v3` uses for
+`button`/`duration`) avoids all three, but was judged more surface than the drift it removes for a
+single field. The finding fields have already drifted across four schemas — `click_v3` is missing
+`timeout` too — and unifying them is its own change, not a rider on this one.
+
+**Option 4 (document it)** makes every author carry a workaround for a one-field omission.
+
+### Consequences
+
+* Good: the guard-`find` scaffolding in `annotate.spec.json` can be deleted; the fixture says what
+  it means.
+* Good: screenshot `annotations` gain the same knob at no extra cost.
+* Good: no default is duplicated in the runtime. `criteriaFromTarget` passes `undefined` through
+  when the target omits `timeout`, and find applies its own 5000 ms.
+* Neutral: the `default: 5000` in the schema is inert at runtime — Ajv ignores `default` inside
+  `anyOf`, which is how every target is reached. It exists to document the wait on the generated
+  reference page, exactly as `find_v3`'s does.
+* Bad/limit: `renderLayer` re-resolves **every** stored annotation on each render, including the
+  navigation re-mount in [src/core/tests.ts](../src/core/tests.ts). A long `timeout` is therefore
+  paid again on each re-render, not only the first. Applying it uniformly was chosen over
+  first-resolve-only because the alternative is a hidden special case: the same annotation would
+  wait differently depending on whether a navigation had happened since.
+* Bad/limit: `timeout: 0` is inconsistent across surfaces, because `findElement` uses `|| 5000` on
+  its browser path and `?? 5000` on its app path. So `0` means "check once" on an app surface and
+  "wait 5000 ms" in a browser. This is pre-existing `find` behavior that annotations now inherit
+  rather than anything introduced here; fixing it changes `find` and belongs in its own ADR.
+* Bad/limit: the `{"outline": "#foo"}` string shorthand still cannot carry a timeout. Authors who
+  need one expand to the object form, as they already do for `find`.
+
+### Confirmation
+
+* Schema: positive and negative cases in
+  [src/common/test/validate.test.js](../src/common/test/validate.test.js) — a target with a
+  `timeout` validates, a target whose *only* field is a `timeout` does not, and a non-integer does
+  not.
+* Runtime: [test/annotations-geometry.test.js](../test/annotations-geometry.test.js) pins
+  `criteriaFromTarget`'s pass-through and drives `resolveAnnotationRects` end-to-end against a
+  never-matching driver, asserting a 300 ms target returns in well under the old hardcoded 5000 ms.
+* Failure path unchanged: [test/annotate-step.test.js](../test/annotate-step.test.js) asserts a
+  never-appearing target still FAILs, bounded by the requested deadline, with the stored annotation
+  set left untouched.
+* End-to-end: [test/core-artifacts/recording/annotate-timeout.spec.json](../test/core-artifacts/recording/annotate-timeout.spec.json)
+  annotates an element that appears only after the 5000 ms default would have lapsed, across the
+  single-element, `all`, `update`, and screenshot-annotation paths.
+
+## Pros and Cons of the Options
+
+### 1. `timeout` on the element target
+
+* Good, because it is byte-for-byte the field `find` already has — nothing new to learn.
+* Good, because screenshot `annotations` are covered by the same change.
+* Good, because it is per-target, so one slow element doesn't impose its deadline on the rest.
+* Good, because the runtime change is one field in an existing whitelist.
+* Bad, because the string shorthand can't carry it (as with `find`).
+* Bad, because it adds an eighth duplicated finding field to a set already drifting across four
+  schemas.
+
+### 2. `timeout` on the `annotate` step
+
+* Good, because it works with the string shorthand.
+* Good, because one knob covers a whole payload.
+* Bad, because screenshot `annotations` get nothing, replacing one asymmetry with another.
+* Bad, because a single deadline is wrong for a payload targeting elements with different readiness.
+* Bad, because it invents a placement `find` doesn't have, which is the thing being fixed.
+
+### 3. `$ref` into `find_v3`
+
+* Good, because it would be a genuine single source of truth.
+* Good, because future finding fields would propagate for free.
+* Bad, because it would let annotations carry `click` / `moveTo` / `type` / `surface`.
+* Bad, because `additionalProperties: false` doesn't compose through `allOf`.
+* Bad, because it would inline a 452 KB schema repeatedly and collapse the generated types to index
+  signatures.
+
+### 4. Document the asymmetry
+
+* Good, because it ships without touching code.
+* Good, because the guard-`find` workaround does work today.
+* Bad, because it makes the omission permanent and makes every author pay for it.
+* Bad, because the workaround costs an extra step per annotated element.

--- a/docs/fern/pages/docs/actions/annotate.mdx
+++ b/docs/fern/pages/docs/actions/annotate.mdx
@@ -40,6 +40,28 @@ The [screenshot annotations](/docs/actions/screenshot#annotations) page covers t
 Set `"transition": { "enter": "none" }` on a `blur` you're using to redact. An annotation that fades in leaves the content underneath readable for the length of the animation, and every frame of that is in the recording.
 </Warning>
 
+### Annotate something that hasn't loaded yet
+
+An element target waits up to 5000 milliseconds for its element to appear, then fails the step. When you're annotating something slower than that — a panel behind a fetch, a dashboard that renders after a first sync — set `timeout` on the target:
+
+```json
+{
+  "annotate": {
+    "add": [
+      {
+        "id": "guide",
+        "callout": { "elementTestId": "dashboard", "timeout": 20000 },
+        "label": "Your data lands here after the first sync"
+      }
+    ]
+  }
+}
+```
+
+This is [`find`](/docs/actions/find)'s `timeout`, on the annotation's target. Two things follow from that: it needs the object form of the target, since the string shorthand has nowhere to put it, and it's per-target, so one slow element in a payload doesn't make the others wait.
+
+`update` re-resolves its target, so give it a `timeout` too when you're repointing an annotation at something that isn't on the page yet.
+
 **Outputs:** the action exposes `$$annotationCount`, the number of annotations on screen after the step.
 
 > For comprehensive options, see the [`annotate`](/reference/schemas/annotate) reference.

--- a/docs/fern/pages/docs/actions/annotate.mdx
+++ b/docs/fern/pages/docs/actions/annotate.mdx
@@ -42,7 +42,7 @@ Set `"transition": { "enter": "none" }` on a `blur` you're using to redact. An a
 
 ### Annotate something that hasn't loaded yet
 
-An element target waits up to 5000 milliseconds for its element to appear, then fails the step. When you're annotating something slower than that — a panel behind a fetch, a dashboard that renders after a first sync — set `timeout` on the target:
+An element target waits up to 5000 milliseconds for its element to appear, then fails the step. Set `timeout` on the target when you're annotating something slower than that, such as a panel behind a fetch or a dashboard that renders after a first sync:
 
 ```json
 {
@@ -60,7 +60,7 @@ An element target waits up to 5000 milliseconds for its element to appear, then 
 
 This is [`find`](/docs/actions/find)'s `timeout`, on the annotation's target. Two things follow from that: it needs the object form of the target, since the string shorthand has nowhere to put it, and it's per-target, so one slow element in a payload doesn't make the others wait.
 
-`update` re-resolves its target, so give it a `timeout` too when you're repointing an annotation at something that isn't on the page yet.
+`update` re-resolves its target, so give it a `timeout` too when you point an annotation at something that isn't on the page yet.
 
 **Outputs:** the action exposes `$$annotationCount`, the number of annotations on screen after the step.
 

--- a/docs/fern/pages/docs/actions/screenshot.mdx
+++ b/docs/fern/pages/docs/actions/screenshot.mdx
@@ -63,6 +63,14 @@ A target can be:
 - **An object**, using the same element-finding fields as [`find`](/docs/actions/find). For example, `{ "outline": { "elementTestId": "submit" } }`.
 - **A position**, a fixed spot for annotations that aren't tied to an element. For example, `{ "text": { "position": "top-right" }, "label": "Demo data" }`. Accepts a named region (`top`, `bottom`, `left`, `right`, `center`, `top-left`, `top-right`, `bottom-left`, `bottom-right`) or a point (`{ "x": 640, "y": 220 }`).
 
+An element target waits up to 5000 milliseconds for its element to appear. Set `timeout` on the target to wait longer:
+
+```json
+{ "outline": { "elementTestId": "dashboard", "timeout": 20000 } }
+```
+
+`timeout` works the same way as [`find`](/docs/actions/find)'s, and like find's, it needs the object form of the target: the string shorthand has nowhere to put it.
+
 ### Options
 
 - `label`: Text to display. Used by `badge`, `callout`, and `text`.

--- a/docs/fern/pages/docs/test-docs/annotate-screenshots.mdx
+++ b/docs/fern/pages/docs/test-docs/annotate-screenshots.mdx
@@ -31,6 +31,8 @@ There are six annotation types:
 
 Each annotation names one type, and the type's value is its target. A target can be a string (a selector or display text, the same as [`crop`](/docs/test-docs/capture-screenshots-guide)), an object (the same element-finding fields as [`find`](/docs/selectors/css)), or a position (a named region like `top-right` or a `{ "x": …, "y": … }` point). Shared options include `label` (the text a `badge`, `callout`, or `text` shows), `position` (where the annotation sits relative to its target), `style` (per-annotation visual overrides), and `all` (annotate every matching element instead of only the first).
 
+An object target also takes `timeout`, the number of milliseconds to wait for its element. Annotations wait 5000 by default; raise it for anything slower, such as `{ "outline": { "elementTestId": "dashboard", "timeout": 20000 } }`.
+
 This example numbers the fields of a sign-in form and redacts an email address, all in one capture:
 
 {/* test {"testId":"capture-guide-annotated","detectSteps":false} */}
@@ -80,7 +82,7 @@ Annotations also work on [native app surfaces](/docs/actions/screenshot#app-surf
 
 ## Verify it works
 
-- An annotation whose target doesn't resolve reports `FAIL`, because the annotation can't be placed.
+- An annotation whose target doesn't resolve reports `FAIL`, because the annotation can't be placed. If the element is only slow rather than missing, raise its `timeout` instead of removing the annotation.
 
 ## Troubleshooting
 

--- a/docs/fern/pages/docs/test-docs/annotate-screenshots.mdx
+++ b/docs/fern/pages/docs/test-docs/annotate-screenshots.mdx
@@ -31,7 +31,7 @@ There are six annotation types:
 
 Each annotation names one type, and the type's value is its target. A target can be a string (a selector or display text, the same as [`crop`](/docs/test-docs/capture-screenshots-guide)), an object (the same element-finding fields as [`find`](/docs/selectors/css)), or a position (a named region like `top-right` or a `{ "x": …, "y": … }` point). Shared options include `label` (the text a `badge`, `callout`, or `text` shows), `position` (where the annotation sits relative to its target), `style` (per-annotation visual overrides), and `all` (annotate every matching element instead of only the first).
 
-An object target also takes `timeout`, the number of milliseconds to wait for its element. Annotations wait 5000 by default; raise it for anything slower, such as `{ "outline": { "elementTestId": "dashboard", "timeout": 20000 } }`.
+An object target also takes `timeout`, the number of milliseconds to wait for its element. Annotations wait 5000 by default. Raise it for anything slower, such as `{ "outline": { "elementTestId": "dashboard", "timeout": 20000 } }`.
 
 This example numbers the fields of a sign-in form and redacts an email address, all in one capture:
 
@@ -82,7 +82,7 @@ Annotations also work on [native app surfaces](/docs/actions/screenshot#app-surf
 
 ## Verify it works
 
-- An annotation whose target doesn't resolve reports `FAIL`, because the annotation can't be placed. If the element is only slow rather than missing, raise its `timeout` instead of removing the annotation.
+- An annotation whose target doesn't resolve reports `FAIL`, because Doc Detective has nowhere to put the annotation. If the element is only slow rather than missing, raise its `timeout` instead of removing the annotation.
 
 ## Troubleshooting
 

--- a/docs/fern/pages/reference/schemas/annotation.mdx
+++ b/docs/fern/pages/reference/schemas/annotation.mdx
@@ -110,6 +110,16 @@ all | boolean | Optional. If `true`, annotates every element matching the target
 
 ```json
 {
+  "callout": {
+    "elementTestId": "dashboard-loaded",
+    "timeout": 15000
+  },
+  "label": "Your dashboard, once the first sync finishes"
+}
+```
+
+```json
+{
   "id": "usage-highlight",
   "outline": {
     "elementClass": [

--- a/docs/fern/pages/reference/schemas/element-finding-fields.mdx
+++ b/docs/fern/pages/reference/schemas/element-finding-fields.mdx
@@ -23,6 +23,7 @@ elementTestId | string | Optional. data-testid attribute of the element to annot
 elementClass | one of:<br/>- string<br/>- array of string | Optional. Class or array of classes that the element must have. Each class supports exact match or regex pattern using /pattern/ syntax. Element must have all specified classes. Browser surfaces only. | —
 elementAttribute | object | Optional. Object of attribute key-value pairs that the element must have. Values can be strings (supporting /pattern/ regex), numbers, or booleans. Boolean true matches attribute presence, false matches absence. | —
 elementAria | string | Optional. Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax. | —
+timeout | integer | Optional. Max duration in milliseconds to wait for the element to exist. | `5000`
 
 ## Examples
 
@@ -34,6 +35,7 @@ elementAria | string | Optional. Computed accessible name of the element per ARI
   "elementTestId": "example",
   "elementClass": "example",
   "elementAttribute": {},
-  "elementAria": "example"
+  "elementAria": "example",
+  "timeout": 5000
 }
 ```

--- a/docs/fern/pages/reference/schemas/target-by-element-detailed.mdx
+++ b/docs/fern/pages/reference/schemas/target-by-element-detailed.mdx
@@ -25,6 +25,7 @@ elementTestId | string | Optional. data-testid attribute of the element to annot
 elementClass | one of:<br/>- string<br/>- array of string | Optional. Class or array of classes that the element must have. Each class supports exact match or regex pattern using /pattern/ syntax. Element must have all specified classes. Browser surfaces only. | —
 elementAttribute | object | Optional. Object of attribute key-value pairs that the element must have. Values can be strings (supporting /pattern/ regex), numbers, or booleans. Boolean true matches attribute presence, false matches absence. | —
 elementAria | string | Optional. Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax. | —
+timeout | integer | Optional. Max duration in milliseconds to wait for the element to exist. | `5000`
 
 ## Examples
 
@@ -36,6 +37,7 @@ elementAria | string | Optional. Computed accessible name of the element per ARI
   "elementTestId": "example",
   "elementClass": "example",
   "elementAttribute": {},
-  "elementAria": "example"
+  "elementAria": "example",
+  "timeout": 5000
 }
 ```

--- a/src/common/src/schemas/output_schemas/annotate_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/annotate_v3.schema.json
@@ -92,6 +92,12 @@
                               "elementAria": {
                                 "type": "string",
                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                              },
+                              "timeout": {
+                                "type": "integer",
+                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                "default": 5000,
+                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                               }
                             }
                           },
@@ -268,6 +274,12 @@
                               "elementAria": {
                                 "type": "string",
                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                              },
+                              "timeout": {
+                                "type": "integer",
+                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                "default": 5000,
+                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                               }
                             }
                           },
@@ -444,6 +456,12 @@
                               "elementAria": {
                                 "type": "string",
                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                              },
+                              "timeout": {
+                                "type": "integer",
+                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                "default": 5000,
+                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                               }
                             }
                           },
@@ -620,6 +638,12 @@
                               "elementAria": {
                                 "type": "string",
                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                              },
+                              "timeout": {
+                                "type": "integer",
+                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                "default": 5000,
+                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                               }
                             }
                           },
@@ -796,6 +820,12 @@
                               "elementAria": {
                                 "type": "string",
                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                              },
+                              "timeout": {
+                                "type": "integer",
+                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                "default": 5000,
+                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                               }
                             }
                           },
@@ -972,6 +1002,12 @@
                               "elementAria": {
                                 "type": "string",
                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                              },
+                              "timeout": {
+                                "type": "integer",
+                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                "default": 5000,
+                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                               }
                             }
                           },
@@ -1381,6 +1417,12 @@
                             "elementAria": {
                               "type": "string",
                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                            },
+                            "timeout": {
+                              "type": "integer",
+                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                              "default": 5000,
+                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                             }
                           }
                         },
@@ -1549,6 +1591,12 @@
                         "elementAria": {
                           "type": "string",
                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                        },
+                        "timeout": {
+                          "type": "integer",
+                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                          "default": 5000,
+                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                         }
                       }
                     },
@@ -1706,6 +1754,12 @@
                     "elementAria": {
                       "type": "string",
                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                    },
+                    "timeout": {
+                      "type": "integer",
+                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                      "default": 5000,
+                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                     }
                   }
                 },
@@ -2045,6 +2099,13 @@
                 }
               },
               {
+                "callout": {
+                  "elementTestId": "dashboard-loaded",
+                  "timeout": 15000
+                },
+                "label": "Your dashboard, once the first sync finishes"
+              },
+              {
                 "id": "usage-highlight",
                 "outline": {
                   "elementClass": [
@@ -2149,6 +2210,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -2325,6 +2392,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -2501,6 +2574,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -2677,6 +2756,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -2853,6 +2938,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -3029,6 +3120,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -3438,6 +3535,12 @@
                                 "elementAria": {
                                   "type": "string",
                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                  "default": 5000,
+                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                 }
                               }
                             },
@@ -3606,6 +3709,12 @@
                             "elementAria": {
                               "type": "string",
                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                            },
+                            "timeout": {
+                              "type": "integer",
+                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                              "default": 5000,
+                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                             }
                           }
                         },
@@ -3763,6 +3872,12 @@
                         "elementAria": {
                           "type": "string",
                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                        },
+                        "timeout": {
+                          "type": "integer",
+                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                          "default": 5000,
+                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                         }
                       }
                     },
@@ -4100,6 +4215,13 @@
                     "transition": {
                       "enter": "none"
                     }
+                  },
+                  {
+                    "callout": {
+                      "elementTestId": "dashboard-loaded",
+                      "timeout": 15000
+                    },
+                    "label": "Your dashboard, once the first sync finishes"
                   },
                   {
                     "id": "usage-highlight",

--- a/src/common/src/schemas/output_schemas/annotation_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/annotation_v3.schema.json
@@ -78,6 +78,12 @@
                     "elementAria": {
                       "type": "string",
                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                    },
+                    "timeout": {
+                      "type": "integer",
+                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                      "default": 5000,
+                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                     }
                   }
                 },
@@ -254,6 +260,12 @@
                     "elementAria": {
                       "type": "string",
                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                    },
+                    "timeout": {
+                      "type": "integer",
+                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                      "default": 5000,
+                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                     }
                   }
                 },
@@ -430,6 +442,12 @@
                     "elementAria": {
                       "type": "string",
                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                    },
+                    "timeout": {
+                      "type": "integer",
+                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                      "default": 5000,
+                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                     }
                   }
                 },
@@ -606,6 +624,12 @@
                     "elementAria": {
                       "type": "string",
                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                    },
+                    "timeout": {
+                      "type": "integer",
+                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                      "default": 5000,
+                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                     }
                   }
                 },
@@ -782,6 +806,12 @@
                     "elementAria": {
                       "type": "string",
                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                    },
+                    "timeout": {
+                      "type": "integer",
+                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                      "default": 5000,
+                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                     }
                   }
                 },
@@ -958,6 +988,12 @@
                     "elementAria": {
                       "type": "string",
                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                    },
+                    "timeout": {
+                      "type": "integer",
+                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                      "default": 5000,
+                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                     }
                   }
                 },
@@ -1367,6 +1403,12 @@
                   "elementAria": {
                     "type": "string",
                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                  },
+                  "timeout": {
+                    "type": "integer",
+                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                    "default": 5000,
+                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                   }
                 }
               },
@@ -1535,6 +1577,12 @@
               "elementAria": {
                 "type": "string",
                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+              },
+              "timeout": {
+                "type": "integer",
+                "description": "Max duration in milliseconds to wait for the element to exist.",
+                "default": 5000,
+                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
               }
             }
           },
@@ -1692,6 +1740,12 @@
           "elementAria": {
             "type": "string",
             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+          },
+          "timeout": {
+            "type": "integer",
+            "description": "Max duration in milliseconds to wait for the element to exist.",
+            "default": 5000,
+            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
           }
         }
       },
@@ -2029,6 +2083,13 @@
       "transition": {
         "enter": "none"
       }
+    },
+    {
+      "callout": {
+        "elementTestId": "dashboard-loaded",
+        "timeout": 15000
+      },
+      "label": "Your dashboard, once the first sync finishes"
     },
     {
       "id": "usage-highlight",

--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -28624,6 +28624,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -28800,6 +28806,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -28976,6 +28988,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -29152,6 +29170,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -29328,6 +29352,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -29504,6 +29534,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -29913,6 +29949,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -30081,6 +30123,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -30238,6 +30286,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -30575,6 +30629,13 @@
                                                                   "transition": {
                                                                     "enter": "none"
                                                                   }
+                                                                },
+                                                                {
+                                                                  "callout": {
+                                                                    "elementTestId": "dashboard-loaded",
+                                                                    "timeout": 15000
+                                                                  },
+                                                                  "label": "Your dashboard, once the first sync finishes"
                                                                 },
                                                                 {
                                                                   "id": "usage-highlight",
@@ -31175,6 +31236,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -31351,6 +31418,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -31527,6 +31600,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -31703,6 +31782,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -31879,6 +31964,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -32055,6 +32146,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -32464,6 +32561,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -32632,6 +32735,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -32789,6 +32898,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -33126,6 +33241,13 @@
                                                                     "transition": {
                                                                       "enter": "none"
                                                                     }
+                                                                  },
+                                                                  {
+                                                                    "callout": {
+                                                                      "elementTestId": "dashboard-loaded",
+                                                                      "timeout": 15000
+                                                                    },
+                                                                    "label": "Your dashboard, once the first sync finishes"
                                                                   },
                                                                   {
                                                                     "id": "usage-highlight",
@@ -33705,6 +33827,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -33881,6 +34009,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -34057,6 +34191,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -34233,6 +34373,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -34409,6 +34555,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -34585,6 +34737,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -34994,6 +35152,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -35162,6 +35326,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -35319,6 +35489,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -35656,6 +35832,13 @@
                                                                 "transition": {
                                                                   "enter": "none"
                                                                 }
+                                                              },
+                                                              {
+                                                                "callout": {
+                                                                  "elementTestId": "dashboard-loaded",
+                                                                  "timeout": 15000
+                                                                },
+                                                                "label": "Your dashboard, once the first sync finishes"
                                                               },
                                                               {
                                                                 "id": "usage-highlight",
@@ -52691,6 +52874,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -52867,6 +53056,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -53043,6 +53238,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -53219,6 +53420,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -53395,6 +53602,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -53571,6 +53784,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -53980,6 +54199,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -54148,6 +54373,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -54305,6 +54536,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -54644,6 +54881,13 @@
                                                               }
                                                             },
                                                             {
+                                                              "callout": {
+                                                                "elementTestId": "dashboard-loaded",
+                                                                "timeout": 15000
+                                                              },
+                                                              "label": "Your dashboard, once the first sync finishes"
+                                                            },
+                                                            {
                                                               "id": "usage-highlight",
                                                               "outline": {
                                                                 "elementClass": [
@@ -54748,6 +54992,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -54924,6 +55174,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -55100,6 +55356,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -55276,6 +55538,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -55452,6 +55720,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -55628,6 +55902,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -56037,6 +56317,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -56205,6 +56491,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -56362,6 +56654,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -56699,6 +56997,13 @@
                                                                   "transition": {
                                                                     "enter": "none"
                                                                   }
+                                                                },
+                                                                {
+                                                                  "callout": {
+                                                                    "elementTestId": "dashboard-loaded",
+                                                                    "timeout": 15000
+                                                                  },
+                                                                  "label": "Your dashboard, once the first sync finishes"
                                                                 },
                                                                 {
                                                                   "id": "usage-highlight",
@@ -86404,6 +86709,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -86580,6 +86891,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -86756,6 +87073,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -86932,6 +87255,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -87108,6 +87437,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -87284,6 +87619,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -87693,6 +88034,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -87861,6 +88208,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -88018,6 +88371,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -88355,6 +88714,13 @@
                                                     "transition": {
                                                       "enter": "none"
                                                     }
+                                                  },
+                                                  {
+                                                    "callout": {
+                                                      "elementTestId": "dashboard-loaded",
+                                                      "timeout": 15000
+                                                    },
+                                                    "label": "Your dashboard, once the first sync finishes"
                                                   },
                                                   {
                                                     "id": "usage-highlight",
@@ -88955,6 +89321,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -89131,6 +89503,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -89307,6 +89685,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -89483,6 +89867,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -89659,6 +90049,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -89835,6 +90231,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -90244,6 +90646,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -90412,6 +90820,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -90569,6 +90983,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -90906,6 +91326,13 @@
                                                       "transition": {
                                                         "enter": "none"
                                                       }
+                                                    },
+                                                    {
+                                                      "callout": {
+                                                        "elementTestId": "dashboard-loaded",
+                                                        "timeout": 15000
+                                                      },
+                                                      "label": "Your dashboard, once the first sync finishes"
                                                     },
                                                     {
                                                       "id": "usage-highlight",
@@ -91485,6 +91912,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -91661,6 +92094,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -91837,6 +92276,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -92013,6 +92458,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -92189,6 +92640,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -92365,6 +92822,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -92774,6 +93237,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -92942,6 +93411,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -93099,6 +93574,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -93436,6 +93917,13 @@
                                                   "transition": {
                                                     "enter": "none"
                                                   }
+                                                },
+                                                {
+                                                  "callout": {
+                                                    "elementTestId": "dashboard-loaded",
+                                                    "timeout": 15000
+                                                  },
+                                                  "label": "Your dashboard, once the first sync finishes"
                                                 },
                                                 {
                                                   "id": "usage-highlight",
@@ -110471,6 +110959,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -110647,6 +111141,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -110823,6 +111323,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -110999,6 +111505,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -111175,6 +111687,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -111351,6 +111869,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -111760,6 +112284,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -111928,6 +112458,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -112085,6 +112621,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -112424,6 +112966,13 @@
                                                 }
                                               },
                                               {
+                                                "callout": {
+                                                  "elementTestId": "dashboard-loaded",
+                                                  "timeout": 15000
+                                                },
+                                                "label": "Your dashboard, once the first sync finishes"
+                                              },
+                                              {
                                                 "id": "usage-highlight",
                                                 "outline": {
                                                   "elementClass": [
@@ -112528,6 +113077,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -112704,6 +113259,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -112880,6 +113441,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -113056,6 +113623,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -113232,6 +113805,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -113408,6 +113987,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -113817,6 +114402,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -113985,6 +114576,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -114142,6 +114739,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -114479,6 +115082,13 @@
                                                     "transition": {
                                                       "enter": "none"
                                                     }
+                                                  },
+                                                  {
+                                                    "callout": {
+                                                      "elementTestId": "dashboard-loaded",
+                                                      "timeout": 15000
+                                                    },
+                                                    "label": "Your dashboard, once the first sync finishes"
                                                   },
                                                   {
                                                     "id": "usage-highlight",

--- a/src/common/src/schemas/output_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/report_v3.schema.json
@@ -31115,6 +31115,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -31291,6 +31297,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -31467,6 +31479,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -31643,6 +31661,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -31819,6 +31843,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -31995,6 +32025,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -32404,6 +32440,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -32572,6 +32614,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -32729,6 +32777,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -33066,6 +33120,13 @@
                                                           "transition": {
                                                             "enter": "none"
                                                           }
+                                                        },
+                                                        {
+                                                          "callout": {
+                                                            "elementTestId": "dashboard-loaded",
+                                                            "timeout": 15000
+                                                          },
+                                                          "label": "Your dashboard, once the first sync finishes"
                                                         },
                                                         {
                                                           "id": "usage-highlight",
@@ -33666,6 +33727,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -33842,6 +33909,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -34018,6 +34091,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -34194,6 +34273,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -34370,6 +34455,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -34546,6 +34637,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -34955,6 +35052,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -35123,6 +35226,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -35280,6 +35389,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -35617,6 +35732,13 @@
                                                             "transition": {
                                                               "enter": "none"
                                                             }
+                                                          },
+                                                          {
+                                                            "callout": {
+                                                              "elementTestId": "dashboard-loaded",
+                                                              "timeout": 15000
+                                                            },
+                                                            "label": "Your dashboard, once the first sync finishes"
                                                           },
                                                           {
                                                             "id": "usage-highlight",
@@ -36196,6 +36318,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -36372,6 +36500,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -36548,6 +36682,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -36724,6 +36864,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -36900,6 +37046,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -37076,6 +37228,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -37485,6 +37643,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -37653,6 +37817,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -37810,6 +37980,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -38147,6 +38323,13 @@
                                                         "transition": {
                                                           "enter": "none"
                                                         }
+                                                      },
+                                                      {
+                                                        "callout": {
+                                                          "elementTestId": "dashboard-loaded",
+                                                          "timeout": 15000
+                                                        },
+                                                        "label": "Your dashboard, once the first sync finishes"
                                                       },
                                                       {
                                                         "id": "usage-highlight",
@@ -55182,6 +55365,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -55358,6 +55547,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -55534,6 +55729,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -55710,6 +55911,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -55886,6 +56093,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -56062,6 +56275,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -56471,6 +56690,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -56639,6 +56864,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -56796,6 +57027,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -57135,6 +57372,13 @@
                                                       }
                                                     },
                                                     {
+                                                      "callout": {
+                                                        "elementTestId": "dashboard-loaded",
+                                                        "timeout": 15000
+                                                      },
+                                                      "label": "Your dashboard, once the first sync finishes"
+                                                    },
+                                                    {
                                                       "id": "usage-highlight",
                                                       "outline": {
                                                         "elementClass": [
@@ -57239,6 +57483,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -57415,6 +57665,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -57591,6 +57847,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -57767,6 +58029,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -57943,6 +58211,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -58119,6 +58393,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -58528,6 +58808,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -58696,6 +58982,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -58853,6 +59145,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -59190,6 +59488,13 @@
                                                           "transition": {
                                                             "enter": "none"
                                                           }
+                                                        },
+                                                        {
+                                                          "callout": {
+                                                            "elementTestId": "dashboard-loaded",
+                                                            "timeout": 15000
+                                                          },
+                                                          "label": "Your dashboard, once the first sync finishes"
                                                         },
                                                         {
                                                           "id": "usage-highlight",
@@ -87598,6 +87903,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -87774,6 +88085,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -87950,6 +88267,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -88126,6 +88449,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -88302,6 +88631,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -88478,6 +88813,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -88887,6 +89228,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -89055,6 +89402,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -89212,6 +89565,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -89549,6 +89908,13 @@
                                                                 "transition": {
                                                                   "enter": "none"
                                                                 }
+                                                              },
+                                                              {
+                                                                "callout": {
+                                                                  "elementTestId": "dashboard-loaded",
+                                                                  "timeout": 15000
+                                                                },
+                                                                "label": "Your dashboard, once the first sync finishes"
                                                               },
                                                               {
                                                                 "id": "usage-highlight",
@@ -90149,6 +90515,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -90325,6 +90697,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -90501,6 +90879,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -90677,6 +91061,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -90853,6 +91243,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -91029,6 +91425,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -91438,6 +91840,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -91606,6 +92014,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -91763,6 +92177,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -92100,6 +92520,13 @@
                                                                   "transition": {
                                                                     "enter": "none"
                                                                   }
+                                                                },
+                                                                {
+                                                                  "callout": {
+                                                                    "elementTestId": "dashboard-loaded",
+                                                                    "timeout": 15000
+                                                                  },
+                                                                  "label": "Your dashboard, once the first sync finishes"
                                                                 },
                                                                 {
                                                                   "id": "usage-highlight",
@@ -92679,6 +93106,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -92855,6 +93288,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -93031,6 +93470,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -93207,6 +93652,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -93383,6 +93834,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -93559,6 +94016,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -93968,6 +94431,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -94136,6 +94605,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -94293,6 +94768,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -94630,6 +95111,13 @@
                                                               "transition": {
                                                                 "enter": "none"
                                                               }
+                                                            },
+                                                            {
+                                                              "callout": {
+                                                                "elementTestId": "dashboard-loaded",
+                                                                "timeout": 15000
+                                                              },
+                                                              "label": "Your dashboard, once the first sync finishes"
                                                             },
                                                             {
                                                               "id": "usage-highlight",
@@ -111665,6 +112153,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -111841,6 +112335,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -112017,6 +112517,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -112193,6 +112699,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -112369,6 +112881,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -112545,6 +113063,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -112954,6 +113478,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -113122,6 +113652,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -113279,6 +113815,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -113618,6 +114160,13 @@
                                                             }
                                                           },
                                                           {
+                                                            "callout": {
+                                                              "elementTestId": "dashboard-loaded",
+                                                              "timeout": 15000
+                                                            },
+                                                            "label": "Your dashboard, once the first sync finishes"
+                                                          },
+                                                          {
                                                             "id": "usage-highlight",
                                                             "outline": {
                                                               "elementClass": [
@@ -113722,6 +114271,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -113898,6 +114453,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -114074,6 +114635,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -114250,6 +114817,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -114426,6 +114999,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -114602,6 +115181,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -115011,6 +115596,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -115179,6 +115770,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -115336,6 +115933,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -115673,6 +116276,13 @@
                                                                 "transition": {
                                                                   "enter": "none"
                                                                 }
+                                                              },
+                                                              {
+                                                                "callout": {
+                                                                  "elementTestId": "dashboard-loaded",
+                                                                  "timeout": 15000
+                                                                },
+                                                                "label": "Your dashboard, once the first sync finishes"
                                                               },
                                                               {
                                                                 "id": "usage-highlight",

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -28637,6 +28637,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -28813,6 +28819,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -28989,6 +29001,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -29165,6 +29183,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -29341,6 +29365,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -29517,6 +29547,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -29926,6 +29962,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -30094,6 +30136,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -30251,6 +30299,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -30588,6 +30642,13 @@
                                                                       "transition": {
                                                                         "enter": "none"
                                                                       }
+                                                                    },
+                                                                    {
+                                                                      "callout": {
+                                                                        "elementTestId": "dashboard-loaded",
+                                                                        "timeout": 15000
+                                                                      },
+                                                                      "label": "Your dashboard, once the first sync finishes"
                                                                     },
                                                                     {
                                                                       "id": "usage-highlight",
@@ -31188,6 +31249,12 @@
                                                                                       "elementAria": {
                                                                                         "type": "string",
                                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                      },
+                                                                                      "timeout": {
+                                                                                        "type": "integer",
+                                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                        "default": 5000,
+                                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                       }
                                                                                     }
                                                                                   },
@@ -31364,6 +31431,12 @@
                                                                                       "elementAria": {
                                                                                         "type": "string",
                                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                      },
+                                                                                      "timeout": {
+                                                                                        "type": "integer",
+                                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                        "default": 5000,
+                                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                       }
                                                                                     }
                                                                                   },
@@ -31540,6 +31613,12 @@
                                                                                       "elementAria": {
                                                                                         "type": "string",
                                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                      },
+                                                                                      "timeout": {
+                                                                                        "type": "integer",
+                                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                        "default": 5000,
+                                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                       }
                                                                                     }
                                                                                   },
@@ -31716,6 +31795,12 @@
                                                                                       "elementAria": {
                                                                                         "type": "string",
                                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                      },
+                                                                                      "timeout": {
+                                                                                        "type": "integer",
+                                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                        "default": 5000,
+                                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                       }
                                                                                     }
                                                                                   },
@@ -31892,6 +31977,12 @@
                                                                                       "elementAria": {
                                                                                         "type": "string",
                                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                      },
+                                                                                      "timeout": {
+                                                                                        "type": "integer",
+                                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                        "default": 5000,
+                                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                       }
                                                                                     }
                                                                                   },
@@ -32068,6 +32159,12 @@
                                                                                       "elementAria": {
                                                                                         "type": "string",
                                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                      },
+                                                                                      "timeout": {
+                                                                                        "type": "integer",
+                                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                        "default": 5000,
+                                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                       }
                                                                                     }
                                                                                   },
@@ -32477,6 +32574,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -32645,6 +32748,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -32802,6 +32911,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -33139,6 +33254,13 @@
                                                                         "transition": {
                                                                           "enter": "none"
                                                                         }
+                                                                      },
+                                                                      {
+                                                                        "callout": {
+                                                                          "elementTestId": "dashboard-loaded",
+                                                                          "timeout": 15000
+                                                                        },
+                                                                        "label": "Your dashboard, once the first sync finishes"
                                                                       },
                                                                       {
                                                                         "id": "usage-highlight",
@@ -33718,6 +33840,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -33894,6 +34022,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -34070,6 +34204,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -34246,6 +34386,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -34422,6 +34568,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -34598,6 +34750,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -35007,6 +35165,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -35175,6 +35339,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -35332,6 +35502,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -35669,6 +35845,13 @@
                                                                     "transition": {
                                                                       "enter": "none"
                                                                     }
+                                                                  },
+                                                                  {
+                                                                    "callout": {
+                                                                      "elementTestId": "dashboard-loaded",
+                                                                      "timeout": 15000
+                                                                    },
+                                                                    "label": "Your dashboard, once the first sync finishes"
                                                                   },
                                                                   {
                                                                     "id": "usage-highlight",
@@ -52704,6 +52887,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -52880,6 +53069,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -53056,6 +53251,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -53232,6 +53433,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -53408,6 +53615,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -53584,6 +53797,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -53993,6 +54212,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -54161,6 +54386,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -54318,6 +54549,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -54657,6 +54894,13 @@
                                                                   }
                                                                 },
                                                                 {
+                                                                  "callout": {
+                                                                    "elementTestId": "dashboard-loaded",
+                                                                    "timeout": 15000
+                                                                  },
+                                                                  "label": "Your dashboard, once the first sync finishes"
+                                                                },
+                                                                {
                                                                   "id": "usage-highlight",
                                                                   "outline": {
                                                                     "elementClass": [
@@ -54761,6 +55005,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -54937,6 +55187,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -55113,6 +55369,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -55289,6 +55551,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -55465,6 +55733,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -55641,6 +55915,12 @@
                                                                                     "elementAria": {
                                                                                       "type": "string",
                                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                    },
+                                                                                    "timeout": {
+                                                                                      "type": "integer",
+                                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                      "default": 5000,
+                                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                     }
                                                                                   }
                                                                                 },
@@ -56050,6 +56330,12 @@
                                                                                   "elementAria": {
                                                                                     "type": "string",
                                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                  },
+                                                                                  "timeout": {
+                                                                                    "type": "integer",
+                                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                    "default": 5000,
+                                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                   }
                                                                                 }
                                                                               },
@@ -56218,6 +56504,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -56375,6 +56667,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -56712,6 +57010,13 @@
                                                                       "transition": {
                                                                         "enter": "none"
                                                                       }
+                                                                    },
+                                                                    {
+                                                                      "callout": {
+                                                                        "elementTestId": "dashboard-loaded",
+                                                                        "timeout": 15000
+                                                                      },
+                                                                      "label": "Your dashboard, once the first sync finishes"
                                                                     },
                                                                     {
                                                                       "id": "usage-highlight",
@@ -86417,6 +86722,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -86593,6 +86904,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -86769,6 +87086,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -86945,6 +87268,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -87121,6 +87450,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -87297,6 +87632,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -87706,6 +88047,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -87874,6 +88221,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -88031,6 +88384,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -88368,6 +88727,13 @@
                                                         "transition": {
                                                           "enter": "none"
                                                         }
+                                                      },
+                                                      {
+                                                        "callout": {
+                                                          "elementTestId": "dashboard-loaded",
+                                                          "timeout": 15000
+                                                        },
+                                                        "label": "Your dashboard, once the first sync finishes"
                                                       },
                                                       {
                                                         "id": "usage-highlight",
@@ -88968,6 +89334,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -89144,6 +89516,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -89320,6 +89698,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -89496,6 +89880,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -89672,6 +90062,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -89848,6 +90244,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -90257,6 +90659,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -90425,6 +90833,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -90582,6 +90996,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -90919,6 +91339,13 @@
                                                           "transition": {
                                                             "enter": "none"
                                                           }
+                                                        },
+                                                        {
+                                                          "callout": {
+                                                            "elementTestId": "dashboard-loaded",
+                                                            "timeout": 15000
+                                                          },
+                                                          "label": "Your dashboard, once the first sync finishes"
                                                         },
                                                         {
                                                           "id": "usage-highlight",
@@ -91498,6 +91925,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -91674,6 +92107,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -91850,6 +92289,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -92026,6 +92471,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -92202,6 +92653,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -92378,6 +92835,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -92787,6 +93250,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -92955,6 +93424,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -93112,6 +93587,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -93449,6 +93930,13 @@
                                                       "transition": {
                                                         "enter": "none"
                                                       }
+                                                    },
+                                                    {
+                                                      "callout": {
+                                                        "elementTestId": "dashboard-loaded",
+                                                        "timeout": 15000
+                                                      },
+                                                      "label": "Your dashboard, once the first sync finishes"
                                                     },
                                                     {
                                                       "id": "usage-highlight",
@@ -110484,6 +110972,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -110660,6 +111154,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -110836,6 +111336,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -111012,6 +111518,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -111188,6 +111700,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -111364,6 +111882,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -111773,6 +112297,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -111941,6 +112471,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -112098,6 +112634,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -112437,6 +112979,13 @@
                                                     }
                                                   },
                                                   {
+                                                    "callout": {
+                                                      "elementTestId": "dashboard-loaded",
+                                                      "timeout": 15000
+                                                    },
+                                                    "label": "Your dashboard, once the first sync finishes"
+                                                  },
+                                                  {
                                                     "id": "usage-highlight",
                                                     "outline": {
                                                       "elementClass": [
@@ -112541,6 +113090,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -112717,6 +113272,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -112893,6 +113454,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -113069,6 +113636,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -113245,6 +113818,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -113421,6 +114000,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -113830,6 +114415,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -113998,6 +114589,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -114155,6 +114752,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -114492,6 +115095,13 @@
                                                         "transition": {
                                                           "enter": "none"
                                                         }
+                                                      },
+                                                      {
+                                                        "callout": {
+                                                          "elementTestId": "dashboard-loaded",
+                                                          "timeout": 15000
+                                                        },
+                                                        "label": "Your dashboard, once the first sync finishes"
                                                       },
                                                       {
                                                         "id": "usage-highlight",
@@ -146491,6 +147101,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -146667,6 +147283,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -146843,6 +147465,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -147019,6 +147647,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -147195,6 +147829,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -147371,6 +148011,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -147780,6 +148426,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -147948,6 +148600,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -148105,6 +148763,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -148442,6 +149106,13 @@
                                                           "transition": {
                                                             "enter": "none"
                                                           }
+                                                        },
+                                                        {
+                                                          "callout": {
+                                                            "elementTestId": "dashboard-loaded",
+                                                            "timeout": 15000
+                                                          },
+                                                          "label": "Your dashboard, once the first sync finishes"
                                                         },
                                                         {
                                                           "id": "usage-highlight",
@@ -149042,6 +149713,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -149218,6 +149895,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -149394,6 +150077,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -149570,6 +150259,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -149746,6 +150441,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -149922,6 +150623,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -150331,6 +151038,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -150499,6 +151212,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -150656,6 +151375,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -150993,6 +151718,13 @@
                                                             "transition": {
                                                               "enter": "none"
                                                             }
+                                                          },
+                                                          {
+                                                            "callout": {
+                                                              "elementTestId": "dashboard-loaded",
+                                                              "timeout": 15000
+                                                            },
+                                                            "label": "Your dashboard, once the first sync finishes"
                                                           },
                                                           {
                                                             "id": "usage-highlight",
@@ -151572,6 +152304,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -151748,6 +152486,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -151924,6 +152668,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -152100,6 +152850,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -152276,6 +153032,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -152452,6 +153214,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -152861,6 +153629,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -153029,6 +153803,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -153186,6 +153966,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -153523,6 +154309,13 @@
                                                         "transition": {
                                                           "enter": "none"
                                                         }
+                                                      },
+                                                      {
+                                                        "callout": {
+                                                          "elementTestId": "dashboard-loaded",
+                                                          "timeout": 15000
+                                                        },
+                                                        "label": "Your dashboard, once the first sync finishes"
                                                       },
                                                       {
                                                         "id": "usage-highlight",
@@ -170558,6 +171351,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -170734,6 +171533,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -170910,6 +171715,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -171086,6 +171897,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -171262,6 +172079,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -171438,6 +172261,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -171847,6 +172676,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -172015,6 +172850,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -172172,6 +173013,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -172511,6 +173358,13 @@
                                                       }
                                                     },
                                                     {
+                                                      "callout": {
+                                                        "elementTestId": "dashboard-loaded",
+                                                        "timeout": 15000
+                                                      },
+                                                      "label": "Your dashboard, once the first sync finishes"
+                                                    },
+                                                    {
                                                       "id": "usage-highlight",
                                                       "outline": {
                                                         "elementClass": [
@@ -172615,6 +173469,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -172791,6 +173651,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -172967,6 +173833,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -173143,6 +174015,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -173319,6 +174197,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -173495,6 +174379,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -173904,6 +174794,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -174072,6 +174968,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -174229,6 +175131,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -174566,6 +175474,13 @@
                                                           "transition": {
                                                             "enter": "none"
                                                           }
+                                                        },
+                                                        {
+                                                          "callout": {
+                                                            "elementTestId": "dashboard-loaded",
+                                                            "timeout": 15000
+                                                          },
+                                                          "label": "Your dashboard, once the first sync finishes"
                                                         },
                                                         {
                                                           "id": "usage-highlight",
@@ -202974,6 +203889,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -203150,6 +204071,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -203326,6 +204253,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -203502,6 +204435,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -203678,6 +204617,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -203854,6 +204799,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -204263,6 +205214,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -204431,6 +205388,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -204588,6 +205551,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -204925,6 +205894,13 @@
                                                                 "transition": {
                                                                   "enter": "none"
                                                                 }
+                                                              },
+                                                              {
+                                                                "callout": {
+                                                                  "elementTestId": "dashboard-loaded",
+                                                                  "timeout": 15000
+                                                                },
+                                                                "label": "Your dashboard, once the first sync finishes"
                                                               },
                                                               {
                                                                 "id": "usage-highlight",
@@ -205525,6 +206501,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -205701,6 +206683,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -205877,6 +206865,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -206053,6 +207047,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -206229,6 +207229,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -206405,6 +207411,12 @@
                                                                                 "elementAria": {
                                                                                   "type": "string",
                                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                                },
+                                                                                "timeout": {
+                                                                                  "type": "integer",
+                                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                  "default": 5000,
+                                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                                 }
                                                                               }
                                                                             },
@@ -206814,6 +207826,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -206982,6 +208000,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -207139,6 +208163,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -207476,6 +208506,13 @@
                                                                   "transition": {
                                                                     "enter": "none"
                                                                   }
+                                                                },
+                                                                {
+                                                                  "callout": {
+                                                                    "elementTestId": "dashboard-loaded",
+                                                                    "timeout": 15000
+                                                                  },
+                                                                  "label": "Your dashboard, once the first sync finishes"
                                                                 },
                                                                 {
                                                                   "id": "usage-highlight",
@@ -208055,6 +209092,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -208231,6 +209274,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -208407,6 +209456,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -208583,6 +209638,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -208759,6 +209820,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -208935,6 +210002,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -209344,6 +210417,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -209512,6 +210591,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -209669,6 +210754,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -210006,6 +211097,13 @@
                                                               "transition": {
                                                                 "enter": "none"
                                                               }
+                                                            },
+                                                            {
+                                                              "callout": {
+                                                                "elementTestId": "dashboard-loaded",
+                                                                "timeout": 15000
+                                                              },
+                                                              "label": "Your dashboard, once the first sync finishes"
                                                             },
                                                             {
                                                               "id": "usage-highlight",
@@ -227041,6 +228139,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -227217,6 +228321,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -227393,6 +228503,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -227569,6 +228685,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -227745,6 +228867,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -227921,6 +229049,12 @@
                                                                           "elementAria": {
                                                                             "type": "string",
                                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                          },
+                                                                          "timeout": {
+                                                                            "type": "integer",
+                                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                            "default": 5000,
+                                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                           }
                                                                         }
                                                                       },
@@ -228330,6 +229464,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -228498,6 +229638,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -228655,6 +229801,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -228994,6 +230146,13 @@
                                                             }
                                                           },
                                                           {
+                                                            "callout": {
+                                                              "elementTestId": "dashboard-loaded",
+                                                              "timeout": 15000
+                                                            },
+                                                            "label": "Your dashboard, once the first sync finishes"
+                                                          },
+                                                          {
                                                             "id": "usage-highlight",
                                                             "outline": {
                                                               "elementClass": [
@@ -229098,6 +230257,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -229274,6 +230439,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -229450,6 +230621,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -229626,6 +230803,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -229802,6 +230985,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -229978,6 +231167,12 @@
                                                                               "elementAria": {
                                                                                 "type": "string",
                                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                              },
+                                                                              "timeout": {
+                                                                                "type": "integer",
+                                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                                "default": 5000,
+                                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                               }
                                                                             }
                                                                           },
@@ -230387,6 +231582,12 @@
                                                                             "elementAria": {
                                                                               "type": "string",
                                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                            },
+                                                                            "timeout": {
+                                                                              "type": "integer",
+                                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                              "default": 5000,
+                                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                             }
                                                                           }
                                                                         },
@@ -230555,6 +231756,12 @@
                                                                         "elementAria": {
                                                                           "type": "string",
                                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                        },
+                                                                        "timeout": {
+                                                                          "type": "integer",
+                                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                          "default": 5000,
+                                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                         }
                                                                       }
                                                                     },
@@ -230712,6 +231919,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -231049,6 +232262,13 @@
                                                                 "transition": {
                                                                   "enter": "none"
                                                                 }
+                                                              },
+                                                              {
+                                                                "callout": {
+                                                                  "elementTestId": "dashboard-loaded",
+                                                                  "timeout": 15000
+                                                                },
+                                                                "label": "Your dashboard, once the first sync finishes"
                                                               },
                                                               {
                                                                 "id": "usage-highlight",

--- a/src/common/src/schemas/output_schemas/screenshot_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/screenshot_v3.schema.json
@@ -496,6 +496,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -672,6 +678,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -848,6 +860,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -1024,6 +1042,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -1200,6 +1224,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -1376,6 +1406,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -1785,6 +1821,12 @@
                                 "elementAria": {
                                   "type": "string",
                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                  "default": 5000,
+                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                 }
                               }
                             },
@@ -1953,6 +1995,12 @@
                             "elementAria": {
                               "type": "string",
                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                            },
+                            "timeout": {
+                              "type": "integer",
+                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                              "default": 5000,
+                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                             }
                           }
                         },
@@ -2110,6 +2158,12 @@
                         "elementAria": {
                           "type": "string",
                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                        },
+                        "timeout": {
+                          "type": "integer",
+                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                          "default": 5000,
+                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                         }
                       }
                     },
@@ -2447,6 +2501,13 @@
                     "transition": {
                       "enter": "none"
                     }
+                  },
+                  {
+                    "callout": {
+                      "elementTestId": "dashboard-loaded",
+                      "timeout": 15000
+                    },
+                    "label": "Your dashboard, once the first sync finishes"
                   },
                   {
                     "id": "usage-highlight",
@@ -3047,6 +3108,12 @@
                                     "elementAria": {
                                       "type": "string",
                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                      "default": 5000,
+                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                     }
                                   }
                                 },
@@ -3223,6 +3290,12 @@
                                     "elementAria": {
                                       "type": "string",
                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                      "default": 5000,
+                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                     }
                                   }
                                 },
@@ -3399,6 +3472,12 @@
                                     "elementAria": {
                                       "type": "string",
                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                      "default": 5000,
+                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                     }
                                   }
                                 },
@@ -3575,6 +3654,12 @@
                                     "elementAria": {
                                       "type": "string",
                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                      "default": 5000,
+                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                     }
                                   }
                                 },
@@ -3751,6 +3836,12 @@
                                     "elementAria": {
                                       "type": "string",
                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                      "default": 5000,
+                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                     }
                                   }
                                 },
@@ -3927,6 +4018,12 @@
                                     "elementAria": {
                                       "type": "string",
                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                      "default": 5000,
+                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                     }
                                   }
                                 },
@@ -4336,6 +4433,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -4504,6 +4607,12 @@
                               "elementAria": {
                                 "type": "string",
                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                              },
+                              "timeout": {
+                                "type": "integer",
+                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                "default": 5000,
+                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                               }
                             }
                           },
@@ -4661,6 +4770,12 @@
                           "elementAria": {
                             "type": "string",
                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                          },
+                          "timeout": {
+                            "type": "integer",
+                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                            "default": 5000,
+                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                           }
                         }
                       },
@@ -4998,6 +5113,13 @@
                       "transition": {
                         "enter": "none"
                       }
+                    },
+                    {
+                      "callout": {
+                        "elementTestId": "dashboard-loaded",
+                        "timeout": 15000
+                      },
+                      "label": "Your dashboard, once the first sync finishes"
                     },
                     {
                       "id": "usage-highlight",
@@ -5577,6 +5699,12 @@
                                 "elementAria": {
                                   "type": "string",
                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                  "default": 5000,
+                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                 }
                               }
                             },
@@ -5753,6 +5881,12 @@
                                 "elementAria": {
                                   "type": "string",
                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                  "default": 5000,
+                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                 }
                               }
                             },
@@ -5929,6 +6063,12 @@
                                 "elementAria": {
                                   "type": "string",
                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                  "default": 5000,
+                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                 }
                               }
                             },
@@ -6105,6 +6245,12 @@
                                 "elementAria": {
                                   "type": "string",
                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                  "default": 5000,
+                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                 }
                               }
                             },
@@ -6281,6 +6427,12 @@
                                 "elementAria": {
                                   "type": "string",
                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                  "default": 5000,
+                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                 }
                               }
                             },
@@ -6457,6 +6609,12 @@
                                 "elementAria": {
                                   "type": "string",
                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                  "default": 5000,
+                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                 }
                               }
                             },
@@ -6866,6 +7024,12 @@
                               "elementAria": {
                                 "type": "string",
                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                              },
+                              "timeout": {
+                                "type": "integer",
+                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                "default": 5000,
+                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                               }
                             }
                           },
@@ -7034,6 +7198,12 @@
                           "elementAria": {
                             "type": "string",
                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                          },
+                          "timeout": {
+                            "type": "integer",
+                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                            "default": 5000,
+                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                           }
                         }
                       },
@@ -7191,6 +7361,12 @@
                       "elementAria": {
                         "type": "string",
                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                      },
+                      "timeout": {
+                        "type": "integer",
+                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                        "default": 5000,
+                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                       }
                     }
                   },
@@ -7528,6 +7704,13 @@
                   "transition": {
                     "enter": "none"
                   }
+                },
+                {
+                  "callout": {
+                    "elementTestId": "dashboard-loaded",
+                    "timeout": 15000
+                  },
+                  "label": "Your dashboard, once the first sync finishes"
                 },
                 {
                   "id": "usage-highlight",

--- a/src/common/src/schemas/output_schemas/spec_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/spec_v3.schema.json
@@ -31087,6 +31087,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -31263,6 +31269,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -31439,6 +31451,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -31615,6 +31633,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -31791,6 +31815,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -31967,6 +31997,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -32376,6 +32412,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -32544,6 +32586,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -32701,6 +32749,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -33038,6 +33092,13 @@
                                                 "transition": {
                                                   "enter": "none"
                                                 }
+                                              },
+                                              {
+                                                "callout": {
+                                                  "elementTestId": "dashboard-loaded",
+                                                  "timeout": 15000
+                                                },
+                                                "label": "Your dashboard, once the first sync finishes"
                                               },
                                               {
                                                 "id": "usage-highlight",
@@ -33638,6 +33699,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -33814,6 +33881,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -33990,6 +34063,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -34166,6 +34245,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -34342,6 +34427,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -34518,6 +34609,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -34927,6 +35024,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -35095,6 +35198,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -35252,6 +35361,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -35589,6 +35704,13 @@
                                                   "transition": {
                                                     "enter": "none"
                                                   }
+                                                },
+                                                {
+                                                  "callout": {
+                                                    "elementTestId": "dashboard-loaded",
+                                                    "timeout": 15000
+                                                  },
+                                                  "label": "Your dashboard, once the first sync finishes"
                                                 },
                                                 {
                                                   "id": "usage-highlight",
@@ -36168,6 +36290,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -36344,6 +36472,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -36520,6 +36654,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -36696,6 +36836,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -36872,6 +37018,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -37048,6 +37200,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -37457,6 +37615,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -37625,6 +37789,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -37782,6 +37952,12 @@
                                                   "elementAria": {
                                                     "type": "string",
                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                  },
+                                                  "timeout": {
+                                                    "type": "integer",
+                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                    "default": 5000,
+                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                   }
                                                 }
                                               },
@@ -38119,6 +38295,13 @@
                                               "transition": {
                                                 "enter": "none"
                                               }
+                                            },
+                                            {
+                                              "callout": {
+                                                "elementTestId": "dashboard-loaded",
+                                                "timeout": 15000
+                                              },
+                                              "label": "Your dashboard, once the first sync finishes"
                                             },
                                             {
                                               "id": "usage-highlight",
@@ -55154,6 +55337,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -55330,6 +55519,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -55506,6 +55701,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -55682,6 +55883,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -55858,6 +56065,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -56034,6 +56247,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -56443,6 +56662,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -56611,6 +56836,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -56768,6 +56999,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -57107,6 +57344,13 @@
                                             }
                                           },
                                           {
+                                            "callout": {
+                                              "elementTestId": "dashboard-loaded",
+                                              "timeout": 15000
+                                            },
+                                            "label": "Your dashboard, once the first sync finishes"
+                                          },
+                                          {
                                             "id": "usage-highlight",
                                             "outline": {
                                               "elementClass": [
@@ -57211,6 +57455,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -57387,6 +57637,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -57563,6 +57819,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -57739,6 +58001,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -57915,6 +58183,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -58091,6 +58365,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -58500,6 +58780,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -58668,6 +58954,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -58825,6 +59117,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -59162,6 +59460,13 @@
                                                 "transition": {
                                                   "enter": "none"
                                                 }
+                                              },
+                                              {
+                                                "callout": {
+                                                  "elementTestId": "dashboard-loaded",
+                                                  "timeout": 15000
+                                                },
+                                                "label": "Your dashboard, once the first sync finishes"
                                               },
                                               {
                                                 "id": "usage-highlight",
@@ -87570,6 +87875,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -87746,6 +88057,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -87922,6 +88239,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -88098,6 +88421,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -88274,6 +88603,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -88450,6 +88785,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -88859,6 +89200,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -89027,6 +89374,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -89184,6 +89537,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -89521,6 +89880,13 @@
                                                       "transition": {
                                                         "enter": "none"
                                                       }
+                                                    },
+                                                    {
+                                                      "callout": {
+                                                        "elementTestId": "dashboard-loaded",
+                                                        "timeout": 15000
+                                                      },
+                                                      "label": "Your dashboard, once the first sync finishes"
                                                     },
                                                     {
                                                       "id": "usage-highlight",
@@ -90121,6 +90487,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -90297,6 +90669,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -90473,6 +90851,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -90649,6 +91033,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -90825,6 +91215,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -91001,6 +91397,12 @@
                                                                       "elementAria": {
                                                                         "type": "string",
                                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                      },
+                                                                      "timeout": {
+                                                                        "type": "integer",
+                                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                        "default": 5000,
+                                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                       }
                                                                     }
                                                                   },
@@ -91410,6 +91812,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -91578,6 +91986,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -91735,6 +92149,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -92072,6 +92492,13 @@
                                                         "transition": {
                                                           "enter": "none"
                                                         }
+                                                      },
+                                                      {
+                                                        "callout": {
+                                                          "elementTestId": "dashboard-loaded",
+                                                          "timeout": 15000
+                                                        },
+                                                        "label": "Your dashboard, once the first sync finishes"
                                                       },
                                                       {
                                                         "id": "usage-highlight",
@@ -92651,6 +93078,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -92827,6 +93260,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -93003,6 +93442,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -93179,6 +93624,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -93355,6 +93806,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -93531,6 +93988,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -93940,6 +94403,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -94108,6 +94577,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -94265,6 +94740,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -94602,6 +95083,13 @@
                                                     "transition": {
                                                       "enter": "none"
                                                     }
+                                                  },
+                                                  {
+                                                    "callout": {
+                                                      "elementTestId": "dashboard-loaded",
+                                                      "timeout": 15000
+                                                    },
+                                                    "label": "Your dashboard, once the first sync finishes"
                                                   },
                                                   {
                                                     "id": "usage-highlight",
@@ -111637,6 +112125,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -111813,6 +112307,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -111989,6 +112489,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -112165,6 +112671,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -112341,6 +112853,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -112517,6 +113035,12 @@
                                                                 "elementAria": {
                                                                   "type": "string",
                                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                },
+                                                                "timeout": {
+                                                                  "type": "integer",
+                                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                  "default": 5000,
+                                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                 }
                                                               }
                                                             },
@@ -112926,6 +113450,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -113094,6 +113624,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -113251,6 +113787,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -113590,6 +114132,13 @@
                                                   }
                                                 },
                                                 {
+                                                  "callout": {
+                                                    "elementTestId": "dashboard-loaded",
+                                                    "timeout": 15000
+                                                  },
+                                                  "label": "Your dashboard, once the first sync finishes"
+                                                },
+                                                {
                                                   "id": "usage-highlight",
                                                   "outline": {
                                                     "elementClass": [
@@ -113694,6 +114243,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -113870,6 +114425,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -114046,6 +114607,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -114222,6 +114789,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -114398,6 +114971,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -114574,6 +115153,12 @@
                                                                     "elementAria": {
                                                                       "type": "string",
                                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                    },
+                                                                    "timeout": {
+                                                                      "type": "integer",
+                                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                      "default": 5000,
+                                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                     }
                                                                   }
                                                                 },
@@ -114983,6 +115568,12 @@
                                                                   "elementAria": {
                                                                     "type": "string",
                                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                                  },
+                                                                  "timeout": {
+                                                                    "type": "integer",
+                                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                    "default": 5000,
+                                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                                   }
                                                                 }
                                                               },
@@ -115151,6 +115742,12 @@
                                                               "elementAria": {
                                                                 "type": "string",
                                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                              },
+                                                              "timeout": {
+                                                                "type": "integer",
+                                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                                "default": 5000,
+                                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                               }
                                                             }
                                                           },
@@ -115308,6 +115905,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -115645,6 +116248,13 @@
                                                       "transition": {
                                                         "enter": "none"
                                                       }
+                                                    },
+                                                    {
+                                                      "callout": {
+                                                        "elementTestId": "dashboard-loaded",
+                                                        "timeout": 15000
+                                                      },
+                                                      "label": "Your dashboard, once the first sync finishes"
                                                     },
                                                     {
                                                       "id": "usage-highlight",

--- a/src/common/src/schemas/output_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/step_v3.schema.json
@@ -27539,6 +27539,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -27715,6 +27721,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -27891,6 +27903,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -28067,6 +28085,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -28243,6 +28267,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -28419,6 +28449,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -28828,6 +28864,12 @@
                                             "elementAria": {
                                               "type": "string",
                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                            },
+                                            "timeout": {
+                                              "type": "integer",
+                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                              "default": 5000,
+                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                             }
                                           }
                                         },
@@ -28996,6 +29038,12 @@
                                         "elementAria": {
                                           "type": "string",
                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                        },
+                                        "timeout": {
+                                          "type": "integer",
+                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                          "default": 5000,
+                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                         }
                                       }
                                     },
@@ -29153,6 +29201,12 @@
                                     "elementAria": {
                                       "type": "string",
                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                      "default": 5000,
+                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                     }
                                   }
                                 },
@@ -29490,6 +29544,13 @@
                                 "transition": {
                                   "enter": "none"
                                 }
+                              },
+                              {
+                                "callout": {
+                                  "elementTestId": "dashboard-loaded",
+                                  "timeout": 15000
+                                },
+                                "label": "Your dashboard, once the first sync finishes"
                               },
                               {
                                 "id": "usage-highlight",
@@ -30090,6 +30151,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -30266,6 +30333,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -30442,6 +30515,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -30618,6 +30697,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -30794,6 +30879,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -30970,6 +31061,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -31379,6 +31476,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -31547,6 +31650,12 @@
                                           "elementAria": {
                                             "type": "string",
                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                          },
+                                          "timeout": {
+                                            "type": "integer",
+                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                            "default": 5000,
+                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                           }
                                         }
                                       },
@@ -31704,6 +31813,12 @@
                                       "elementAria": {
                                         "type": "string",
                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                      },
+                                      "timeout": {
+                                        "type": "integer",
+                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                        "default": 5000,
+                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                       }
                                     }
                                   },
@@ -32041,6 +32156,13 @@
                                   "transition": {
                                     "enter": "none"
                                   }
+                                },
+                                {
+                                  "callout": {
+                                    "elementTestId": "dashboard-loaded",
+                                    "timeout": 15000
+                                  },
+                                  "label": "Your dashboard, once the first sync finishes"
                                 },
                                 {
                                   "id": "usage-highlight",
@@ -32620,6 +32742,12 @@
                                             "elementAria": {
                                               "type": "string",
                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                            },
+                                            "timeout": {
+                                              "type": "integer",
+                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                              "default": 5000,
+                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                             }
                                           }
                                         },
@@ -32796,6 +32924,12 @@
                                             "elementAria": {
                                               "type": "string",
                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                            },
+                                            "timeout": {
+                                              "type": "integer",
+                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                              "default": 5000,
+                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                             }
                                           }
                                         },
@@ -32972,6 +33106,12 @@
                                             "elementAria": {
                                               "type": "string",
                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                            },
+                                            "timeout": {
+                                              "type": "integer",
+                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                              "default": 5000,
+                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                             }
                                           }
                                         },
@@ -33148,6 +33288,12 @@
                                             "elementAria": {
                                               "type": "string",
                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                            },
+                                            "timeout": {
+                                              "type": "integer",
+                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                              "default": 5000,
+                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                             }
                                           }
                                         },
@@ -33324,6 +33470,12 @@
                                             "elementAria": {
                                               "type": "string",
                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                            },
+                                            "timeout": {
+                                              "type": "integer",
+                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                              "default": 5000,
+                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                             }
                                           }
                                         },
@@ -33500,6 +33652,12 @@
                                             "elementAria": {
                                               "type": "string",
                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                            },
+                                            "timeout": {
+                                              "type": "integer",
+                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                              "default": 5000,
+                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                             }
                                           }
                                         },
@@ -33909,6 +34067,12 @@
                                           "elementAria": {
                                             "type": "string",
                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                          },
+                                          "timeout": {
+                                            "type": "integer",
+                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                            "default": 5000,
+                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                           }
                                         }
                                       },
@@ -34077,6 +34241,12 @@
                                       "elementAria": {
                                         "type": "string",
                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                      },
+                                      "timeout": {
+                                        "type": "integer",
+                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                        "default": 5000,
+                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                       }
                                     }
                                   },
@@ -34234,6 +34404,12 @@
                                   "elementAria": {
                                     "type": "string",
                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000,
+                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                   }
                                 }
                               },
@@ -34571,6 +34747,13 @@
                               "transition": {
                                 "enter": "none"
                               }
+                            },
+                            {
+                              "callout": {
+                                "elementTestId": "dashboard-loaded",
+                                "timeout": 15000
+                              },
+                              "label": "Your dashboard, once the first sync finishes"
                             },
                             {
                               "id": "usage-highlight",
@@ -51606,6 +51789,12 @@
                                           "elementAria": {
                                             "type": "string",
                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                          },
+                                          "timeout": {
+                                            "type": "integer",
+                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                            "default": 5000,
+                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                           }
                                         }
                                       },
@@ -51782,6 +51971,12 @@
                                           "elementAria": {
                                             "type": "string",
                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                          },
+                                          "timeout": {
+                                            "type": "integer",
+                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                            "default": 5000,
+                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                           }
                                         }
                                       },
@@ -51958,6 +52153,12 @@
                                           "elementAria": {
                                             "type": "string",
                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                          },
+                                          "timeout": {
+                                            "type": "integer",
+                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                            "default": 5000,
+                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                           }
                                         }
                                       },
@@ -52134,6 +52335,12 @@
                                           "elementAria": {
                                             "type": "string",
                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                          },
+                                          "timeout": {
+                                            "type": "integer",
+                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                            "default": 5000,
+                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                           }
                                         }
                                       },
@@ -52310,6 +52517,12 @@
                                           "elementAria": {
                                             "type": "string",
                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                          },
+                                          "timeout": {
+                                            "type": "integer",
+                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                            "default": 5000,
+                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                           }
                                         }
                                       },
@@ -52486,6 +52699,12 @@
                                           "elementAria": {
                                             "type": "string",
                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                          },
+                                          "timeout": {
+                                            "type": "integer",
+                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                            "default": 5000,
+                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                           }
                                         }
                                       },
@@ -52895,6 +53114,12 @@
                                         "elementAria": {
                                           "type": "string",
                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                        },
+                                        "timeout": {
+                                          "type": "integer",
+                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                          "default": 5000,
+                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                         }
                                       }
                                     },
@@ -53063,6 +53288,12 @@
                                     "elementAria": {
                                       "type": "string",
                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                      "default": 5000,
+                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                     }
                                   }
                                 },
@@ -53220,6 +53451,12 @@
                                 "elementAria": {
                                   "type": "string",
                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                },
+                                "timeout": {
+                                  "type": "integer",
+                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                  "default": 5000,
+                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                 }
                               }
                             },
@@ -53559,6 +53796,13 @@
                             }
                           },
                           {
+                            "callout": {
+                              "elementTestId": "dashboard-loaded",
+                              "timeout": 15000
+                            },
+                            "label": "Your dashboard, once the first sync finishes"
+                          },
+                          {
                             "id": "usage-highlight",
                             "outline": {
                               "elementClass": [
@@ -53663,6 +53907,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -53839,6 +54089,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -54015,6 +54271,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -54191,6 +54453,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -54367,6 +54635,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -54543,6 +54817,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -54952,6 +55232,12 @@
                                             "elementAria": {
                                               "type": "string",
                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                            },
+                                            "timeout": {
+                                              "type": "integer",
+                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                              "default": 5000,
+                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                             }
                                           }
                                         },
@@ -55120,6 +55406,12 @@
                                         "elementAria": {
                                           "type": "string",
                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                        },
+                                        "timeout": {
+                                          "type": "integer",
+                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                          "default": 5000,
+                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                         }
                                       }
                                     },
@@ -55277,6 +55569,12 @@
                                     "elementAria": {
                                       "type": "string",
                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                      "default": 5000,
+                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                     }
                                   }
                                 },
@@ -55614,6 +55912,13 @@
                                 "transition": {
                                   "enter": "none"
                                 }
+                              },
+                              {
+                                "callout": {
+                                  "elementTestId": "dashboard-loaded",
+                                  "timeout": 15000
+                                },
+                                "label": "Your dashboard, once the first sync finishes"
                               },
                               {
                                 "id": "usage-highlight",

--- a/src/common/src/schemas/output_schemas/test_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/test_v3.schema.json
@@ -29654,6 +29654,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -29830,6 +29836,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -30006,6 +30018,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -30182,6 +30200,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -30358,6 +30382,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -30534,6 +30564,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -30943,6 +30979,12 @@
                                                   "elementAria": {
                                                     "type": "string",
                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                  },
+                                                  "timeout": {
+                                                    "type": "integer",
+                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                    "default": 5000,
+                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                   }
                                                 }
                                               },
@@ -31111,6 +31153,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -31268,6 +31316,12 @@
                                           "elementAria": {
                                             "type": "string",
                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                          },
+                                          "timeout": {
+                                            "type": "integer",
+                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                            "default": 5000,
+                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                           }
                                         }
                                       },
@@ -31605,6 +31659,13 @@
                                       "transition": {
                                         "enter": "none"
                                       }
+                                    },
+                                    {
+                                      "callout": {
+                                        "elementTestId": "dashboard-loaded",
+                                        "timeout": 15000
+                                      },
+                                      "label": "Your dashboard, once the first sync finishes"
                                     },
                                     {
                                       "id": "usage-highlight",
@@ -32205,6 +32266,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -32381,6 +32448,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -32557,6 +32630,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -32733,6 +32812,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -32909,6 +32994,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -33085,6 +33176,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -33494,6 +33591,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -33662,6 +33765,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -33819,6 +33928,12 @@
                                             "elementAria": {
                                               "type": "string",
                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                            },
+                                            "timeout": {
+                                              "type": "integer",
+                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                              "default": 5000,
+                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                             }
                                           }
                                         },
@@ -34156,6 +34271,13 @@
                                         "transition": {
                                           "enter": "none"
                                         }
+                                      },
+                                      {
+                                        "callout": {
+                                          "elementTestId": "dashboard-loaded",
+                                          "timeout": 15000
+                                        },
+                                        "label": "Your dashboard, once the first sync finishes"
                                       },
                                       {
                                         "id": "usage-highlight",
@@ -34735,6 +34857,12 @@
                                                   "elementAria": {
                                                     "type": "string",
                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                  },
+                                                  "timeout": {
+                                                    "type": "integer",
+                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                    "default": 5000,
+                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                   }
                                                 }
                                               },
@@ -34911,6 +35039,12 @@
                                                   "elementAria": {
                                                     "type": "string",
                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                  },
+                                                  "timeout": {
+                                                    "type": "integer",
+                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                    "default": 5000,
+                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                   }
                                                 }
                                               },
@@ -35087,6 +35221,12 @@
                                                   "elementAria": {
                                                     "type": "string",
                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                  },
+                                                  "timeout": {
+                                                    "type": "integer",
+                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                    "default": 5000,
+                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                   }
                                                 }
                                               },
@@ -35263,6 +35403,12 @@
                                                   "elementAria": {
                                                     "type": "string",
                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                  },
+                                                  "timeout": {
+                                                    "type": "integer",
+                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                    "default": 5000,
+                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                   }
                                                 }
                                               },
@@ -35439,6 +35585,12 @@
                                                   "elementAria": {
                                                     "type": "string",
                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                  },
+                                                  "timeout": {
+                                                    "type": "integer",
+                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                    "default": 5000,
+                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                   }
                                                 }
                                               },
@@ -35615,6 +35767,12 @@
                                                   "elementAria": {
                                                     "type": "string",
                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                  },
+                                                  "timeout": {
+                                                    "type": "integer",
+                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                    "default": 5000,
+                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                   }
                                                 }
                                               },
@@ -36024,6 +36182,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -36192,6 +36356,12 @@
                                             "elementAria": {
                                               "type": "string",
                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                            },
+                                            "timeout": {
+                                              "type": "integer",
+                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                              "default": 5000,
+                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                             }
                                           }
                                         },
@@ -36349,6 +36519,12 @@
                                         "elementAria": {
                                           "type": "string",
                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                        },
+                                        "timeout": {
+                                          "type": "integer",
+                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                          "default": 5000,
+                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                         }
                                       }
                                     },
@@ -36686,6 +36862,13 @@
                                     "transition": {
                                       "enter": "none"
                                     }
+                                  },
+                                  {
+                                    "callout": {
+                                      "elementTestId": "dashboard-loaded",
+                                      "timeout": 15000
+                                    },
+                                    "label": "Your dashboard, once the first sync finishes"
                                   },
                                   {
                                     "id": "usage-highlight",
@@ -53721,6 +53904,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -53897,6 +54086,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -54073,6 +54268,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -54249,6 +54450,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -54425,6 +54632,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -54601,6 +54814,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -55010,6 +55229,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -55178,6 +55403,12 @@
                                           "elementAria": {
                                             "type": "string",
                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                          },
+                                          "timeout": {
+                                            "type": "integer",
+                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                            "default": 5000,
+                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                           }
                                         }
                                       },
@@ -55335,6 +55566,12 @@
                                       "elementAria": {
                                         "type": "string",
                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                      },
+                                      "timeout": {
+                                        "type": "integer",
+                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                        "default": 5000,
+                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                       }
                                     }
                                   },
@@ -55674,6 +55911,13 @@
                                   }
                                 },
                                 {
+                                  "callout": {
+                                    "elementTestId": "dashboard-loaded",
+                                    "timeout": 15000
+                                  },
+                                  "label": "Your dashboard, once the first sync finishes"
+                                },
+                                {
                                   "id": "usage-highlight",
                                   "outline": {
                                     "elementClass": [
@@ -55778,6 +56022,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -55954,6 +56204,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -56130,6 +56386,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -56306,6 +56568,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -56482,6 +56750,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -56658,6 +56932,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -57067,6 +57347,12 @@
                                                   "elementAria": {
                                                     "type": "string",
                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                  },
+                                                  "timeout": {
+                                                    "type": "integer",
+                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                    "default": 5000,
+                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                   }
                                                 }
                                               },
@@ -57235,6 +57521,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -57392,6 +57684,12 @@
                                           "elementAria": {
                                             "type": "string",
                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                          },
+                                          "timeout": {
+                                            "type": "integer",
+                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                            "default": 5000,
+                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                           }
                                         }
                                       },
@@ -57729,6 +58027,13 @@
                                       "transition": {
                                         "enter": "none"
                                       }
+                                    },
+                                    {
+                                      "callout": {
+                                        "elementTestId": "dashboard-loaded",
+                                        "timeout": 15000
+                                      },
+                                      "label": "Your dashboard, once the first sync finishes"
                                     },
                                     {
                                       "id": "usage-highlight",
@@ -86137,6 +86442,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -86313,6 +86624,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -86489,6 +86806,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -86665,6 +86988,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -86841,6 +87170,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -87017,6 +87352,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -87426,6 +87767,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -87594,6 +87941,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -87751,6 +88104,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -88088,6 +88447,13 @@
                                             "transition": {
                                               "enter": "none"
                                             }
+                                          },
+                                          {
+                                            "callout": {
+                                              "elementTestId": "dashboard-loaded",
+                                              "timeout": 15000
+                                            },
+                                            "label": "Your dashboard, once the first sync finishes"
                                           },
                                           {
                                             "id": "usage-highlight",
@@ -88688,6 +89054,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -88864,6 +89236,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -89040,6 +89418,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -89216,6 +89600,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -89392,6 +89782,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -89568,6 +89964,12 @@
                                                             "elementAria": {
                                                               "type": "string",
                                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                            },
+                                                            "timeout": {
+                                                              "type": "integer",
+                                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                              "default": 5000,
+                                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                             }
                                                           }
                                                         },
@@ -89977,6 +90379,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -90145,6 +90553,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -90302,6 +90716,12 @@
                                                   "elementAria": {
                                                     "type": "string",
                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                  },
+                                                  "timeout": {
+                                                    "type": "integer",
+                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                    "default": 5000,
+                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                   }
                                                 }
                                               },
@@ -90639,6 +91059,13 @@
                                               "transition": {
                                                 "enter": "none"
                                               }
+                                            },
+                                            {
+                                              "callout": {
+                                                "elementTestId": "dashboard-loaded",
+                                                "timeout": 15000
+                                              },
+                                              "label": "Your dashboard, once the first sync finishes"
                                             },
                                             {
                                               "id": "usage-highlight",
@@ -91218,6 +91645,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -91394,6 +91827,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -91570,6 +92009,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -91746,6 +92191,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -91922,6 +92373,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -92098,6 +92555,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -92507,6 +92970,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -92675,6 +93144,12 @@
                                                   "elementAria": {
                                                     "type": "string",
                                                     "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                  },
+                                                  "timeout": {
+                                                    "type": "integer",
+                                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                    "default": 5000,
+                                                    "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                   }
                                                 }
                                               },
@@ -92832,6 +93307,12 @@
                                               "elementAria": {
                                                 "type": "string",
                                                 "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                              },
+                                              "timeout": {
+                                                "type": "integer",
+                                                "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                "default": 5000,
+                                                "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                               }
                                             }
                                           },
@@ -93169,6 +93650,13 @@
                                           "transition": {
                                             "enter": "none"
                                           }
+                                        },
+                                        {
+                                          "callout": {
+                                            "elementTestId": "dashboard-loaded",
+                                            "timeout": 15000
+                                          },
+                                          "label": "Your dashboard, once the first sync finishes"
                                         },
                                         {
                                           "id": "usage-highlight",
@@ -110204,6 +110692,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -110380,6 +110874,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -110556,6 +111056,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -110732,6 +111238,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -110908,6 +111420,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -111084,6 +111602,12 @@
                                                       "elementAria": {
                                                         "type": "string",
                                                         "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                      },
+                                                      "timeout": {
+                                                        "type": "integer",
+                                                        "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                        "default": 5000,
+                                                        "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                       }
                                                     }
                                                   },
@@ -111493,6 +112017,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -111661,6 +112191,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -111818,6 +112354,12 @@
                                             "elementAria": {
                                               "type": "string",
                                               "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                            },
+                                            "timeout": {
+                                              "type": "integer",
+                                              "description": "Max duration in milliseconds to wait for the element to exist.",
+                                              "default": 5000,
+                                              "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                             }
                                           }
                                         },
@@ -112157,6 +112699,13 @@
                                         }
                                       },
                                       {
+                                        "callout": {
+                                          "elementTestId": "dashboard-loaded",
+                                          "timeout": 15000
+                                        },
+                                        "label": "Your dashboard, once the first sync finishes"
+                                      },
+                                      {
                                         "id": "usage-highlight",
                                         "outline": {
                                           "elementClass": [
@@ -112261,6 +112810,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -112437,6 +112992,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -112613,6 +113174,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -112789,6 +113356,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -112965,6 +113538,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -113141,6 +113720,12 @@
                                                           "elementAria": {
                                                             "type": "string",
                                                             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                          },
+                                                          "timeout": {
+                                                            "type": "integer",
+                                                            "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                            "default": 5000,
+                                                            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                           }
                                                         }
                                                       },
@@ -113550,6 +114135,12 @@
                                                         "elementAria": {
                                                           "type": "string",
                                                           "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                        },
+                                                        "timeout": {
+                                                          "type": "integer",
+                                                          "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                          "default": 5000,
+                                                          "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                         }
                                                       }
                                                     },
@@ -113718,6 +114309,12 @@
                                                     "elementAria": {
                                                       "type": "string",
                                                       "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                    },
+                                                    "timeout": {
+                                                      "type": "integer",
+                                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                      "default": 5000,
+                                                      "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                     }
                                                   }
                                                 },
@@ -113875,6 +114472,12 @@
                                                 "elementAria": {
                                                   "type": "string",
                                                   "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+                                                },
+                                                "timeout": {
+                                                  "type": "integer",
+                                                  "description": "Max duration in milliseconds to wait for the element to exist.",
+                                                  "default": 5000,
+                                                  "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
                                                 }
                                               }
                                             },
@@ -114212,6 +114815,13 @@
                                             "transition": {
                                               "enter": "none"
                                             }
+                                          },
+                                          {
+                                            "callout": {
+                                              "elementTestId": "dashboard-loaded",
+                                              "timeout": 15000
+                                            },
+                                            "label": "Your dashboard, once the first sync finishes"
                                           },
                                           {
                                             "id": "usage-highlight",

--- a/src/common/src/schemas/src_schemas/annotation_v3.schema.json
+++ b/src/common/src/schemas/src_schemas/annotation_v3.schema.json
@@ -251,6 +251,12 @@
           "elementAria": {
             "type": "string",
             "description": "Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax."
+          },
+          "timeout": {
+            "type": "integer",
+            "description": "Max duration in milliseconds to wait for the element to exist.",
+            "default": 5000,
+            "$comment": "Kept identical to find_v3's timeout, deliberately: annotation targets resolve through the same findElement, so a different name, unit, or default here would be a difference without a distinction. NOT listed in target_element_guard — a deadline can't be the only thing identifying an element. The `default` is safe despite the no-defaults rule on the sibling `style` component: that rule protects annotationDefaults' config->spec->test cascade, and annotationDefaults_v3 spells its own properties out rather than referencing this shape. It's inert at runtime either way (Ajv ignores `default` inside anyOf, which is how every target is reached) and exists to document the 5000 ms wait on the generated reference page."
           }
         }
       },
@@ -499,6 +505,13 @@
       "transition": {
         "enter": "none"
       }
+    },
+    {
+      "callout": {
+        "elementTestId": "dashboard-loaded",
+        "timeout": 15000
+      },
+      "label": "Your dashboard, once the first sync finishes"
     },
     {
       "id": "usage-highlight",

--- a/src/common/src/types/generated/annotate_v3.ts
+++ b/src/common/src/types/generated/annotate_v3.ts
@@ -449,6 +449,10 @@ export interface ElementFindingFields {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -500,6 +504,10 @@ export interface ElementFindingFields1 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -551,6 +559,10 @@ export interface ElementFindingFields2 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -602,6 +614,10 @@ export interface ElementFindingFields3 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -653,6 +669,10 @@ export interface ElementFindingFields4 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -704,6 +724,10 @@ export interface ElementFindingFields5 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -900,6 +924,10 @@ export interface ElementFindingFields6 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -951,6 +979,10 @@ export interface ElementFindingFields7 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -1002,6 +1034,10 @@ export interface ElementFindingFields8 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -1053,6 +1089,10 @@ export interface ElementFindingFields9 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -1104,6 +1144,10 @@ export interface ElementFindingFields10 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -1155,6 +1199,10 @@ export interface ElementFindingFields11 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.

--- a/src/common/src/types/generated/annotation_v3.ts
+++ b/src/common/src/types/generated/annotation_v3.ts
@@ -252,6 +252,10 @@ export interface ElementFindingFields {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -303,6 +307,10 @@ export interface ElementFindingFields1 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -354,6 +362,10 @@ export interface ElementFindingFields2 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -405,6 +417,10 @@ export interface ElementFindingFields3 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -456,6 +472,10 @@ export interface ElementFindingFields4 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -507,6 +527,10 @@ export interface ElementFindingFields5 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.

--- a/src/common/src/types/generated/screenshot_v3.ts
+++ b/src/common/src/types/generated/screenshot_v3.ts
@@ -414,6 +414,10 @@ export interface ElementFindingFields {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -465,6 +469,10 @@ export interface ElementFindingFields1 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -516,6 +524,10 @@ export interface ElementFindingFields2 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -567,6 +579,10 @@ export interface ElementFindingFields3 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -618,6 +634,10 @@ export interface ElementFindingFields4 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -669,6 +689,10 @@ export interface ElementFindingFields5 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.

--- a/src/common/src/types/generated/step_v3.ts
+++ b/src/common/src/types/generated/step_v3.ts
@@ -4118,6 +4118,10 @@ export interface ElementFindingFields {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -4169,6 +4173,10 @@ export interface ElementFindingFields1 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -4220,6 +4228,10 @@ export interface ElementFindingFields2 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -4271,6 +4283,10 @@ export interface ElementFindingFields3 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -4322,6 +4338,10 @@ export interface ElementFindingFields4 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -4373,6 +4393,10 @@ export interface ElementFindingFields5 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -7195,6 +7219,10 @@ export interface ElementFindingFields6 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -7246,6 +7274,10 @@ export interface ElementFindingFields7 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -7297,6 +7329,10 @@ export interface ElementFindingFields8 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -7348,6 +7384,10 @@ export interface ElementFindingFields9 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -7399,6 +7439,10 @@ export interface ElementFindingFields10 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -7450,6 +7494,10 @@ export interface ElementFindingFields11 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -7646,6 +7694,10 @@ export interface ElementFindingFields12 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -7697,6 +7749,10 @@ export interface ElementFindingFields13 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -7748,6 +7804,10 @@ export interface ElementFindingFields14 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -7799,6 +7859,10 @@ export interface ElementFindingFields15 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -7850,6 +7914,10 @@ export interface ElementFindingFields16 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -7901,6 +7969,10 @@ export interface ElementFindingFields17 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.

--- a/src/common/src/types/generated/test_v3.ts
+++ b/src/common/src/types/generated/test_v3.ts
@@ -10108,6 +10108,10 @@ export interface ElementFindingFields {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -10159,6 +10163,10 @@ export interface ElementFindingFields1 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -10210,6 +10218,10 @@ export interface ElementFindingFields2 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -10261,6 +10273,10 @@ export interface ElementFindingFields3 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -10312,6 +10328,10 @@ export interface ElementFindingFields4 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -10363,6 +10383,10 @@ export interface ElementFindingFields5 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -13207,6 +13231,10 @@ export interface ElementFindingFields6 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -13258,6 +13286,10 @@ export interface ElementFindingFields7 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -13309,6 +13341,10 @@ export interface ElementFindingFields8 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -13360,6 +13396,10 @@ export interface ElementFindingFields9 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -13411,6 +13451,10 @@ export interface ElementFindingFields10 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -13462,6 +13506,10 @@ export interface ElementFindingFields11 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -13658,6 +13706,10 @@ export interface ElementFindingFields12 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -13709,6 +13761,10 @@ export interface ElementFindingFields13 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -13760,6 +13816,10 @@ export interface ElementFindingFields14 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -13811,6 +13871,10 @@ export interface ElementFindingFields15 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -13862,6 +13926,10 @@ export interface ElementFindingFields16 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -13913,6 +13981,10 @@ export interface ElementFindingFields17 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -16241,6 +16313,10 @@ export interface ElementFindingFields18 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -16292,6 +16368,10 @@ export interface ElementFindingFields19 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -16343,6 +16423,10 @@ export interface ElementFindingFields20 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -16394,6 +16478,10 @@ export interface ElementFindingFields21 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -16445,6 +16533,10 @@ export interface ElementFindingFields22 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -16496,6 +16588,10 @@ export interface ElementFindingFields23 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -19340,6 +19436,10 @@ export interface ElementFindingFields24 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -19391,6 +19491,10 @@ export interface ElementFindingFields25 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -19442,6 +19546,10 @@ export interface ElementFindingFields26 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -19493,6 +19601,10 @@ export interface ElementFindingFields27 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -19544,6 +19656,10 @@ export interface ElementFindingFields28 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -19595,6 +19711,10 @@ export interface ElementFindingFields29 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -19791,6 +19911,10 @@ export interface ElementFindingFields30 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -19842,6 +19966,10 @@ export interface ElementFindingFields31 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -19893,6 +20021,10 @@ export interface ElementFindingFields32 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -19944,6 +20076,10 @@ export interface ElementFindingFields33 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -19995,6 +20131,10 @@ export interface ElementFindingFields34 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.
@@ -20046,6 +20186,10 @@ export interface ElementFindingFields35 {
    * Computed accessible name of the element per ARIA specification. Supports exact match or regex pattern using /pattern/ syntax.
    */
   elementAria?: string;
+  /**
+   * Max duration in milliseconds to wait for the element to exist.
+   */
+  timeout?: number;
 }
 /**
  * A fixed spot in the capture, for annotations that aren't anchored to an element.

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -1429,6 +1429,26 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.object).to.deep.equal({ outline: "#a" });
       });
 
+      it("should not inject the target timeout default into an object target", function () {
+        // The string form above never enters target_element_shape, so it
+        // can't exercise the one `default` that shape carries. This does.
+        //
+        // `timeout` declares `"default": 5000` to document the wait on the
+        // generated reference page, and it stays inert only because Ajv skips
+        // defaults inside `anyOf` — which is how every target is reached. If
+        // that ever changed, every annotation target would silently gain a
+        // timeout it didn't ask for, and the runtime's own default (find's)
+        // would stop being the one in charge.
+        const result = validate({
+          schemaKey: "annotation_v3",
+          object: { outline: { selector: "#a" } },
+        });
+
+        expect(result.valid, result.errors).to.be.true;
+        expect(result.object).to.deep.equal({ outline: { selector: "#a" } });
+        expect(result.object.outline.timeout).to.equal(undefined);
+      });
+
       it("should validate a screenshot step with an annotations array", function () {
         const result = validate({
           schemaKey: "step_v3",

--- a/src/common/test/validate.test.js
+++ b/src/common/test/validate.test.js
@@ -1308,6 +1308,40 @@ import { validate, transformToSchemaKey } from "../dist/validate.js";
         expect(result.valid, result.errors).to.be.true;
       });
 
+      it("should validate an annotation_v3 target with a timeout", function () {
+        // Annotation targets resolve through the same findElement as `find`,
+        // so they take the same `timeout`. Without it every target polls for a
+        // hardcoded 5s and authors have to precede `annotate` with a guard
+        // `find` just to buy a longer wait.
+        const result = validate({
+          schemaKey: "annotation_v3",
+          object: { outline: { selector: "#slow-widget", timeout: 15000 } },
+        });
+
+        expect(result.valid, result.errors).to.be.true;
+        expect(result.object.outline.timeout).to.equal(15000);
+      });
+
+      it("should reject an annotation_v3 target whose only field is a timeout", function () {
+        // `timeout` is a deadline, not a way to find an element — it can't
+        // satisfy the at-least-one-element-finding-field guard on its own.
+        const result = validate({
+          schemaKey: "annotation_v3",
+          object: { outline: { timeout: 15000 } },
+        });
+
+        expect(result.valid).to.be.false;
+      });
+
+      it("should reject a non-integer annotation_v3 target timeout", function () {
+        const result = validate({
+          schemaKey: "annotation_v3",
+          object: { outline: { selector: "#a", timeout: "soon" } },
+        });
+
+        expect(result.valid).to.be.false;
+      });
+
       it("should validate an annotation_v3 object with a position target", function () {
         const named = validate({
           schemaKey: "annotation_v3",

--- a/src/core/annotations/geometry.ts
+++ b/src/core/annotations/geometry.ts
@@ -43,6 +43,7 @@ export {
   appCriteriaError,
   allTargetError,
   appWindowOrigin,
+  criteriaFromTarget,
   resolveAnnotationRects,
   APP_UNSUPPORTED_CRITERIA,
   APP_SUPPORTED_CRITERIA,
@@ -204,6 +205,15 @@ function allTargetError(
 
 // Turn an annotation target into the criteria object findElement expects.
 // A string target passes straight through as find's selector-or-text shorthand.
+//
+// `timeout` rides along with the finding fields rather than being handled
+// separately, because every consumer below already knows what to do with it:
+// findElement reads `step.find.timeout` on both its browser and app paths, and
+// findElementByCriteria takes it as a parameter. Leaving it out of this list
+// was the only reason annotation targets were pinned to the hardcoded 5000 ms
+// while `find` could ask for longer. Deliberately NOT defaulted here — the
+// number belongs to find, and a copy of it here would be a second thing to
+// keep in sync.
 function criteriaFromTarget(target: any): any {
   if (typeof target === "string") return target;
   return {
@@ -214,6 +224,7 @@ function criteriaFromTarget(target: any): any {
     elementClass: target?.elementClass,
     elementAttribute: target?.elementAttribute,
     elementAria: target?.elementAria,
+    timeout: target?.timeout,
   };
 }
 

--- a/src/hints/context.ts
+++ b/src/hints/context.ts
@@ -490,14 +490,40 @@ function emptyWalkData(): WalkData {
 export const ANNOTATION_TARGET_MISSING = /element to annotate/;
 
 /**
- * Whether any annotation in this step already asked for extra time.
+ * The annotation type keys, whose value is the annotation's target. Mirrors
+ * the `oneOf` branches in `annotation_v3.schema.json`; listed rather than
+ * inferred because the target has to be told apart from the sibling options
+ * (`label` is a string too, and a top-level `position` is placement, not a
+ * target). Drift degrades to silence — a new type the hint doesn't know about
+ * simply won't trigger it — which is the right failure mode for a hint.
+ */
+const ANNOTATION_TYPE_KEYS = [
+  "outline",
+  "arrow",
+  "badge",
+  "callout",
+  "blur",
+  "text",
+];
+
+/**
+ * Whether this step has an element target that could have waited longer.
+ *
+ * Requires BOTH that the step declares at least one element-anchored target
+ * and that none of them asked for extra time:
+ *
+ * - No element target at all (a `clear`-only step, or position-anchored
+ *   annotations) means there is nothing to put a `timeout` on. That case is
+ *   reachable — renderLayer re-resolves every surviving annotation on each
+ *   render, so a `clear` step can FAIL on an annotation some earlier step
+ *   added, which may already carry a `timeout` of its own.
+ * - One target already carrying a `timeout` is enough to stay quiet: the
+ *   author knows the field exists, and which target needed it is their call.
  *
  * Covers both surfaces the field lives on: an `annotate` step's `add`/`update`
- * entries, and a screenshot's own `annotations`. One target carrying a
- * `timeout` is enough to stay quiet — the author knows the field exists, and
- * which target needed it is their call, not a hint's.
+ * entries, and a screenshot's own `annotations`.
  */
-function annotationTargetsAskForTime(step: any): boolean {
+function annotationTargetCouldWaitLonger(step: any): boolean {
   const annotations = [
     ...(Array.isArray(step?.annotate?.add) ? step.annotate.add : []),
     ...(Array.isArray(step?.annotate?.update) ? step.annotate.update : []),
@@ -505,14 +531,26 @@ function annotationTargetsAskForTime(step: any): boolean {
       ? step.screenshot.annotations
       : []),
   ];
-  return annotations.some((annotation: any) =>
-    // The target is the value of whichever type key the annotation names, so
-    // scan the values rather than hardcoding the six type names — a new
-    // annotation type shouldn't silently start producing a wrong hint.
-    Object.values(annotation ?? {}).some(
-      (value: any) => typeof value?.timeout === "number"
-    )
-  );
+
+  let sawElementTarget = false;
+  for (const annotation of annotations) {
+    for (const key of ANNOTATION_TYPE_KEYS) {
+      const target = annotation?.[key];
+      if (target === undefined) continue;
+      // The selector-or-text shorthand is element-anchored but has nowhere to
+      // put a timeout — exactly the case worth teaching.
+      if (typeof target === "string") {
+        sawElementTarget = true;
+        continue;
+      }
+      if (!target || typeof target !== "object") continue;
+      // A position target resolves without a driver, so waiting is meaningless.
+      if (target.position !== undefined) continue;
+      if (typeof target.timeout === "number") return false;
+      sawElementTarget = true;
+    }
+  }
+  return sawElementTarget;
 }
 
 // The step keys whose actions route through the active-surface resolver
@@ -709,16 +747,16 @@ function inspectStep(step: any, data: WalkData): void {
   }
 
   // A step that FAILed because an annotation's target was never found, where
-  // no target asked for extra time. Gated on the resolution message rather
-  // than "an annotate step FAILed": the other failure modes (an invalid
-  // payload, updating an id that isn't on screen) have nothing to do with
-  // waiting, and a timeout suggestion there is noise. Powers
-  // `setAnnotationTimeout`.
+  // the step has an element target that could have waited longer. Gated on
+  // the resolution message rather than "an annotate step FAILed": the other
+  // failure modes (an invalid payload, updating an id that isn't on screen)
+  // have nothing to do with waiting, and a timeout suggestion there is noise.
+  // Powers `setAnnotationTimeout`.
   if (
     step.result === "FAIL" &&
     typeof step.resultDescription === "string" &&
     ANNOTATION_TARGET_MISSING.test(step.resultDescription) &&
-    !annotationTargetsAskForTime(step)
+    annotationTargetCouldWaitLonger(step)
   ) {
     data.failedAnnotationTargetWithoutTimeout = true;
   }

--- a/src/hints/context.ts
+++ b/src/hints/context.ts
@@ -149,6 +149,8 @@ export async function buildHintContext(
     usedRetry: walkData.usedRetry,
     failedTransientRequest: walkData.failedTransientRequest,
     failedRunShellWithoutShell: walkData.failedRunShellWithoutShell,
+    failedAnnotationTargetWithoutTimeout:
+      walkData.failedAnnotationTargetWithoutTimeout,
     ranIosContexts: walkData.ranIosContexts,
     viewportFloored: walkData.viewportFloored,
     ranMobileContexts: walkData.ranMobileContexts,
@@ -405,6 +407,11 @@ interface WalkData {
   usedRetry: boolean;
   failedTransientRequest: boolean;
   failedRunShellWithoutShell: boolean;
+  // True when a step FAILed specifically because an annotation's target
+  // couldn't be found, and no target in that step asked for extra time. The
+  // fix is a `timeout` on the target (ADR 01085). Powers
+  // `setAnnotationTimeout`.
+  failedAnnotationTargetWithoutTimeout: boolean;
   ranIosContexts: boolean;
   hasStaleRecordings: boolean;
   viewportFloored: boolean;
@@ -460,6 +467,7 @@ function emptyWalkData(): WalkData {
     usedRetry: false,
     failedTransientRequest: false,
     failedRunShellWithoutShell: false,
+    failedAnnotationTargetWithoutTimeout: false,
     ranIosContexts: false,
     hasStaleRecordings: false,
     viewportFloored: false,
@@ -467,6 +475,44 @@ function emptyWalkData(): WalkData {
     repeatedAppSurfaceRefs: false,
     appSurfaceRefCounts: new Map(),
   };
+}
+
+/**
+ * Matches the runner's "target didn't resolve" annotation failures — both the
+ * single-element form ("the element to annotate") and the `all` form ("any
+ * element to annotate"). Mirrors the messages in
+ * `src/core/annotations/geometry.ts`; matched on text rather than imported so
+ * `hints/` stays free of the core module graph, the same trade the viewport
+ * tolerance and surface-key list above make. Exported so `test/hints.test.js`
+ * can drive a real resolution failure through geometry and assert the message
+ * still matches — a reword there would otherwise silence the hint quietly.
+ */
+export const ANNOTATION_TARGET_MISSING = /element to annotate/;
+
+/**
+ * Whether any annotation in this step already asked for extra time.
+ *
+ * Covers both surfaces the field lives on: an `annotate` step's `add`/`update`
+ * entries, and a screenshot's own `annotations`. One target carrying a
+ * `timeout` is enough to stay quiet — the author knows the field exists, and
+ * which target needed it is their call, not a hint's.
+ */
+function annotationTargetsAskForTime(step: any): boolean {
+  const annotations = [
+    ...(Array.isArray(step?.annotate?.add) ? step.annotate.add : []),
+    ...(Array.isArray(step?.annotate?.update) ? step.annotate.update : []),
+    ...(Array.isArray(step?.screenshot?.annotations)
+      ? step.screenshot.annotations
+      : []),
+  ];
+  return annotations.some((annotation: any) =>
+    // The target is the value of whichever type key the annotation names, so
+    // scan the values rather than hardcoding the six type names — a new
+    // annotation type shouldn't silently start producing a wrong hint.
+    Object.values(annotation ?? {}).some(
+      (value: any) => typeof value?.timeout === "number"
+    )
+  );
 }
 
 // The step keys whose actions route through the active-surface resolver
@@ -660,6 +706,21 @@ function inspectStep(step: any, data: WalkData): void {
     typeof step.runShell?.shell !== "string"
   ) {
     data.failedRunShellWithoutShell = true;
+  }
+
+  // A step that FAILed because an annotation's target was never found, where
+  // no target asked for extra time. Gated on the resolution message rather
+  // than "an annotate step FAILed": the other failure modes (an invalid
+  // payload, updating an id that isn't on screen) have nothing to do with
+  // waiting, and a timeout suggestion there is noise. Powers
+  // `setAnnotationTimeout`.
+  if (
+    step.result === "FAIL" &&
+    typeof step.resultDescription === "string" &&
+    ANNOTATION_TARGET_MISSING.test(step.resultDescription) &&
+    !annotationTargetsAskForTime(step)
+  ) {
+    data.failedAnnotationTargetWithoutTimeout = true;
   }
 
   // runShell command sniffing.

--- a/src/hints/hints.ts
+++ b/src/hints/hints.ts
@@ -359,6 +359,26 @@ export const HINTS: Hint[] = [
   },
 
   // ------------------------------------------------------------------
+  // setAnnotationTimeout (current-run problems)
+  // ------------------------------------------------------------------
+  {
+    id: "setAnnotationTimeout",
+    priority: 20,
+    markdown: [
+      "An annotation's target wasn't on the page yet. Element targets wait 5 seconds by default — give a slower one more time with `timeout`, the same field `find` takes:",
+      "",
+      "```json",
+      '{ "annotate": { "add": [{ "callout": { "selector": "#dashboard", "timeout": 20000 }, "label": "Your data" }] } }',
+      "```",
+      "",
+      "It works the same on a screenshot's own `annotations`, and it needs the object form of the target — the string shorthand has nowhere to put it.",
+      "",
+      "More: [annotate](https://doc-detective.com/docs/actions/annotate)",
+    ].join("\n"),
+    when: (ctx) => ctx.failedAnnotationTargetWithoutTimeout === true,
+  },
+
+  // ------------------------------------------------------------------
   // setConcurrentRunners (optimization & advanced)
   // ------------------------------------------------------------------
   {

--- a/src/hints/types.ts
+++ b/src/hints/types.ts
@@ -208,6 +208,14 @@ export interface HintContext {
    */
   failedRunShellWithoutShell: boolean;
   /**
+   * True if any step FAILed specifically because an annotation's target
+   * couldn't be found, and no annotation in that step asked for extra time
+   * with `timeout`. Powers `setAnnotationTimeout`. Covers both surfaces the
+   * field lives on — an `annotate` step and a screenshot's own `annotations`.
+   * Sourced from the `walkResults` step pass.
+   */
+  failedAnnotationTargetWithoutTimeout: boolean;
+  /**
    * True if any context in this run resolved to an iOS device
    * (`context.device.platform === "ios"`). Powers `prebuildWebDriverAgent`.
    * Sourced from the `walkResults` context pass.

--- a/test/annotate-step.test.js
+++ b/test/annotate-step.test.js
@@ -183,6 +183,46 @@ describe("annotate step", function () {
     assert.match(result.description, /No annotation with id "nope"/);
   });
 
+  it("FAILs on a target that never appears, on the deadline the target asked for", async function () {
+    // A `timeout` buys a longer wait; it doesn't turn a missing element into a
+    // pass. The failure message is unchanged — only when it arrives is now the
+    // author's to set. This lives in mocha rather than a fixture because a
+    // fixture may never FAIL.
+    const driver = {
+      state: {},
+      async $$() {
+        return [];
+      },
+      async execute(fn) {
+        if (String(fn).includes("innerWidth"))
+          return { width: 800, height: 600 };
+        return undefined;
+      },
+    };
+
+    const started = Date.now();
+    const result = await annotate({
+      config: {},
+      step: {
+        annotate: {
+          add: [{ blur: { selector: ".never-appears", timeout: 300 }, all: true }],
+        },
+      },
+      driver,
+    });
+    const elapsed = Date.now() - started;
+
+    assert.equal(result.status, "FAIL");
+    assert.match(result.description, /Couldn't resolve every annotation target/);
+    assert.ok(
+      elapsed < 2500,
+      `expected the 300ms timeout to bound the failure, took ${elapsed}ms`
+    );
+    // A failed resolve leaves the stored set untouched, so a later step isn't
+    // rendering against a half-applied payload.
+    assert.deepEqual(driver.state.annotations, []);
+  });
+
   it("gives every match of an `all` annotation its own render id", async function () {
     // One stored annotation with `all: true` expands to one placed item per
     // match. If they shared an id the page's querySelector would only ever

--- a/test/annotations-geometry.test.js
+++ b/test/annotations-geometry.test.js
@@ -6,6 +6,8 @@ import {
   appWindowOrigin,
   APP_UNSUPPORTED_CRITERIA,
   appCriteriaError,
+  criteriaFromTarget,
+  resolveAnnotationRects,
 } from "../dist/core/annotations/geometry.js";
 
 describe("annotations/geometry", function () {
@@ -212,6 +214,66 @@ describe("annotations/geometry", function () {
       assert.equal(
         allTargetError({ elementText: "Account ID" }, false, true),
         null
+      );
+    });
+  });
+
+  describe("target timeout", function () {
+    // Annotation targets resolve through the same findElement as `find`, so
+    // they take the same `timeout`. The only thing that used to stop it
+    // working was criteriaFromTarget's field whitelist dropping it, which
+    // pinned every target to findElementByCriteria's hardcoded 5000 ms.
+
+    it("carries a target's timeout into the find criteria", function () {
+      assert.equal(
+        criteriaFromTarget({ selector: "#slow", timeout: 15000 }).timeout,
+        15000
+      );
+    });
+
+    it("leaves the timeout unset when the target omits it, so find applies its own default", function () {
+      // Not defaulted to 5000 here: the number lives in one place (find), and
+      // duplicating it would be a second thing to keep in sync.
+      assert.equal(criteriaFromTarget({ selector: "#fast" }).timeout, undefined);
+    });
+
+    it("passes a string target through untouched", function () {
+      // The selector-or-text shorthand can't carry a timeout, exactly as
+      // find's own string form can't.
+      assert.equal(criteriaFromTarget("#submit"), "#submit");
+    });
+
+    it("honors the target's timeout when resolving an `all` target", async function () {
+      // End-to-end through the real findElementByCriteria against a driver
+      // that never matches: the deadline the target asks for is the deadline
+      // the poll actually uses. Before this field existed the call fell back
+      // to the hardcoded 5000 ms, so a short timeout here is what proves the
+      // value is threaded rather than ignored.
+      const driver = {
+        async $$() {
+          return [];
+        },
+      };
+      const started = Date.now();
+      const { placed, errors } = await resolveAnnotationRects({
+        config: {},
+        annotations: [
+          { type: "blur", target: { selector: ".nope", timeout: 300 }, all: true },
+        ],
+        driver,
+        canvas: { width: 800, height: 600 },
+        scale: 1,
+      });
+      const elapsed = Date.now() - started;
+
+      assert.equal(placed.length, 0);
+      assert.equal(errors.length, 1);
+      assert.match(errors[0], /Couldn't find any element to annotate/);
+      // Generous upper bound — the point is 300 ms rather than 5000 ms, not
+      // millisecond accuracy on a loaded CI runner.
+      assert.ok(
+        elapsed < 2500,
+        `expected the 300ms timeout to be honored, took ${elapsed}ms`
       );
     });
   });

--- a/test/core-artifacts/capture/screenshot-annotations.spec.json
+++ b/test/core-artifacts/capture/screenshot-annotations.spec.json
@@ -431,6 +431,48 @@
           }
         }
       ]
+    },
+    {
+      "testId": "annotations-target-timeout",
+      "description": "`timeout` on an annotation's element target (ADR 01085). Screenshot annotations resolve their targets through the same code as an `annotate` step, so they take the same field — closing the gap for one and not the other would have traded one asymmetry for another. Both targets here appear at 6500 ms, past the 5000 ms default, so a permutation that dropped its `timeout` would FAIL rather than pass anyway. The annotate-step half lives in recording/annotate-timeout.spec.json.",
+      "steps": [
+        {
+          "goTo": "http://localhost:8092/annotate-late-element.html"
+        },
+        {
+          "stepId": "annotation-late-single",
+          "screenshot": {
+            "path": "annotation-late-single.png",
+            "directory": "static/images",
+            "overwrite": "true",
+            "annotations": [
+              {
+                "outline": {
+                  "elementTestId": "late-panel",
+                  "timeout": 20000
+                }
+              }
+            ]
+          }
+        },
+        {
+          "stepId": "annotation-late-redaction",
+          "screenshot": {
+            "path": "annotation-late-redaction.png",
+            "directory": "static/images",
+            "overwrite": "true",
+            "annotations": [
+              {
+                "blur": {
+                  "selector": ".late-secret",
+                  "timeout": 20000
+                },
+                "all": true
+              }
+            ]
+          }
+        }
+      ]
     }
   ]
 }

--- a/test/core-artifacts/recording/annotate-timeout.spec.json
+++ b/test/core-artifacts/recording/annotate-timeout.spec.json
@@ -1,0 +1,117 @@
+{
+  "specId": "annotate-timeout",
+  "description": "`timeout` on an annotation's element target (ADR 01085). Annotation targets resolve through the same findElement as `find`, so they take the same `timeout`; before it was threaded through, every target was pinned to a hardcoded 5000 ms and authors had to precede `annotate` with a guard `find` just to buy a longer wait. Every target here lives on annotate-late-element.html and appears at 6500 ms — deliberately past that default, so a permutation that dropped its `timeout` would FAIL rather than pass anyway. These permutations assert resolution, not visible output, so unlike annotate.spec.json they need no display and run headless everywhere. The FAIL path (a target that never appears) is pinned in test/annotate-step.test.js, since a spec can't assert FAIL. The screenshot-annotation half of the same field lives in capture/screenshot-annotations.spec.json.",
+  "tests": [
+    {
+      "testId": "annotate-timeout-omitted",
+      "description": "Control: a target that's present at load, with no `timeout`. Find applies its own default, exactly as before — the new field is opt-in and changes nothing when unset.",
+      "steps": [
+        {
+          "goTo": "http://localhost:8092/annotate-late-element.html"
+        },
+        {
+          "stepId": "annotate-default-timeout",
+          "annotate": {
+            "add": [
+              {
+                "id": "instant",
+                "outline": {
+                  "selector": "#instant-target"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "testId": "annotate-timeout-single-element",
+      "description": "The permutation the feature exists for: annotate an element that appears at 6500 ms, with no guard `find` in front of it. The 20000 ms `timeout` is what makes this resolve — on the old hardcoded 5000 ms the target isn't in the DOM yet and the step FAILs.",
+      "steps": [
+        {
+          "goTo": "http://localhost:8092/annotate-late-element.html"
+        },
+        {
+          "stepId": "annotate-late-target",
+          "annotate": {
+            "add": [
+              {
+                "id": "late-callout",
+                "callout": {
+                  "elementTestId": "late-panel",
+                  "timeout": 20000
+                },
+                "label": "Appears once the first sync finishes"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "testId": "annotate-timeout-all-matches",
+      "description": "`all: true` takes a different code path — it reaches findElementByCriteria directly instead of going through findElement — so it needs its own permutation. Redacting only some of the late `.late-secret` elements because the rest hadn't rendered would be a disclosure, not a cosmetic miss.",
+      "steps": [
+        {
+          "goTo": "http://localhost:8092/annotate-late-element.html"
+        },
+        {
+          "stepId": "annotate-late-redaction",
+          "annotate": {
+            "add": [
+              {
+                "id": "redact-late-secrets",
+                "blur": {
+                  "selector": ".late-secret",
+                  "timeout": 20000
+                },
+                "all": true,
+                "transition": {
+                  "enter": "none"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "testId": "annotate-timeout-on-update",
+      "description": "`update` re-resolves its target, so it needs a `timeout` of its own. Here the annotation starts on an element present at load and is then repointed at one that doesn't appear until 8000 ms.",
+      "steps": [
+        {
+          "goTo": "http://localhost:8092/annotate-late-element.html"
+        },
+        {
+          "stepId": "annotate-update-seed",
+          "annotate": {
+            "add": [
+              {
+                "id": "wandering",
+                "badge": {
+                  "selector": "#instant-target"
+                },
+                "label": "1"
+              }
+            ]
+          }
+        },
+        {
+          "stepId": "annotate-update-late",
+          "annotate": {
+            "update": [
+              {
+                "id": "wandering",
+                "badge": {
+                  "selector": "#late-second",
+                  "timeout": 20000
+                },
+                "label": "2"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/core-artifacts/recording/annotate.spec.json
+++ b/test/core-artifacts/recording/annotate.spec.json
@@ -359,7 +359,7 @@
           }
         },
         {
-          "description": "Not a guard — this `find` is what scrolls the page, which is the thing being tested. Its default moveTo brings #contact-email into view, and the tracked outline has to follow #submit-button as it moves.",
+          "description": "Kept rather than folded into a target `timeout`: it advances the page past the annotated element, which is what the tracking loop is here to survive. Note it does NOT scroll — findElement applies `moveTo: step.find.moveTo || false`, and find_v3's `\"default\": true` is inert because Ajv skips defaults inside anyOf. Add an explicit `moveTo: true` if this test should assert scroll-tracking rather than just re-anchoring.",
           "find": {
             "selector": "#contact-email"
           }

--- a/test/core-artifacts/recording/annotate.spec.json
+++ b/test/core-artifacts/recording/annotate.spec.json
@@ -1,6 +1,6 @@
 {
   "specId": "annotate",
-  "description": "The annotate step: annotations drawn into the page, so they persist across steps and appear in recordings. Unlike screenshot annotations (composited into one image), these need a live browser, so the permutations that assert visible behavior are gated to headed Chrome on Windows/macOS like the rest of this bundle; headless Linux lands them SKIPPED, which passes the gate. FAIL paths (updating an absent id, an invalid payload) and the no-browser SKIP are pinned in test/annotate-step.test.js, since a spec can't assert FAIL.",
+  "description": "The annotate step: annotations drawn into the page, so they persist across steps and appear in recordings. Unlike screenshot annotations (composited into one image), these need a live browser, so the permutations that assert visible behavior are gated to headed Chrome on Windows/macOS like the rest of this bundle; headless Linux lands them SKIPPED, which passes the gate. FAIL paths (updating an absent id, an invalid payload) and the no-browser SKIP are pinned in test/annotate-step.test.js, since a spec can't assert FAIL. Element targets carry `timeout: 20000` (ADR 01085) because these tests reuse a browser context that recording has made slow — on a cold headed CI runner, notably Windows, the default 5s can lapse before the page is queryable. That `timeout` replaced a guard `find` in front of every element-targeting annotate, which existed only to buy the wait the target can now ask for itself; the `click` and the scroll-inducing `find` that remain are doing real work.",
   "tests": [
     {
       "testId": "annotate-lifecycle-in-recording",
@@ -22,13 +22,6 @@
           "goTo": "http://localhost:8092/enhanced-elements.html"
         },
         {
-          "description": "Guard every annotation target with a preceding `find`. `annotate` resolves its target once with no polling, so on a slow headed browser (notably Windows CI) a bare goTo/navigation can hand off before the element is queryable and the annotate FAILs; `find` waits for the element, closing that race. Every element-targeting `annotate` in this spec (including `update` and each transition, which re-target new elements) is paired with a matching `find` for the same target. The first find after each navigation carries a generous `timeout` because later tests reuse a browser context that recording has made slow — the default 5s can lapse before the page is queryable on a cold CI runner.",
-          "find": {
-            "selector": "#username-input",
-            "timeout": 20000
-          }
-        },
-        {
           "record": {
             "path": "annotate-lifecycle.webm",
             "overwrite": "true"
@@ -40,12 +33,18 @@
             "add": [
               {
                 "id": "step-counter",
-                "badge": "#username-input",
+                "badge": {
+                  "selector": "#username-input",
+                  "timeout": 20000
+                },
                 "label": "1"
               },
               {
                 "id": "guide",
-                "callout": "#username-input",
+                "callout": {
+                  "selector": "#username-input",
+                  "timeout": 20000
+                },
                 "label": "Enter your username first",
                 "position": "right",
                 "track": true
@@ -57,23 +56,24 @@
           "click": "#username-input"
         },
         {
-          "find": {
-            "selector": "#submit-button"
-          }
-        },
-        {
           "stepId": "annotate-update",
-          "description": "Move the same annotations to the next control by id.",
+          "description": "Move the same annotations to the next control by id. `update` re-resolves its target, so it carries its own timeout.",
           "annotate": {
             "update": [
               {
                 "id": "step-counter",
-                "badge": "#submit-button",
+                "badge": {
+                  "selector": "#submit-button",
+                  "timeout": 20000
+                },
                 "label": "2"
               },
               {
                 "id": "guide",
-                "callout": "#submit-button",
+                "callout": {
+                  "selector": "#submit-button",
+                  "timeout": 20000
+                },
                 "label": "Then submit",
                 "position": "right",
                 "track": true
@@ -120,17 +120,14 @@
           "goTo": "http://localhost:8092/enhanced-elements.html"
         },
         {
-          "find": {
-            "selector": "#submit-button",
-            "timeout": 20000
-          }
-        },
-        {
           "annotate": {
             "add": [
               {
                 "id": "persist",
-                "outline": "#submit-button"
+                "outline": {
+                  "selector": "#submit-button",
+                  "timeout": 20000
+                }
               }
             ]
           }
@@ -221,18 +218,15 @@
           "goTo": "http://localhost:8092/enhanced-elements.html"
         },
         {
-          "find": {
-            "selector": "#username-input",
-            "timeout": 20000
-          }
-        },
-        {
           "stepId": "annotate-transition-fade",
           "annotate": {
             "add": [
               {
                 "id": "t-fade",
-                "outline": "#username-input",
+                "outline": {
+                  "selector": "#username-input",
+                  "timeout": 20000
+                },
                 "transition": {
                   "enter": "fade",
                   "durationMs": 300
@@ -242,17 +236,15 @@
           }
         },
         {
-          "find": {
-            "selector": "#submit-button"
-          }
-        },
-        {
           "stepId": "annotate-transition-pop",
           "annotate": {
             "add": [
               {
                 "id": "t-pop",
-                "badge": "#submit-button",
+                "badge": {
+                  "selector": "#submit-button",
+                  "timeout": 20000
+                },
                 "label": "1",
                 "transition": {
                   "enter": "pop",
@@ -263,18 +255,14 @@
           }
         },
         {
-          "find": {
-            "elementTestId": "password-field"
-          }
-        },
-        {
           "stepId": "annotate-transition-draw",
           "annotate": {
             "add": [
               {
                 "id": "t-draw",
                 "outline": {
-                  "elementTestId": "password-field"
+                  "elementTestId": "password-field",
+                  "timeout": 20000
                 },
                 "transition": {
                   "enter": "draw",
@@ -285,18 +273,16 @@
           }
         },
         {
-          "find": {
-            "selector": "#contact-email"
-          }
-        },
-        {
           "stepId": "annotate-transition-none",
           "description": "A blur must never fade in — that would show the sensitive content while it animates.",
           "annotate": {
             "add": [
               {
                 "id": "t-none",
-                "blur": "#contact-email",
+                "blur": {
+                  "selector": "#contact-email",
+                  "timeout": 20000
+                },
                 "transition": {
                   "enter": "none"
                 }
@@ -305,17 +291,15 @@
           }
         },
         {
-          "find": {
-            "selector": "#primary-action"
-          }
-        },
-        {
           "stepId": "annotate-duration",
           "annotate": {
             "add": [
               {
                 "id": "t-timed",
-                "outline": "#primary-action",
+                "outline": {
+                  "selector": "#primary-action",
+                  "timeout": 20000
+                },
                 "duration": 800
               }
             ]
@@ -360,24 +344,22 @@
           "goTo": "http://localhost:8092/enhanced-elements.html"
         },
         {
-          "find": {
-            "selector": "#submit-button",
-            "timeout": 20000
-          }
-        },
-        {
           "stepId": "annotate-tracked",
           "annotate": {
             "add": [
               {
                 "id": "tracked",
-                "outline": "#submit-button",
+                "outline": {
+                  "selector": "#submit-button",
+                  "timeout": 20000
+                },
                 "track": true
               }
             ]
           }
         },
         {
+          "description": "Not a guard — this `find` is what scrolls the page, which is the thing being tested. Its default moveTo brings #contact-email into view, and the tracked outline has to follow #submit-button as it moves.",
           "find": {
             "selector": "#contact-email"
           }
@@ -412,19 +394,14 @@
           "goTo": "http://localhost:8092/enhanced-elements.html"
         },
         {
-          "find": {
-            "selector": ".form-control",
-            "timeout": 20000
-          }
-        },
-        {
           "stepId": "annotate-redact-all",
           "annotate": {
             "add": [
               {
                 "id": "redact",
                 "blur": {
-                  "selector": ".form-control"
+                  "selector": ".form-control",
+                  "timeout": 20000
                 },
                 "all": true,
                 "track": true,

--- a/test/hints.test.js
+++ b/test/hints.test.js
@@ -991,6 +991,50 @@ describe("hints/context", function () {
         ] }] }] }],
       });
       expect(passed.failedAnnotationTargetWithoutTimeout).to.equal(false);
+
+      // A `clear`-only step can FAIL with this message: renderLayer
+      // re-resolves every SURVIVING annotation on each render, so an
+      // annotation an earlier step added can go missing here. There's no
+      // target in this step to put a timeout on, and the one that failed may
+      // already have had one -> stay quiet.
+      const clearOnly = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          {
+            annotate: { clear: ["b"] },
+            result: "FAIL",
+            resultDescription: missing,
+          },
+        ] }] }] }],
+      });
+      expect(clearOnly.failedAnnotationTargetWithoutTimeout).to.equal(false);
+
+      // Position-anchored annotations resolve without a driver, so waiting
+      // longer is meaningless -> stay quiet.
+      const positionOnly = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          {
+            annotate: {
+              add: [{ text: { position: "top-left" }, label: "Demo" }],
+            },
+            result: "FAIL",
+            resultDescription: missing,
+          },
+        ] }] }] }],
+      });
+      expect(positionOnly.failedAnnotationTargetWithoutTimeout).to.equal(false);
+
+      // A bare string target is element-anchored with nowhere to put a
+      // timeout — exactly the case worth teaching -> fire.
+      const stringTarget = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          {
+            annotate: { add: [{ outline: "#late" }] },
+            result: "FAIL",
+            resultDescription: missing,
+          },
+        ] }] }] }],
+      });
+      expect(stringTarget.failedAnnotationTargetWithoutTimeout).to.equal(true);
     });
   });
 

--- a/test/hints.test.js
+++ b/test/hints.test.js
@@ -20,8 +20,10 @@ import {
   runInvokesDocDetective,
   VIEWPORT_FLOOR_TOLERANCE_PX,
   SURFACE_SENSITIVE_HINT_KEYS,
+  ANNOTATION_TARGET_MISSING,
 } from "../dist/hints/context.js";
 import { SURFACE_SENSITIVE_STEP_KEYS } from "../dist/runtime/browserStepKeys.js";
+import { resolveAnnotationRects } from "../dist/core/annotations/geometry.js";
 import { maybeShowHint, pickByPriority, priorityWeight } from "../dist/hints/index.js";
 import { HINTS } from "../dist/hints/hints.js";
 import fs from "node:fs";
@@ -871,6 +873,124 @@ describe("hints/context", function () {
         ] }] }] }],
       });
       expect(other.failedRunShellWithoutShell).to.equal(false);
+    });
+
+    it("ANNOTATION_TARGET_MISSING still matches the messages geometry actually produces", async function () {
+      // The hint reads a message rather than importing from core, so a reword
+      // in geometry.ts would silence it with nothing failing. Drive both real
+      // failure shapes and assert the pattern still catches them.
+      const driver = {
+        async $$() {
+          return [];
+        },
+      };
+      const { errors: allErrors } = await resolveAnnotationRects({
+        config: {},
+        annotations: [
+          { type: "blur", target: { selector: ".nope", timeout: 50 }, all: true },
+        ],
+        driver,
+        canvas: { width: 800, height: 600 },
+        scale: 1,
+      });
+      expect(allErrors).to.have.lengthOf(1);
+      expect(ANNOTATION_TARGET_MISSING.test(allErrors[0])).to.equal(true);
+
+      // The single-element form goes through findElement, whose message
+      // differs ("the element" vs "any element") — both must match.
+      const { errors: singleErrors } = await resolveAnnotationRects({
+        config: {},
+        annotations: [
+          { type: "outline", target: { selector: ".nope", timeout: 50 } },
+        ],
+        driver,
+        canvas: { width: 800, height: 600 },
+        scale: 1,
+      });
+      expect(singleErrors).to.have.lengthOf(1);
+      expect(ANNOTATION_TARGET_MISSING.test(singleErrors[0])).to.equal(true);
+    });
+
+    it("failedAnnotationTargetWithoutTimeout is true only when an annotation target went missing and asked for no extra time", function () {
+      const missing =
+        'Couldn\'t resolve every annotation target. Couldn\'t find the element to annotate: {"elementTestId":"late-panel"}.';
+
+      // An annotate step whose target never resolved, with no timeout asked
+      // for -> the author can buy more time. True.
+      const annotateFailed = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          {
+            annotate: { add: [{ outline: { selector: "#late" } }] },
+            result: "FAIL",
+            resultDescription: missing,
+          },
+        ] }] }] }],
+      });
+      expect(annotateFailed.failedAnnotationTargetWithoutTimeout).to.equal(true);
+
+      // Same failure on a screenshot's own annotations — same field, same
+      // advice.
+      const screenshotFailed = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          {
+            screenshot: { path: "a.png", annotations: [{ blur: ".secret" }] },
+            result: "FAIL",
+            resultDescription: missing,
+          },
+        ] }] }] }],
+      });
+      expect(screenshotFailed.failedAnnotationTargetWithoutTimeout).to.equal(
+        true
+      );
+
+      // The author already set a timeout -> waiting longer is their call to
+      // make again, not something to teach. False.
+      const alreadyTimed = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          {
+            annotate: {
+              add: [{ outline: { selector: "#late", timeout: 20000 } }],
+            },
+            result: "FAIL",
+            resultDescription: missing,
+          },
+        ] }] }] }],
+      });
+      expect(alreadyTimed.failedAnnotationTargetWithoutTimeout).to.equal(false);
+
+      // An `update` target counts too — update re-resolves.
+      const updateFailed = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          {
+            annotate: { update: [{ id: "a", badge: { selector: "#late" } }] },
+            result: "FAIL",
+            resultDescription: missing,
+          },
+        ] }] }] }],
+      });
+      expect(updateFailed.failedAnnotationTargetWithoutTimeout).to.equal(true);
+
+      // An annotate step that FAILed for an unrelated reason -> a timeout
+      // wouldn't have helped, so suggesting one is noise. False.
+      const otherFailure = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          {
+            annotate: { update: [{ id: "nope", outline: "#a" }] },
+            result: "FAIL",
+            resultDescription:
+              'No annotation with id "nope" is on screen to update.',
+          },
+        ] }] }] }],
+      });
+      expect(otherFailure.failedAnnotationTargetWithoutTimeout).to.equal(false);
+
+      // A passing annotate step -> false.
+      const passed = walkResults({
+        specs: [{ tests: [{ contexts: [{ steps: [
+          { annotate: { add: [{ outline: "#a" }] }, result: "PASS" },
+        ] }] }] }],
+      });
+      expect(passed.failedAnnotationTargetWithoutTimeout).to.equal(false);
     });
   });
 
@@ -2502,6 +2622,23 @@ describe("hints/hints (registry)", function () {
         })
       )
     ).to.equal(false);
+  });
+
+  it("setAnnotationTimeout: fires when an annotation target went missing and asked for no extra time", function () {
+    const h = findHint("setAnnotationTimeout");
+    expect(h.priority).to.equal(20);
+    // Positive: a target never resolved and nothing asked to wait longer.
+    expect(
+      h.when(fakeCtx({ failedAnnotationTargetWithoutTimeout: true }))
+    ).to.equal(true);
+    // Negative: no such failure -> skip.
+    expect(
+      h.when(fakeCtx({ failedAnnotationTargetWithoutTimeout: false }))
+    ).to.equal(false);
+    // The payload has to name the field and show where it goes, or it isn't
+    // actionable.
+    expect(h.markdown).to.contain("timeout");
+    expect(h.markdown).to.contain("annotate");
   });
 
   it("useRunBrowserScriptStep: fires on browser + find when runBrowserScript isn't used", function () {

--- a/test/server/public/annotate-late-element.html
+++ b/test/server/public/annotate-late-element.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Late Element - Annotate Timeout Test</title>
+</head>
+<body>
+    <h1>Annotate Timeout Test</h1>
+    <p>Targets on this page appear well after an annotation's default 5000 ms wait.</p>
+
+    <!-- Present at load: the control for the "timeout omitted" permutation. -->
+    <div id="instant-target">Ready immediately</div>
+
+    <div id="container"></div>
+
+    <script>
+        // 6500 ms is deliberately PAST the 5000 ms default an annotation target
+        // falls back to. A shorter delay would let the fixture pass whether or
+        // not `timeout` is honored, which would prove nothing.
+        setTimeout(() => {
+            const container = document.getElementById('container');
+
+            const panel = document.createElement('div');
+            panel.id = 'late-panel';
+            panel.setAttribute('data-testid', 'late-panel');
+            panel.textContent = 'Dashboard';
+            container.appendChild(panel);
+
+            // Several matches, so `all: true` has more than one element to
+            // redact — the branch that reaches findElementByCriteria directly
+            // rather than going through findElement.
+            for (let i = 1; i <= 3; i++) {
+                const secret = document.createElement('div');
+                secret.className = 'late-secret';
+                secret.textContent = 'API key ' + i;
+                container.appendChild(secret);
+            }
+        }, 6500);
+
+        // A second late target, for the `update` permutation: the update has to
+        // re-resolve against an element that isn't there yet either.
+        setTimeout(() => {
+            const later = document.createElement('div');
+            later.id = 'late-second';
+            later.textContent = 'Billing';
+            document.getElementById('container').appendChild(later);
+        }, 8000);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Closes the `find`-vs-`annotate` asymmetry that #679 set out to document. **#679 is superseded by this and should be closed rather than merged.**

## Problem

Annotation targets already resolve through the same `findElement()` that `find`, `click`, `dragAndDrop`, and `goTo` use. But `criteriaFromTarget` in `src/core/annotations/geometry.ts` whitelisted seven fields and dropped `timeout` on the floor, so every target fell back to `findElementByCriteria`'s hardcoded 5000 ms. `find` could ask for longer; an annotation pointing at the *same element* could not.

That wasn't a decision — it was an omission in a field list. And we were already paying for it: `recording/annotate.spec.json` paired **every** element-targeting `annotate` with a guard `find` at `timeout: 20000`, plus a paragraph of prose explaining why.

#679's response was to document the gap and teach the guard-`find` workaround. This closes it instead.

## Change

`timeout` on `annotation_v3`'s element-target shape, worded identically to `find_v3`'s. Because `annotation_v3` is shared, screenshot `annotations` get it too — closing it for one surface and not the other would have traded one asymmetry for another.

```json
{ "annotate": { "add": [{ "callout": { "elementTestId": "dashboard", "timeout": 20000 }, "label": "Your data" }] } }
```

The runtime change is **one field**. `findElement` reads `step.find.timeout` on both its browser and app paths, and `findElementByCriteria` takes it as a parameter, so there's no second resolution path.

`timeout` is deliberately *not* in `target_element_guard` — `{"outline": {"timeout": 8000}}` stays invalid.

### Why not `$ref` find_v3's schema

Considered and rejected in the ADR, for three concrete reasons: `find_v3`'s detailed object bundles action fields (`click`, `moveTo`, `type`, `surface`) that an annotation must not accept; draft-07's `additionalProperties: false` doesn't compose through `allOf`; and dereferenced `find_v3` is 452 KB whose `FindElementDetailed` already generates as a collapsed `{[k: string]: unknown}` index signature, which would erase the real types annotation targets have today.

### Also included

A `setAnnotationTimeout` post-run hint, gated on the resolution message so the unrelated annotate failures (invalid payload, updating an absent id) stay quiet — verified both ways against real runner output.

The second commit deletes the ten guard `find` steps from `annotate.spec.json`. Kept separate so a regression in a historically flaky headed-CI fixture stays separable from the feature.

## ADR

`adrs/01085-configurable-timeout-for-annotation-targets.md` — four options weighed, with the per-render re-resolution cost and the pre-existing `timeout: 0` browser/app inconsistency recorded as limits.

## Docs impact

**Yes** — new user-facing field. Persona Wren (documentation engineer) capturing a walkthrough of a slow-loading app; fits existing pages, so no new page and no IA entry.

- `docs/actions/annotate.mdx`, `docs/actions/screenshot.mdx`, `docs/test-docs/annotate-screenshots.mdx`
- Reference pages regenerated via `npm run docs:build-schema-refs` (the `Default` column now reads `5000`)

## Verification

- Full mocha suite: **3992 passing, 0 failing**; `src/common` 378 passing, coverage ratchet 100% held
- New fixture `recording/annotate-timeout.spec.json` (4 permutations) + a screenshot-annotation permutation in `capture/screenshot-annotations.spec.json`, both against a page whose targets appear at 6500 ms — past the old default
- **Control run**: with every `timeout` stripped, 3 of the 4 permutations FAIL (`the element to annotate` and `any element to annotate`). The fixture genuinely exercises the field rather than passing either way.
- `annotate.spec.json` before/after: identical pass/fail profile locally, step count 45 → 35
- Inline doc tests pass for all three edited pages under `docs/.doc-detective.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Annotation targets (element-anchored) can now include a custom `timeout`, covering `annotate`, `all`, `update`, and screenshot annotations—especially for elements that appear late.
* **Documentation**
  * Updated annotate/screenshot docs and schema reference examples to describe the default 5s wait, longer waits via `timeout`, and the required object target format.
  * Added guidance to increase `timeout` when targets fail to appear in time.
* **Bug Fixes**
  * Target resolution now honors the configured timeout (and falls back to the existing default when omitted).
* **Tests**
  * Added fixtures and validation/geometry/hints coverage for annotation target timeouts and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->