### PR TITLE
fix(surfaces): honor timeout 0 and stop deleting unadjudicated surfaces

### DIFF
--- a/adrs/01087-non-destructive-surface-bookkeeping-and-zero-timeout.md
+++ b/adrs/01087-non-destructive-surface-bookkeeping-and-zero-timeout.md
@@ -1,0 +1,168 @@
+---
+status: accepted
+date: 2026-07-28
+decision-makers: hawkeyexl
+---
+
+# Non-destructive active-surface bookkeeping, and `timeout: 0` as an immediate check
+
+## Context and Problem Statement
+
+While auditing the active-surface routing layer (chasing the Windows
+`start-surface-parallel` failure tracked in
+[#696](https://github.com/doc-detective/doc-detective/issues/696)), three defects
+surfaced that are independent of that investigation. None was the cause of the
+Windows flake — that audit came back empty — but each is a real behavior bug or a
+latent one, and they share a theme: **state that is silently wrong is worse than
+state that fails loudly.**
+
+1. **`find: { timeout: 0 }` did not mean what it says on a browser surface.**
+   [`findElement.ts`](../src/core/tests/findElement.ts) defaulted with
+   `step.find.timeout || 5000`, so an explicit `0` — a valid schema value — was
+   clobbered to the 5-second default. The app path one screen above used
+   `?? 5000` with a comment stating that `timeout: 0` must stay an immediate
+   check. The same schema field therefore behaved differently depending on which
+   surface kind the step resolved to.
+
+   Fixing only the operator would have traded one wrong behavior for another:
+   both polling strategies in
+   [`findStrategies.ts`](../src/core/tests/findStrategies.ts) are
+   `while (Date.now() - startTime < timeout)`, so an honored `timeout: 0` would
+   have meant *never check at all* rather than *check once, now*.
+
+2. **`currentSurface` deleted live surfaces when a registry wasn't supplied.**
+   [`activeSurface.ts`](../src/core/tests/activeSurface.ts) prunes dead handles
+   lazily and writes the result back (`tracker.mru = live`) — closes need no
+   tracker bookkeeping, which is a good design. But `isLive` returns `false` both
+   for "this surface is gone" and for "you didn't give me the registry that would
+   tell me", and the prune is destructive. A caller that omitted a registry
+   permanently deleted that kind's live handles from shared per-context state,
+   breaking routing for every later step that *did* supply it.
+
+   All four call sites (`findElement`, `saveScreenshot`, `swipe`, `typeKeys`)
+   currently pass every registry, so nothing triggers this today. It is a trap
+   for the next call site, not an active bug.
+
+3. **A failed activation re-assert was silently discarded.**
+   [`startSurface.ts`](../src/core/tests/startSurface.ts) ignored
+   `activateSession`'s `false` return in the array form's authored-order
+   re-assert. A miss would leave `registry.activeName` pointing at the previous
+   session while the MRU tracker reported the new one — every later surface-less
+   step would act on the wrong browser, with no error anywhere. Not reachable
+   today (`openSession` registers under the name its outputs carry), so this is
+   defense against a future divergence rather than a fix for a live fault.
+
+## Decision Drivers
+
+* A schema field must mean the same thing regardless of which surface kind a step
+  resolves to.
+* Shared per-context state must not be corrupted by a caller that merely knows
+  less than another caller.
+* An internal inconsistency should produce a diagnosable error, not a silently
+  wrong run — the Windows investigation lost time precisely to a failure that
+  reported success at every step.
+* Changes must not alter behavior for the overwhelmingly common cases (positive
+  timeouts, callers that supply every registry).
+
+## Considered Options
+
+* **Fix all three, scoped so the common paths are untouched.**
+* **Fix only the `||` → `??` clobber.**
+* **Leave the latent defects (2 and 3) alone and document them.**
+* **Rework routing so there is a single source of truth for the active surface.**
+
+## Decision Outcome
+
+Chosen option: **fix all three, scoped so the common paths are untouched**,
+because each is cheap, independently testable, and reduces the class of failure
+that costs the most to debug — the silently wrong one.
+
+Concretely:
+
+1. `findElement` defaults the browser path with `?? 5000`, matching the app path;
+   and both polling strategies in `findStrategies` become `do { … } while (…)`,
+   so `timeout: 0` performs exactly one immediate check. For any positive
+   timeout the first iteration always ran, so nothing changes there.
+2. `currentSurface` prunes only handles whose registry the caller actually
+   supplied (`canAdjudicate`), and selects only among those. Unknown is no longer
+   treated as dead. The lazy-prune contract is preserved: when the registry *is*
+   supplied and the surface isn't in it, the handle is still dropped.
+3. The array-form re-assert checks `activateSession`'s return and, on a miss,
+   marks that descriptor `FAIL` with an explanatory message, which the existing
+   roll-up (`FAIL > SKIPPED > PASS`) surfaces on the step.
+
+Note that "two sources of truth for the active surface" was considered and
+**rejected as a mischaracterization**: `registry.activeName` answers *which
+browser session*, while the MRU tracker answers *which surface kind is active*.
+They are different questions, and ADR 01081's rule — an omitted `surface` acts on
+the most recently active surface of any kind, and a step whose action that kind
+can't perform fails with a capability error — depends on both. No rework there.
+
+### Consequences
+
+* Good, because `timeout: 0` now means the same thing on every surface kind, and
+  means something useful ("check once") rather than something degenerate.
+* Good, because a future `resolveTargetSurface` caller that forgets a registry
+  gets a step that can't route through that kind, instead of silently corrupting
+  routing for the rest of the context.
+* Good, because an activation miss becomes a message naming the surface.
+* Bad, because `timeout: 0` on a browser find changes from "waits 5s, probably
+  succeeds" to "checks once, probably fails". Any spec relying on the clobbered
+  default while writing `0` will now fail. That behavior was never documented and
+  contradicted the schema, so the exposure is judged negligible.
+* Neutral, because none of this affects the Windows `start-surface-parallel`
+  failure; that remains open in
+  [#696](https://github.com/doc-detective/doc-detective/issues/696).
+
+### Confirmation
+
+Three hermetic tests in
+[`test/active-surface.test.js`](../test/active-surface.test.js), each written
+red→green:
+
+* `timeout: 0` polls exactly once instead of spinning (was 47 polls over ~5s).
+* A handle survives a `currentSurface` call whose registry was not supplied, and
+  is still routable to a caller that does supply it.
+* A handle whose registry *is* supplied and reports it gone is still pruned —
+  guarding the lazy-prune contract against regression.
+
+## Pros and Cons of the Options
+
+### Fix all three, scoped
+
+* Good, because it removes a live inconsistency and two silent-failure traps in
+  one reviewable change.
+* Good, because every change is a no-op on the common path.
+* Bad, because it bundles one real bug with two defensive hardenings, which a
+  reviewer must evaluate on different evidence standards.
+
+### Fix only the `||` → `??` clobber
+
+* Good, because it is the only change backed by a demonstrated live bug.
+* Bad, because on its own it makes `timeout: 0` mean "never check", which is
+  worse than the bug it fixes.
+
+### Leave the latent defects alone and document them
+
+* Good, because it keeps unreachable-code changes out of the tree.
+* Bad, because both traps are one careless line away from becoming real, and both
+  fail silently — the most expensive failure mode, as #696 demonstrated.
+
+### Rework routing to a single source of truth
+
+* Good, because it would remove a whole category of divergence question.
+* Bad, because the premise is wrong: the two mechanisms answer different
+  questions, and collapsing them would break ADR 01081's cross-kind capability
+  errors.
+* Bad, because routing every surface-less browser step through `switchToSurface`
+  adds WebDriver round-trips and activation side effects to every step.
+
+## Documentation impact
+
+None. No user-facing surface is added, changed, or removed: no step type, action
+option, config or CLI flag, engine, output format, supported platform, or
+integration. The one observable change — `find: { timeout: 0 }` on a browser
+surface — brings the runtime into line with what
+[`find_v3.schema.json`](../src/common/src/schemas/src_schemas/find_v3.schema.json)
+already documents ("Max duration in milliseconds to wait for the element to
+exist", default `5000`), so the reference stays accurate as written.

--- a/adrs/01087-non-destructive-surface-bookkeeping-and-zero-timeout.md
+++ b/adrs/01087-non-destructive-surface-bookkeeping-and-zero-timeout.md
@@ -139,6 +139,11 @@ red→green:
   is still routable to a caller that does supply it.
 * A handle whose registry *is* supplied and reports it gone is still pruned —
   guarding the lazy-prune contract against regression.
+* An array-form `startSurface` whose opened session can't be resolved by name
+  FAILs that descriptor and names the surface, instead of silently leaving the
+  previous session active. Verified red with the guard removed. A companion case
+  asserts a healthy open still PASSes and becomes active, so the guard can't fire
+  on the normal path.
 
 ## Pros and Cons of the Options
 

--- a/adrs/01087-non-destructive-surface-bookkeeping-and-zero-timeout.md
+++ b/adrs/01087-non-destructive-surface-bookkeeping-and-zero-timeout.md
@@ -128,9 +128,13 @@ Three hermetic tests in
 red→green:
 
 * `timeout: 0` polls exactly once instead of spinning (was 47 polls over ~5s),
-  **and returns promptly** rather than sleeping a poll interval first. The test
-  asserts both the poll count and elapsed time, because the count alone passed
-  while the call still took ~870ms.
+  **and schedules no poll-interval sleep** before returning. The test asserts
+  both, because the poll count alone passed while the call still took ~870ms.
+
+  The sleep assertion observes `setTimeout` rather than measuring elapsed wall
+  time. A duration threshold is the wrong instrument here: it is flaky on a
+  loaded runner, and "did it schedule a sleep" is the actual contract. Verified
+  to fail (`slept 100ms`) with any one of the three guards removed.
 * A handle survives a `currentSurface` call whose registry was not supplied, and
   is still routable to a caller that does supply it.
 * A handle whose registry *is* supplied and reports it gone is still pruned —

--- a/adrs/01087-non-destructive-surface-bookkeeping-and-zero-timeout.md
+++ b/adrs/01087-non-destructive-surface-bookkeeping-and-zero-timeout.md
@@ -83,6 +83,13 @@ Concretely:
    and both polling strategies in `findStrategies` become `do { … } while (…)`,
    so `timeout: 0` performs exactly one immediate check. For any positive
    timeout the first iteration always ran, so nothing changes there.
+
+   The loop shape alone is not sufficient: every sleep site must also be guarded
+   by the deadline. A `do/while` that sleeps the poll interval *before*
+   re-evaluating its condition still turns "now" into "in 100ms", so each of the
+   three sleep sites (including the empty-candidate `continue` path) returns
+   early when the budget is already spent. A positive timeout that expires now
+   also skips one final pointless sleep before giving up.
 2. `currentSurface` prunes only handles whose registry the caller actually
    supplied (`canAdjudicate`), and selects only among those. Unknown is no longer
    treated as dead. The lazy-prune contract is preserved: when the registry *is*
@@ -120,7 +127,10 @@ Three hermetic tests in
 [`test/active-surface.test.js`](../test/active-surface.test.js), each written
 red→green:
 
-* `timeout: 0` polls exactly once instead of spinning (was 47 polls over ~5s).
+* `timeout: 0` polls exactly once instead of spinning (was 47 polls over ~5s),
+  **and returns promptly** rather than sleeping a poll interval first. The test
+  asserts both the poll count and elapsed time, because the count alone passed
+  while the call still took ~870ms.
 * A handle survives a `currentSurface` call whose registry was not supplied, and
   is still routable to a caller that does supply it.
 * A handle whose registry *is* supplied and reports it gone is still pruned —

--- a/src/core/tests/activeSurface.ts
+++ b/src/core/tests/activeSurface.ts
@@ -89,6 +89,18 @@ function isLive(handle: SurfaceHandle, registries: SurfaceRegistries): boolean {
   return !!registries.processRegistry?.has(handle.name);
 }
 
+// Whether this caller supplied the registry that adjudicates `handle`'s kind.
+// Without it, liveness is UNKNOWN — distinct from dead, and the difference
+// matters because the prune below is destructive.
+function canAdjudicate(
+  handle: SurfaceHandle,
+  registries: SurfaceRegistries
+): boolean {
+  if (handle.kind === "browser") return !!registries.browserRegistry;
+  if (handle.kind === "app") return !!registries.appSession;
+  return !!registries.processRegistry;
+}
+
 // The active surface: the most recently activated handle whose surface is
 // still open. Dead entries (closed surfaces) are pruned as they're passed
 // over, so closes never have to touch the tracker.
@@ -97,9 +109,17 @@ function currentSurface(
   registries: SurfaceRegistries
 ): SurfaceHandle | null {
   if (!tracker) return null;
-  const live = tracker.mru.filter((h) => isLive(h, registries));
-  tracker.mru = live;
-  return live[0] ?? null;
+  // Prune only what this caller can actually adjudicate. A kind whose registry
+  // wasn't supplied is unknown, not dead: dropping it would delete a LIVE
+  // surface from shared per-context state, breaking routing for every later
+  // step that does supply that registry.
+  tracker.mru = tracker.mru.filter(
+    (h) => !canAdjudicate(h, registries) || isLive(h, registries)
+  );
+  return (
+    tracker.mru.find((h) => canAdjudicate(h, registries) && isLive(h, registries)) ??
+    null
+  );
 }
 
 // Classify a step's surface target. Explicit references resolve by shape —

--- a/src/core/tests/findElement.ts
+++ b/src/core/tests/findElement.ts
@@ -297,7 +297,10 @@ async function findElement({ config, step, driver, click, appSession, processReg
   step.find = {
     ...step.find,
     selector: step.find.selector || "",
-    timeout: step.find.timeout || 5000,
+    // ?? not ||, matching the app path above: an explicit `timeout: 0` is a
+    // valid schema value meaning "check once, now", and || would clobber it
+    // to the 5s default.
+    timeout: step.find.timeout ?? 5000,
     elementText: step.find.elementText || "",
     moveTo: step.find.moveTo || false,
     click: step.find.click || false,

--- a/src/core/tests/findStrategies.ts
+++ b/src/core/tests/findStrategies.ts
@@ -274,7 +274,10 @@ async function findElementBySelectorAndText({
     return { element: null, foundBy: null }; // No selector or text
   }
   const startTime = Date.now();
-  while (Date.now() - startTime < timeout) {
+  // do/while so `timeout: 0` means "check once, now" rather than "never check
+  // at all". For any positive timeout this is unchanged: the first iteration
+  // always ran anyway.
+  do {
     const candidates = await driver.$$(selector);
     elements = [];
     for (const el of candidates) {
@@ -300,7 +303,7 @@ async function findElementBySelectorAndText({
     }
     // Wait 100ms before trying again
     await new Promise((resolve) => setTimeout(resolve, 100));
-  }
+  } while (Date.now() - startTime < timeout);
   if (elements.length === 0) {
     return { element: null, foundBy: null }; // No matching elements
   }
@@ -457,8 +460,10 @@ async function findElementByCriteria({
   const startTime = Date.now();
   const pollingInterval = 100; // Check every 100ms
 
-  // Poll for elements until timeout
-  while (Date.now() - startTime < timeout) {
+  // Poll for elements until timeout. do/while so `timeout: 0` means "check
+  // once, now" rather than "never check at all"; for any positive timeout the
+  // first iteration always ran anyway, so behavior there is unchanged.
+  do {
     let candidates: any[] = [];
 
     try {
@@ -709,7 +714,7 @@ async function findElementByCriteria({
 
     // No matching elements found, wait before retrying
     await new Promise((resolve) => setTimeout(resolve, pollingInterval));
-  }
+  } while (Date.now() - startTime < timeout);
 
   // Timeout reached, return error
   return {

--- a/src/core/tests/findStrategies.ts
+++ b/src/core/tests/findStrategies.ts
@@ -301,6 +301,9 @@ async function findElementBySelectorAndText({
     if (elements.length > 0) {
       break;
     }
+    // Budget already spent — return now rather than sleeping first, or
+    // `timeout: 0` would mean "in 100ms" instead of "now".
+    if (Date.now() - startTime >= timeout) break;
     // Wait 100ms before trying again
     await new Promise((resolve) => setTimeout(resolve, 100));
   } while (Date.now() - startTime < timeout);
@@ -569,6 +572,9 @@ async function findElementByCriteria({
 
       // Skip if no candidates found
       if (candidates.length === 0) {
+        // Same immediate-return rule as the tail of the loop: don't sleep out
+        // a budget that's already gone.
+        if (Date.now() - startTime >= timeout) break;
         await new Promise((resolve) => setTimeout(resolve, pollingInterval));
         continue;
       }
@@ -712,7 +718,10 @@ async function findElementByCriteria({
       console.error("Error finding elements:", error);
     }
 
-    // No matching elements found, wait before retrying
+    // No matching elements found. Return now if the budget is spent, so
+    // `timeout: 0` is a genuine immediate check.
+    if (Date.now() - startTime >= timeout) break;
+    // Wait before retrying
     await new Promise((resolve) => setTimeout(resolve, pollingInterval));
   } while (Date.now() - startTime < timeout);
 

--- a/src/core/tests/startSurface.ts
+++ b/src/core/tests/startSurface.ts
@@ -376,7 +376,19 @@ async function startSurfaceStep({
   if (browserRegistry) {
     for (const slot of browserSlots) {
       if (results[slot.i]?.status === "PASS") {
-        activateSession(browserRegistry, results[slot.i].outputs?.name ?? slot.name);
+        const name = results[slot.i].outputs?.name ?? slot.name;
+        // A miss means the session opened but isn't in the registry under the
+        // name we'd address it by, so `activeName` would silently keep pointing
+        // at the previous session while the MRU tracker says otherwise — every
+        // later surface-less step would then act on the wrong browser. Fail
+        // loudly instead: a diagnosable error beats a wrong-surface run.
+        if (!activateSession(browserRegistry, name)) {
+          results[slot.i] = {
+            ...results[slot.i],
+            status: "FAIL",
+            description: `Opened browser surface "${name}", but it couldn't be made the active surface — no session is registered under that name. This is a runner bug; surface-less steps after this one would act on the wrong browser.`,
+          };
+        }
       }
     }
   }

--- a/test/active-surface.test.js
+++ b/test/active-surface.test.js
@@ -706,3 +706,79 @@ describe("handler routing — no active surface", function () {
     assert.match(result.description, /No active surface to act on/);
   });
 });
+
+describe("active-surface bookkeeping is non-destructive and honors timeout 0", function () {
+  it("currentSurface keeps handles whose registry wasn't supplied", function () {
+    // A caller that omits a registry doesn't know whether that kind's surfaces
+    // are alive — treating "unknown" as "dead" and deleting the handle would
+    // corrupt routing for every later step that DOES supply the registry.
+    const tracker = createActiveSurfaceTracker();
+    activateSurface(tracker, { kind: "process", name: "server" });
+    const processRegistry = new Map([["server", { pid: 1 }]]);
+
+    // Resolve once WITHOUT the process registry (the ignorant caller).
+    currentSurface(tracker, {});
+
+    // The live process must still be routable for a caller that supplies it.
+    assert.deepEqual(
+      currentSurface(tracker, { processRegistry }),
+      { kind: "process", name: "server" }
+    );
+  });
+
+  it("currentSurface still prunes a surface its registry says is gone", function () {
+    // The lazy-prune contract must survive the fix above: when the registry IS
+    // supplied and the surface isn't in it, the handle is genuinely dead.
+    const tracker = createActiveSurfaceTracker();
+    activateSurface(tracker, { kind: "process", name: "gone" });
+    assert.equal(currentSurface(tracker, { processRegistry: new Map() }), null);
+    assert.deepEqual(tracker.mru, []);
+  });
+
+  it("a browser find honors an explicit timeout of 0", async function () {
+    // The app path uses `?? 5000` precisely so `timeout: 0` stays an immediate
+    // check; the browser path must not clobber it back to the default.
+    let polls = 0;
+    // setElementOutputs probes a wide element API; stub it all so the test
+    // fails on the timeout assertion alone, never on a missing method.
+    const element = new Proxy(
+      {
+        async waitForExist() {},
+        async getText() {
+          return "Ready";
+        },
+        elementId: "e1",
+      },
+      {
+        get(target, prop) {
+          if (prop in target) return target[prop];
+          return async () => undefined;
+        },
+      }
+    );
+    const driver = {
+      state: {},
+      async $() {
+        return element;
+      },
+      // No candidates ever match: the poll COUNT is then what distinguishes an
+      // honored `timeout: 0` (one immediate check) from one clobbered to the
+      // 5s default (spins for five seconds).
+      async $$() {
+        polls++;
+        return [];
+      },
+      async pause() {},
+    };
+    const result = await findElement({
+      config: {},
+      step: { find: { selector: "#x", timeout: 0 } },
+      driver,
+    });
+    // `timeout: 0` means "check once, now" — not "wait the 5s default" (which
+    // the browser path did by clobbering 0 through `||`), and not "never check"
+    // (which a `while (elapsed < timeout)` poll does for 0).
+    assert.equal(result.outputs.found, false);
+    assert.equal(polls, 1, "timeout 0 must poll exactly once, not spin for 5s");
+  });
+});

--- a/test/active-surface.test.js
+++ b/test/active-surface.test.js
@@ -770,15 +770,25 @@ describe("active-surface bookkeeping is non-destructive and honors timeout 0", f
       },
       async pause() {},
     };
+    const startedAt = Date.now();
     const result = await findElement({
       config: {},
       step: { find: { selector: "#x", timeout: 0 } },
       driver,
     });
+    const elapsed = Date.now() - startedAt;
     // `timeout: 0` means "check once, now" — not "wait the 5s default" (which
     // the browser path did by clobbering 0 through `||`), and not "never check"
     // (which a `while (elapsed < timeout)` poll does for 0).
     assert.equal(result.outputs.found, false);
     assert.equal(polls, 1, "timeout 0 must poll exactly once, not spin for 5s");
+    // Polling once isn't enough: sleeping the 100ms poll interval before
+    // re-checking the deadline would still make "now" mean "in 100ms". The
+    // driver is stubbed (no I/O), so the honest path is single-digit ms; the
+    // bug floor is a full 100ms interval.
+    assert.ok(
+      elapsed < 75,
+      `timeout 0 must return immediately, took ${elapsed}ms`
+    );
   });
 });

--- a/test/active-surface.test.js
+++ b/test/active-surface.test.js
@@ -17,6 +17,7 @@ import { findElement } from "../dist/core/tests/findElement.js";
 import { typeKeys } from "../dist/core/tests/typeKeys.js";
 import { saveScreenshot } from "../dist/core/tests/saveScreenshot.js";
 import { swipeSurface } from "../dist/core/tests/swipe.js";
+import { startSurfaceStep } from "../dist/core/tests/startSurface.js";
 import {
   createSessionRegistry,
   registerSession,
@@ -807,6 +808,9 @@ describe("active-surface bookkeeping is non-destructive and honors timeout 0", f
 });
 
 describe("startSurface array form: activation re-assert failure is loud", function () {
+  // startSurface drags in the app/process/browser lanes; the first load on a
+  // cold CI runner can outrun mocha's 2s default.
+  this.timeout(20000);
   it("FAILs the descriptor when the opened session can't be made active", async function () {
     // The guard exists because a silent miss is the worst outcome: the session
     // opens, `activeName` keeps pointing at the PREVIOUS session, and every
@@ -817,9 +821,6 @@ describe("startSurface array form: activation re-assert failure is loud", functi
     // simulated: a sessions map that accepts writes but never returns them, so
     // the re-assert's lookup misses exactly as it would if the registry and the
     // opened session ever disagreed on the name.
-    const { startSurfaceStep } = await import(
-      "../dist/core/tests/startSurface.js"
-    );
     class WriteOnlyMap extends Map {
       get() {
         return undefined;
@@ -850,9 +851,6 @@ describe("startSurface array form: activation re-assert failure is loud", functi
 
   it("PASSes when the session is addressable, and makes it active", async function () {
     // Guard the guard: the failure path above must not fire on a healthy open.
-    const { startSurfaceStep } = await import(
-      "../dist/core/tests/startSurface.js"
-    );
     const tracker = createActiveSurfaceTracker();
     const registry = {
       sessions: new Map(),

--- a/test/active-surface.test.js
+++ b/test/active-surface.test.js
@@ -770,25 +770,38 @@ describe("active-surface bookkeeping is non-destructive and honors timeout 0", f
       },
       async pause() {},
     };
-    const startedAt = Date.now();
-    const result = await findElement({
-      config: {},
-      step: { find: { selector: "#x", timeout: 0 } },
-      driver,
-    });
-    const elapsed = Date.now() - startedAt;
+    // Observe the poll-interval sleeps directly rather than timing the call: a
+    // wall-clock threshold would be flaky on a loaded runner, and "did it
+    // schedule a sleep" is the actual contract. Recording only — the timer
+    // still behaves normally, so a regression fails on the assertion below
+    // rather than hanging.
+    const sleeps = [];
+    const realSetTimeout = global.setTimeout;
+    global.setTimeout = function (fn, delay, ...rest) {
+      if (delay >= 50) sleeps.push(delay);
+      return realSetTimeout(fn, delay, ...rest);
+    };
+    let result;
+    try {
+      result = await findElement({
+        config: {},
+        step: { find: { selector: "#x", timeout: 0 } },
+        driver,
+      });
+    } finally {
+      global.setTimeout = realSetTimeout;
+    }
     // `timeout: 0` means "check once, now" — not "wait the 5s default" (which
     // the browser path did by clobbering 0 through `||`), and not "never check"
     // (which a `while (elapsed < timeout)` poll does for 0).
     assert.equal(result.outputs.found, false);
     assert.equal(polls, 1, "timeout 0 must poll exactly once, not spin for 5s");
-    // Polling once isn't enough: sleeping the 100ms poll interval before
-    // re-checking the deadline would still make "now" mean "in 100ms". The
-    // driver is stubbed (no I/O), so the honest path is single-digit ms; the
-    // bug floor is a full 100ms interval.
-    assert.ok(
-      elapsed < 75,
-      `timeout 0 must return immediately, took ${elapsed}ms`
+    // Polling once isn't enough: sleeping the poll interval before re-checking
+    // the deadline would still make "now" mean "in 100ms".
+    assert.deepEqual(
+      sleeps,
+      [],
+      `timeout 0 must not sleep before returning; slept ${sleeps.join(", ")}ms`
     );
   });
 });

--- a/test/active-surface.test.js
+++ b/test/active-surface.test.js
@@ -805,3 +805,74 @@ describe("active-surface bookkeeping is non-destructive and honors timeout 0", f
     );
   });
 });
+
+describe("startSurface array form: activation re-assert failure is loud", function () {
+  it("FAILs the descriptor when the opened session can't be made active", async function () {
+    // The guard exists because a silent miss is the worst outcome: the session
+    // opens, `activeName` keeps pointing at the PREVIOUS session, and every
+    // later surface-less step acts on the wrong browser with no error anywhere.
+    //
+    // The miss isn't reachable through the normal path (openSession registers
+    // under the same name its outputs carry), so the corrupted state is
+    // simulated: a sessions map that accepts writes but never returns them, so
+    // the re-assert's lookup misses exactly as it would if the registry and the
+    // opened session ever disagreed on the name.
+    const { startSurfaceStep } = await import(
+      "../dist/core/tests/startSurface.js"
+    );
+    class WriteOnlyMap extends Map {
+      get() {
+        return undefined;
+      }
+    }
+    const tracker = createActiveSurfaceTracker();
+    const registry = {
+      sessions: new WriteOnlyMap(),
+      activeName: null,
+      focusSeq: 0,
+      tracker,
+      open: async () => ({ state: {} }),
+    };
+    const driver = { state: { sessionRegistry: registry } };
+
+    const result = await startSurfaceStep({
+      config: {},
+      step: { startSurface: [{ browser: "chrome", name: "par-chrome" }] },
+      platform: "windows",
+      driver,
+      surfaceTracker: tracker,
+    });
+
+    assert.equal(result.status, "FAIL");
+    assert.match(result.description, /par-chrome/);
+    assert.match(result.description, /active surface/i);
+  });
+
+  it("PASSes when the session is addressable, and makes it active", async function () {
+    // Guard the guard: the failure path above must not fire on a healthy open.
+    const { startSurfaceStep } = await import(
+      "../dist/core/tests/startSurface.js"
+    );
+    const tracker = createActiveSurfaceTracker();
+    const registry = {
+      sessions: new Map(),
+      activeName: null,
+      focusSeq: 0,
+      tracker,
+      open: async () => ({ state: {} }),
+    };
+    const driver = { state: { sessionRegistry: registry } };
+
+    const result = await startSurfaceStep({
+      config: {},
+      step: { startSurface: [{ browser: "chrome", name: "ok-chrome" }] },
+      platform: "windows",
+      driver,
+      surfaceTracker: tracker,
+    });
+
+    assert.equal(result.status, "PASS");
+    assert.equal(registry.activeName, "ok-chrome");
+    assert.deepEqual(tracker.mru[0], { kind: "browser", name: "ok-chrome" });
+  });
+});


### PR DESCRIPTION
Three defects in the active-surface layer, found while auditing it for [#696](https://github.com/doc-detective/doc-detective/issues/696). **None of them caused that Windows failure** — that audit came back empty, and the routing layer has since been exonerated by live CI evidence. These are independent bugs the audit turned up on the way.

Split out of [#695](https://github.com/doc-detective/doc-detective/pull/695) so the ready work isn't blocked behind an open investigation. #695 keeps the fixture diagnostics and the triage-playbook row.

See [ADR 01087](adrs/01087-non-destructive-surface-bookkeeping-and-zero-timeout.md).

## 1. `find: { timeout: 0 }` was ignored on browser surfaces

The browser path defaulted with `|| 5000`, clobbering an explicit `0`. The app path one screen above uses `?? 5000` and carries a comment saying `0` must stay an immediate check. Same schema field, two behaviors depending on which surface kind the step resolved to.

Switching the operator alone would have made it worse: both poll loops are `while (elapsed < timeout)`, so an honored `0` would mean *never check at all*. They become `do/while`.

That still wasn't sufficient — every sleep site awaited the poll interval **before** the loop condition was re-evaluated, so `timeout: 0` polled once and then slept anyway. Measured **872ms** for a supposedly-immediate check. All three sleep sites (including the empty-candidate `continue` path) now return early when the budget is spent. A positive timeout that expires also skips one final pointless sleep before giving up.

## 2. `currentSurface` deleted live surfaces

`isLive` returns `false` both for "this surface is gone" and for "you didn't supply the registry that would tell me", and the prune writes back to shared per-context state. A caller that omitted a registry **permanently deleted that kind's live handles**, breaking routing for every later step that did supply it.

It now prunes and selects only among kinds it can adjudicate. The lazy-prune contract is preserved, with a dedicated test so the fix can't over-correct into never pruning.

## 3. A failed activation re-assert was silently discarded

The array-form `startSurface` ignored `activateSession`'s `false` return. A miss would leave `activeName` on the previous session while the MRU reported the new one — every later surface-less step acting on the wrong browser, with no error anywhere. It now fails that descriptor with a message naming the surface.

## Reachability, honestly

Only #1 is a live bug. #2 and #3 are not reachable today — all four `resolveTargetSurface` call sites pass every registry, and `openSession` registers under the name its outputs carry. Both are one careless line from becoming real, and both fail *silently*, which is the mode that cost the most time in #696.

## Verification

Each fix written red→green:

- `timeout: 0` polled **47 times over ~5s** before the fix.
- The sleep-guard bug survived a passing poll-count assertion — `polls === 1` held while the call took 872ms — so the test now also asserts that **no poll-interval sleep is scheduled**, observing `setTimeout` rather than measuring elapsed time. A wall-clock threshold would be flaky on a loaded runner, and "did it schedule a sleep" is the actual contract. Verified to fail (`slept 100ms`) with any one of the three guards removed.
- A guard test proves a supplied-but-missing registry still prunes.

Full suite: **4004 passing, 0 failing** (measured before the last test-only refactor; `test/active-surface.test.js` is 37 passing on this branch).

## Companion artifacts

**ADR:** [01087](adrs/01087-non-destructive-surface-bookkeeping-and-zero-timeout.md).

**Docs impact:** none. No user-facing surface is added, changed, or removed. The one observable change — `find: { timeout: 0 }` on a browser surface — brings the runtime into line with what `find_v3.schema.json` already documents, so the reference stays accurate as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `timeout: 0` is now handled consistently across browser/app flows and polling, performing exactly one immediate check (no defaulting or extra waiting).
  * Active-surface MRU pruning is now non-destructive when a caller omits surface registry info; unknown surfaces remain routable.
  * Array-form start steps now surface browser activation mismatches as clear `FAIL` results with an explanatory message.

* **Tests**
  * Added regression coverage for zero-timeout polling, non-destructive active-surface bookkeeping, and start-surface activation failure/success.

* **Documentation**
  * Added an ADR documenting the updated timeout and active-surface bookkeeping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->