### PR TITLE
fix(platform): resolve symlinks in the runner bin entry guard

### DIFF
--- a/adrs/01087-resolve-symlinks-in-the-runner-bin-entry-guard.md
+++ b/adrs/01087-resolve-symlinks-in-the-runner-bin-entry-guard.md
@@ -1,0 +1,151 @@
+---
+status: accepted
+date: 2026-07-29
+decision-makers: doc-detective maintainers
+---
+
+# Resolve symlinks in the runner entrypoint's "am I the entry module?" guard
+
+## Context and Problem Statement
+
+`bin/runner-entrypoint.js` ends with a guard so the test suite can `import` its helpers without
+executing `main()`:
+
+```js
+const isEntry = import.meta.url === `file://${process.argv[1]}`;
+if (isEntry) { main().then(...).catch(...) }
+```
+
+That comparison holds when the file is invoked by its real path (`node bin/runner-entrypoint.js`),
+which is how every test and every local invocation ran it. It does **not** hold when the file is
+invoked the way it actually ships.
+
+`package.json` registers `doc-detective-runner` as a `bin`, and npm installs `bin` entries as
+**symlinks**: `/usr/local/bin/doc-detective-runner` → `../lib/node_modules/doc-detective/bin/runner-entrypoint.js`.
+When the container's entrypoint runs `doc-detective-runner`, `process.argv[1]` is the *symlink*
+path, while `import.meta.url` is the *realpath* under `node_modules`. The two are never equal, so
+`isEntry` is `false`, `main()` is never called, the module merely defines and exports its functions,
+and **Node exits 0 having done nothing and printed nothing**.
+
+This shipped. The doc-detective.com platform sets Fly's `init.entrypoint` to
+`["doc-detective-runner"]`, so every dispatched run booted a machine that pulled the image, started,
+ran for ~4 seconds, and exited cleanly:
+
+```text
+INFO Preparing to run: `doc-detective-runner` as root
+INFO Main child exited normally with code: 0
+```
+
+No `/spec` call, no log lines, no finalize, exit 0. Server-side the run sat at `status='starting'`
+with `machine_started_at` NULL (that column is stamped by the `/spec` handler) until watchdog Sweep A
+reaped it as `cold_start_exceeded`. The failure was maximally misleading in three directions at once:
+Fly reported success, the platform reported a cold-start timeout, and the platform's HTTP logs showed
+no request at all — so the natural hypotheses were all about *networking* (deployment protection, DNS,
+egress, an unreachable `PUBLIC_APP_URL`), none of which were true. Diagnosing it took an extended
+multi-session investigation that also produced [ADR 01045](01045-surface-spec-fetch-failures-in-finalize.md),
+whose extra error reporting could never have fired here — the code that would report was never reached.
+
+The bug is invisible to the existing test suite by construction: the tests either `import` the module
+(where `isEntry: false` is the *desired* outcome) or call `main()` directly. Nothing exercised the
+one path that production uses — spawning the file through a symlink.
+
+## Decision Drivers
+
+* The published `bin` must actually run. This is the only invocation form real users and the platform
+  container ever use, and it was the one form with no test coverage.
+* The failure mode must not be silent. A guard that evaluates false costs an exit-0 no-op with zero
+  diagnostics — strictly worse than a crash.
+* The guard must keep working for its original purpose: `import`ing the module from tests must not
+  run `main()`.
+* Correctness beyond the symlink case: the hand-built `file://${...}` template is also wrong for
+  Windows paths (`file://C:\...`) and for any path containing a space, `#`, or `?`.
+
+## Considered Options
+
+* **A. Resolve `process.argv[1]` with `realpathSync` and convert with `pathToFileURL` before
+  comparing** (chosen).
+* **B. Drop the guard; always call `main()`, and have tests import a separate module.** Would require
+  splitting the file into a library module plus a thin bin wrapper (as `bin/doc-detective.js` does,
+  which is a one-line `import "../dist/cli.js"` and therefore never had this bug).
+* **C. Compare basenames, or check `process.argv[1]` ends with `doc-detective-runner`.** Cheap, but
+  matches on a filename rather than an identity — a differently-named symlink or a same-named file
+  elsewhere both misbehave.
+* **D. Use `require.main === module`.** Not available in ESM; the file is `"type": "module"`.
+
+## Decision Outcome
+
+Chosen option: **A**. The guard now resolves the symlink and builds the URL properly:
+
+```js
+const isEntry = (() => {
+	const argv1 = process.argv[1];
+	if (!argv1) return false;
+	try {
+		return import.meta.url === pathToFileURL(realpathSync(argv1)).href;
+	} catch {
+		return false;
+	}
+})();
+```
+
+`realpathSync` collapses the npm bin symlink to the same real path `import.meta.url` reports.
+`pathToFileURL` handles drive letters and percent-encoding, fixing the Windows and special-character
+cases in the same change. The `try/catch` covers an unresolvable `argv[1]` (deleted file, permission
+error) by falling back to "not the entrypoint" — the pre-existing behavior, so the guard can never
+throw during module load.
+
+Option B is arguably the more robust structure and matches `bin/doc-detective.js`, but it is a larger
+refactor of a file that is otherwise working, and it does not by itself prevent a future guard
+elsewhere from repeating the mistake. Option C trades a correctness bug for a subtler one. Option D
+is unavailable in ESM.
+
+## Consequences
+
+* **Good** — `doc-detective-runner` executes `main()` when invoked through its installed symlink, so
+  platform runs actually start. This unblocks the entire Fly dispatch path.
+* **Good** — Windows and special-character paths are handled correctly, a latent bug fixed for free.
+* **Good** — the regression is now covered by a test that spawns the file *through a symlink*, the
+  exact production shape, closing the coverage gap that let this ship.
+* **Neutral** — one added `realpathSync` at startup (a single stat-level syscall).
+* **Note** — the diagnostics added in ADR 01045 remain correct and become reachable for the first
+  time; that ADR's reasoning is unaffected, its code simply never ran in production before this fix.
+
+## Confirmation
+
+* New `runner-entrypoint: bin entry guard` describe block in `test/runner-entrypoint.test.js` spawns
+  the entrypoint via a symlink in a tmpdir with no `DD_*` env, and asserts exit code **1** plus
+  `entrypoint crashed` / `DD_API_BASE` in the output. Before the fix this test observed exit **0**
+  with completely empty output; after, it passes. A companion test asserts real-path invocation still
+  works, and the symlink test skips on Windows hosts that can't create symlinks unprivileged.
+* Full `test/runner-entrypoint.test.js` suite green (54 passing, up from 52) with no regressions to
+  the import-without-running behavior every other test in the file depends on.
+* Manually reproduced before the fix: `node bin/runner-entrypoint.js` logged a fatal and exited 1,
+  while `node <symlink-to-it>` produced no output and exited 0 — matching the Fly machine logs
+  exactly.
+
+## Pros and Cons of the Options
+
+### A. `realpathSync` + `pathToFileURL` before comparing
+
+* Good: minimal diff; keeps the guard's original purpose intact.
+* Good: fixes the Windows/special-character URL construction in the same stroke.
+* Neutral: one extra syscall at startup.
+* Bad: still an idiom that is easy to get subtly wrong in a future copy-paste — mitigated by the
+  comment and the regression test.
+
+### B. Split into library module + thin bin wrapper
+
+* Good: removes the failure mode structurally rather than fixing one instance of it; mirrors
+  `bin/doc-detective.js`, which never had the bug precisely because it has no guard.
+* Bad: larger refactor with a bigger blast radius on a file that otherwise works; changes the public
+  export surface that `test/runner-entrypoint.test.js` imports from.
+
+### C. Basename / suffix match on `process.argv[1]`
+
+* Good: trivially symlink-proof.
+* Bad: matches on name rather than identity; a same-named file in another location, or a symlink
+  installed under a different name, both give the wrong answer.
+
+### D. `require.main === module`
+
+* Bad: not available in ESM, and the package is `"type": "module"`.

--- a/bin/runner-entrypoint.js
+++ b/bin/runner-entrypoint.js
@@ -35,9 +35,11 @@
  */
 
 import { spawn } from 'node:child_process';
+import { realpathSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 
 const WORKSPACE_DIR = '/workspace';
 const SPECS_SUBDIR = 'specs';
@@ -767,10 +769,29 @@ async function main() {
 }
 
 // Module-import guard so the test file can `import` from this module
-// without triggering main(). Node's `import.meta.url === ...` idiom
-// for "am I the entrypoint?" — works under both `node` and `tsx` and
-// doesn't require require.main.
-const isEntry = import.meta.url === `file://${process.argv[1]}`;
+// without triggering main().
+//
+// Both halves of this comparison matter. npm installs `bin` entries as
+// symlinks, so when the container runs `doc-detective-runner`,
+// process.argv[1] is /usr/local/bin/doc-detective-runner while
+// import.meta.url is the realpath under node_modules — hence realpathSync
+// before comparing. And a hand-built `file://${...}` template mangles
+// Windows paths and anything containing a space or `#`, so the conversion
+// goes through pathToFileURL. Getting either wrong makes this silently
+// false: main() never runs, nothing is logged, and the process exits 0
+// looking like a clean success. See ADR 01087.
+const isEntry = (() => {
+	const argv1 = process.argv[1];
+	if (!argv1) return false;
+	try {
+		return import.meta.url === pathToFileURL(realpathSync(argv1)).href;
+	} catch {
+		// argv[1] can be unresolvable (deleted file, permission error). Not
+		// being the entrypoint is the safe answer — worst case the process
+		// no-ops, exactly as it would have before.
+		return false;
+	}
+})();
 if (isEntry) {
 	main()
 		.then((code) => process.exit(code))

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -1055,7 +1055,7 @@ describe("runner-entrypoint: bin entry guard", () => {
 
   /** Runs the entrypoint with no DD_* env, so main() fails fast and loudly. */
   function runEntrypoint(target) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const child = spawn(process.execPath, [target], {
         env: {
           PATH: process.env.PATH,
@@ -1067,6 +1067,13 @@ describe("runner-entrypoint: bin entry guard", () => {
       let out = "";
       child.stdout.on("data", (c) => (out += c));
       child.stderr.on("data", (c) => (out += c));
+      // A failed spawn emits 'error', and 'close' is not guaranteed to
+      // follow — without this the promise never settles and the test dies
+      // on the mocha timeout instead of naming the cause. Whichever event
+      // fires first wins; a later one is a no-op.
+      child.on("error", (err) =>
+        reject(new Error(`failed to spawn ${target}: ${err.message}`))
+      );
       child.on("close", (code) => resolve({ code, out }));
     });
   }

--- a/test/runner-entrypoint.test.js
+++ b/test/runner-entrypoint.test.js
@@ -3,6 +3,9 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { symlinkSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import {
   apiCall,
   buildEffectiveConfig,
@@ -1030,5 +1033,67 @@ describe("runner-entrypoint: main()", () => {
     assert.equal(code, 1);
     assert.equal(observed.finalize.status, "failed");
     assert.equal(observed.finalize.summary.reason, "workspace_provision_failed");
+  });
+});
+
+describe("runner-entrypoint: bin entry guard", () => {
+  // Regression: npm links `bin` entries as symlinks, so process.argv[1] is
+  // /usr/local/bin/doc-detective-runner while import.meta.url resolves to the
+  // real file under node_modules. A `file://${process.argv[1]}` comparison
+  // never matches, main() never runs, and the process exits 0 having done
+  // nothing — which on Fly looked like a machine that booted, "succeeded",
+  // and never called /spec. See ADR 01087.
+  let dir;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "dd-bin-entry-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  /** Runs the entrypoint with no DD_* env, so main() fails fast and loudly. */
+  function runEntrypoint(target) {
+    return new Promise((resolve) => {
+      const child = spawn(process.execPath, [target], {
+        env: {
+          PATH: process.env.PATH,
+          HOME: process.env.HOME,
+          SystemRoot: process.env.SystemRoot,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let out = "";
+      child.stdout.on("data", (c) => (out += c));
+      child.stderr.on("data", (c) => (out += c));
+      child.on("close", (code) => resolve({ code, out }));
+    });
+  }
+
+  const realEntrypoint = fileURLToPath(
+    new URL("../bin/runner-entrypoint.js", import.meta.url)
+  );
+
+  it("runs main() when invoked through a symlink, as npm installs it", async function () {
+    const link = path.join(dir, "doc-detective-runner");
+    try {
+      symlinkSync(realEntrypoint, link);
+    } catch {
+      // Windows without developer mode can't create symlinks unprivileged.
+      this.skip();
+    }
+    const { code, out } = await runEntrypoint(link);
+    // Missing DD_API_BASE => readRequiredEnv throws => fatal log, exit 1.
+    // Before the fix this was a silent exit 0 with no output at all.
+    assert.equal(code, 1, `expected exit 1, got ${code}; output: ${out}`);
+    assert.match(out, /entrypoint crashed/);
+    assert.match(out, /DD_API_BASE/);
+  });
+
+  it("still runs main() when invoked by its real path", async () => {
+    const { code, out } = await runEntrypoint(realEntrypoint);
+    assert.equal(code, 1, `expected exit 1, got ${code}; output: ${out}`);
+    assert.match(out, /DD_API_BASE/);
   });
 });


### PR DESCRIPTION
## The bug

`bin/runner-entrypoint.js` guarded its `main()` call with:

```js
const isEntry = import.meta.url === `file://${process.argv[1]}`;
```

npm installs `bin` entries as **symlinks**. When the container runs `doc-detective-runner`, `process.argv[1]` is `/usr/local/bin/doc-detective-runner` while `import.meta.url` is the realpath under `node_modules`. They are never equal — so in the one invocation form that actually ships, `isEntry` was always `false`. `main()` never ran, the module just defined and exported its functions, and **Node exited 0 having done nothing and printed nothing.**

## Why this was so hard to find

Every doc-detective.com platform run booted a machine that pulled the image, started, ran for ~4 seconds, and exited cleanly:

```text
INFO Preparing to run: `doc-detective-runner` as root
INFO Main child exited normally with code: 0
```

No `/spec` call, no log lines, no finalize. Server-side the run sat at `status='starting'` with `machine_started_at` NULL (that column is stamped by the `/spec` handler) until the watchdog reaped it as `cold_start_exceeded`.

So the three available signals all pointed the wrong way at once: **Fly reported success**, **the platform reported a cold-start timeout**, and **the platform's HTTP logs showed no request at all**. Every natural hypothesis was about networking — deployment protection, DNS, egress, a wrong `PUBLIC_APP_URL` — and none of them were true. It also meant the error reporting added in ADR 01045 could never fire here: the code that would report was never reached.

## The fix

```js
const isEntry = (() => {
	const argv1 = process.argv[1];
	if (!argv1) return false;
	try {
		return import.meta.url === pathToFileURL(realpathSync(argv1)).href;
	} catch {
		return false;
	}
})();
```

`realpathSync` collapses the npm bin symlink to the path `import.meta.url` reports. `pathToFileURL` replaces the hand-rolled `file://` template, which was **also** wrong for Windows drive letters and for any path containing a space, `#`, or `?` — fixed here for free. The `try/catch` covers an unresolvable `argv[1]` by falling back to the pre-existing behavior, so the guard can't throw during module load.

## Why the tests missed it

By construction. The suite either `import`s the module — where `isEntry: false` is the *desired* outcome — or calls `main()` directly. Nothing ever spawned the file **through a symlink**, the one shape production uses.

New `runner-entrypoint: bin entry guard` block closes that gap: it symlinks the entrypoint into a tmpdir, spawns it with no `DD_*` env, and asserts exit **1** plus `entrypoint crashed` / `DD_API_BASE` in the output. Confirmed red → green:

- **Before**: `expected exit 1, got 0; output:` *(empty)* — exactly the Fly logs
- **After**: passes

A companion test asserts real-path invocation still works. The symlink test skips on Windows hosts that can't create symlinks unprivileged.

## Verification

- `test/runner-entrypoint.test.js`: **54 passing**, 0 failing (up from 52)
- Manually reproduced pre-fix: `node bin/runner-entrypoint.js` logged a fatal and exited 1; `node <symlink>` printed nothing and exited 0

## ADR

[`adrs/01087-resolve-symlinks-in-the-runner-bin-entry-guard.md`](adrs/01087-resolve-symlinks-in-the-runner-bin-entry-guard.md) — records the decision, the three rejected alternatives (drop the guard and split into library + thin wrapper à la `bin/doc-detective.js`; basename matching; `require.main`), and the confirmation steps.

## Docs impact

**None.** `doc-detective-runner` is the platform's internal container entrypoint, not a documented end-user surface — no step type, action option, config key, CLI flag, or output format changes. The user-visible CLI (`bin/doc-detective.js`) was never affected: it's a one-line `import "../dist/cli.js"` with no guard, which is precisely why it never had this bug.

## Feature fixtures

**N/A.** This isn't a runner feature (step type / flag / engine / output format) that `test/core-artifacts/` can exercise — it's whether the platform entrypoint binary executes at all. The spawn-through-symlink test is the correct level for that.

## Release note

This needs to land as a `fix:` so semantic-release cuts a patch and the Docker image rebuilds — the platform pins `RUNNER_IMAGE` to a published tag, and no released image currently contains a runner that actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ncx411jEevDgGyvoEeBJVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ncx411jEevDgGyvoEeBJVs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed runner startup when launched through an installed symlink.
  - Improved entrypoint detection for cross-platform path and `file://` URL handling (including spaces/special characters).
  - Prevented cases where the runner exited successfully without running when required configuration was missing.
- **Tests**
  - Added end-to-end coverage for runner execution via both symlinked and resolved entrypoint paths.
- **Documentation**
  - Added an ADR describing the production issue, the resolution approach, and the added testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->