### PR TITLE
fix(common): silence AJV strictTypes compile-time warnings

### DIFF
--- a/src/common/src/validate.ts
+++ b/src/common/src/validate.ts
@@ -27,6 +27,11 @@ function getRandomUUID(): string {
 // @ts-expect-error - CJS/ESM interop: Ajv constructor is callable at runtime
 const ajv = new Ajv({
   strictSchema: false,
+  // strictTypes defaults to 'log', which prints a 'strict mode: missing type ...'
+  // warning for every if/then/required branch in the schemas at compile time --
+  // hundreds of lines per run for every consumer. It is a compile-time lint
+  // only and has no effect on validation results.
+  strictTypes: false,
   useDefaults: true,
   allErrors: true,
   allowUnionTypes: true,
@@ -51,6 +56,11 @@ const ajv = new Ajv({
 // @ts-expect-error - CJS/ESM interop: Ajv constructor is callable at runtime
 const ajvCheck = new Ajv({
   strictSchema: false,
+  // strictTypes defaults to 'log', which prints a 'strict mode: missing type ...'
+  // warning for every if/then/required branch in the schemas at compile time --
+  // hundreds of lines per run for every consumer. It is a compile-time lint
+  // only and has no effect on validation results.
+  strictTypes: false,
   useDefaults: false,
   allErrors: true,
   allowUnionTypes: true,


### PR DESCRIPTION
## Problem

Every Doc Detective run prints hundreds of AJV warnings at schema compile time:

```
strict mode: missing type "object" for keyword "required" at "spec_v3#/properties/tests/items/anyOf/0/..." (strictTypes)
```

A single `validate()` call against `spec_v3` emits 120 of them, and a typical CI run logs 360+. They drown out real output and get mistaken for test failures — our docs team escalated a "failing" run twice this week that was actually green, because the log opens with a wall of these warnings.

## Cause

Both Ajv instances in `src/common/src/validate.ts` set `strictSchema: false` but not `strictTypes`. In AJV v8, `strictTypes` is a separate strict-mode flag that defaults to `"log"`, so AJV logs a warning for every `if`/`then`/`required` branch that lacks an explicit `type` keyword — which the generated schemas use extensively and intentionally.

## Fix

Set `strictTypes: false` on both instances (`ajv` and `ajvCheck`), with a comment explaining why. `strictTypes` is a compile-time lint only — it has no effect on validation results.

Verified against `doc-detective-common@4.37.1`: patching the published build the same way takes a `spec_v3` validation from 120 warnings to 0, while validation behavior is unchanged (valid spec → `valid: true`, invalid step field → `valid: false`).

An alternative would be adding explicit `type: "object"` to every flagged schema branch, but that touches hundreds of generated schema nodes for the same observable result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary validation warnings related to type definitions.
  * Preserved existing validation behavior for both standard and non-mutating checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->