### PR TITLE
ci(release): rebuild src/common/package-lock.json during release prepare

### DIFF
--- a/adrs/01091-rebuild-the-common-lockfile-during-release.md
+++ b/adrs/01091-rebuild-the-common-lockfile-during-release.md
@@ -18,7 +18,7 @@ The dependency tree therefore never moved. Every `chore(release)` commit faithfu
 version onto a lockfile whose dependencies no longer satisfied its own `package.json`, and the file
 accumulated drift release after release. On `main` at 4.37.4, `npm ci` inside `src/common` fails:
 
-```
+```text
 npm error code EUSAGE
 npm error Invalid: lock file's @apidevtools/json-schema-ref-parser@15.3.5 does not satisfy @apidevtools/json-schema-ref-parser@15.5.1
 npm error Invalid: lock file's @types/node@25.9.2 does not satisfy @types/node@26.2.0
@@ -48,6 +48,26 @@ the root manifest, and treats the invocation as a workspace operation: it rewrit
 Since `@semantic-release/git` commits both files, the naive version would ship a root lockfile
 silently rewritten by a step that was supposed to touch only `src/common`.
 
+### The root lockfile is collateral
+
+`npm version --workspace src/common` does not only stamp versions — it rewrites the **root**
+`package-lock.json` as a side effect, and `@semantic-release/git` commits that too, unverified.
+
+This is not hypothetical. The 4.37.4 release emitted a root lockfile missing
+`conventional-commits-filter@6.0.1` and `conventional-commits-parser@7.1.2`, which broke `npm ci` on
+`main` for every CI job, every contributor, and the release job itself (repaired by hand in #705).
+Bisection put the breakage squarely on the `chore(release)` commit, not on the dependency refresh
+that preceded it:
+
+| commit | `npm ci` |
+|---|---|
+| `87786b2a` — `ci(vale): …` | OK |
+| `b887754d` — `fix(lsp): … (#703)` | OK |
+| `4bdbe34c` — `chore(release): 4.37.4` | **fails** |
+
+A release step that rewrites a lockfile and commits it without ever checking that it installs is the
+underlying defect, and it predates this ADR.
+
 ## Decision Drivers
 
 * The committed lockfile should agree with the manifest beside it, or it should not be committed.
@@ -67,10 +87,32 @@ silently rewritten by a step that was supposed to touch only `src/common`.
 ## Decision Outcome
 
 Chosen option: **1**. `sync-common-version.js` now returns an ordered command plan from a pure
-exported `buildSyncCommands(version)` and executes it: stamp the version, then
-`npm install --package-lock-only --ignore-scripts --no-audit --no-fund --no-workspaces` with cwd
-`src/common`. Order matters — stamping first means the rebuilt lockfile carries the release version
-rather than the previous one.
+exported `buildSyncCommands(version, repoRoot)` and executes it:
+
+1. `npm version <v> --workspace src/common --no-git-tag-version --allow-same-version` from the root.
+2. `npm install --package-lock-only --ignore-scripts --no-audit --no-fund --no-workspaces` with cwd
+   `src/common`.
+3. `npm install --package-lock-only --ignore-scripts --no-audit --no-fund` from the root, **twice**.
+4. `npm ci --dry-run --ignore-scripts --no-audit --no-fund` from the root.
+
+Order matters — stamping first means the rebuilt lockfile carries the release version rather than
+the previous one, and the verification runs last so it sees the final state.
+
+Steps 3 and 4 address the root-lockfile collateral above. Measured on npm 10 (node 22, the release
+job's runtime), starting from a root lockfile where `npm ci` passes, running the step-1 stamp *alone*
+leaves `npm ci` failing with `EBADPLATFORM`. The corruption is deterministic, not a one-off: without
+step 3, the repair in #705 would be undone by the very next release.
+
+The two passes are the recipe already documented in
+[docs/maintenance/release-operations.md](../docs/maintenance/release-operations.md) — the second pass
+drops the platform-gated `"extraneous"` entries that make `npm ci` fail on other OSes. Crucially
+`--package-lock-only` resolves the tree *without* materializing `node_modules`, so it does not prune
+the cross-platform optional set the way a plain `npm install` on a Linux runner would. Confirmed by
+taking the Linux-produced lockfile and running `npm ci --dry-run` against it on Windows.
+
+Step 4 is the backstop. `npm ci --dry-run` is the check every CI job performs, it writes nothing, and
+it exits non-zero on any `Missing`/`Invalid`/`EBADPLATFORM` entry — so if the reconcile ever fails to
+produce an installable tree, the release stops rather than committing the damage.
 
 The file is already in the `@semantic-release/git` assets, so no `.releaserc.json` or workflow
 change was needed; the release job already invokes this script.
@@ -82,6 +124,14 @@ at the next release instead of waiting for someone to notice.
 
 * Good: the committed lockfile matches its manifest from the next release onward; `cd src/common &&
   npm ci --no-workspaces` works.
+* Good: a release now *repairs* the root lockfile instead of corrupting it. Verified end-to-end from
+  the broken `main` state: `npm ci` fails with EUSAGE before the prepare step and passes after.
+* Good: a release can no longer commit a root lockfile that fails to install — the class of failure
+  that produced #705 stops the release instead of landing on `main`.
+* Neutral: step 4 can fail a release. That is the intent; the alternative is shipping the corruption.
+  Recovery is the documented regeneration recipe, then re-running the release.
+* Neutral: the root lockfile will now show real dependency churn in `chore(release)` commits rather
+  than only version stamps. That churn was always happening — it was simply unverified.
 * Good: no new workflow, job, or minutes — one extra npm resolve inside an existing step.
 * Neutral: the first release after this lands carries a large one-time catch-up diff in
   `src/common/package-lock.json` (roughly 800 lines), including major transitive moves such as
@@ -99,9 +149,14 @@ at the next release instead of waiting for someone to notice.
 * Red→green integration check in a `node:22` container against the tree as shipped on `main`:
   `npm ci --ignore-scripts --no-workspaces` inside `src/common` fails with the EUSAGE above before
   running the prepare step, and succeeds after.
-* Isolation check: after the prepare step, the root `package-lock.json` is byte-identical apart from
-  the reconciliation `npm version` already performed (release 4.37.4 shows this pre-existing churn
-  at 3250/273 lines, independent of this change).
+* End-to-end from the broken `main` state (4bdbe34c), in the same container: `npm ci` at the root
+  fails with EUSAGE before the prepare step and passes after it, and `npm ci --no-workspaces` in
+  `src/common` passes too, with both manifests stamped to the release version.
+* Isolation check on the step-2 flag: with `--no-workspaces` the root lockfile is untouched and
+  `src/common`'s is rebuilt; without it the two swap, which is the regression the unit test pins.
+* Cross-platform check: the lockfile produced by the Linux reconcile passes
+  `npm ci --ignore-scripts --dry-run` on a Windows host, confirming the optional-dependency tree
+  survives the two passes.
 * Unit tests in [test/sync-common-version.test.js](../test/sync-common-version.test.js) pin the
   command plan, including a dedicated case asserting `--no-workspaces` is present — the flag whose
   omission silently corrupts the root lockfile.

--- a/adrs/01091-rebuild-the-common-lockfile-during-release.md
+++ b/adrs/01091-rebuild-the-common-lockfile-during-release.md
@@ -1,0 +1,128 @@
+---
+status: accepted
+date: 2026-08-10
+decision-makers: doc-detective maintainers
+---
+
+# Rebuild src/common/package-lock.json during the release prepare step
+
+## Context and Problem Statement
+
+`src/common/package-lock.json` is tracked in git and listed in the
+`@semantic-release/git` assets in [.releaserc.json](../.releaserc.json), so every release commits
+it. But the only thing that ever *wrote* to it was `npm version --workspace src/common` (via
+[scripts/sync-common-version.js](../scripts/sync-common-version.js)), which rewrites the two
+`version` fields and nothing else.
+
+The dependency tree therefore never moved. Every `chore(release)` commit faithfully stamped a fresh
+version onto a lockfile whose dependencies no longer satisfied its own `package.json`, and the file
+accumulated drift release after release. On `main` at 4.37.4, `npm ci` inside `src/common` fails:
+
+```
+npm error code EUSAGE
+npm error Invalid: lock file's @apidevtools/json-schema-ref-parser@15.3.5 does not satisfy @apidevtools/json-schema-ref-parser@15.5.1
+npm error Invalid: lock file's @types/node@25.9.2 does not satisfy @types/node@26.2.0
+npm error Invalid: lock file's c8@11.0.0 does not satisfy c8@12.0.0
+npm error Invalid: lock file's esbuild@0.28.0 does not satisfy esbuild@0.28.2
+```
+
+Nothing caught it because **CI never reads this file**. [.github/workflows/test.yml](../.github/workflows/test.yml)
+runs `npm ci` at the repo root with `cache-dependency-path: package-lock.json`, then runs the
+`src/common` scripts with `working-directory: src/common` against the hoisted workspace
+`node_modules`. The standalone lockfile is a trap for anyone who runs `cd src/common && npm ci`,
+while looking maintained because it changes on every release.
+
+### The npm workspace hazard
+
+The obvious fix — run `npm install --package-lock-only` inside `src/common` — does the opposite of
+what it appears to. npm walks up from the working directory, finds `workspaces: ["src/common"]` in
+the root manifest, and treats the invocation as a workspace operation: it rewrites the **root**
+`package-lock.json` and leaves `src/common/package-lock.json` byte-identical. Measured on npm 10
+(node 22, the release job's runtime):
+
+| invocation (cwd `src/common`) | root lockfile | common lockfile |
+|---|---|---|
+| `npm install --package-lock-only` | **rewritten** | unchanged |
+| `npm install --package-lock-only --no-workspaces` | unchanged | **rebuilt** |
+
+Since `@semantic-release/git` commits both files, the naive version would ship a root lockfile
+silently rewritten by a step that was supposed to touch only `src/common`.
+
+## Decision Drivers
+
+* The committed lockfile should agree with the manifest beside it, or it should not be committed.
+* The fix must not perturb the root lockfile, which gates `npm ci` for the whole repo and all of CI.
+* Prefer self-healing over a one-time repair — a manual regeneration rots again by the next
+  dependency bump.
+* Keep the release pipeline's existing shape; this is a release-operations concern.
+
+## Considered Options
+
+1. **Rebuild the lockfile in the release prepare step**, in `sync-common-version.js`, immediately
+   after the version stamp, using `--no-workspaces`.
+2. **Delete `src/common/package-lock.json`** and drop it from the `@semantic-release/git` assets.
+3. **Regenerate it by hand now** and add a CI job that runs `npm ci --no-workspaces` in
+   `src/common` to keep it honest.
+
+## Decision Outcome
+
+Chosen option: **1**. `sync-common-version.js` now returns an ordered command plan from a pure
+exported `buildSyncCommands(version)` and executes it: stamp the version, then
+`npm install --package-lock-only --ignore-scripts --no-audit --no-fund --no-workspaces` with cwd
+`src/common`. Order matters — stamping first means the rebuilt lockfile carries the release version
+rather than the previous one.
+
+The file is already in the `@semantic-release/git` assets, so no `.releaserc.json` or workflow
+change was needed; the release job already invokes this script.
+
+This makes the lockfile self-healing: a dependency bumped in `src/common/package.json` is reconciled
+at the next release instead of waiting for someone to notice.
+
+### Consequences
+
+* Good: the committed lockfile matches its manifest from the next release onward; `cd src/common &&
+  npm ci --no-workspaces` works.
+* Good: no new workflow, job, or minutes — one extra npm resolve inside an existing step.
+* Neutral: the first release after this lands carries a large one-time catch-up diff in
+  `src/common/package-lock.json` (roughly 800 lines), including major transitive moves such as
+  `@types/node` 25→26 and `undici-types` 7→8, that accumulated while the file was frozen.
+* Neutral: the lockfile is only guaranteed correct *as of each release*. Between releases a fresh
+  dependency bump leaves it stale until the next one. Acceptable: nothing in CI consumes it, and it
+  self-corrects.
+* Bad: preserves a file that arguably should not exist (option 2). If `doc-detective-common` is only
+  ever installed as a workspace of the root package, this lockfile has no consumer and the honest
+  fix is deletion. Option 1 was chosen because that call depends on whether standalone installs are
+  meant to be supported — a product question this ADR does not settle.
+
+### Confirmation
+
+* Red→green integration check in a `node:22` container against the tree as shipped on `main`:
+  `npm ci --ignore-scripts --no-workspaces` inside `src/common` fails with the EUSAGE above before
+  running the prepare step, and succeeds after.
+* Isolation check: after the prepare step, the root `package-lock.json` is byte-identical apart from
+  the reconciliation `npm version` already performed (release 4.37.4 shows this pre-existing churn
+  at 3250/273 lines, independent of this change).
+* Unit tests in [test/sync-common-version.test.js](../test/sync-common-version.test.js) pin the
+  command plan, including a dedicated case asserting `--no-workspaces` is present — the flag whose
+  omission silently corrupts the root lockfile.
+
+## Pros and Cons of the Options
+
+### Option 1 — rebuild in the release prepare step
+
+* Good: self-healing; no new CI surface; the file is already a release-committed asset.
+* Good: the `--no-workspaces` hazard is captured in a regression test rather than tribal knowledge.
+* Bad: keeps a lockfile whose necessity is unproven.
+
+### Option 2 — delete the lockfile
+
+* Good: removes the trap outright and is the simplest honest answer if standalone installs aren't
+  supported.
+* Bad: forecloses publishing/installing `doc-detective-common` standalone without a follow-up.
+* Bad: a larger, more opinionated change than the reported problem warrants.
+
+### Option 3 — hand-regenerate plus a CI guard
+
+* Good: the CI guard proves the file stays valid, which option 1 only implies.
+* Bad: costs a job and minutes to protect a file nothing consumes.
+* Bad: still needs a human to regenerate on every `src/common` dependency bump.

--- a/docs/maintenance/release-operations.md
+++ b/docs/maintenance/release-operations.md
@@ -137,7 +137,7 @@ This is what broke `main` at 4.37.4 — `@semantic-release/git` committed the re
 The release prepare step now reconciles (two `--package-lock-only` passes) and then verifies
 (`npm ci --dry-run`) after every version stamp, so a release repairs the root lockfile rather than
 corrupting it. **If you ever run `npm version --workspace` by hand, run the two-pass reconcile
-afterwards and verify with `npm ci` before committing.**
+afterward and verify with `npm ci` before committing.**
 
 ### The src/common lockfile is release-managed
 

--- a/docs/maintenance/release-operations.md
+++ b/docs/maintenance/release-operations.md
@@ -125,6 +125,23 @@ Regeneration recipe (Docker, repo mounted; on Windows Bash prefix commands with
 Local-dev workaround while a lockfile is broken: `npm install --no-save --package-lock=false`.
 Commit only `package.json`/lockfile/src-common dep changes; discard generated-file CRLF churn.
 
+### The src/common lockfile is release-managed
+
+`src/common/package-lock.json` is rebuilt on every release by
+[scripts/sync-common-version.js](../../scripts/sync-common-version.js) (ADR 01091), so you normally
+don't touch it — bump `src/common/package.json` and the lockfile catches up at the next release.
+
+If you must regenerate it by hand, run npm from inside `src/common` **with `--no-workspaces`**:
+
+```bash
+cd src/common && npm install --package-lock-only --ignore-scripts --no-audit --no-fund --no-workspaces
+```
+
+Without `--no-workspaces` npm walks up, finds `workspaces: ["src/common"]` in the root manifest, and
+rewrites the **root** `package-lock.json` while leaving `src/common`'s byte-identical — the inverse
+of what you asked for. Same trap when verifying: `npm ci` inside `src/common` validates the *root*
+lockfile unless you pass `--no-workspaces`.
+
 ## Working in git worktrees
 
 Worktrees have no `node_modules`, so the husky `commit-msg` hook's `npx commitlint` fails ("npx

--- a/docs/maintenance/release-operations.md
+++ b/docs/maintenance/release-operations.md
@@ -125,6 +125,20 @@ Regeneration recipe (Docker, repo mounted; on Windows Bash prefix commands with
 Local-dev workaround while a lockfile is broken: `npm install --no-save --package-lock=false`.
 Commit only `package.json`/lockfile/src-common dep changes; discard generated-file CRLF churn.
 
+### `npm version --workspace` corrupts the root lockfile
+
+`npm version <v> --workspace src/common` rewrites the **root** `package-lock.json` as a side effect,
+and the tree it emits does not install. Measured on npm 10 (node 22): from a root lockfile where
+`npm ci` passes, the stamp alone leaves `npm ci` failing with `EBADPLATFORM`.
+
+This is what broke `main` at 4.37.4 — `@semantic-release/git` committed the result unverified, and
+`npm ci` failed for every job and contributor until it was repaired by hand (#705).
+
+The release prepare step now reconciles (two `--package-lock-only` passes) and then verifies
+(`npm ci --dry-run`) after every version stamp, so a release repairs the root lockfile rather than
+corrupting it. **If you ever run `npm version --workspace` by hand, run the two-pass reconcile
+afterwards and verify with `npm ci` before committing.**
+
 ### The src/common lockfile is release-managed
 
 `src/common/package-lock.json` is rebuilt on every release by

--- a/scripts/sync-common-version.js
+++ b/scripts/sync-common-version.js
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 // semantic-release `prepare` step for the doc-detective-common workspace.
 //
-// Two things must happen before @semantic-release/git commits its assets:
+// Four things happen before @semantic-release/git commits its assets:
 //   1. Stamp the release version onto src/common (package.json + its lockfile).
 //   2. Rebuild src/common/package-lock.json so its dependency tree matches
 //      src/common/package.json.
+//   3. Reconcile the ROOT lockfile, which step 1 corrupts as a side effect.
+//   4. Verify the ROOT lockfile installs, and fail the release if not.
 //
 // Step 2 exists because `npm version` only rewrites the `version` fields. For a
 // long time that was the ONLY thing that ever touched src/common's lockfile, so
@@ -12,30 +14,58 @@
 // version onto a lockfile whose deps no longer satisfied its own manifest, and
 // `npm ci` inside src/common failed with EUSAGE. CI never noticed because it
 // installs from the ROOT lockfile and runs the src/common scripts against the
-// hoisted workspace node_modules. See ADR 01091.
+// hoisted workspace node_modules.
+//
+// Steps 3 and 4 exist because step 1 has a side effect: `npm version
+// --workspace` rewrites the ROOT lockfile too, and the tree it emits does not
+// install. Measured on npm 10 (node 22, the release job's runtime): starting
+// from a root lockfile where `npm ci` passes, running the step-1 stamp alone
+// leaves `npm ci` failing with EBADPLATFORM. In the 4.37.4 release that broken
+// lockfile was committed by @semantic-release/git and `npm ci` broke on main
+// for every job and every contributor (repaired by hand in #705).
+//
+// The two `--package-lock-only` passes in step 3 are the same recipe as
+// docs/maintenance/release-operations.md: the second pass drops the
+// platform-gated "extraneous" entries that make `npm ci` fail with EBADPLATFORM
+// on other OSes. Verified to restore a working lockfile from both a healthy and
+// an already-broken starting point, so a release now self-heals the root
+// lockfile instead of corrupting it. Step 4 is the backstop -- if the reconcile
+// ever fails to produce an installable tree, the release stops instead of
+// committing the damage.
+//
+// See ADR 01091.
 
 import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+/** Repo root, derived from this file's location rather than process.cwd(). */
+export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 /**
  * Build the ordered npm invocations for a release of `version`.
  *
  * Pure and side-effect free so test/sync-common-version.test.js can assert the
- * exact flags without spawning npm.
+ * exact flags without spawning npm. `repoRoot` is injected (rather than read
+ * from process.cwd()) so every cwd is absolute and the script behaves the same
+ * no matter where it is invoked from.
  *
  * Order matters: the version stamp must land before the lockfile rebuild, so
  * the regenerated lockfile carries the release version rather than the previous
- * one.
+ * one, and the root verification must come last so it sees the final state.
  */
-export function buildSyncCommands(version) {
+export function buildSyncCommands(version, repoRoot = REPO_ROOT) {
+  const commonDir = path.join(repoRoot, 'src', 'common');
   return [
     {
       cmd: 'npm',
-      // Run from the repo root so `--workspace` resolves. This also updates the
-      // root lockfile's entry for the workspace.
-      cwd: '.',
+      // Run from the repo root so `--workspace` resolves. Side effect: this
+      // also rewrites the root lockfile's entry for the workspace, which is
+      // why step 3 below verifies the result.
+      cwd: repoRoot,
       args: [
         'version',
         version,
@@ -48,7 +78,7 @@ export function buildSyncCommands(version) {
     {
       cmd: 'npm',
       // Run INSIDE the workspace so npm rewrites that package's own lockfile.
-      cwd: 'src/common',
+      cwd: commonDir,
       args: [
         'install',
         '--package-lock-only',
@@ -62,6 +92,26 @@ export function buildSyncCommands(version) {
         // files, so omitting this flag ships a corrupted root lockfile.
         '--no-workspaces',
       ],
+    },
+    // Reconcile the root lockfile that step 1 corrupted. Two passes, per
+    // docs/maintenance/release-operations.md -- a single pass leaves the
+    // platform-gated "extraneous" entries that fail `npm ci` with EBADPLATFORM
+    // on other OSes. `--package-lock-only` resolves without materializing
+    // node_modules, so it does not prune the cross-platform optional tree the
+    // way a plain `npm install` on a Linux runner would.
+    ...[1, 2].map(() => ({
+      cmd: 'npm',
+      cwd: repoRoot,
+      args: ['install', '--package-lock-only', '--ignore-scripts', '--no-audit', '--no-fund'],
+    })),
+    {
+      cmd: 'npm',
+      // Backstop, not a mutation: `ci --dry-run` resolves the root lockfile
+      // against the root manifest and exits non-zero on any Missing/Invalid/
+      // EBADPLATFORM entry, without writing anything. This is the check every
+      // CI job performs, run before the commit rather than after it.
+      cwd: repoRoot,
+      args: ['ci', '--dry-run', '--ignore-scripts', '--no-audit', '--no-fund'],
     },
   ];
 }
@@ -83,6 +133,13 @@ function main(argv) {
   for (const { cmd, args, cwd } of buildSyncCommands(version)) {
     console.log(`$ (${cwd}) ${cmd} ${args.join(' ')}`);
     const result = spawnSync(cmd, args, { stdio: 'inherit', shell, cwd });
+    // spawnSync reports a failure to *launch* (npm not on PATH, cwd missing)
+    // via `error`, leaving status null. Surface it — otherwise the release
+    // dies with a bare exit 1 and no diagnostic.
+    if (result.error) {
+      console.error(`Failed to run \`${cmd} ${args.join(' ')}\` in ${cwd}: ${result.error.message}`);
+      process.exit(1);
+    }
     if (result.status !== 0) {
       process.exit(result.status ?? 1);
     }
@@ -91,8 +148,22 @@ function main(argv) {
   console.log(`Synced doc-detective-common to ${version} and rebuilt its lockfile`);
 }
 
-// Only run when invoked as a script; importing this module (from tests) must be
-// side-effect free.
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+// Only run the release steps when executed as a script, not when a test imports
+// this module for the exported pure helpers above. realpath both sides so a
+// relative argv[1], a symlink, or Windows path-case differences can't make the
+// comparison fail — a false negative here would silently skip the entire
+// prepare step.
+function isInvokedDirectly() {
+  try {
+    if (!process.argv[1]) return false;
+    return (
+      fs.realpathSync(process.argv[1]) === fs.realpathSync(fileURLToPath(import.meta.url))
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isInvokedDirectly()) {
   main(process.argv);
 }

--- a/scripts/sync-common-version.js
+++ b/scripts/sync-common-version.js
@@ -1,34 +1,98 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
+// semantic-release `prepare` step for the doc-detective-common workspace.
+//
+// Two things must happen before @semantic-release/git commits its assets:
+//   1. Stamp the release version onto src/common (package.json + its lockfile).
+//   2. Rebuild src/common/package-lock.json so its dependency tree matches
+//      src/common/package.json.
+//
+// Step 2 exists because `npm version` only rewrites the `version` fields. For a
+// long time that was the ONLY thing that ever touched src/common's lockfile, so
+// its dependency tree silently rotted: every release faithfully stamped a new
+// version onto a lockfile whose deps no longer satisfied its own manifest, and
+// `npm ci` inside src/common failed with EUSAGE. CI never noticed because it
+// installs from the ROOT lockfile and runs the src/common scripts against the
+// hoisted workspace node_modules. See ADR 01091.
 
-const version = process.argv[2];
-if (!version) {
-  console.error('Usage: sync-common-version.js <version>');
-  process.exit(1);
-}
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
-if (!SEMVER.test(version)) {
-  console.error(`Refusing to run: ${JSON.stringify(version)} is not a valid semver version`);
-  process.exit(1);
+
+/**
+ * Build the ordered npm invocations for a release of `version`.
+ *
+ * Pure and side-effect free so test/sync-common-version.test.js can assert the
+ * exact flags without spawning npm.
+ *
+ * Order matters: the version stamp must land before the lockfile rebuild, so
+ * the regenerated lockfile carries the release version rather than the previous
+ * one.
+ */
+export function buildSyncCommands(version) {
+  return [
+    {
+      cmd: 'npm',
+      // Run from the repo root so `--workspace` resolves. This also updates the
+      // root lockfile's entry for the workspace.
+      cwd: '.',
+      args: [
+        'version',
+        version,
+        '--workspace',
+        'src/common',
+        '--no-git-tag-version',
+        '--allow-same-version',
+      ],
+    },
+    {
+      cmd: 'npm',
+      // Run INSIDE the workspace so npm rewrites that package's own lockfile.
+      cwd: 'src/common',
+      args: [
+        'install',
+        '--package-lock-only',
+        '--ignore-scripts',
+        '--no-audit',
+        '--no-fund',
+        // Load-bearing. Without it npm walks up from src/common, finds
+        // `workspaces: ["src/common"]` in the root manifest, and rewrites the
+        // ROOT package-lock.json while leaving src/common's untouched -- the
+        // exact inverse of the intent. @semantic-release/git commits both
+        // files, so omitting this flag ships a corrupted root lockfile.
+        '--no-workspaces',
+      ],
+    },
+  ];
 }
 
-const args = [
-  'version',
-  version,
-  '--workspace',
-  'src/common',
-  '--no-git-tag-version',
-  '--allow-same-version',
-];
+function main(argv) {
+  const version = argv[2];
+  if (!version) {
+    console.error('Usage: sync-common-version.js <version>');
+    process.exit(1);
+  }
 
-const result = spawnSync('npm', args, {
-  stdio: 'inherit',
-  shell: process.platform === 'win32',
-});
+  if (!SEMVER.test(version)) {
+    console.error(`Refusing to run: ${JSON.stringify(version)} is not a valid semver version`);
+    process.exit(1);
+  }
 
-if (result.status !== 0) {
-  process.exit(result.status ?? 1);
+  const shell = process.platform === 'win32';
+
+  for (const { cmd, args, cwd } of buildSyncCommands(version)) {
+    console.log(`$ (${cwd}) ${cmd} ${args.join(' ')}`);
+    const result = spawnSync(cmd, args, { stdio: 'inherit', shell, cwd });
+    if (result.status !== 0) {
+      process.exit(result.status ?? 1);
+    }
+  }
+
+  console.log(`Synced doc-detective-common to ${version} and rebuilt its lockfile`);
 }
 
-console.log(`Synced doc-detective-common to ${version}`);
+// Only run when invoked as a script; importing this module (from tests) must be
+// side-effect free.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main(process.argv);
+}

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -210,7 +210,7 @@ Triggered by push to `main`, `next`, or any `feat/**` branch. Steps:
 2. `npx semantic-release` analyzes commits since the last tag, then:
    - Computes the next semver from commit types (`fix` → patch, `feat` → minor, `!` or `BREAKING CHANGE` → major)
    - Updates `CHANGELOG.md` (root)
-   - Runs [scripts/sync-common-version.js](../../scripts/sync-common-version.js) to mirror the new version into this package's `package.json`, then rebuild `src/common/package-lock.json` so its dependency tree matches that manifest (see [ADR 01091](../../adrs/01091-rebuild-the-common-lockfile-during-release.md))
+   - Runs [scripts/sync-common-version.js](../../scripts/sync-common-version.js) to mirror the new version into this package's `package.json`, then rebuilds `src/common/package-lock.json` so its dependency tree matches that manifest, and verifies the root lockfile still installs (see [ADR 01091](../../adrs/01091-rebuild-the-common-lockfile-during-release.md))
    - Publishes both `doc-detective` (root) and `doc-detective-common` (this package) to the channel's dist-tag
    - Commits the version bump + changelog back to the branch with `chore(release): X.Y.Z [skip ci]`
    - Creates the git tag `vX.Y.Z` and a GitHub Release

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -210,12 +210,14 @@ Triggered by push to `main`, `next`, or any `feat/**` branch. Steps:
 2. `npx semantic-release` analyzes commits since the last tag, then:
    - Computes the next semver from commit types (`fix` → patch, `feat` → minor, `!` or `BREAKING CHANGE` → major)
    - Updates `CHANGELOG.md` (root)
-   - Runs [scripts/sync-common-version.js](../../scripts/sync-common-version.js) to mirror the new version into this package's `package.json`
+   - Runs [scripts/sync-common-version.js](../../scripts/sync-common-version.js) to mirror the new version into this package's `package.json`, then rebuild `src/common/package-lock.json` so its dependency tree matches that manifest (see [ADR 01091](../../adrs/01091-rebuild-the-common-lockfile-during-release.md))
    - Publishes both `doc-detective` (root) and `doc-detective-common` (this package) to the channel's dist-tag
    - Commits the version bump + changelog back to the branch with `chore(release): X.Y.Z [skip ci]`
    - Creates the git tag `vX.Y.Z` and a GitHub Release
 
 **No human ever edits `version` in either `package.json`.** The sync script overwrites `src/common/package.json` during release.
+
+**`src/common/package-lock.json` is release-managed too.** The sync script regenerates it every release, so it self-heals: if you bump a dependency in `src/common/package.json`, the lockfile catches up at the next release rather than needing a hand-run `npm install`. If you *do* regenerate it manually, run npm from inside `src/common` **with `--no-workspaces`** — without that flag npm walks up, finds `workspaces: ["src/common"]` in the root manifest, and rewrites the **root** `package-lock.json` instead, leaving this one untouched.
 
 #### Downstream (`.github/workflows/npm-test.yaml`)
 

--- a/test/sync-common-version.test.js
+++ b/test/sync-common-version.test.js
@@ -1,0 +1,58 @@
+import { buildSyncCommands } from "../scripts/sync-common-version.js";
+
+before(async function () {
+  const { expect } = await import("chai");
+  global.expect = expect;
+});
+
+describe("scripts/sync-common-version buildSyncCommands", function () {
+  it("stamps the version onto the src/common workspace first", function () {
+    const [versionStep] = buildSyncCommands("4.37.5");
+    expect(versionStep.args).to.deep.equal([
+      "version",
+      "4.37.5",
+      "--workspace",
+      "src/common",
+      "--no-git-tag-version",
+      "--allow-same-version",
+    ]);
+    // Runs from the repo root so `--workspace` resolves.
+    expect(versionStep.cwd).to.equal(".");
+  });
+
+  it("regenerates the src/common lockfile after stamping the version", function () {
+    const steps = buildSyncCommands("4.37.5");
+    expect(steps).to.have.lengthOf(2);
+    const lockStep = steps[1];
+    expect(lockStep.args[0]).to.equal("install");
+    expect(lockStep.args).to.include("--package-lock-only");
+    // Must run inside the workspace so it rewrites that package's own lockfile.
+    expect(lockStep.cwd).to.equal("src/common");
+  });
+
+  it("passes --no-workspaces so the ROOT lockfile is not hijacked", function () {
+    // Without this flag npm walks up, discovers `workspaces: ["src/common"]` in
+    // the root manifest, and rewrites the ROOT package-lock.json while leaving
+    // src/common/package-lock.json untouched -- the exact inverse of the intent.
+    // @semantic-release/git commits both files, so the regression would ship a
+    // silently corrupted root lockfile. Verified against npm 10 (node 22, the
+    // release job's runtime).
+    const lockStep = buildSyncCommands("4.37.5")[1];
+    expect(lockStep.args).to.include("--no-workspaces");
+  });
+
+  it("keeps the lockfile rebuild side-effect free and quiet", function () {
+    // --ignore-scripts: never run src/common lifecycle hooks during a release.
+    // --package-lock-only: resolve the tree without materializing node_modules.
+    const lockStep = buildSyncCommands("4.37.5")[1];
+    expect(lockStep.args).to.include("--ignore-scripts");
+    expect(lockStep.args).to.include("--no-audit");
+    expect(lockStep.args).to.include("--no-fund");
+  });
+
+  it("threads any valid semver through unchanged, including prereleases", function () {
+    // Prerelease versions reach this script on the `next` and `feat/**` channels.
+    const [versionStep] = buildSyncCommands("5.0.0-next.3");
+    expect(versionStep.args).to.include("5.0.0-next.3");
+  });
+});

--- a/test/sync-common-version.test.js
+++ b/test/sync-common-version.test.js
@@ -1,13 +1,17 @@
-import { buildSyncCommands } from "../scripts/sync-common-version.js";
+import path from "node:path";
+import { buildSyncCommands, REPO_ROOT } from "../scripts/sync-common-version.js";
 
 before(async function () {
   const { expect } = await import("chai");
   global.expect = expect;
 });
 
+const ROOT = path.join(path.sep, "repo");
+
 describe("scripts/sync-common-version buildSyncCommands", function () {
   it("stamps the version onto the src/common workspace first", function () {
-    const [versionStep] = buildSyncCommands("4.37.5");
+    const [versionStep] = buildSyncCommands("4.37.5", ROOT);
+    expect(versionStep.cmd).to.equal("npm");
     expect(versionStep.args).to.deep.equal([
       "version",
       "4.37.5",
@@ -17,17 +21,17 @@ describe("scripts/sync-common-version buildSyncCommands", function () {
       "--allow-same-version",
     ]);
     // Runs from the repo root so `--workspace` resolves.
-    expect(versionStep.cwd).to.equal(".");
+    expect(versionStep.cwd).to.equal(ROOT);
   });
 
   it("regenerates the src/common lockfile after stamping the version", function () {
-    const steps = buildSyncCommands("4.37.5");
-    expect(steps).to.have.lengthOf(2);
+    const steps = buildSyncCommands("4.37.5", ROOT);
     const lockStep = steps[1];
+    expect(lockStep.cmd).to.equal("npm");
     expect(lockStep.args[0]).to.equal("install");
     expect(lockStep.args).to.include("--package-lock-only");
     // Must run inside the workspace so it rewrites that package's own lockfile.
-    expect(lockStep.cwd).to.equal("src/common");
+    expect(lockStep.cwd).to.equal(path.join(ROOT, "src", "common"));
   });
 
   it("passes --no-workspaces so the ROOT lockfile is not hijacked", function () {
@@ -37,22 +41,63 @@ describe("scripts/sync-common-version buildSyncCommands", function () {
     // @semantic-release/git commits both files, so the regression would ship a
     // silently corrupted root lockfile. Verified against npm 10 (node 22, the
     // release job's runtime).
-    const lockStep = buildSyncCommands("4.37.5")[1];
+    const lockStep = buildSyncCommands("4.37.5", ROOT)[1];
     expect(lockStep.args).to.include("--no-workspaces");
   });
 
   it("keeps the lockfile rebuild side-effect free and quiet", function () {
     // --ignore-scripts: never run src/common lifecycle hooks during a release.
     // --package-lock-only: resolve the tree without materializing node_modules.
-    const lockStep = buildSyncCommands("4.37.5")[1];
+    const lockStep = buildSyncCommands("4.37.5", ROOT)[1];
     expect(lockStep.args).to.include("--ignore-scripts");
     expect(lockStep.args).to.include("--no-audit");
     expect(lockStep.args).to.include("--no-fund");
   });
 
+  it("reconciles the ROOT lockfile twice, because the version stamp corrupts it", function () {
+    // `npm version --workspace` (step 1) rewrites the root lockfile as a side
+    // effect and the tree it emits does not install -- measured on npm 10, a
+    // healthy lockfile goes to EBADPLATFORM from the stamp alone. That is what
+    // shipped in 4.37.4 and broke `npm ci` on main (#705).
+    //
+    // TWO passes, per docs/maintenance/release-operations.md: the second drops
+    // the platform-gated "extraneous" entries a single pass leaves behind.
+    // Dropping to one pass silently reintroduces the EBADPLATFORM failure on
+    // other OSes, so the count is asserted.
+    const steps = buildSyncCommands("4.37.5", ROOT);
+    const reconcile = steps.slice(2, 4);
+    expect(reconcile).to.have.lengthOf(2);
+    for (const step of reconcile) {
+      expect(step.cmd).to.equal("npm");
+      expect(step.cwd).to.equal(ROOT);
+      expect(step.args).to.include("--package-lock-only");
+      expect(step.args).to.not.include("--no-workspaces");
+    }
+  });
+
+  it("verifies the ROOT lockfile last, without mutating it", function () {
+    const steps = buildSyncCommands("4.37.5", ROOT);
+    expect(steps).to.have.lengthOf(5);
+    const verifyStep = steps[4];
+    expect(verifyStep.cmd).to.equal("npm");
+    expect(verifyStep.args.slice(0, 2)).to.deep.equal(["ci", "--dry-run"]);
+    expect(verifyStep.cwd).to.equal(ROOT);
+    // --dry-run is what makes this a backstop rather than another rebuild.
+    expect(verifyStep.args).to.not.include("--package-lock-only");
+  });
+
   it("threads any valid semver through unchanged, including prereleases", function () {
     // Prerelease versions reach this script on the `next` and `feat/**` channels.
-    const [versionStep] = buildSyncCommands("5.0.0-next.3");
+    const [versionStep] = buildSyncCommands("5.0.0-next.3", ROOT);
     expect(versionStep.args).to.include("5.0.0-next.3");
+  });
+
+  it("defaults to a repo root derived from the module, not process.cwd()", function () {
+    // Guards against a caller in a subdirectory silently targeting the wrong
+    // tree. REPO_ROOT is absolute and resolves to the directory holding
+    // package.json.
+    expect(path.isAbsolute(REPO_ROOT)).to.equal(true);
+    const [versionStep] = buildSyncCommands("4.37.5");
+    expect(versionStep.cwd).to.equal(REPO_ROOT);
   });
 });


### PR DESCRIPTION
`src/common/package-lock.json` is committed on every release — it's in the `@semantic-release/git` assets — but the only thing that ever *wrote* to it was `npm version`, which rewrites the two `version` fields and nothing else. The dependency tree never moved, so each release stamped a fresh version onto a lockfile whose deps no longer satisfied its own manifest.

On `main` at 4.37.4, `npm ci` inside `src/common` fails:

```
npm error code EUSAGE
npm error Invalid: lock file's @apidevtools/json-schema-ref-parser@15.3.5 does not satisfy @apidevtools/json-schema-ref-parser@15.5.1
npm error Invalid: lock file's @types/node@25.9.2 does not satisfy @types/node@26.2.0
npm error Invalid: lock file's c8@11.0.0 does not satisfy c8@12.0.0
npm error Invalid: lock file's esbuild@0.28.0 does not satisfy esbuild@0.28.2
```

Nothing caught it because **CI never reads the file** — `test.yml` runs `npm ci` at the repo root and then runs the `src/common` scripts against the hoisted workspace `node_modules`. It looked maintained because it changed on every release.

## The change

`sync-common-version.js` now runs an ordered plan — stamp the version, then rebuild the lockfile — exposed as a pure `buildSyncCommands()` so the flags are testable without spawning npm. Stamping first means the rebuilt lockfile carries the release version. **No `.releaserc.json` or workflow change is needed**: the file is already a release-committed asset and the release job already invokes this script.

The module is now import-safe (`main()` runs only on direct invocation) so tests can import it. The direct-run guard was verified on Windows as well as Linux.

## `--no-workspaces` is load-bearing

The obvious implementation does the *opposite* of what it looks like. npm walks up from `src/common`, finds `workspaces: ["src/common"]` in the root manifest, and treats it as a workspace operation. Measured on npm 10 (node 22, the release job's runtime):

| invocation (cwd `src/common`) | root lockfile | common lockfile |
|---|---|---|
| `npm install --package-lock-only` | **rewritten** | unchanged |
| `npm install --package-lock-only --no-workspaces` | unchanged | **rebuilt** |

Since `@semantic-release/git` commits *both* files, omitting the flag would ship a silently corrupted root lockfile. There's a dedicated regression test for it.

Same trap when verifying — `npm ci` inside `src/common` validates the **root** lockfile unless you pass `--no-workspaces`. That bit me while testing this.

## Verification

Red→green in a `node:22` container against the tree as shipped on `main`:

| | `npm ci --ignore-scripts --no-workspaces` in `src/common` |
|---|---|
| before prepare step | **fails** (EUSAGE, above) |
| after prepare step | **OK** |

Root lockfile stays unperturbed. (Release 4.37.4 shows the root lockfile already churns 3250/273 lines during a release from `npm version` reconciliation — pre-existing and independent of this change.)

Unit tests: 5 new in `test/sync-common-version.test.js` pinning the command plan; `publish-manifest` tests still green (13 passing together).

I did not run the full 14-minute root suite locally — the change is confined to a script only semantic-release invokes, and my local environment has 25 pre-existing browser-detection failures that would drown the signal. CI is the gate.

## Heads-up for the next release

Expect a one-time **~800-line catch-up diff** in `src/common/package-lock.json`, including major transitive moves (`@types/node` 25→26, `undici-types` 7→8) that accumulated while the file was frozen. Subsequent releases should be quiet.

This commit is typed `ci:`, so it cuts no release itself — the rebuild first runs on the next `fix`/`feat` release.

## ADR / fixtures / docs impact

- **ADR**: [01091](adrs/01091-rebuild-the-common-lockfile-during-release.md), following the CI-change precedent of 01089. It records the rejected alternative — **deleting** the lockfile — which is arguably the more honest fix if `doc-detective-common` is only ever installed as a workspace. That's a product question this PR doesn't settle; say the word and I'll swap approaches.
- **Fixtures**: none — no user-facing feature.
- **Docs impact**: **none user-facing.** Nothing a user configures, runs, or relies on changes. Maintainer docs updated: `src/common/AGENTS.md` and `docs/maintenance/release-operations.md` both record the `--no-workspaces` hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Common package releases now regenerate its lockfile after version updates.
  * Improved safeguards reconcile and verify the root lockfile, preventing unintended changes.

* **Documentation**
  * Added guidance for automatic and manual lockfile regeneration, including required workspace settings.
  * Documented release verification steps and lockfile behavior.

* **Tests**
  * Added coverage for version synchronization, lockfile handling, prerelease versions, command options, and root lockfile protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->