### PR TITLE
fix(release): verify the root lockfile as the last prepare step

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -35,6 +35,7 @@
     [
       "@semantic-release/exec",
       {
+        "prepareCmd": "node scripts/reconcile-root-lockfile.js",
         "publishCmd": "node scripts/publish-staged-release.js ${nextRelease.version} ${nextRelease.channel ? nextRelease.channel : 'staging-' + nextRelease.version}",
         "successCmd": "echo 'version=${nextRelease.version}' >> \"$GITHUB_OUTPUT\" && echo 'channel=${nextRelease.channel || \"\"}' >> \"$GITHUB_OUTPUT\" && echo 'published=true' >> \"$GITHUB_OUTPUT\""
       }

--- a/adrs/01093-verify-the-root-lockfile-as-the-last-prepare-step.md
+++ b/adrs/01093-verify-the-root-lockfile-as-the-last-prepare-step.md
@@ -11,22 +11,28 @@ decision-makers: doc-detective maintainers
 Two consecutive releases committed a root `package-lock.json` that does not install, breaking `main`
 for every CI job and every contributor:
 
+**Three** consecutive releases committed a root `package-lock.json` that does not install, breaking
+`main` for every CI job and every contributor:
+
 | release | symptom | repaired by |
 |---|---|---|
 | 4.37.4 | `npm ci` → `EUSAGE Missing: conventional-commits-filter@6.0.1` | #705, deliberately |
 | 4.37.5 | identical | #702, incidentally |
+| 4.38.0 | identical | this change |
 
-Both times the same two `"optional": true, "peer": true` entries under
+Every time, the same two `"optional": true, "peer": true` entries under
 `@commitlint/read/node_modules/` were pruned from the tree.
 
-The second repair is worth dwelling on, because it is the reason this ADR is not simply "fix the
-lockfile again." Nobody fixed it. #702 was a reporters feature that happened to carry a lockfile
-regenerated from a healthy tree, and merging it restored the missing entries as a side effect. Had
-that PR not landed when it did, `main` would still be red. **The repo recovered by luck**, which is
-not a property anyone can rely on twice.
+The middle row is the one to dwell on, and the last row is why. Nobody fixed 4.37.5: #702 was a
+reporters feature that happened to carry a lockfile regenerated from a healthy tree, and merging it
+restored the entries as a side effect. **The repo recovered by luck.**
 
-That is also why this change carries no `package-lock.json` edit: by the time it was rebased, there
-was nothing left to repair. Only the guard remains — and the guard is the point.
+That luck held for about four hours. Merging #702 is what triggered the 4.38.0 release, and 4.38.0
+pruned the same two entries again — while this ADR sat unmerged, describing the guard that would have
+caught it. The accidental repair and the next breakage were the same event.
+
+So the case does not rest on argument any more. Three releases, one signature, one of them repaired
+purely by chance: **a lockfile that is committed without being verified will keep being wrong.**
 
 [ADR 01091](01091-rebuild-the-common-lockfile-during-release.md) added a root reconcile and an
 `npm ci --dry-run` backstop to [scripts/sync-common-version.js](../scripts/sync-common-version.js),

--- a/adrs/01093-verify-the-root-lockfile-as-the-last-prepare-step.md
+++ b/adrs/01093-verify-the-root-lockfile-as-the-last-prepare-step.md
@@ -14,7 +14,7 @@ for every CI job and every contributor:
 | release | symptom | repaired in |
 |---|---|---|
 | 4.37.4 | `npm ci` → `EUSAGE Missing: conventional-commits-filter@6.0.1` | #705 |
-| 4.37.5 | identical | #706 |
+| 4.37.5 | identical | #707 |
 
 Both times the same two `"optional": true, "peer": true` entries under
 `@commitlint/read/node_modules/` were pruned from the tree.

--- a/adrs/01093-verify-the-root-lockfile-as-the-last-prepare-step.md
+++ b/adrs/01093-verify-the-root-lockfile-as-the-last-prepare-step.md
@@ -1,0 +1,104 @@
+---
+status: accepted
+date: 2026-08-11
+decision-makers: doc-detective maintainers
+---
+
+# Reconcile and verify the root lockfile as the last prepare step
+
+## Context and Problem Statement
+
+Two consecutive releases committed a root `package-lock.json` that does not install, breaking `main`
+for every CI job and every contributor:
+
+| release | symptom | repaired in |
+|---|---|---|
+| 4.37.4 | `npm ci` → `EUSAGE Missing: conventional-commits-filter@6.0.1` | #705 |
+| 4.37.5 | identical | #706 |
+
+Both times the same two `"optional": true, "peer": true` entries under
+`@commitlint/read/node_modules/` were pruned from the tree.
+
+[ADR 01091](01091-rebuild-the-common-lockfile-during-release.md) added a root reconcile and an
+`npm ci --dry-run` backstop to [scripts/sync-common-version.js](../scripts/sync-common-version.js),
+and 4.37.5 was the first release to run it. **It still shipped a broken lockfile**, and the
+verification passed on the way through.
+
+### Why the guard did not fire
+
+semantic-release runs each plugin's `prepare` in plugin order. The relevant slice of
+[.releaserc.json](../.releaserc.json) was:
+
+```text
+@semantic-release/changelog     prepare
+@semantic-release/exec          prepare -> sync-common-version.js   <- reconcile + verify lived here
+@semantic-release/npm           prepare -> npm version (root)       <- rewrites the lockfile again
+@semantic-release/exec          publish
+@semantic-release/git           prepare -> commits the assets
+```
+
+The reconcile and verification ran *before* `@semantic-release/npm` stamped the root version. That
+stamp rewrites `package-lock.json` as a side effect, after the check had already passed. The
+verification was structurally incapable of seeing the state that actually got committed.
+
+A guard that runs before the last writer is not a guard.
+
+## Decision Drivers
+
+* Whatever verifies the lockfile must observe the exact bytes `@semantic-release/git` will commit.
+* Prefer a structural fix over widening the earlier guard — any future plugin that stamps a version
+  would defeat a guard placed before it.
+* Keep the concerns separable: the `src/common` lockfile and the root lockfile fail for different
+  reasons and are fixed by different commands.
+
+## Considered Options
+
+1. **Move root reconciliation into its own script, wired as the last `prepare` before
+   `@semantic-release/git`.**
+2. **Widen the existing `sync-common-version.js` guard** to also run after the npm plugin — not
+   expressible; a plugin's `prepareCmd` runs once, at its position in the sequence.
+3. **Drop `package-lock.json` from the `@semantic-release/git` assets** so releases never commit it.
+   Leaves the committed lockfile permanently stale against released versions.
+4. **Verify in a post-release CI job** and alert. Detects the breakage instead of preventing it;
+   `main` is already broken by then — which is exactly the state this ADR exists to end.
+
+## Decision Outcome
+
+Chosen option: **1**. Root reconciliation and verification move to
+[scripts/reconcile-root-lockfile.js](../scripts/reconcile-root-lockfile.js), wired as a `prepareCmd`
+on the `@semantic-release/exec` entry that already sits between `@semantic-release/npm` and
+`@semantic-release/git`. Nothing rewrites the lockfile after it runs.
+
+`sync-common-version.js` keeps only what it can validly own: stamping the `src/common` version and
+rebuilding that workspace's own lockfile. Its root-lockfile steps are removed rather than left as
+dead weight that implies a guarantee it cannot provide.
+
+The mechanics are unchanged from ADR 01091 — two `--package-lock-only` passes (the second drops the
+platform-gated `"extraneous"` entries that fail `npm ci` with EBADPLATFORM elsewhere), then
+`npm ci --dry-run` as a non-mutating backstop that stops the release rather than committing damage.
+
+### Consequences
+
+* Good: the committed root lockfile is verified in the state it is committed in.
+* Good: robust against future plugin additions, as long as the reconcile stays last. A unit test
+  asserts its position in `.releaserc.json` relative to the npm and git plugins, so reordering the
+  plugin list fails the suite rather than silently reintroducing this bug.
+* Neutral: a release can now fail at prepare. That is the intent; recovery is the regeneration
+  recipe in [docs/maintenance/release-operations.md](../docs/maintenance/release-operations.md)
+  followed by re-running the release.
+* Bad: this is the second attempt at the same defect. The first shipped because it was validated in
+  isolation — running the script by hand against a checkout — rather than against the real plugin
+  sequence. The wiring test exists so the *ordering*, not just the script, is covered.
+
+### Confirmation
+
+* Unit tests in [test/reconcile-root-lockfile.test.js](../test/reconcile-root-lockfile.test.js)
+  pin the command plan and assert the `prepareCmd` sits after `@semantic-release/npm` and before
+  `@semantic-release/git` in `.releaserc.json`.
+* [test/sync-common-version.test.js](../test/sync-common-version.test.js) asserts that script no
+  longer issues any root-directory `install` or `ci`, so the responsibility cannot drift back.
+* The repaired 4.37.5 lockfile installs under node:22 and node:24 Linux.
+* Residual risk, stated plainly: the end-to-end behavior of the *new ordering* is only exercised by
+  a real release. Local replays of the prepare sequence — including with `node_modules` present, as
+  in the release job — did not reproduce the pruning, so the next release is the real test. The
+  backstop is designed to fail the release rather than commit a bad lockfile if it recurs.

--- a/adrs/01093-verify-the-root-lockfile-as-the-last-prepare-step.md
+++ b/adrs/01093-verify-the-root-lockfile-as-the-last-prepare-step.md
@@ -8,9 +8,6 @@ decision-makers: doc-detective maintainers
 
 ## Context and Problem Statement
 
-Two consecutive releases committed a root `package-lock.json` that does not install, breaking `main`
-for every CI job and every contributor:
-
 **Three** consecutive releases committed a root `package-lock.json` that does not install, breaking
 `main` for every CI job and every contributor:
 

--- a/adrs/01093-verify-the-root-lockfile-as-the-last-prepare-step.md
+++ b/adrs/01093-verify-the-root-lockfile-as-the-last-prepare-step.md
@@ -11,13 +11,22 @@ decision-makers: doc-detective maintainers
 Two consecutive releases committed a root `package-lock.json` that does not install, breaking `main`
 for every CI job and every contributor:
 
-| release | symptom | repaired in |
+| release | symptom | repaired by |
 |---|---|---|
-| 4.37.4 | `npm ci` → `EUSAGE Missing: conventional-commits-filter@6.0.1` | #705 |
-| 4.37.5 | identical | #707 |
+| 4.37.4 | `npm ci` → `EUSAGE Missing: conventional-commits-filter@6.0.1` | #705, deliberately |
+| 4.37.5 | identical | #702, incidentally |
 
 Both times the same two `"optional": true, "peer": true` entries under
 `@commitlint/read/node_modules/` were pruned from the tree.
+
+The second repair is worth dwelling on, because it is the reason this ADR is not simply "fix the
+lockfile again." Nobody fixed it. #702 was a reporters feature that happened to carry a lockfile
+regenerated from a healthy tree, and merging it restored the missing entries as a side effect. Had
+that PR not landed when it did, `main` would still be red. **The repo recovered by luck**, which is
+not a property anyone can rely on twice.
+
+That is also why this change carries no `package-lock.json` edit: by the time it was rebased, there
+was nothing left to repair. Only the guard remains — and the guard is the point.
 
 [ADR 01091](01091-rebuild-the-common-lockfile-during-release.md) added a root reconcile and an
 `npm ci --dry-run` backstop to [scripts/sync-common-version.js](../scripts/sync-common-version.js),
@@ -97,7 +106,11 @@ platform-gated `"extraneous"` entries that fail `npm ci` with EBADPLATFORM elsew
   `@semantic-release/git` in `.releaserc.json`.
 * [test/sync-common-version.test.js](../test/sync-common-version.test.js) asserts that script no
   longer issues any root-directory `install` or `ci`, so the responsibility cannot drift back.
-* The repaired 4.37.5 lockfile installs under node:22 and node:24 Linux.
+* `npm ci` on `main` resolves 1136 packages into an empty directory under npm 10.9.8 (the release
+  job's npm), so the tree this guard now protects is known-good as of the rebase.
+* Moving the `prepareCmd` back before `@semantic-release/npm` fails the suite — checked by mutating
+  `.releaserc.json`, not assumed. Without that, the wiring test would pass on the exact defect it
+  exists to catch.
 * Residual risk, stated plainly: the end-to-end behavior of the *new ordering* is only exercised by
   a real release. Local replays of the prepare sequence — including with `node_modules` present, as
   in the release job — did not reproduce the pruning, so the next release is the real test. The

--- a/docs/maintenance/release-operations.md
+++ b/docs/maintenance/release-operations.md
@@ -131,13 +131,21 @@ Commit only `package.json`/lockfile/src-common dep changes; discard generated-fi
 and the tree it emits does not install. Measured on npm 10 (node 22): from a root lockfile where
 `npm ci` passes, the stamp alone leaves `npm ci` failing with `EBADPLATFORM`.
 
-This is what broke `main` at 4.37.4 — `@semantic-release/git` committed the result unverified, and
-`npm ci` failed for every job and contributor until it was repaired by hand (#705).
+This broke `main` twice — 4.37.4 (repaired in #705) and 4.37.5 (repaired in #706) — with the same two
+`"optional": true, "peer": true` entries under `@commitlint/read/node_modules/` pruned each time.
+`@semantic-release/git` committed the result unverified, and `npm ci` failed for every job and
+contributor until it was repaired by hand.
 
-The release prepare step now reconciles (two `--package-lock-only` passes) and then verifies
-(`npm ci --dry-run`) after every version stamp, so a release repairs the root lockfile rather than
-corrupting it. **If you ever run `npm version --workspace` by hand, run the two-pass reconcile
-afterward and verify with `npm ci` before committing.**
+[scripts/reconcile-root-lockfile.js](../../scripts/reconcile-root-lockfile.js) reconciles (two
+`--package-lock-only` passes) and then verifies (`npm ci --dry-run`) as the **last** prepare step
+before `@semantic-release/git` commits. **If you ever run `npm version --workspace` by hand, run the
+two-pass reconcile afterward and verify with `npm ci` before committing.**
+
+That ordering is load-bearing, and getting it wrong is how 4.37.5 broke despite a guard being in
+place (ADR 01093): the reconcile originally lived in `sync-common-version.js`, which runs *before*
+`@semantic-release/npm` stamps the root version — so the check passed and the lockfile was rewritten
+afterward. **Any new lockfile check must be wired after every plugin that stamps a version.** A unit
+test asserts that position in `.releaserc.json`, so reordering the plugin list fails the suite.
 
 ### The src/common lockfile is release-managed
 

--- a/docs/maintenance/release-operations.md
+++ b/docs/maintenance/release-operations.md
@@ -131,10 +131,14 @@ Commit only `package.json`/lockfile/src-common dep changes; discard generated-fi
 and the tree it emits does not install. Measured on npm 10 (node 22): from a root lockfile where
 `npm ci` passes, the stamp alone leaves `npm ci` failing with `EBADPLATFORM`.
 
-This broke `main` twice — 4.37.4 (repaired in #705) and 4.37.5 (repaired in #707) — with the same two
-`"optional": true, "peer": true` entries under `@commitlint/read/node_modules/` pruned each time.
-`@semantic-release/git` committed the result unverified, and `npm ci` failed for every job and
-contributor until it was repaired by hand.
+This broke `main` twice — 4.37.4 and 4.37.5 — with the same two `"optional": true, "peer": true`
+entries under `@commitlint/read/node_modules/` pruned each time. `@semantic-release/git` committed
+the result unverified, and `npm ci` failed for every job and every contributor.
+
+4.37.4 was repaired by hand in #705. 4.37.5 was repaired by *accident*: #702, an unrelated reporters
+feature, happened to carry a lockfile regenerated from a healthy tree, and merging it restored the
+entries. Don't count on that a third time — if you find `main` red this way, regenerate deliberately
+using the recipe above.
 
 [scripts/reconcile-root-lockfile.js](../../scripts/reconcile-root-lockfile.js) reconciles (two
 `--package-lock-only` passes) and then verifies (`npm ci --dry-run`) as the **last** prepare step

--- a/docs/maintenance/release-operations.md
+++ b/docs/maintenance/release-operations.md
@@ -131,7 +131,7 @@ Commit only `package.json`/lockfile/src-common dep changes; discard generated-fi
 and the tree it emits does not install. Measured on npm 10 (node 22): from a root lockfile where
 `npm ci` passes, the stamp alone leaves `npm ci` failing with `EBADPLATFORM`.
 
-This broke `main` twice — 4.37.4 (repaired in #705) and 4.37.5 (repaired in #706) — with the same two
+This broke `main` twice — 4.37.4 (repaired in #705) and 4.37.5 (repaired in #707) — with the same two
 `"optional": true, "peer": true` entries under `@commitlint/read/node_modules/` pruned each time.
 `@semantic-release/git` committed the result unverified, and `npm ci` failed for every job and
 contributor until it was repaired by hand.

--- a/docs/maintenance/release-operations.md
+++ b/docs/maintenance/release-operations.md
@@ -131,14 +131,19 @@ Commit only `package.json`/lockfile/src-common dep changes; discard generated-fi
 and the tree it emits does not install. Measured on npm 10 (node 22): from a root lockfile where
 `npm ci` passes, the stamp alone leaves `npm ci` failing with `EBADPLATFORM`.
 
-This broke `main` twice — 4.37.4 and 4.37.5 — with the same two `"optional": true, "peer": true`
-entries under `@commitlint/read/node_modules/` pruned each time. `@semantic-release/git` committed
-the result unverified, and `npm ci` failed for every job and every contributor.
+This broke `main` three times — 4.37.4, 4.37.5, and 4.38.0 — with the same two
+`"optional": true, "peer": true` entries under `@commitlint/read/node_modules/` pruned each time.
+`@semantic-release/git` committed the result unverified, and `npm ci` failed for every job and every
+contributor.
 
 4.37.4 was repaired by hand in #705. 4.37.5 was repaired by *accident*: #702, an unrelated reporters
 feature, happened to carry a lockfile regenerated from a healthy tree, and merging it restored the
-entries. Don't count on that a third time — if you find `main` red this way, regenerate deliberately
-using the recipe above.
+entries. That merge is also what triggered the 4.38.0 release, which pruned them again about four
+hours later — the accidental repair and the next breakage were the same event.
+
+**If you find `main` red this way, regenerate deliberately using the recipe above.** Waiting for
+another PR to carry a healthy lockfile is not a plan; it happened once, by chance, and it did not
+last a day.
 
 [scripts/reconcile-root-lockfile.js](../../scripts/reconcile-root-lockfile.js) reconciles (two
 `--package-lock-only` passes) and then verifies (`npm ci --dry-run`) as the **last** prepare step

--- a/package-lock.json
+++ b/package-lock.json
@@ -874,6 +874,37 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-parser": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
+      "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
@@ -4888,9 +4919,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4906,9 +4934,6 @@
       "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -7955,9 +7980,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8115,9 +8137,6 @@
       "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -874,37 +874,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
-      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@commitlint/read/node_modules/conventional-commits-parser": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
-      "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^2.0.0",
-        "argue-cli": "^3.1.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
@@ -4919,6 +4888,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4934,6 +4906,9 @@
       "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -7980,6 +7955,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8137,6 +8115,9 @@
       "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/scripts/reconcile-root-lockfile.js
+++ b/scripts/reconcile-root-lockfile.js
@@ -8,7 +8,7 @@
 // contributor:
 //
 //   4.37.4 -> repaired in #705
-//   4.37.5 -> repaired in #706
+//   4.37.5 -> repaired in #707
 //
 // Both times the same two `"optional": true, "peer": true` entries under
 // @commitlint/read/node_modules were pruned.

--- a/scripts/reconcile-root-lockfile.js
+++ b/scripts/reconcile-root-lockfile.js
@@ -3,12 +3,15 @@
 //
 // Every plugin that stamps a version rewrites the root package-lock.json as a
 // side effect, and the tree npm emits can drop entries the manifest still
-// requires. Twice now that produced a root lockfile which fails `npm ci`, was
+// requires. Three times now that produced a root lockfile which fails `npm ci`, was
 // committed by @semantic-release/git, and broke main for every job and every
 // contributor:
 //
 //   4.37.4 -> repaired deliberately, in #705
 //   4.37.5 -> repaired by accident, when #702 landed a healthy lockfile
+//   4.38.0 -> broke again ~4h later; merging #702 is what triggered that
+//             release, so the accidental repair and the next breakage were the
+//             same event
 //
 // Both times the same two `"optional": true, "peer": true` entries under
 // @commitlint/read/node_modules were pruned.

--- a/scripts/reconcile-root-lockfile.js
+++ b/scripts/reconcile-root-lockfile.js
@@ -13,7 +13,7 @@
 //             release, so the accidental repair and the next breakage were the
 //             same event
 //
-// Both times the same two `"optional": true, "peer": true` entries under
+// Every time, the same two `"optional": true, "peer": true` entries under
 // @commitlint/read/node_modules were pruned.
 //
 // ORDER IS THE WHOLE POINT. scripts/sync-common-version.js runs earlier in the

--- a/scripts/reconcile-root-lockfile.js
+++ b/scripts/reconcile-root-lockfile.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// semantic-release `prepare` step that runs AFTER @semantic-release/npm.
+//
+// Every plugin that stamps a version rewrites the root package-lock.json as a
+// side effect, and the tree npm emits can drop entries the manifest still
+// requires. Twice now that produced a root lockfile which fails `npm ci`, was
+// committed by @semantic-release/git, and broke main for every job and every
+// contributor:
+//
+//   4.37.4 -> repaired in #705
+//   4.37.5 -> repaired in #706
+//
+// Both times the same two `"optional": true, "peer": true` entries under
+// @commitlint/read/node_modules were pruned.
+//
+// ORDER IS THE WHOLE POINT. scripts/sync-common-version.js runs earlier in the
+// prepare sequence, so its reconcile could not see what @semantic-release/npm
+// did to the lockfile afterward -- which is why the 4.37.5 release still
+// shipped a broken one despite that script verifying successfully. This script
+// is wired as the LAST prepare step before @semantic-release/git commits, so
+// nothing rewrites the lockfile after it has been checked.
+//
+// Two `--package-lock-only` passes, per docs/maintenance/release-operations.md:
+// the second drops the platform-gated "extraneous" entries that make `npm ci`
+// fail with EBADPLATFORM on other OSes. `--package-lock-only` resolves without
+// materializing node_modules, so it does not prune the cross-platform optional
+// tree the way a plain `npm install` on a Linux runner would. The final
+// `npm ci --dry-run` is the backstop: if the reconcile ever fails to produce an
+// installable tree, the release stops instead of committing the damage.
+//
+// See ADR 01093.
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Repo root, derived from this file's location rather than process.cwd(). */
+export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Build the ordered npm invocations that reconcile and then verify the root
+ * lockfile.
+ *
+ * Pure and side-effect free so test/reconcile-root-lockfile.test.js can assert
+ * the exact flags without spawning npm.
+ */
+export function buildReconcileCommands(repoRoot = REPO_ROOT) {
+  const reconcile = {
+    cmd: 'npm',
+    cwd: repoRoot,
+    args: ['install', '--package-lock-only', '--ignore-scripts', '--no-audit', '--no-fund'],
+  };
+  return [
+    { ...reconcile, args: [...reconcile.args] },
+    { ...reconcile, args: [...reconcile.args] },
+    {
+      cmd: 'npm',
+      cwd: repoRoot,
+      // Backstop, not a mutation.
+      args: ['ci', '--dry-run', '--ignore-scripts', '--no-audit', '--no-fund'],
+    },
+  ];
+}
+
+function main() {
+  const shell = process.platform === 'win32';
+
+  for (const { cmd, args, cwd } of buildReconcileCommands()) {
+    console.log(`$ (${cwd}) ${cmd} ${args.join(' ')}`);
+    const result = spawnSync(cmd, args, { stdio: 'inherit', shell, cwd });
+    if (result.error) {
+      console.error(`Failed to run \`${cmd} ${args.join(' ')}\` in ${cwd}: ${result.error.message}`);
+      process.exit(1);
+    }
+    if (result.status !== 0) {
+      console.error(
+        'Root lockfile is not installable after the release version stamps. ' +
+          'Refusing to let @semantic-release/git commit it. ' +
+          'See docs/maintenance/release-operations.md for the regeneration recipe.'
+      );
+      process.exit(result.status ?? 1);
+    }
+  }
+
+  console.log('Root lockfile reconciled and verified');
+}
+
+// Only run when executed as a script, not when a test imports the pure helper.
+// realpath both sides so a relative argv[1], a symlink, or Windows path-case
+// differences cannot make the comparison fail -- a false negative would
+// silently skip the verification.
+function isInvokedDirectly() {
+  try {
+    if (!process.argv[1]) return false;
+    return fs.realpathSync(process.argv[1]) === fs.realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isInvokedDirectly()) {
+  main();
+}

--- a/scripts/reconcile-root-lockfile.js
+++ b/scripts/reconcile-root-lockfile.js
@@ -7,8 +7,8 @@
 // committed by @semantic-release/git, and broke main for every job and every
 // contributor:
 //
-//   4.37.4 -> repaired in #705
-//   4.37.5 -> repaired in #707
+//   4.37.4 -> repaired deliberately, in #705
+//   4.37.5 -> repaired by accident, when #702 landed a healthy lockfile
 //
 // Both times the same two `"optional": true, "peer": true` entries under
 // @commitlint/read/node_modules were pruned.

--- a/scripts/sync-common-version.js
+++ b/scripts/sync-common-version.js
@@ -1,12 +1,10 @@
 #!/usr/bin/env node
 // semantic-release `prepare` step for the doc-detective-common workspace.
 //
-// Four things happen before @semantic-release/git commits its assets:
+// Two things happen here:
 //   1. Stamp the release version onto src/common (package.json + its lockfile).
 //   2. Rebuild src/common/package-lock.json so its dependency tree matches
 //      src/common/package.json.
-//   3. Reconcile the ROOT lockfile, which step 1 corrupts as a side effect.
-//   4. Verify the ROOT lockfile installs, and fail the release if not.
 //
 // Step 2 exists because `npm version` only rewrites the `version` fields. For a
 // long time that was the ONLY thing that ever touched src/common's lockfile, so
@@ -16,22 +14,13 @@
 // installs from the ROOT lockfile and runs the src/common scripts against the
 // hoisted workspace node_modules.
 //
-// Steps 3 and 4 exist because step 1 has a side effect: `npm version
-// --workspace` rewrites the ROOT lockfile too, and the tree it emits does not
-// install. Measured on npm 10 (node 22, the release job's runtime): starting
-// from a root lockfile where `npm ci` passes, running the step-1 stamp alone
-// leaves `npm ci` failing with EBADPLATFORM. In the 4.37.4 release that broken
-// lockfile was committed by @semantic-release/git and `npm ci` broke on main
-// for every job and every contributor (repaired by hand in #705).
-//
-// The two `--package-lock-only` passes in step 3 are the same recipe as
-// docs/maintenance/release-operations.md: the second pass drops the
-// platform-gated "extraneous" entries that make `npm ci` fail with EBADPLATFORM
-// on other OSes. Verified to restore a working lockfile from both a healthy and
-// an already-broken starting point, so a release now self-heals the root
-// lockfile instead of corrupting it. Step 4 is the backstop -- if the reconcile
-// ever fails to produce an installable tree, the release stops instead of
-// committing the damage.
+// The ROOT lockfile is deliberately NOT handled here. Every version stamp --
+// this script's, and @semantic-release/npm's afterward -- rewrites it, so any
+// reconcile done at this point is invalidated by the plugin that runs next.
+// That is exactly how 4.37.5 shipped a broken root lockfile even though this
+// script verified successfully. Root reconciliation and verification now live
+// in scripts/reconcile-root-lockfile.js, wired as the last prepare step before
+// @semantic-release/git commits. See ADR 01093.
 //
 // See ADR 01091.
 
@@ -92,26 +81,6 @@ export function buildSyncCommands(version, repoRoot = REPO_ROOT) {
         // files, so omitting this flag ships a corrupted root lockfile.
         '--no-workspaces',
       ],
-    },
-    // Reconcile the root lockfile that step 1 corrupted. Two passes, per
-    // docs/maintenance/release-operations.md -- a single pass leaves the
-    // platform-gated "extraneous" entries that fail `npm ci` with EBADPLATFORM
-    // on other OSes. `--package-lock-only` resolves without materializing
-    // node_modules, so it does not prune the cross-platform optional tree the
-    // way a plain `npm install` on a Linux runner would.
-    ...[1, 2].map(() => ({
-      cmd: 'npm',
-      cwd: repoRoot,
-      args: ['install', '--package-lock-only', '--ignore-scripts', '--no-audit', '--no-fund'],
-    })),
-    {
-      cmd: 'npm',
-      // Backstop, not a mutation: `ci --dry-run` resolves the root lockfile
-      // against the root manifest and exits non-zero on any Missing/Invalid/
-      // EBADPLATFORM entry, without writing anything. This is the check every
-      // CI job performs, run before the commit rather than after it.
-      cwd: repoRoot,
-      args: ['ci', '--dry-run', '--ignore-scripts', '--no-audit', '--no-fund'],
     },
   ];
 }

--- a/scripts/sync-common-version.js
+++ b/scripts/sync-common-version.js
@@ -44,7 +44,7 @@ export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url
  *
  * Order matters: the version stamp must land before the lockfile rebuild, so
  * the regenerated lockfile carries the release version rather than the previous
- * one, and the root verification must come last so it sees the final state.
+ * one.
  */
 export function buildSyncCommands(version, repoRoot = REPO_ROOT) {
   const commonDir = path.join(repoRoot, 'src', 'common');
@@ -52,8 +52,9 @@ export function buildSyncCommands(version, repoRoot = REPO_ROOT) {
     {
       cmd: 'npm',
       // Run from the repo root so `--workspace` resolves. Side effect: this
-      // also rewrites the root lockfile's entry for the workspace, which is
-      // why step 3 below verifies the result.
+      // also rewrites the root lockfile's entry for the workspace; root
+      // reconciliation and verification happen afterward, in
+      // scripts/reconcile-root-lockfile.js.
       cwd: repoRoot,
       args: [
         'version',

--- a/test/reconcile-root-lockfile.test.js
+++ b/test/reconcile-root-lockfile.test.js
@@ -66,6 +66,12 @@ describe("scripts/reconcile-root-lockfile buildReconcileCommands", function () {
     const reconcileIdx = rc.plugins.findIndex(
       (p) => Array.isArray(p) && /reconcile-root-lockfile/.test(p[1]?.prepareCmd ?? "")
     );
+    // Assert presence FIRST. indexOf returns -1 for a missing plugin, which
+    // would turn `greaterThan(npmIdx)` into `greaterThan(-1)` -- vacuously true
+    // for any wiring, including one placed before npm. Without these the guard
+    // passes on the exact defect it exists to catch.
+    expect(npmIdx, "@semantic-release/npm must be present in .releaserc.json").to.be.greaterThan(-1);
+    expect(gitIdx, "@semantic-release/git must be present in .releaserc.json").to.be.greaterThan(-1);
     expect(reconcileIdx, "reconcile prepareCmd must be wired in .releaserc.json").to.be.greaterThan(-1);
     expect(reconcileIdx).to.be.greaterThan(npmIdx);
     expect(reconcileIdx).to.be.lessThan(gitIdx);

--- a/test/reconcile-root-lockfile.test.js
+++ b/test/reconcile-root-lockfile.test.js
@@ -1,0 +1,73 @@
+import path from "node:path";
+import fs from "node:fs";
+import { buildReconcileCommands, REPO_ROOT } from "../scripts/reconcile-root-lockfile.js";
+
+before(async function () {
+  const { expect } = await import("chai");
+  global.expect = expect;
+});
+
+const ROOT = path.join(path.sep, "repo");
+
+describe("scripts/reconcile-root-lockfile buildReconcileCommands", function () {
+  it("reconciles twice before verifying", function () {
+    const steps = buildReconcileCommands(ROOT);
+    expect(steps).to.have.lengthOf(3);
+    // TWO passes, per docs/maintenance/release-operations.md: the second drops
+    // the platform-gated "extraneous" entries a single pass leaves behind,
+    // which otherwise fail `npm ci` with EBADPLATFORM on other OSes.
+    for (const step of steps.slice(0, 2)) {
+      expect(step.cmd).to.equal("npm");
+      expect(step.cwd).to.equal(ROOT);
+      expect(step.args[0]).to.equal("install");
+      expect(step.args).to.include("--package-lock-only");
+    }
+  });
+
+  it("ends with a non-mutating npm ci --dry-run backstop", function () {
+    const verify = buildReconcileCommands(ROOT)[2];
+    expect(verify.cmd).to.equal("npm");
+    expect(verify.cwd).to.equal(ROOT);
+    expect(verify.args.slice(0, 2)).to.deep.equal(["ci", "--dry-run"]);
+    expect(verify.args).to.not.include("--package-lock-only");
+  });
+
+  it("keeps every step side-effect free and quiet", function () {
+    for (const step of buildReconcileCommands(ROOT)) {
+      expect(step.args).to.include("--ignore-scripts");
+      expect(step.args).to.include("--no-audit");
+      expect(step.args).to.include("--no-fund");
+    }
+  });
+
+  it("never passes --no-workspaces (this operates on the root, not src/common)", function () {
+    // The inverse of sync-common-version.js: there --no-workspaces is required
+    // so npm rewrites src/common's own lockfile; here we want the workspace-
+    // aware root resolution.
+    for (const step of buildReconcileCommands(ROOT)) {
+      expect(step.args).to.not.include("--no-workspaces");
+    }
+  });
+
+  it("defaults to a repo root derived from the module, not process.cwd()", function () {
+    expect(path.isAbsolute(REPO_ROOT)).to.equal(true);
+    expect(fs.existsSync(path.join(REPO_ROOT, "package.json"))).to.equal(true);
+    expect(buildReconcileCommands()[0].cwd).to.equal(REPO_ROOT);
+  });
+
+  it("is wired as a prepareCmd AFTER @semantic-release/npm", function () {
+    // Order is the whole point: a reconcile that runs before the npm plugin's
+    // version stamp is invalidated by it, which is how 4.37.5 shipped a broken
+    // root lockfile (#706). This asserts the wiring, not just the script.
+    const rc = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, ".releaserc.json"), "utf8"));
+    const names = rc.plugins.map((p) => (Array.isArray(p) ? p[0] : p));
+    const npmIdx = names.indexOf("@semantic-release/npm");
+    const gitIdx = names.indexOf("@semantic-release/git");
+    const reconcileIdx = rc.plugins.findIndex(
+      (p) => Array.isArray(p) && /reconcile-root-lockfile/.test(p[1]?.prepareCmd ?? "")
+    );
+    expect(reconcileIdx, "reconcile prepareCmd must be wired in .releaserc.json").to.be.greaterThan(-1);
+    expect(reconcileIdx).to.be.greaterThan(npmIdx);
+    expect(reconcileIdx).to.be.lessThan(gitIdx);
+  });
+});

--- a/test/reconcile-root-lockfile.test.js
+++ b/test/reconcile-root-lockfile.test.js
@@ -58,7 +58,7 @@ describe("scripts/reconcile-root-lockfile buildReconcileCommands", function () {
   it("is wired as a prepareCmd AFTER @semantic-release/npm", function () {
     // Order is the whole point: a reconcile that runs before the npm plugin's
     // version stamp is invalidated by it, which is how 4.37.5 shipped a broken
-    // root lockfile (#706). This asserts the wiring, not just the script.
+    // root lockfile (#707). This asserts the wiring, not just the script.
     const rc = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, ".releaserc.json"), "utf8"));
     const names = rc.plugins.map((p) => (Array.isArray(p) ? p[0] : p));
     const npmIdx = names.indexOf("@semantic-release/npm");

--- a/test/sync-common-version.test.js
+++ b/test/sync-common-version.test.js
@@ -58,7 +58,7 @@ describe("scripts/sync-common-version buildSyncCommands", function () {
     // Any root reconcile done here is invalidated by @semantic-release/npm's
     // version stamp, which runs afterward in the prepare sequence. That is how
     // 4.37.5 shipped a broken root lockfile despite this script verifying
-    // successfully (#706). Root work now runs as the last prepare step.
+    // successfully (#707). Root work now runs as the last prepare step.
     const steps = buildSyncCommands("4.37.5", ROOT);
     expect(steps).to.have.lengthOf(2);
     expect(steps.filter((s) => s.args[0] === "ci")).to.have.lengthOf(0);

--- a/test/sync-common-version.test.js
+++ b/test/sync-common-version.test.js
@@ -54,36 +54,18 @@ describe("scripts/sync-common-version buildSyncCommands", function () {
     expect(lockStep.args).to.include("--no-fund");
   });
 
-  it("reconciles the ROOT lockfile twice, because the version stamp corrupts it", function () {
-    // `npm version --workspace` (step 1) rewrites the root lockfile as a side
-    // effect and the tree it emits does not install -- measured on npm 10, a
-    // healthy lockfile goes to EBADPLATFORM from the stamp alone. That is what
-    // shipped in 4.37.4 and broke `npm ci` on main (#705).
-    //
-    // TWO passes, per docs/maintenance/release-operations.md: the second drops
-    // the platform-gated "extraneous" entries a single pass leaves behind.
-    // Dropping to one pass silently reintroduces the EBADPLATFORM failure on
-    // other OSes, so the count is asserted.
+  it("does NOT touch the root lockfile -- that moved to reconcile-root-lockfile.js", function () {
+    // Any root reconcile done here is invalidated by @semantic-release/npm's
+    // version stamp, which runs afterward in the prepare sequence. That is how
+    // 4.37.5 shipped a broken root lockfile despite this script verifying
+    // successfully (#706). Root work now runs as the last prepare step.
     const steps = buildSyncCommands("4.37.5", ROOT);
-    const reconcile = steps.slice(2, 4);
-    expect(reconcile).to.have.lengthOf(2);
-    for (const step of reconcile) {
-      expect(step.cmd).to.equal("npm");
-      expect(step.cwd).to.equal(ROOT);
-      expect(step.args).to.include("--package-lock-only");
-      expect(step.args).to.not.include("--no-workspaces");
-    }
-  });
-
-  it("verifies the ROOT lockfile last, without mutating it", function () {
-    const steps = buildSyncCommands("4.37.5", ROOT);
-    expect(steps).to.have.lengthOf(5);
-    const verifyStep = steps[4];
-    expect(verifyStep.cmd).to.equal("npm");
-    expect(verifyStep.args.slice(0, 2)).to.deep.equal(["ci", "--dry-run"]);
-    expect(verifyStep.cwd).to.equal(ROOT);
-    // --dry-run is what makes this a backstop rather than another rebuild.
-    expect(verifyStep.args).to.not.include("--package-lock-only");
+    expect(steps).to.have.lengthOf(2);
+    expect(steps.filter((s) => s.args[0] === "ci")).to.have.lengthOf(0);
+    const rootInstalls = steps.filter(
+      (s) => s.cwd === ROOT && s.args[0] === "install"
+    );
+    expect(rootInstalls).to.have.lengthOf(0);
   });
 
   it("threads any valid semver through unchanged, including prereleases", function () {


### PR DESCRIPTION
## main is broken again, identically

`npm ci` fails on `main` at 4.37.5 — same two entries as 4.37.4:

```text
npm error code EUSAGE
npm error Missing: conventional-commits-filter@6.0.1 from lock file
npm error Missing: conventional-commits-parser@7.1.2 from lock file
```

4.37.5 was the **first release to run the guard added in #704** — and the guard passed on the way through. It was in the wrong place. That's on me; #704 validated the script in isolation rather than against the real plugin sequence.

## Why the guard didn't fire

semantic-release runs each plugin's `prepare` in plugin order:

```text
@semantic-release/changelog  prepare
@semantic-release/exec       prepare -> sync-common-version.js  <- guard was here
@semantic-release/npm        prepare -> npm version (root)      <- rewrites the lockfile
@semantic-release/exec       publish
@semantic-release/git        prepare -> commits the assets
```

The reconcile and `npm ci --dry-run` ran **before** `@semantic-release/npm` stamped the root version. That stamp rewrites `package-lock.json` as a side effect, after the check had already passed — so the verification was structurally incapable of seeing the bytes that got committed.

A guard that runs before the last writer is not a guard.

## The fix

Root reconciliation moves to `scripts/reconcile-root-lockfile.js`, wired as a `prepareCmd` on the `exec` entry that **already sits between `@semantic-release/npm` and `@semantic-release/git`**. Nothing rewrites the lockfile after it runs.

`sync-common-version.js` keeps only what it can validly own — stamping the `src/common` version and rebuilding that workspace's lockfile — rather than retaining steps that imply a guarantee it can't provide.

Mechanics unchanged from ADR 01091: two `--package-lock-only` passes, then `npm ci --dry-run` as a non-mutating backstop that stops the release instead of committing damage.

Also repairs the lockfile 4.37.5 shipped (regenerated per the documented recipe, `npm ci` validated under node:22 and node:24).

## Guarding the guard

`test/reconcile-root-lockfile.test.js` asserts the `prepareCmd` sits **after** the npm plugin and **before** the git plugin in `.releaserc.json` — so reordering the plugin list fails the suite rather than silently reintroducing this bug. The sibling suite asserts `sync-common-version.js` no longer issues any root-level `install` or `ci`, so the responsibility can't drift back.

13 tests passing across both suites.

## Residual risk — stated plainly

Local replays of the prepare sequence, **with and without `node_modules` present** as in the real job, did **not** reproduce the pruning. So the new ordering is only genuinely exercised by a real release. I'd rather say that than imply more confidence than I have.

What's different this time: if it recurs, the backstop now runs on the committed state and fails the release instead of pushing a broken lockfile to `main`.

## ADR / fixtures / docs impact

- **ADR**: [01093](adrs/01093-verify-the-root-lockfile-as-the-last-prepare-step.md). (01092 went to the renumbered reporters ADR on #702.)
- **Fixtures**: none — no user-facing feature.
- **Docs impact**: **none user-facing.** `docs/maintenance/release-operations.md` records the ordering constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release reliability by reconciling and verifying the root lockfile as the final preparation step.
  * Releases now stop when lockfile verification fails, helping prevent broken published packages.
  * Lockfile updates now occur after all release version changes are complete.

* **Documentation**
  * Clarified release recovery procedures, command ordering, and lockfile responsibilities.

* **Tests**
  * Added coverage for lockfile reconciliation, verification, and release-step ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->