### PR TITLE
build(schemas): regenerate the drifted schema and type artifacts

### DIFF
--- a/docs/fern/pages/reference/schemas/app-readiness.mdx
+++ b/docs/fern/pages/reference/schemas/app-readiness.mdx
@@ -16,7 +16,7 @@ description: "Reference for the `App readiness` schema."
 Field | Type | Description | Default
 :-- | :-- | :-- | :--
 delayMs | integer | Optional. Fixed delay (ms).<br/><br/>Minimum: 0 | —
-find | object([Element criteria](/reference/schemas/element-criteria)) | Optional. Wait for a specific element to be present. At least one finding field must be specified. | —
+find | object([Element criteria](/reference/schemas/element-criteria)) | Optional. Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named. | —
 
 ## Examples
 

--- a/src/common/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/config_v3.schema.json
@@ -8634,9 +8634,9 @@
                                                                                 "description": "Fixed delay (ms)."
                                                                               },
                                                                               "find": {
+                                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                 "title": "Element criteria",
                                                                                 "type": "object",
-                                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                 "additionalProperties": false,
                                                                                 "anyOf": [
                                                                                   {
@@ -9070,9 +9070,9 @@
                                                                               "description": "Fixed delay (ms)."
                                                                             },
                                                                             "find": {
+                                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                               "title": "Element criteria",
                                                                               "type": "object",
-                                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                               "additionalProperties": false,
                                                                               "anyOf": [
                                                                                 {
@@ -10131,9 +10131,9 @@
                                                                                   "description": "Fixed delay (ms)."
                                                                                 },
                                                                                 "find": {
+                                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                   "title": "Element criteria",
                                                                                   "type": "object",
-                                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                   "additionalProperties": false,
                                                                                   "anyOf": [
                                                                                     {
@@ -10567,9 +10567,9 @@
                                                                                 "description": "Fixed delay (ms)."
                                                                               },
                                                                               "find": {
+                                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                 "title": "Element criteria",
                                                                                 "type": "object",
-                                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                 "additionalProperties": false,
                                                                                 "anyOf": [
                                                                                   {
@@ -12781,9 +12781,9 @@
                                                                                   "description": "Fixed delay (ms)."
                                                                                 },
                                                                                 "find": {
+                                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                   "title": "Element criteria",
                                                                                   "type": "object",
-                                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                   "additionalProperties": false,
                                                                                   "anyOf": [
                                                                                     {
@@ -13217,9 +13217,9 @@
                                                                                 "description": "Fixed delay (ms)."
                                                                               },
                                                                               "find": {
+                                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                 "title": "Element criteria",
                                                                                 "type": "object",
-                                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                 "additionalProperties": false,
                                                                                 "anyOf": [
                                                                                   {
@@ -14278,9 +14278,9 @@
                                                                                     "description": "Fixed delay (ms)."
                                                                                   },
                                                                                   "find": {
+                                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                     "title": "Element criteria",
                                                                                     "type": "object",
-                                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                     "additionalProperties": false,
                                                                                     "anyOf": [
                                                                                       {
@@ -14714,9 +14714,9 @@
                                                                                   "description": "Fixed delay (ms)."
                                                                                 },
                                                                                 "find": {
+                                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                   "title": "Element criteria",
                                                                                   "type": "object",
-                                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                   "additionalProperties": false,
                                                                                   "anyOf": [
                                                                                     {
@@ -25006,9 +25006,9 @@
                                                                     "description": "Fixed delay (ms)."
                                                                   },
                                                                   "find": {
+                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                     "title": "Element criteria",
                                                                     "type": "object",
-                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                     "additionalProperties": false,
                                                                     "anyOf": [
                                                                       {
@@ -25442,9 +25442,9 @@
                                                                   "description": "Fixed delay (ms)."
                                                                 },
                                                                 "find": {
+                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                   "title": "Element criteria",
                                                                   "type": "object",
-                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                   "additionalProperties": false,
                                                                   "anyOf": [
                                                                     {
@@ -26503,9 +26503,9 @@
                                                                       "description": "Fixed delay (ms)."
                                                                     },
                                                                     "find": {
+                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                       "title": "Element criteria",
                                                                       "type": "object",
-                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                       "additionalProperties": false,
                                                                       "anyOf": [
                                                                         {
@@ -26939,9 +26939,9 @@
                                                                     "description": "Fixed delay (ms)."
                                                                   },
                                                                   "find": {
+                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                     "title": "Element criteria",
                                                                     "type": "object",
-                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                     "additionalProperties": false,
                                                                     "anyOf": [
                                                                       {
@@ -43620,6 +43620,7 @@
                                                         "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                       },
                                                       "waitUntil": {
+                                                        "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                         "title": "App readiness",
                                                         "type": "object",
                                                         "additionalProperties": false,
@@ -43631,9 +43632,9 @@
                                                             "description": "Fixed delay (ms)."
                                                           },
                                                           "find": {
+                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                             "title": "Element criteria",
                                                             "type": "object",
-                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                             "additionalProperties": false,
                                                             "anyOf": [
                                                               {
@@ -43726,8 +43727,7 @@
                                                               }
                                                             }
                                                           }
-                                                        },
-                                                        "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                        }
                                                       },
                                                       "timeout": {
                                                         "type": "integer",
@@ -44037,6 +44037,7 @@
                                                               "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                             },
                                                             "waitUntil": {
+                                                              "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                               "title": "App readiness",
                                                               "type": "object",
                                                               "additionalProperties": false,
@@ -44048,9 +44049,9 @@
                                                                   "description": "Fixed delay (ms)."
                                                                 },
                                                                 "find": {
+                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                   "title": "Element criteria",
                                                                   "type": "object",
-                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                   "additionalProperties": false,
                                                                   "anyOf": [
                                                                     {
@@ -44143,8 +44144,7 @@
                                                                     }
                                                                   }
                                                                 }
-                                                              },
-                                                              "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                              }
                                                             },
                                                             "timeout": {
                                                               "type": "integer",
@@ -44636,6 +44636,7 @@
                                                           "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                         },
                                                         "waitUntil": {
+                                                          "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                           "title": "App readiness",
                                                           "type": "object",
                                                           "additionalProperties": false,
@@ -44647,9 +44648,9 @@
                                                               "description": "Fixed delay (ms)."
                                                             },
                                                             "find": {
+                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                               "title": "Element criteria",
                                                               "type": "object",
-                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                               "additionalProperties": false,
                                                               "anyOf": [
                                                                 {
@@ -44742,8 +44743,7 @@
                                                                 }
                                                               }
                                                             }
-                                                          },
-                                                          "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                          }
                                                         },
                                                         "timeout": {
                                                           "type": "integer",
@@ -66859,9 +66859,9 @@
                                                                   "description": "Fixed delay (ms)."
                                                                 },
                                                                 "find": {
+                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                   "title": "Element criteria",
                                                                   "type": "object",
-                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                   "additionalProperties": false,
                                                                   "anyOf": [
                                                                     {
@@ -67295,9 +67295,9 @@
                                                                 "description": "Fixed delay (ms)."
                                                               },
                                                               "find": {
+                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                 "title": "Element criteria",
                                                                 "type": "object",
-                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                 "additionalProperties": false,
                                                                 "anyOf": [
                                                                   {
@@ -68356,9 +68356,9 @@
                                                                     "description": "Fixed delay (ms)."
                                                                   },
                                                                   "find": {
+                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                     "title": "Element criteria",
                                                                     "type": "object",
-                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                     "additionalProperties": false,
                                                                     "anyOf": [
                                                                       {
@@ -68792,9 +68792,9 @@
                                                                   "description": "Fixed delay (ms)."
                                                                 },
                                                                 "find": {
+                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                   "title": "Element criteria",
                                                                   "type": "object",
-                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                   "additionalProperties": false,
                                                                   "anyOf": [
                                                                     {
@@ -71006,9 +71006,9 @@
                                                                     "description": "Fixed delay (ms)."
                                                                   },
                                                                   "find": {
+                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                     "title": "Element criteria",
                                                                     "type": "object",
-                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                     "additionalProperties": false,
                                                                     "anyOf": [
                                                                       {
@@ -71442,9 +71442,9 @@
                                                                   "description": "Fixed delay (ms)."
                                                                 },
                                                                 "find": {
+                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                   "title": "Element criteria",
                                                                   "type": "object",
-                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                   "additionalProperties": false,
                                                                   "anyOf": [
                                                                     {
@@ -72503,9 +72503,9 @@
                                                                       "description": "Fixed delay (ms)."
                                                                     },
                                                                     "find": {
+                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                       "title": "Element criteria",
                                                                       "type": "object",
-                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                       "additionalProperties": false,
                                                                       "anyOf": [
                                                                         {
@@ -72939,9 +72939,9 @@
                                                                     "description": "Fixed delay (ms)."
                                                                   },
                                                                   "find": {
+                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                     "title": "Element criteria",
                                                                     "type": "object",
-                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                     "additionalProperties": false,
                                                                     "anyOf": [
                                                                       {
@@ -83231,9 +83231,9 @@
                                                       "description": "Fixed delay (ms)."
                                                     },
                                                     "find": {
+                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                       "title": "Element criteria",
                                                       "type": "object",
-                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                       "additionalProperties": false,
                                                       "anyOf": [
                                                         {
@@ -83667,9 +83667,9 @@
                                                     "description": "Fixed delay (ms)."
                                                   },
                                                   "find": {
+                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                     "title": "Element criteria",
                                                     "type": "object",
-                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                     "additionalProperties": false,
                                                     "anyOf": [
                                                       {
@@ -84728,9 +84728,9 @@
                                                         "description": "Fixed delay (ms)."
                                                       },
                                                       "find": {
+                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                         "title": "Element criteria",
                                                         "type": "object",
-                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                         "additionalProperties": false,
                                                         "anyOf": [
                                                           {
@@ -85164,9 +85164,9 @@
                                                       "description": "Fixed delay (ms)."
                                                     },
                                                     "find": {
+                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                       "title": "Element criteria",
                                                       "type": "object",
-                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                       "additionalProperties": false,
                                                       "anyOf": [
                                                         {
@@ -101845,6 +101845,7 @@
                                           "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                         },
                                         "waitUntil": {
+                                          "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                           "title": "App readiness",
                                           "type": "object",
                                           "additionalProperties": false,
@@ -101856,9 +101857,9 @@
                                               "description": "Fixed delay (ms)."
                                             },
                                             "find": {
+                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                               "title": "Element criteria",
                                               "type": "object",
-                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                               "additionalProperties": false,
                                               "anyOf": [
                                                 {
@@ -101951,8 +101952,7 @@
                                                 }
                                               }
                                             }
-                                          },
-                                          "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                          }
                                         },
                                         "timeout": {
                                           "type": "integer",
@@ -102262,6 +102262,7 @@
                                                 "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                               },
                                               "waitUntil": {
+                                                "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                 "title": "App readiness",
                                                 "type": "object",
                                                 "additionalProperties": false,
@@ -102273,9 +102274,9 @@
                                                     "description": "Fixed delay (ms)."
                                                   },
                                                   "find": {
+                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                     "title": "Element criteria",
                                                     "type": "object",
-                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                     "additionalProperties": false,
                                                     "anyOf": [
                                                       {
@@ -102368,8 +102369,7 @@
                                                       }
                                                     }
                                                   }
-                                                },
-                                                "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                }
                                               },
                                               "timeout": {
                                                 "type": "integer",
@@ -102861,6 +102861,7 @@
                                             "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                           },
                                           "waitUntil": {
+                                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                             "title": "App readiness",
                                             "type": "object",
                                             "additionalProperties": false,
@@ -102872,9 +102873,9 @@
                                                 "description": "Fixed delay (ms)."
                                               },
                                               "find": {
+                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                 "title": "Element criteria",
                                                 "type": "object",
-                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                 "additionalProperties": false,
                                                 "anyOf": [
                                                   {
@@ -102967,8 +102968,7 @@
                                                   }
                                                 }
                                               }
-                                            },
-                                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                            }
                                           },
                                           "timeout": {
                                             "type": "integer",

--- a/src/common/src/schemas/output_schemas/find_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/find_v3.schema.json
@@ -1889,9 +1889,9 @@
                                   "description": "Fixed delay (ms)."
                                 },
                                 "find": {
+                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                   "title": "Element criteria",
                                   "type": "object",
-                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                   "additionalProperties": false,
                                   "anyOf": [
                                     {
@@ -2325,9 +2325,9 @@
                                 "description": "Fixed delay (ms)."
                               },
                               "find": {
+                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                 "title": "Element criteria",
                                 "type": "object",
-                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                 "additionalProperties": false,
                                 "anyOf": [
                                   {
@@ -3386,9 +3386,9 @@
                                     "description": "Fixed delay (ms)."
                                   },
                                   "find": {
+                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                     "title": "Element criteria",
                                     "type": "object",
-                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                     "additionalProperties": false,
                                     "anyOf": [
                                       {
@@ -3822,9 +3822,9 @@
                                   "description": "Fixed delay (ms)."
                                 },
                                 "find": {
+                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                   "title": "Element criteria",
                                   "type": "object",
-                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                   "additionalProperties": false,
                                   "anyOf": [
                                     {
@@ -6036,9 +6036,9 @@
                                     "description": "Fixed delay (ms)."
                                   },
                                   "find": {
+                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                     "title": "Element criteria",
                                     "type": "object",
-                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                     "additionalProperties": false,
                                     "anyOf": [
                                       {
@@ -6472,9 +6472,9 @@
                                   "description": "Fixed delay (ms)."
                                 },
                                 "find": {
+                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                   "title": "Element criteria",
                                   "type": "object",
-                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                   "additionalProperties": false,
                                   "anyOf": [
                                     {
@@ -7533,9 +7533,9 @@
                                       "description": "Fixed delay (ms)."
                                     },
                                     "find": {
+                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                       "title": "Element criteria",
                                       "type": "object",
-                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                       "additionalProperties": false,
                                       "anyOf": [
                                         {
@@ -7969,9 +7969,9 @@
                                     "description": "Fixed delay (ms)."
                                   },
                                   "find": {
+                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                     "title": "Element criteria",
                                     "type": "object",
-                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                     "additionalProperties": false,
                                     "anyOf": [
                                       {

--- a/src/common/src/schemas/output_schemas/report_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/report_v3.schema.json
@@ -11137,9 +11137,9 @@
                                                                         "description": "Fixed delay (ms)."
                                                                       },
                                                                       "find": {
+                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                         "title": "Element criteria",
                                                                         "type": "object",
-                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                         "additionalProperties": false,
                                                                         "anyOf": [
                                                                           {
@@ -11573,9 +11573,9 @@
                                                                       "description": "Fixed delay (ms)."
                                                                     },
                                                                     "find": {
+                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                       "title": "Element criteria",
                                                                       "type": "object",
-                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                       "additionalProperties": false,
                                                                       "anyOf": [
                                                                         {
@@ -12634,9 +12634,9 @@
                                                                           "description": "Fixed delay (ms)."
                                                                         },
                                                                         "find": {
+                                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                           "title": "Element criteria",
                                                                           "type": "object",
-                                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                           "additionalProperties": false,
                                                                           "anyOf": [
                                                                             {
@@ -13070,9 +13070,9 @@
                                                                         "description": "Fixed delay (ms)."
                                                                       },
                                                                       "find": {
+                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                         "title": "Element criteria",
                                                                         "type": "object",
-                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                         "additionalProperties": false,
                                                                         "anyOf": [
                                                                           {
@@ -15284,9 +15284,9 @@
                                                                           "description": "Fixed delay (ms)."
                                                                         },
                                                                         "find": {
+                                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                           "title": "Element criteria",
                                                                           "type": "object",
-                                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                           "additionalProperties": false,
                                                                           "anyOf": [
                                                                             {
@@ -15720,9 +15720,9 @@
                                                                         "description": "Fixed delay (ms)."
                                                                       },
                                                                       "find": {
+                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                         "title": "Element criteria",
                                                                         "type": "object",
-                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                         "additionalProperties": false,
                                                                         "anyOf": [
                                                                           {
@@ -16781,9 +16781,9 @@
                                                                             "description": "Fixed delay (ms)."
                                                                           },
                                                                           "find": {
+                                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                             "title": "Element criteria",
                                                                             "type": "object",
-                                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                             "additionalProperties": false,
                                                                             "anyOf": [
                                                                               {
@@ -17217,9 +17217,9 @@
                                                                           "description": "Fixed delay (ms)."
                                                                         },
                                                                         "find": {
+                                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                           "title": "Element criteria",
                                                                           "type": "object",
-                                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                           "additionalProperties": false,
                                                                           "anyOf": [
                                                                             {
@@ -27509,9 +27509,9 @@
                                                             "description": "Fixed delay (ms)."
                                                           },
                                                           "find": {
+                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                             "title": "Element criteria",
                                                             "type": "object",
-                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                             "additionalProperties": false,
                                                             "anyOf": [
                                                               {
@@ -27945,9 +27945,9 @@
                                                           "description": "Fixed delay (ms)."
                                                         },
                                                         "find": {
+                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                           "title": "Element criteria",
                                                           "type": "object",
-                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                           "additionalProperties": false,
                                                           "anyOf": [
                                                             {
@@ -29006,9 +29006,9 @@
                                                               "description": "Fixed delay (ms)."
                                                             },
                                                             "find": {
+                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                               "title": "Element criteria",
                                                               "type": "object",
-                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                               "additionalProperties": false,
                                                               "anyOf": [
                                                                 {
@@ -29442,9 +29442,9 @@
                                                             "description": "Fixed delay (ms)."
                                                           },
                                                           "find": {
+                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                             "title": "Element criteria",
                                                             "type": "object",
-                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                             "additionalProperties": false,
                                                             "anyOf": [
                                                               {
@@ -46123,6 +46123,7 @@
                                                 "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                               },
                                               "waitUntil": {
+                                                "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                 "title": "App readiness",
                                                 "type": "object",
                                                 "additionalProperties": false,
@@ -46134,9 +46135,9 @@
                                                     "description": "Fixed delay (ms)."
                                                   },
                                                   "find": {
+                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                     "title": "Element criteria",
                                                     "type": "object",
-                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                     "additionalProperties": false,
                                                     "anyOf": [
                                                       {
@@ -46229,8 +46230,7 @@
                                                       }
                                                     }
                                                   }
-                                                },
-                                                "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                }
                                               },
                                               "timeout": {
                                                 "type": "integer",
@@ -46540,6 +46540,7 @@
                                                       "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                     },
                                                     "waitUntil": {
+                                                      "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                       "title": "App readiness",
                                                       "type": "object",
                                                       "additionalProperties": false,
@@ -46551,9 +46552,9 @@
                                                           "description": "Fixed delay (ms)."
                                                         },
                                                         "find": {
+                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                           "title": "Element criteria",
                                                           "type": "object",
-                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                           "additionalProperties": false,
                                                           "anyOf": [
                                                             {
@@ -46646,8 +46647,7 @@
                                                             }
                                                           }
                                                         }
-                                                      },
-                                                      "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                      }
                                                     },
                                                     "timeout": {
                                                       "type": "integer",
@@ -47139,6 +47139,7 @@
                                                   "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                 },
                                                 "waitUntil": {
+                                                  "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                   "title": "App readiness",
                                                   "type": "object",
                                                   "additionalProperties": false,
@@ -47150,9 +47151,9 @@
                                                       "description": "Fixed delay (ms)."
                                                     },
                                                     "find": {
+                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                       "title": "Element criteria",
                                                       "type": "object",
-                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                       "additionalProperties": false,
                                                       "anyOf": [
                                                         {
@@ -47245,8 +47246,7 @@
                                                         }
                                                       }
                                                     }
-                                                  },
-                                                  "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                  }
                                                 },
                                                 "timeout": {
                                                   "type": "integer",
@@ -68077,9 +68077,9 @@
                                                                               "description": "Fixed delay (ms)."
                                                                             },
                                                                             "find": {
+                                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                               "title": "Element criteria",
                                                                               "type": "object",
-                                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                               "additionalProperties": false,
                                                                               "anyOf": [
                                                                                 {
@@ -68513,9 +68513,9 @@
                                                                             "description": "Fixed delay (ms)."
                                                                           },
                                                                           "find": {
+                                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                             "title": "Element criteria",
                                                                             "type": "object",
-                                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                             "additionalProperties": false,
                                                                             "anyOf": [
                                                                               {
@@ -69574,9 +69574,9 @@
                                                                                 "description": "Fixed delay (ms)."
                                                                               },
                                                                               "find": {
+                                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                 "title": "Element criteria",
                                                                                 "type": "object",
-                                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                 "additionalProperties": false,
                                                                                 "anyOf": [
                                                                                   {
@@ -70010,9 +70010,9 @@
                                                                               "description": "Fixed delay (ms)."
                                                                             },
                                                                             "find": {
+                                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                               "title": "Element criteria",
                                                                               "type": "object",
-                                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                               "additionalProperties": false,
                                                                               "anyOf": [
                                                                                 {
@@ -72224,9 +72224,9 @@
                                                                                 "description": "Fixed delay (ms)."
                                                                               },
                                                                               "find": {
+                                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                 "title": "Element criteria",
                                                                                 "type": "object",
-                                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                 "additionalProperties": false,
                                                                                 "anyOf": [
                                                                                   {
@@ -72660,9 +72660,9 @@
                                                                               "description": "Fixed delay (ms)."
                                                                             },
                                                                             "find": {
+                                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                               "title": "Element criteria",
                                                                               "type": "object",
-                                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                               "additionalProperties": false,
                                                                               "anyOf": [
                                                                                 {
@@ -73721,9 +73721,9 @@
                                                                                   "description": "Fixed delay (ms)."
                                                                                 },
                                                                                 "find": {
+                                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                   "title": "Element criteria",
                                                                                   "type": "object",
-                                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                   "additionalProperties": false,
                                                                                   "anyOf": [
                                                                                     {
@@ -74157,9 +74157,9 @@
                                                                                 "description": "Fixed delay (ms)."
                                                                               },
                                                                               "find": {
+                                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                 "title": "Element criteria",
                                                                                 "type": "object",
-                                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                 "additionalProperties": false,
                                                                                 "anyOf": [
                                                                                   {
@@ -84449,9 +84449,9 @@
                                                                   "description": "Fixed delay (ms)."
                                                                 },
                                                                 "find": {
+                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                   "title": "Element criteria",
                                                                   "type": "object",
-                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                   "additionalProperties": false,
                                                                   "anyOf": [
                                                                     {
@@ -84885,9 +84885,9 @@
                                                                 "description": "Fixed delay (ms)."
                                                               },
                                                               "find": {
+                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                 "title": "Element criteria",
                                                                 "type": "object",
-                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                 "additionalProperties": false,
                                                                 "anyOf": [
                                                                   {
@@ -85946,9 +85946,9 @@
                                                                     "description": "Fixed delay (ms)."
                                                                   },
                                                                   "find": {
+                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                     "title": "Element criteria",
                                                                     "type": "object",
-                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                     "additionalProperties": false,
                                                                     "anyOf": [
                                                                       {
@@ -86382,9 +86382,9 @@
                                                                   "description": "Fixed delay (ms)."
                                                                 },
                                                                 "find": {
+                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                   "title": "Element criteria",
                                                                   "type": "object",
-                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                   "additionalProperties": false,
                                                                   "anyOf": [
                                                                     {
@@ -103063,6 +103063,7 @@
                                                       "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                     },
                                                     "waitUntil": {
+                                                      "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                       "title": "App readiness",
                                                       "type": "object",
                                                       "additionalProperties": false,
@@ -103074,9 +103075,9 @@
                                                           "description": "Fixed delay (ms)."
                                                         },
                                                         "find": {
+                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                           "title": "Element criteria",
                                                           "type": "object",
-                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                           "additionalProperties": false,
                                                           "anyOf": [
                                                             {
@@ -103169,8 +103170,7 @@
                                                             }
                                                           }
                                                         }
-                                                      },
-                                                      "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                      }
                                                     },
                                                     "timeout": {
                                                       "type": "integer",
@@ -103480,6 +103480,7 @@
                                                             "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                           },
                                                           "waitUntil": {
+                                                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                             "title": "App readiness",
                                                             "type": "object",
                                                             "additionalProperties": false,
@@ -103491,9 +103492,9 @@
                                                                 "description": "Fixed delay (ms)."
                                                               },
                                                               "find": {
+                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                 "title": "Element criteria",
                                                                 "type": "object",
-                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                 "additionalProperties": false,
                                                                 "anyOf": [
                                                                   {
@@ -103586,8 +103587,7 @@
                                                                   }
                                                                 }
                                                               }
-                                                            },
-                                                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                            }
                                                           },
                                                           "timeout": {
                                                             "type": "integer",
@@ -104079,6 +104079,7 @@
                                                         "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                       },
                                                       "waitUntil": {
+                                                        "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                         "title": "App readiness",
                                                         "type": "object",
                                                         "additionalProperties": false,
@@ -104090,9 +104091,9 @@
                                                             "description": "Fixed delay (ms)."
                                                           },
                                                           "find": {
+                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                             "title": "Element criteria",
                                                             "type": "object",
-                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                             "additionalProperties": false,
                                                             "anyOf": [
                                                               {
@@ -104185,8 +104186,7 @@
                                                               }
                                                             }
                                                           }
-                                                        },
-                                                        "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                        }
                                                       },
                                                       "timeout": {
                                                         "type": "integer",

--- a/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/resolvedTests_v3.schema.json
@@ -8647,9 +8647,9 @@
                                                                                     "description": "Fixed delay (ms)."
                                                                                   },
                                                                                   "find": {
+                                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                     "title": "Element criteria",
                                                                                     "type": "object",
-                                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                     "additionalProperties": false,
                                                                                     "anyOf": [
                                                                                       {
@@ -9083,9 +9083,9 @@
                                                                                   "description": "Fixed delay (ms)."
                                                                                 },
                                                                                 "find": {
+                                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                   "title": "Element criteria",
                                                                                   "type": "object",
-                                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                   "additionalProperties": false,
                                                                                   "anyOf": [
                                                                                     {
@@ -10144,9 +10144,9 @@
                                                                                       "description": "Fixed delay (ms)."
                                                                                     },
                                                                                     "find": {
+                                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                       "title": "Element criteria",
                                                                                       "type": "object",
-                                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                       "additionalProperties": false,
                                                                                       "anyOf": [
                                                                                         {
@@ -10580,9 +10580,9 @@
                                                                                     "description": "Fixed delay (ms)."
                                                                                   },
                                                                                   "find": {
+                                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                     "title": "Element criteria",
                                                                                     "type": "object",
-                                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                     "additionalProperties": false,
                                                                                     "anyOf": [
                                                                                       {
@@ -12794,9 +12794,9 @@
                                                                                       "description": "Fixed delay (ms)."
                                                                                     },
                                                                                     "find": {
+                                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                       "title": "Element criteria",
                                                                                       "type": "object",
-                                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                       "additionalProperties": false,
                                                                                       "anyOf": [
                                                                                         {
@@ -13230,9 +13230,9 @@
                                                                                     "description": "Fixed delay (ms)."
                                                                                   },
                                                                                   "find": {
+                                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                     "title": "Element criteria",
                                                                                     "type": "object",
-                                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                     "additionalProperties": false,
                                                                                     "anyOf": [
                                                                                       {
@@ -14291,9 +14291,9 @@
                                                                                         "description": "Fixed delay (ms)."
                                                                                       },
                                                                                       "find": {
+                                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                         "title": "Element criteria",
                                                                                         "type": "object",
-                                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                         "additionalProperties": false,
                                                                                         "anyOf": [
                                                                                           {
@@ -14727,9 +14727,9 @@
                                                                                       "description": "Fixed delay (ms)."
                                                                                     },
                                                                                     "find": {
+                                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                       "title": "Element criteria",
                                                                                       "type": "object",
-                                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                       "additionalProperties": false,
                                                                                       "anyOf": [
                                                                                         {
@@ -25019,9 +25019,9 @@
                                                                         "description": "Fixed delay (ms)."
                                                                       },
                                                                       "find": {
+                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                         "title": "Element criteria",
                                                                         "type": "object",
-                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                         "additionalProperties": false,
                                                                         "anyOf": [
                                                                           {
@@ -25455,9 +25455,9 @@
                                                                       "description": "Fixed delay (ms)."
                                                                     },
                                                                     "find": {
+                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                       "title": "Element criteria",
                                                                       "type": "object",
-                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                       "additionalProperties": false,
                                                                       "anyOf": [
                                                                         {
@@ -26516,9 +26516,9 @@
                                                                           "description": "Fixed delay (ms)."
                                                                         },
                                                                         "find": {
+                                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                           "title": "Element criteria",
                                                                           "type": "object",
-                                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                           "additionalProperties": false,
                                                                           "anyOf": [
                                                                             {
@@ -26952,9 +26952,9 @@
                                                                         "description": "Fixed delay (ms)."
                                                                       },
                                                                       "find": {
+                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                         "title": "Element criteria",
                                                                         "type": "object",
-                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                         "additionalProperties": false,
                                                                         "anyOf": [
                                                                           {
@@ -43633,6 +43633,7 @@
                                                             "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                           },
                                                           "waitUntil": {
+                                                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                             "title": "App readiness",
                                                             "type": "object",
                                                             "additionalProperties": false,
@@ -43644,9 +43645,9 @@
                                                                 "description": "Fixed delay (ms)."
                                                               },
                                                               "find": {
+                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                 "title": "Element criteria",
                                                                 "type": "object",
-                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                 "additionalProperties": false,
                                                                 "anyOf": [
                                                                   {
@@ -43739,8 +43740,7 @@
                                                                   }
                                                                 }
                                                               }
-                                                            },
-                                                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                            }
                                                           },
                                                           "timeout": {
                                                             "type": "integer",
@@ -44050,6 +44050,7 @@
                                                                   "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                                 },
                                                                 "waitUntil": {
+                                                                  "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                                   "title": "App readiness",
                                                                   "type": "object",
                                                                   "additionalProperties": false,
@@ -44061,9 +44062,9 @@
                                                                       "description": "Fixed delay (ms)."
                                                                     },
                                                                     "find": {
+                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                       "title": "Element criteria",
                                                                       "type": "object",
-                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                       "additionalProperties": false,
                                                                       "anyOf": [
                                                                         {
@@ -44156,8 +44157,7 @@
                                                                         }
                                                                       }
                                                                     }
-                                                                  },
-                                                                  "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                                  }
                                                                 },
                                                                 "timeout": {
                                                                   "type": "integer",
@@ -44649,6 +44649,7 @@
                                                               "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                             },
                                                             "waitUntil": {
+                                                              "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                               "title": "App readiness",
                                                               "type": "object",
                                                               "additionalProperties": false,
@@ -44660,9 +44661,9 @@
                                                                   "description": "Fixed delay (ms)."
                                                                 },
                                                                 "find": {
+                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                   "title": "Element criteria",
                                                                   "type": "object",
-                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                   "additionalProperties": false,
                                                                   "anyOf": [
                                                                     {
@@ -44755,8 +44756,7 @@
                                                                     }
                                                                   }
                                                                 }
-                                                              },
-                                                              "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                              }
                                                             },
                                                             "timeout": {
                                                               "type": "integer",
@@ -66872,9 +66872,9 @@
                                                                       "description": "Fixed delay (ms)."
                                                                     },
                                                                     "find": {
+                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                       "title": "Element criteria",
                                                                       "type": "object",
-                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                       "additionalProperties": false,
                                                                       "anyOf": [
                                                                         {
@@ -67308,9 +67308,9 @@
                                                                     "description": "Fixed delay (ms)."
                                                                   },
                                                                   "find": {
+                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                     "title": "Element criteria",
                                                                     "type": "object",
-                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                     "additionalProperties": false,
                                                                     "anyOf": [
                                                                       {
@@ -68369,9 +68369,9 @@
                                                                         "description": "Fixed delay (ms)."
                                                                       },
                                                                       "find": {
+                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                         "title": "Element criteria",
                                                                         "type": "object",
-                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                         "additionalProperties": false,
                                                                         "anyOf": [
                                                                           {
@@ -68805,9 +68805,9 @@
                                                                       "description": "Fixed delay (ms)."
                                                                     },
                                                                     "find": {
+                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                       "title": "Element criteria",
                                                                       "type": "object",
-                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                       "additionalProperties": false,
                                                                       "anyOf": [
                                                                         {
@@ -71019,9 +71019,9 @@
                                                                         "description": "Fixed delay (ms)."
                                                                       },
                                                                       "find": {
+                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                         "title": "Element criteria",
                                                                         "type": "object",
-                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                         "additionalProperties": false,
                                                                         "anyOf": [
                                                                           {
@@ -71455,9 +71455,9 @@
                                                                       "description": "Fixed delay (ms)."
                                                                     },
                                                                     "find": {
+                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                       "title": "Element criteria",
                                                                       "type": "object",
-                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                       "additionalProperties": false,
                                                                       "anyOf": [
                                                                         {
@@ -72516,9 +72516,9 @@
                                                                           "description": "Fixed delay (ms)."
                                                                         },
                                                                         "find": {
+                                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                           "title": "Element criteria",
                                                                           "type": "object",
-                                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                           "additionalProperties": false,
                                                                           "anyOf": [
                                                                             {
@@ -72952,9 +72952,9 @@
                                                                         "description": "Fixed delay (ms)."
                                                                       },
                                                                       "find": {
+                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                         "title": "Element criteria",
                                                                         "type": "object",
-                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                         "additionalProperties": false,
                                                                         "anyOf": [
                                                                           {
@@ -83244,9 +83244,9 @@
                                                           "description": "Fixed delay (ms)."
                                                         },
                                                         "find": {
+                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                           "title": "Element criteria",
                                                           "type": "object",
-                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                           "additionalProperties": false,
                                                           "anyOf": [
                                                             {
@@ -83680,9 +83680,9 @@
                                                         "description": "Fixed delay (ms)."
                                                       },
                                                       "find": {
+                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                         "title": "Element criteria",
                                                         "type": "object",
-                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                         "additionalProperties": false,
                                                         "anyOf": [
                                                           {
@@ -84741,9 +84741,9 @@
                                                             "description": "Fixed delay (ms)."
                                                           },
                                                           "find": {
+                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                             "title": "Element criteria",
                                                             "type": "object",
-                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                             "additionalProperties": false,
                                                             "anyOf": [
                                                               {
@@ -85177,9 +85177,9 @@
                                                           "description": "Fixed delay (ms)."
                                                         },
                                                         "find": {
+                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                           "title": "Element criteria",
                                                           "type": "object",
-                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                           "additionalProperties": false,
                                                           "anyOf": [
                                                             {
@@ -101858,6 +101858,7 @@
                                               "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                             },
                                             "waitUntil": {
+                                              "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                               "title": "App readiness",
                                               "type": "object",
                                               "additionalProperties": false,
@@ -101869,9 +101870,9 @@
                                                   "description": "Fixed delay (ms)."
                                                 },
                                                 "find": {
+                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                   "title": "Element criteria",
                                                   "type": "object",
-                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                   "additionalProperties": false,
                                                   "anyOf": [
                                                     {
@@ -101964,8 +101965,7 @@
                                                     }
                                                   }
                                                 }
-                                              },
-                                              "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                              }
                                             },
                                             "timeout": {
                                               "type": "integer",
@@ -102275,6 +102275,7 @@
                                                     "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                   },
                                                   "waitUntil": {
+                                                    "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                     "title": "App readiness",
                                                     "type": "object",
                                                     "additionalProperties": false,
@@ -102286,9 +102287,9 @@
                                                         "description": "Fixed delay (ms)."
                                                       },
                                                       "find": {
+                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                         "title": "Element criteria",
                                                         "type": "object",
-                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                         "additionalProperties": false,
                                                         "anyOf": [
                                                           {
@@ -102381,8 +102382,7 @@
                                                           }
                                                         }
                                                       }
-                                                    },
-                                                    "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                    }
                                                   },
                                                   "timeout": {
                                                     "type": "integer",
@@ -102874,6 +102874,7 @@
                                                 "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                               },
                                               "waitUntil": {
+                                                "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                 "title": "App readiness",
                                                 "type": "object",
                                                 "additionalProperties": false,
@@ -102885,9 +102886,9 @@
                                                     "description": "Fixed delay (ms)."
                                                   },
                                                   "find": {
+                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                     "title": "Element criteria",
                                                     "type": "object",
-                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                     "additionalProperties": false,
                                                     "anyOf": [
                                                       {
@@ -102980,8 +102981,7 @@
                                                       }
                                                     }
                                                   }
-                                                },
-                                                "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                }
                                               },
                                               "timeout": {
                                                 "type": "integer",
@@ -127397,9 +127397,9 @@
                                                                         "description": "Fixed delay (ms)."
                                                                       },
                                                                       "find": {
+                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                         "title": "Element criteria",
                                                                         "type": "object",
-                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                         "additionalProperties": false,
                                                                         "anyOf": [
                                                                           {
@@ -127833,9 +127833,9 @@
                                                                       "description": "Fixed delay (ms)."
                                                                     },
                                                                     "find": {
+                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                       "title": "Element criteria",
                                                                       "type": "object",
-                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                       "additionalProperties": false,
                                                                       "anyOf": [
                                                                         {
@@ -128894,9 +128894,9 @@
                                                                           "description": "Fixed delay (ms)."
                                                                         },
                                                                         "find": {
+                                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                           "title": "Element criteria",
                                                                           "type": "object",
-                                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                           "additionalProperties": false,
                                                                           "anyOf": [
                                                                             {
@@ -129330,9 +129330,9 @@
                                                                         "description": "Fixed delay (ms)."
                                                                       },
                                                                       "find": {
+                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                         "title": "Element criteria",
                                                                         "type": "object",
-                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                         "additionalProperties": false,
                                                                         "anyOf": [
                                                                           {
@@ -131544,9 +131544,9 @@
                                                                           "description": "Fixed delay (ms)."
                                                                         },
                                                                         "find": {
+                                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                           "title": "Element criteria",
                                                                           "type": "object",
-                                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                           "additionalProperties": false,
                                                                           "anyOf": [
                                                                             {
@@ -131980,9 +131980,9 @@
                                                                         "description": "Fixed delay (ms)."
                                                                       },
                                                                       "find": {
+                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                         "title": "Element criteria",
                                                                         "type": "object",
-                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                         "additionalProperties": false,
                                                                         "anyOf": [
                                                                           {
@@ -133041,9 +133041,9 @@
                                                                             "description": "Fixed delay (ms)."
                                                                           },
                                                                           "find": {
+                                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                             "title": "Element criteria",
                                                                             "type": "object",
-                                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                             "additionalProperties": false,
                                                                             "anyOf": [
                                                                               {
@@ -133477,9 +133477,9 @@
                                                                           "description": "Fixed delay (ms)."
                                                                         },
                                                                         "find": {
+                                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                           "title": "Element criteria",
                                                                           "type": "object",
-                                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                           "additionalProperties": false,
                                                                           "anyOf": [
                                                                             {
@@ -143769,9 +143769,9 @@
                                                             "description": "Fixed delay (ms)."
                                                           },
                                                           "find": {
+                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                             "title": "Element criteria",
                                                             "type": "object",
-                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                             "additionalProperties": false,
                                                             "anyOf": [
                                                               {
@@ -144205,9 +144205,9 @@
                                                           "description": "Fixed delay (ms)."
                                                         },
                                                         "find": {
+                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                           "title": "Element criteria",
                                                           "type": "object",
-                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                           "additionalProperties": false,
                                                           "anyOf": [
                                                             {
@@ -145266,9 +145266,9 @@
                                                               "description": "Fixed delay (ms)."
                                                             },
                                                             "find": {
+                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                               "title": "Element criteria",
                                                               "type": "object",
-                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                               "additionalProperties": false,
                                                               "anyOf": [
                                                                 {
@@ -145702,9 +145702,9 @@
                                                             "description": "Fixed delay (ms)."
                                                           },
                                                           "find": {
+                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                             "title": "Element criteria",
                                                             "type": "object",
-                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                             "additionalProperties": false,
                                                             "anyOf": [
                                                               {
@@ -162383,6 +162383,7 @@
                                                 "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                               },
                                               "waitUntil": {
+                                                "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                 "title": "App readiness",
                                                 "type": "object",
                                                 "additionalProperties": false,
@@ -162394,9 +162395,9 @@
                                                     "description": "Fixed delay (ms)."
                                                   },
                                                   "find": {
+                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                     "title": "Element criteria",
                                                     "type": "object",
-                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                     "additionalProperties": false,
                                                     "anyOf": [
                                                       {
@@ -162489,8 +162490,7 @@
                                                       }
                                                     }
                                                   }
-                                                },
-                                                "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                }
                                               },
                                               "timeout": {
                                                 "type": "integer",
@@ -162800,6 +162800,7 @@
                                                       "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                     },
                                                     "waitUntil": {
+                                                      "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                       "title": "App readiness",
                                                       "type": "object",
                                                       "additionalProperties": false,
@@ -162811,9 +162812,9 @@
                                                           "description": "Fixed delay (ms)."
                                                         },
                                                         "find": {
+                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                           "title": "Element criteria",
                                                           "type": "object",
-                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                           "additionalProperties": false,
                                                           "anyOf": [
                                                             {
@@ -162906,8 +162907,7 @@
                                                             }
                                                           }
                                                         }
-                                                      },
-                                                      "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                      }
                                                     },
                                                     "timeout": {
                                                       "type": "integer",
@@ -163399,6 +163399,7 @@
                                                   "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                 },
                                                 "waitUntil": {
+                                                  "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                   "title": "App readiness",
                                                   "type": "object",
                                                   "additionalProperties": false,
@@ -163410,9 +163411,9 @@
                                                       "description": "Fixed delay (ms)."
                                                     },
                                                     "find": {
+                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                       "title": "Element criteria",
                                                       "type": "object",
-                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                       "additionalProperties": false,
                                                       "anyOf": [
                                                         {
@@ -163505,8 +163506,7 @@
                                                         }
                                                       }
                                                     }
-                                                  },
-                                                  "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                  }
                                                 },
                                                 "timeout": {
                                                   "type": "integer",
@@ -184337,9 +184337,9 @@
                                                                               "description": "Fixed delay (ms)."
                                                                             },
                                                                             "find": {
+                                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                               "title": "Element criteria",
                                                                               "type": "object",
-                                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                               "additionalProperties": false,
                                                                               "anyOf": [
                                                                                 {
@@ -184773,9 +184773,9 @@
                                                                             "description": "Fixed delay (ms)."
                                                                           },
                                                                           "find": {
+                                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                             "title": "Element criteria",
                                                                             "type": "object",
-                                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                             "additionalProperties": false,
                                                                             "anyOf": [
                                                                               {
@@ -185834,9 +185834,9 @@
                                                                                 "description": "Fixed delay (ms)."
                                                                               },
                                                                               "find": {
+                                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                 "title": "Element criteria",
                                                                                 "type": "object",
-                                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                 "additionalProperties": false,
                                                                                 "anyOf": [
                                                                                   {
@@ -186270,9 +186270,9 @@
                                                                               "description": "Fixed delay (ms)."
                                                                             },
                                                                             "find": {
+                                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                               "title": "Element criteria",
                                                                               "type": "object",
-                                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                               "additionalProperties": false,
                                                                               "anyOf": [
                                                                                 {
@@ -188484,9 +188484,9 @@
                                                                                 "description": "Fixed delay (ms)."
                                                                               },
                                                                               "find": {
+                                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                 "title": "Element criteria",
                                                                                 "type": "object",
-                                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                 "additionalProperties": false,
                                                                                 "anyOf": [
                                                                                   {
@@ -188920,9 +188920,9 @@
                                                                               "description": "Fixed delay (ms)."
                                                                             },
                                                                             "find": {
+                                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                               "title": "Element criteria",
                                                                               "type": "object",
-                                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                               "additionalProperties": false,
                                                                               "anyOf": [
                                                                                 {
@@ -189981,9 +189981,9 @@
                                                                                   "description": "Fixed delay (ms)."
                                                                                 },
                                                                                 "find": {
+                                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                   "title": "Element criteria",
                                                                                   "type": "object",
-                                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                   "additionalProperties": false,
                                                                                   "anyOf": [
                                                                                     {
@@ -190417,9 +190417,9 @@
                                                                                 "description": "Fixed delay (ms)."
                                                                               },
                                                                               "find": {
+                                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                                 "title": "Element criteria",
                                                                                 "type": "object",
-                                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                                 "additionalProperties": false,
                                                                                 "anyOf": [
                                                                                   {
@@ -200709,9 +200709,9 @@
                                                                   "description": "Fixed delay (ms)."
                                                                 },
                                                                 "find": {
+                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                   "title": "Element criteria",
                                                                   "type": "object",
-                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                   "additionalProperties": false,
                                                                   "anyOf": [
                                                                     {
@@ -201145,9 +201145,9 @@
                                                                 "description": "Fixed delay (ms)."
                                                               },
                                                               "find": {
+                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                 "title": "Element criteria",
                                                                 "type": "object",
-                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                 "additionalProperties": false,
                                                                 "anyOf": [
                                                                   {
@@ -202206,9 +202206,9 @@
                                                                     "description": "Fixed delay (ms)."
                                                                   },
                                                                   "find": {
+                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                     "title": "Element criteria",
                                                                     "type": "object",
-                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                     "additionalProperties": false,
                                                                     "anyOf": [
                                                                       {
@@ -202642,9 +202642,9 @@
                                                                   "description": "Fixed delay (ms)."
                                                                 },
                                                                 "find": {
+                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                   "title": "Element criteria",
                                                                   "type": "object",
-                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                   "additionalProperties": false,
                                                                   "anyOf": [
                                                                     {
@@ -219323,6 +219323,7 @@
                                                       "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                     },
                                                     "waitUntil": {
+                                                      "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                       "title": "App readiness",
                                                       "type": "object",
                                                       "additionalProperties": false,
@@ -219334,9 +219335,9 @@
                                                           "description": "Fixed delay (ms)."
                                                         },
                                                         "find": {
+                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                           "title": "Element criteria",
                                                           "type": "object",
-                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                           "additionalProperties": false,
                                                           "anyOf": [
                                                             {
@@ -219429,8 +219430,7 @@
                                                             }
                                                           }
                                                         }
-                                                      },
-                                                      "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                      }
                                                     },
                                                     "timeout": {
                                                       "type": "integer",
@@ -219740,6 +219740,7 @@
                                                             "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                           },
                                                           "waitUntil": {
+                                                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                             "title": "App readiness",
                                                             "type": "object",
                                                             "additionalProperties": false,
@@ -219751,9 +219752,9 @@
                                                                 "description": "Fixed delay (ms)."
                                                               },
                                                               "find": {
+                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                 "title": "Element criteria",
                                                                 "type": "object",
-                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                 "additionalProperties": false,
                                                                 "anyOf": [
                                                                   {
@@ -219846,8 +219847,7 @@
                                                                   }
                                                                 }
                                                               }
-                                                            },
-                                                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                            }
                                                           },
                                                           "timeout": {
                                                             "type": "integer",
@@ -220339,6 +220339,7 @@
                                                         "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                       },
                                                       "waitUntil": {
+                                                        "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                         "title": "App readiness",
                                                         "type": "object",
                                                         "additionalProperties": false,
@@ -220350,9 +220351,9 @@
                                                             "description": "Fixed delay (ms)."
                                                           },
                                                           "find": {
+                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                             "title": "Element criteria",
                                                             "type": "object",
-                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                             "additionalProperties": false,
                                                             "anyOf": [
                                                               {
@@ -220445,8 +220446,7 @@
                                                               }
                                                             }
                                                           }
-                                                        },
-                                                        "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                        }
                                                       },
                                                       "timeout": {
                                                         "type": "integer",

--- a/src/common/src/schemas/output_schemas/spec_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/spec_v3.schema.json
@@ -11103,9 +11103,9 @@
                                                               "description": "Fixed delay (ms)."
                                                             },
                                                             "find": {
+                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                               "title": "Element criteria",
                                                               "type": "object",
-                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                               "additionalProperties": false,
                                                               "anyOf": [
                                                                 {
@@ -11539,9 +11539,9 @@
                                                             "description": "Fixed delay (ms)."
                                                           },
                                                           "find": {
+                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                             "title": "Element criteria",
                                                             "type": "object",
-                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                             "additionalProperties": false,
                                                             "anyOf": [
                                                               {
@@ -12600,9 +12600,9 @@
                                                                 "description": "Fixed delay (ms)."
                                                               },
                                                               "find": {
+                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                 "title": "Element criteria",
                                                                 "type": "object",
-                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                 "additionalProperties": false,
                                                                 "anyOf": [
                                                                   {
@@ -13036,9 +13036,9 @@
                                                               "description": "Fixed delay (ms)."
                                                             },
                                                             "find": {
+                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                               "title": "Element criteria",
                                                               "type": "object",
-                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                               "additionalProperties": false,
                                                               "anyOf": [
                                                                 {
@@ -15250,9 +15250,9 @@
                                                                 "description": "Fixed delay (ms)."
                                                               },
                                                               "find": {
+                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                 "title": "Element criteria",
                                                                 "type": "object",
-                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                 "additionalProperties": false,
                                                                 "anyOf": [
                                                                   {
@@ -15686,9 +15686,9 @@
                                                               "description": "Fixed delay (ms)."
                                                             },
                                                             "find": {
+                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                               "title": "Element criteria",
                                                               "type": "object",
-                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                               "additionalProperties": false,
                                                               "anyOf": [
                                                                 {
@@ -16747,9 +16747,9 @@
                                                                   "description": "Fixed delay (ms)."
                                                                 },
                                                                 "find": {
+                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                   "title": "Element criteria",
                                                                   "type": "object",
-                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                   "additionalProperties": false,
                                                                   "anyOf": [
                                                                     {
@@ -17183,9 +17183,9 @@
                                                                 "description": "Fixed delay (ms)."
                                                               },
                                                               "find": {
+                                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                 "title": "Element criteria",
                                                                 "type": "object",
-                                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                 "additionalProperties": false,
                                                                 "anyOf": [
                                                                   {
@@ -27475,9 +27475,9 @@
                                                   "description": "Fixed delay (ms)."
                                                 },
                                                 "find": {
+                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                   "title": "Element criteria",
                                                   "type": "object",
-                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                   "additionalProperties": false,
                                                   "anyOf": [
                                                     {
@@ -27911,9 +27911,9 @@
                                                 "description": "Fixed delay (ms)."
                                               },
                                               "find": {
+                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                 "title": "Element criteria",
                                                 "type": "object",
-                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                 "additionalProperties": false,
                                                 "anyOf": [
                                                   {
@@ -28972,9 +28972,9 @@
                                                     "description": "Fixed delay (ms)."
                                                   },
                                                   "find": {
+                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                     "title": "Element criteria",
                                                     "type": "object",
-                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                     "additionalProperties": false,
                                                     "anyOf": [
                                                       {
@@ -29408,9 +29408,9 @@
                                                   "description": "Fixed delay (ms)."
                                                 },
                                                 "find": {
+                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                   "title": "Element criteria",
                                                   "type": "object",
-                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                   "additionalProperties": false,
                                                   "anyOf": [
                                                     {
@@ -46089,6 +46089,7 @@
                                       "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                     },
                                     "waitUntil": {
+                                      "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                       "title": "App readiness",
                                       "type": "object",
                                       "additionalProperties": false,
@@ -46100,9 +46101,9 @@
                                           "description": "Fixed delay (ms)."
                                         },
                                         "find": {
+                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                           "title": "Element criteria",
                                           "type": "object",
-                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                           "additionalProperties": false,
                                           "anyOf": [
                                             {
@@ -46195,8 +46196,7 @@
                                             }
                                           }
                                         }
-                                      },
-                                      "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                      }
                                     },
                                     "timeout": {
                                       "type": "integer",
@@ -46506,6 +46506,7 @@
                                             "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                           },
                                           "waitUntil": {
+                                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                             "title": "App readiness",
                                             "type": "object",
                                             "additionalProperties": false,
@@ -46517,9 +46518,9 @@
                                                 "description": "Fixed delay (ms)."
                                               },
                                               "find": {
+                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                 "title": "Element criteria",
                                                 "type": "object",
-                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                 "additionalProperties": false,
                                                 "anyOf": [
                                                   {
@@ -46612,8 +46613,7 @@
                                                   }
                                                 }
                                               }
-                                            },
-                                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                            }
                                           },
                                           "timeout": {
                                             "type": "integer",
@@ -47105,6 +47105,7 @@
                                         "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                       },
                                       "waitUntil": {
+                                        "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                         "title": "App readiness",
                                         "type": "object",
                                         "additionalProperties": false,
@@ -47116,9 +47117,9 @@
                                             "description": "Fixed delay (ms)."
                                           },
                                           "find": {
+                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                             "title": "Element criteria",
                                             "type": "object",
-                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                             "additionalProperties": false,
                                             "anyOf": [
                                               {
@@ -47211,8 +47212,7 @@
                                               }
                                             }
                                           }
-                                        },
-                                        "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                        }
                                       },
                                       "timeout": {
                                         "type": "integer",
@@ -68043,9 +68043,9 @@
                                                                     "description": "Fixed delay (ms)."
                                                                   },
                                                                   "find": {
+                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                     "title": "Element criteria",
                                                                     "type": "object",
-                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                     "additionalProperties": false,
                                                                     "anyOf": [
                                                                       {
@@ -68479,9 +68479,9 @@
                                                                   "description": "Fixed delay (ms)."
                                                                 },
                                                                 "find": {
+                                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                   "title": "Element criteria",
                                                                   "type": "object",
-                                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                   "additionalProperties": false,
                                                                   "anyOf": [
                                                                     {
@@ -69540,9 +69540,9 @@
                                                                       "description": "Fixed delay (ms)."
                                                                     },
                                                                     "find": {
+                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                       "title": "Element criteria",
                                                                       "type": "object",
-                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                       "additionalProperties": false,
                                                                       "anyOf": [
                                                                         {
@@ -69976,9 +69976,9 @@
                                                                     "description": "Fixed delay (ms)."
                                                                   },
                                                                   "find": {
+                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                     "title": "Element criteria",
                                                                     "type": "object",
-                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                     "additionalProperties": false,
                                                                     "anyOf": [
                                                                       {
@@ -72190,9 +72190,9 @@
                                                                       "description": "Fixed delay (ms)."
                                                                     },
                                                                     "find": {
+                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                       "title": "Element criteria",
                                                                       "type": "object",
-                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                       "additionalProperties": false,
                                                                       "anyOf": [
                                                                         {
@@ -72626,9 +72626,9 @@
                                                                     "description": "Fixed delay (ms)."
                                                                   },
                                                                   "find": {
+                                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                     "title": "Element criteria",
                                                                     "type": "object",
-                                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                     "additionalProperties": false,
                                                                     "anyOf": [
                                                                       {
@@ -73687,9 +73687,9 @@
                                                                         "description": "Fixed delay (ms)."
                                                                       },
                                                                       "find": {
+                                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                         "title": "Element criteria",
                                                                         "type": "object",
-                                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                         "additionalProperties": false,
                                                                         "anyOf": [
                                                                           {
@@ -74123,9 +74123,9 @@
                                                                       "description": "Fixed delay (ms)."
                                                                     },
                                                                     "find": {
+                                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                                       "title": "Element criteria",
                                                                       "type": "object",
-                                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                                       "additionalProperties": false,
                                                                       "anyOf": [
                                                                         {
@@ -84415,9 +84415,9 @@
                                                         "description": "Fixed delay (ms)."
                                                       },
                                                       "find": {
+                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                         "title": "Element criteria",
                                                         "type": "object",
-                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                         "additionalProperties": false,
                                                         "anyOf": [
                                                           {
@@ -84851,9 +84851,9 @@
                                                       "description": "Fixed delay (ms)."
                                                     },
                                                     "find": {
+                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                       "title": "Element criteria",
                                                       "type": "object",
-                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                       "additionalProperties": false,
                                                       "anyOf": [
                                                         {
@@ -85912,9 +85912,9 @@
                                                           "description": "Fixed delay (ms)."
                                                         },
                                                         "find": {
+                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                           "title": "Element criteria",
                                                           "type": "object",
-                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                           "additionalProperties": false,
                                                           "anyOf": [
                                                             {
@@ -86348,9 +86348,9 @@
                                                         "description": "Fixed delay (ms)."
                                                       },
                                                       "find": {
+                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                         "title": "Element criteria",
                                                         "type": "object",
-                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                         "additionalProperties": false,
                                                         "anyOf": [
                                                           {
@@ -103029,6 +103029,7 @@
                                             "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                           },
                                           "waitUntil": {
+                                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                             "title": "App readiness",
                                             "type": "object",
                                             "additionalProperties": false,
@@ -103040,9 +103041,9 @@
                                                 "description": "Fixed delay (ms)."
                                               },
                                               "find": {
+                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                 "title": "Element criteria",
                                                 "type": "object",
-                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                 "additionalProperties": false,
                                                 "anyOf": [
                                                   {
@@ -103135,8 +103136,7 @@
                                                   }
                                                 }
                                               }
-                                            },
-                                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                            }
                                           },
                                           "timeout": {
                                             "type": "integer",
@@ -103446,6 +103446,7 @@
                                                   "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                                 },
                                                 "waitUntil": {
+                                                  "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                                   "title": "App readiness",
                                                   "type": "object",
                                                   "additionalProperties": false,
@@ -103457,9 +103458,9 @@
                                                       "description": "Fixed delay (ms)."
                                                     },
                                                     "find": {
+                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                       "title": "Element criteria",
                                                       "type": "object",
-                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                       "additionalProperties": false,
                                                       "anyOf": [
                                                         {
@@ -103552,8 +103553,7 @@
                                                         }
                                                       }
                                                     }
-                                                  },
-                                                  "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                                  }
                                                 },
                                                 "timeout": {
                                                   "type": "integer",
@@ -104045,6 +104045,7 @@
                                               "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                             },
                                             "waitUntil": {
+                                              "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                               "title": "App readiness",
                                               "type": "object",
                                               "additionalProperties": false,
@@ -104056,9 +104057,9 @@
                                                   "description": "Fixed delay (ms)."
                                                 },
                                                 "find": {
+                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                   "title": "Element criteria",
                                                   "type": "object",
-                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                   "additionalProperties": false,
                                                   "anyOf": [
                                                     {
@@ -104151,8 +104152,7 @@
                                                     }
                                                   }
                                                 }
-                                              },
-                                              "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                              }
                                             },
                                             "timeout": {
                                               "type": "integer",

--- a/src/common/src/schemas/output_schemas/step_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/step_v3.schema.json
@@ -7549,9 +7549,9 @@
                                               "description": "Fixed delay (ms)."
                                             },
                                             "find": {
+                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                               "title": "Element criteria",
                                               "type": "object",
-                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                               "additionalProperties": false,
                                               "anyOf": [
                                                 {
@@ -7985,9 +7985,9 @@
                                             "description": "Fixed delay (ms)."
                                           },
                                           "find": {
+                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                             "title": "Element criteria",
                                             "type": "object",
-                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                             "additionalProperties": false,
                                             "anyOf": [
                                               {
@@ -9046,9 +9046,9 @@
                                                 "description": "Fixed delay (ms)."
                                               },
                                               "find": {
+                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                 "title": "Element criteria",
                                                 "type": "object",
-                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                 "additionalProperties": false,
                                                 "anyOf": [
                                                   {
@@ -9482,9 +9482,9 @@
                                               "description": "Fixed delay (ms)."
                                             },
                                             "find": {
+                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                               "title": "Element criteria",
                                               "type": "object",
-                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                               "additionalProperties": false,
                                               "anyOf": [
                                                 {
@@ -11696,9 +11696,9 @@
                                                 "description": "Fixed delay (ms)."
                                               },
                                               "find": {
+                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                 "title": "Element criteria",
                                                 "type": "object",
-                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                 "additionalProperties": false,
                                                 "anyOf": [
                                                   {
@@ -12132,9 +12132,9 @@
                                               "description": "Fixed delay (ms)."
                                             },
                                             "find": {
+                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                               "title": "Element criteria",
                                               "type": "object",
-                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                               "additionalProperties": false,
                                               "anyOf": [
                                                 {
@@ -13193,9 +13193,9 @@
                                                   "description": "Fixed delay (ms)."
                                                 },
                                                 "find": {
+                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                   "title": "Element criteria",
                                                   "type": "object",
-                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                   "additionalProperties": false,
                                                   "anyOf": [
                                                     {
@@ -13629,9 +13629,9 @@
                                                 "description": "Fixed delay (ms)."
                                               },
                                               "find": {
+                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                 "title": "Element criteria",
                                                 "type": "object",
-                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                 "additionalProperties": false,
                                                 "anyOf": [
                                                   {
@@ -23921,9 +23921,9 @@
                                   "description": "Fixed delay (ms)."
                                 },
                                 "find": {
+                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                   "title": "Element criteria",
                                   "type": "object",
-                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                   "additionalProperties": false,
                                   "anyOf": [
                                     {
@@ -24357,9 +24357,9 @@
                                 "description": "Fixed delay (ms)."
                               },
                               "find": {
+                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                 "title": "Element criteria",
                                 "type": "object",
-                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                 "additionalProperties": false,
                                 "anyOf": [
                                   {
@@ -25418,9 +25418,9 @@
                                     "description": "Fixed delay (ms)."
                                   },
                                   "find": {
+                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                     "title": "Element criteria",
                                     "type": "object",
-                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                     "additionalProperties": false,
                                     "anyOf": [
                                       {
@@ -25854,9 +25854,9 @@
                                   "description": "Fixed delay (ms)."
                                 },
                                 "find": {
+                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                   "title": "Element criteria",
                                   "type": "object",
-                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                   "additionalProperties": false,
                                   "anyOf": [
                                     {
@@ -42535,6 +42535,7 @@
                       "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                     },
                     "waitUntil": {
+                      "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                       "title": "App readiness",
                       "type": "object",
                       "additionalProperties": false,
@@ -42546,9 +42547,9 @@
                           "description": "Fixed delay (ms)."
                         },
                         "find": {
+                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                           "title": "Element criteria",
                           "type": "object",
-                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                           "additionalProperties": false,
                           "anyOf": [
                             {
@@ -42641,8 +42642,7 @@
                             }
                           }
                         }
-                      },
-                      "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                      }
                     },
                     "timeout": {
                       "type": "integer",
@@ -42952,6 +42952,7 @@
                             "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                           },
                           "waitUntil": {
+                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                             "title": "App readiness",
                             "type": "object",
                             "additionalProperties": false,
@@ -42963,9 +42964,9 @@
                                 "description": "Fixed delay (ms)."
                               },
                               "find": {
+                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                 "title": "Element criteria",
                                 "type": "object",
-                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                 "additionalProperties": false,
                                 "anyOf": [
                                   {
@@ -43058,8 +43059,7 @@
                                   }
                                 }
                               }
-                            },
-                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                            }
                           },
                           "timeout": {
                             "type": "integer",
@@ -43551,6 +43551,7 @@
                         "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                       },
                       "waitUntil": {
+                        "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                         "title": "App readiness",
                         "type": "object",
                         "additionalProperties": false,
@@ -43562,9 +43563,9 @@
                             "description": "Fixed delay (ms)."
                           },
                           "find": {
+                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                             "title": "Element criteria",
                             "type": "object",
-                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                             "additionalProperties": false,
                             "anyOf": [
                               {
@@ -43657,8 +43658,7 @@
                               }
                             }
                           }
-                        },
-                        "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                        }
                       },
                       "timeout": {
                         "type": "integer",

--- a/src/common/src/schemas/output_schemas/test_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/test_v3.schema.json
@@ -9664,9 +9664,9 @@
                                                     "description": "Fixed delay (ms)."
                                                   },
                                                   "find": {
+                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                     "title": "Element criteria",
                                                     "type": "object",
-                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                     "additionalProperties": false,
                                                     "anyOf": [
                                                       {
@@ -10100,9 +10100,9 @@
                                                   "description": "Fixed delay (ms)."
                                                 },
                                                 "find": {
+                                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                   "title": "Element criteria",
                                                   "type": "object",
-                                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                   "additionalProperties": false,
                                                   "anyOf": [
                                                     {
@@ -11161,9 +11161,9 @@
                                                       "description": "Fixed delay (ms)."
                                                     },
                                                     "find": {
+                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                       "title": "Element criteria",
                                                       "type": "object",
-                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                       "additionalProperties": false,
                                                       "anyOf": [
                                                         {
@@ -11597,9 +11597,9 @@
                                                     "description": "Fixed delay (ms)."
                                                   },
                                                   "find": {
+                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                     "title": "Element criteria",
                                                     "type": "object",
-                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                     "additionalProperties": false,
                                                     "anyOf": [
                                                       {
@@ -13811,9 +13811,9 @@
                                                       "description": "Fixed delay (ms)."
                                                     },
                                                     "find": {
+                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                       "title": "Element criteria",
                                                       "type": "object",
-                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                       "additionalProperties": false,
                                                       "anyOf": [
                                                         {
@@ -14247,9 +14247,9 @@
                                                     "description": "Fixed delay (ms)."
                                                   },
                                                   "find": {
+                                                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                     "title": "Element criteria",
                                                     "type": "object",
-                                                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                     "additionalProperties": false,
                                                     "anyOf": [
                                                       {
@@ -15308,9 +15308,9 @@
                                                         "description": "Fixed delay (ms)."
                                                       },
                                                       "find": {
+                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                         "title": "Element criteria",
                                                         "type": "object",
-                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                         "additionalProperties": false,
                                                         "anyOf": [
                                                           {
@@ -15744,9 +15744,9 @@
                                                       "description": "Fixed delay (ms)."
                                                     },
                                                     "find": {
+                                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                       "title": "Element criteria",
                                                       "type": "object",
-                                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                       "additionalProperties": false,
                                                       "anyOf": [
                                                         {
@@ -26036,9 +26036,9 @@
                                         "description": "Fixed delay (ms)."
                                       },
                                       "find": {
+                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                         "title": "Element criteria",
                                         "type": "object",
-                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                         "additionalProperties": false,
                                         "anyOf": [
                                           {
@@ -26472,9 +26472,9 @@
                                       "description": "Fixed delay (ms)."
                                     },
                                     "find": {
+                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                       "title": "Element criteria",
                                       "type": "object",
-                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                       "additionalProperties": false,
                                       "anyOf": [
                                         {
@@ -27533,9 +27533,9 @@
                                           "description": "Fixed delay (ms)."
                                         },
                                         "find": {
+                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                           "title": "Element criteria",
                                           "type": "object",
-                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                           "additionalProperties": false,
                                           "anyOf": [
                                             {
@@ -27969,9 +27969,9 @@
                                         "description": "Fixed delay (ms)."
                                       },
                                       "find": {
+                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                         "title": "Element criteria",
                                         "type": "object",
-                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                         "additionalProperties": false,
                                         "anyOf": [
                                           {
@@ -44650,6 +44650,7 @@
                             "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                           },
                           "waitUntil": {
+                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                             "title": "App readiness",
                             "type": "object",
                             "additionalProperties": false,
@@ -44661,9 +44662,9 @@
                                 "description": "Fixed delay (ms)."
                               },
                               "find": {
+                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                 "title": "Element criteria",
                                 "type": "object",
-                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                 "additionalProperties": false,
                                 "anyOf": [
                                   {
@@ -44756,8 +44757,7 @@
                                   }
                                 }
                               }
-                            },
-                            "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                            }
                           },
                           "timeout": {
                             "type": "integer",
@@ -45067,6 +45067,7 @@
                                   "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                 },
                                 "waitUntil": {
+                                  "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                   "title": "App readiness",
                                   "type": "object",
                                   "additionalProperties": false,
@@ -45078,9 +45079,9 @@
                                       "description": "Fixed delay (ms)."
                                     },
                                     "find": {
+                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                       "title": "Element criteria",
                                       "type": "object",
-                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                       "additionalProperties": false,
                                       "anyOf": [
                                         {
@@ -45173,8 +45174,7 @@
                                         }
                                       }
                                     }
-                                  },
-                                  "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                  }
                                 },
                                 "timeout": {
                                   "type": "integer",
@@ -45666,6 +45666,7 @@
                               "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                             },
                             "waitUntil": {
+                              "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                               "title": "App readiness",
                               "type": "object",
                               "additionalProperties": false,
@@ -45677,9 +45678,9 @@
                                   "description": "Fixed delay (ms)."
                                 },
                                 "find": {
+                                  "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                   "title": "Element criteria",
                                   "type": "object",
-                                  "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                   "additionalProperties": false,
                                   "anyOf": [
                                     {
@@ -45772,8 +45773,7 @@
                                     }
                                   }
                                 }
-                              },
-                              "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                              }
                             },
                             "timeout": {
                               "type": "integer",
@@ -66604,9 +66604,9 @@
                                                           "description": "Fixed delay (ms)."
                                                         },
                                                         "find": {
+                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                           "title": "Element criteria",
                                                           "type": "object",
-                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                           "additionalProperties": false,
                                                           "anyOf": [
                                                             {
@@ -67040,9 +67040,9 @@
                                                         "description": "Fixed delay (ms)."
                                                       },
                                                       "find": {
+                                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                         "title": "Element criteria",
                                                         "type": "object",
-                                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                         "additionalProperties": false,
                                                         "anyOf": [
                                                           {
@@ -68101,9 +68101,9 @@
                                                             "description": "Fixed delay (ms)."
                                                           },
                                                           "find": {
+                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                             "title": "Element criteria",
                                                             "type": "object",
-                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                             "additionalProperties": false,
                                                             "anyOf": [
                                                               {
@@ -68537,9 +68537,9 @@
                                                           "description": "Fixed delay (ms)."
                                                         },
                                                         "find": {
+                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                           "title": "Element criteria",
                                                           "type": "object",
-                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                           "additionalProperties": false,
                                                           "anyOf": [
                                                             {
@@ -70751,9 +70751,9 @@
                                                             "description": "Fixed delay (ms)."
                                                           },
                                                           "find": {
+                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                             "title": "Element criteria",
                                                             "type": "object",
-                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                             "additionalProperties": false,
                                                             "anyOf": [
                                                               {
@@ -71187,9 +71187,9 @@
                                                           "description": "Fixed delay (ms)."
                                                         },
                                                         "find": {
+                                                          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                           "title": "Element criteria",
                                                           "type": "object",
-                                                          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                           "additionalProperties": false,
                                                           "anyOf": [
                                                             {
@@ -72248,9 +72248,9 @@
                                                               "description": "Fixed delay (ms)."
                                                             },
                                                             "find": {
+                                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                               "title": "Element criteria",
                                                               "type": "object",
-                                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                               "additionalProperties": false,
                                                               "anyOf": [
                                                                 {
@@ -72684,9 +72684,9 @@
                                                             "description": "Fixed delay (ms)."
                                                           },
                                                           "find": {
+                                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                             "title": "Element criteria",
                                                             "type": "object",
-                                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                             "additionalProperties": false,
                                                             "anyOf": [
                                                               {
@@ -82976,9 +82976,9 @@
                                               "description": "Fixed delay (ms)."
                                             },
                                             "find": {
+                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                               "title": "Element criteria",
                                               "type": "object",
-                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                               "additionalProperties": false,
                                               "anyOf": [
                                                 {
@@ -83412,9 +83412,9 @@
                                             "description": "Fixed delay (ms)."
                                           },
                                           "find": {
+                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                             "title": "Element criteria",
                                             "type": "object",
-                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                             "additionalProperties": false,
                                             "anyOf": [
                                               {
@@ -84473,9 +84473,9 @@
                                                 "description": "Fixed delay (ms)."
                                               },
                                               "find": {
+                                                "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                                 "title": "Element criteria",
                                                 "type": "object",
-                                                "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                                 "additionalProperties": false,
                                                 "anyOf": [
                                                   {
@@ -84909,9 +84909,9 @@
                                               "description": "Fixed delay (ms)."
                                             },
                                             "find": {
+                                              "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                               "title": "Element criteria",
                                               "type": "object",
-                                              "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                               "additionalProperties": false,
                                               "anyOf": [
                                                 {
@@ -101590,6 +101590,7 @@
                                   "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                 },
                                 "waitUntil": {
+                                  "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                   "title": "App readiness",
                                   "type": "object",
                                   "additionalProperties": false,
@@ -101601,9 +101602,9 @@
                                       "description": "Fixed delay (ms)."
                                     },
                                     "find": {
+                                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                       "title": "Element criteria",
                                       "type": "object",
-                                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                       "additionalProperties": false,
                                       "anyOf": [
                                         {
@@ -101696,8 +101697,7 @@
                                         }
                                       }
                                     }
-                                  },
-                                  "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                  }
                                 },
                                 "timeout": {
                                   "type": "integer",
@@ -102007,6 +102007,7 @@
                                         "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                       },
                                       "waitUntil": {
+                                        "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                         "title": "App readiness",
                                         "type": "object",
                                         "additionalProperties": false,
@@ -102018,9 +102019,9 @@
                                             "description": "Fixed delay (ms)."
                                           },
                                           "find": {
+                                            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                             "title": "Element criteria",
                                             "type": "object",
-                                            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                             "additionalProperties": false,
                                             "anyOf": [
                                               {
@@ -102113,8 +102114,7 @@
                                               }
                                             }
                                           }
-                                        },
-                                        "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                        }
                                       },
                                       "timeout": {
                                         "type": "integer",
@@ -102606,6 +102606,7 @@
                                     "description": "Escape-hatch passthrough: merged into the automation session's capabilities after the ones Doc Detective computes (namespaced per driver, e.g. `appium:noReset`). Driver- and version-specific; use sparingly."
                                   },
                                   "waitUntil": {
+                                    "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default.",
                                     "title": "App readiness",
                                     "type": "object",
                                     "additionalProperties": false,
@@ -102617,9 +102618,9 @@
                                         "description": "Fixed delay (ms)."
                                       },
                                       "find": {
+                                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                                         "title": "Element criteria",
                                         "type": "object",
-                                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                                         "additionalProperties": false,
                                         "anyOf": [
                                           {
@@ -102712,8 +102713,7 @@
                                           }
                                         }
                                       }
-                                    },
-                                    "description": "Startup readiness: a fixed delay and/or an element that must exist before the surface is considered open. No condition applies by default."
+                                    }
                                   },
                                   "timeout": {
                                     "type": "integer",

--- a/src/common/src/schemas/output_schemas/type_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/type_v3.schema.json
@@ -820,9 +820,9 @@
                       "description": "Fixed delay (ms)."
                     },
                     "find": {
+                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                       "title": "Element criteria",
                       "type": "object",
-                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                       "additionalProperties": false,
                       "anyOf": [
                         {
@@ -1256,9 +1256,9 @@
                     "description": "Fixed delay (ms)."
                   },
                   "find": {
+                    "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                     "title": "Element criteria",
                     "type": "object",
-                    "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                     "additionalProperties": false,
                     "anyOf": [
                       {
@@ -2317,9 +2317,9 @@
                         "description": "Fixed delay (ms)."
                       },
                       "find": {
+                        "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                         "title": "Element criteria",
                         "type": "object",
-                        "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                         "additionalProperties": false,
                         "anyOf": [
                           {
@@ -2753,9 +2753,9 @@
                       "description": "Fixed delay (ms)."
                     },
                     "find": {
+                      "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
                       "title": "Element criteria",
                       "type": "object",
-                      "description": "Wait for a specific element to be present. At least one finding field must be specified.",
                       "additionalProperties": false,
                       "anyOf": [
                         {

--- a/src/common/src/schemas/output_schemas/waitUntil_v3.schema.json
+++ b/src/common/src/schemas/output_schemas/waitUntil_v3.schema.json
@@ -147,9 +147,9 @@
           "description": "Fixed delay (ms)."
         },
         "find": {
+          "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
           "title": "Element criteria",
           "type": "object",
-          "description": "Wait for a specific element to be present. At least one finding field must be specified.",
           "additionalProperties": false,
           "anyOf": [
             {
@@ -469,9 +469,9 @@
             "description": "Fixed delay (ms)."
           },
           "find": {
+            "description": "Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.",
             "title": "Element criteria",
             "type": "object",
-            "description": "Wait for a specific element to be present. At least one finding field must be specified.",
             "additionalProperties": false,
             "anyOf": [
               {

--- a/src/common/src/types/generated/annotate_v3.ts
+++ b/src/common/src/types/generated/annotate_v3.ts
@@ -27,15 +27,7 @@ export type AtLeastOneElementFindingField = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -51,15 +43,7 @@ export type AtLeastOneElementFindingField1 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion1 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -75,15 +59,7 @@ export type AtLeastOneElementFindingField2 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion2 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -99,15 +75,7 @@ export type AtLeastOneElementFindingField3 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion3 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -123,15 +91,7 @@ export type AtLeastOneElementFindingField4 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion4 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -147,28 +107,12 @@ export type AtLeastOneElementFindingField5 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion5 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion6 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType = {
   [k: string]: unknown;
 };
@@ -195,15 +139,7 @@ export type AtLeastOneElementFindingField6 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion7 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -219,15 +155,7 @@ export type AtLeastOneElementFindingField7 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion8 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -243,15 +171,7 @@ export type AtLeastOneElementFindingField8 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion9 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -267,15 +187,7 @@ export type AtLeastOneElementFindingField9 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion10 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -291,15 +203,7 @@ export type AtLeastOneElementFindingField10 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion11 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -315,28 +219,12 @@ export type AtLeastOneElementFindingField11 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion12 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion13 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType1 = {
   [k: string]: unknown;
 };

--- a/src/common/src/types/generated/annotation_v3.ts
+++ b/src/common/src/types/generated/annotation_v3.ts
@@ -23,15 +23,7 @@ export type AtLeastOneElementFindingField = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -47,15 +39,7 @@ export type AtLeastOneElementFindingField1 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion1 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -71,15 +55,7 @@ export type AtLeastOneElementFindingField2 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion2 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -95,15 +71,7 @@ export type AtLeastOneElementFindingField3 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion3 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -119,15 +87,7 @@ export type AtLeastOneElementFindingField4 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion4 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -143,28 +103,12 @@ export type AtLeastOneElementFindingField5 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion5 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion6 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType = {
   [k: string]: unknown;
 };

--- a/src/common/src/types/generated/report_v3.ts
+++ b/src/common/src/types/generated/report_v3.ts
@@ -73,12 +73,7 @@ export interface Report {
        * What the task pre-pays: a native app driver install, a browser install, a simulator/emulator boot, the managed WebDriverAgent availability check, the concurrent-run driver session probe, or the android mobile-web chromedriver download.
        */
       kind:
-        | "driver-install"
-        | "browser-install"
-        | "device-boot"
-        | "wda-check"
-        | "session-probe"
-        | "chromedriver-prefetch";
+        "driver-install" | "browser-install" | "device-boot" | "wda-check" | "session-probe" | "chromedriver-prefetch";
       /**
        * `warmed` — the work was performed (for device boots, the boot was initiated); `skipped` — nothing to do or the environment isn't ready (the consuming context handles it as usual); `failed` — the attempt failed (logged as a warning; never fails the run).
        */

--- a/src/common/src/types/generated/screenshot_v3.ts
+++ b/src/common/src/types/generated/screenshot_v3.ts
@@ -86,15 +86,7 @@ export type AtLeastOneElementFindingField = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -110,15 +102,7 @@ export type AtLeastOneElementFindingField1 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion1 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -134,15 +118,7 @@ export type AtLeastOneElementFindingField2 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion2 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -158,15 +134,7 @@ export type AtLeastOneElementFindingField3 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion3 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -182,15 +150,7 @@ export type AtLeastOneElementFindingField4 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion4 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -206,28 +166,12 @@ export type AtLeastOneElementFindingField5 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion5 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion6 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType = {
   [k: string]: unknown;
 };

--- a/src/common/src/types/generated/step_v3.ts
+++ b/src/common/src/types/generated/step_v3.ts
@@ -631,7 +631,7 @@ export type ElementCriteria = {
   [k: string]: unknown;
 };
 /**
- * Wait for a specific element to be present. At least one finding field must be specified.
+ * Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.
  */
 export type ElementCriteria1 = {
   [k: string]: unknown;
@@ -750,15 +750,7 @@ export type AtLeastOneElementFindingField = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -774,15 +766,7 @@ export type AtLeastOneElementFindingField1 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion1 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -798,15 +782,7 @@ export type AtLeastOneElementFindingField2 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion2 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -822,15 +798,7 @@ export type AtLeastOneElementFindingField3 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion3 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -846,15 +814,7 @@ export type AtLeastOneElementFindingField4 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion4 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -870,28 +830,12 @@ export type AtLeastOneElementFindingField5 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion5 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion6 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType = {
   [k: string]: unknown;
 };
@@ -1253,7 +1197,7 @@ export type Routing59 = {
 export type StartSurface1 = AppDescriptor | BrowserDescriptor | ProcessDescriptor | ParallelSurfaces;
 export type DeviceByName = string;
 /**
- * Wait for a specific element to be present. At least one finding field must be specified.
+ * Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.
  */
 export type ElementCriteria2 = {
   [k: string]: unknown;
@@ -1269,7 +1213,7 @@ export type ParallelSurfaces = [
 ];
 export type DeviceByName1 = string;
 /**
- * Wait for a specific element to be present. At least one finding field must be specified.
+ * Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.
  */
 export type ElementCriteria3 =
   | {
@@ -1664,15 +1608,7 @@ export type AtLeastOneElementFindingField6 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion7 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1688,15 +1624,7 @@ export type AtLeastOneElementFindingField7 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion8 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1712,15 +1640,7 @@ export type AtLeastOneElementFindingField8 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion9 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1736,15 +1656,7 @@ export type AtLeastOneElementFindingField9 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion10 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1760,15 +1672,7 @@ export type AtLeastOneElementFindingField10 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion11 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1784,28 +1688,12 @@ export type AtLeastOneElementFindingField11 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion12 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion13 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType1 = {
   [k: string]: unknown;
 };
@@ -1832,15 +1720,7 @@ export type AtLeastOneElementFindingField12 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion14 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1856,15 +1736,7 @@ export type AtLeastOneElementFindingField13 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion15 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1880,15 +1752,7 @@ export type AtLeastOneElementFindingField14 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion16 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1904,15 +1768,7 @@ export type AtLeastOneElementFindingField15 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion17 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1928,15 +1784,7 @@ export type AtLeastOneElementFindingField16 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion18 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1952,28 +1800,12 @@ export type AtLeastOneElementFindingField17 = {
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion19 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion20 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType2 = {
   [k: string]: unknown;
 };

--- a/src/common/src/types/generated/test_v3.ts
+++ b/src/common/src/types/generated/test_v3.ts
@@ -1287,7 +1287,7 @@ export type ElementCriteria =
       [k: string]: unknown;
     };
 /**
- * Wait for a specific element to be present. At least one finding field must be specified.
+ * Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.
  */
 export type ElementCriteria1 =
   | {
@@ -1515,15 +1515,7 @@ export type AtLeastOneElementFindingField =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1558,15 +1550,7 @@ export type AtLeastOneElementFindingField1 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion1 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1601,15 +1585,7 @@ export type AtLeastOneElementFindingField2 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion2 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1644,15 +1620,7 @@ export type AtLeastOneElementFindingField3 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion3 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1687,15 +1655,7 @@ export type AtLeastOneElementFindingField4 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion4 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -1730,28 +1690,12 @@ export type AtLeastOneElementFindingField5 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion5 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion6 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType =
   | {
       [k: string]: unknown;
@@ -2393,7 +2337,7 @@ export type Routing63 =
 export type StartSurface1 = AppDescriptor | BrowserDescriptor | ProcessDescriptor | ParallelSurfaces;
 export type DeviceByName1 = string;
 /**
- * Wait for a specific element to be present. At least one finding field must be specified.
+ * Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.
  */
 export type ElementCriteria2 =
   | {
@@ -2428,7 +2372,7 @@ export type ParallelSurfaces = [
 ];
 export type DeviceByName2 = string;
 /**
- * Wait for a specific element to be present. At least one finding field must be specified.
+ * Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.
  */
 export type ElementCriteria3 =
   | {
@@ -3196,15 +3140,7 @@ export type AtLeastOneElementFindingField6 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion7 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -3239,15 +3175,7 @@ export type AtLeastOneElementFindingField7 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion8 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -3282,15 +3210,7 @@ export type AtLeastOneElementFindingField8 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion9 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -3325,15 +3245,7 @@ export type AtLeastOneElementFindingField9 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion10 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -3368,15 +3280,7 @@ export type AtLeastOneElementFindingField10 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion11 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -3411,28 +3315,12 @@ export type AtLeastOneElementFindingField11 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion12 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion13 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType1 =
   | {
       [k: string]: unknown;
@@ -3494,15 +3382,7 @@ export type AtLeastOneElementFindingField12 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion14 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -3537,15 +3417,7 @@ export type AtLeastOneElementFindingField13 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion15 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -3580,15 +3452,7 @@ export type AtLeastOneElementFindingField14 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion16 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -3623,15 +3487,7 @@ export type AtLeastOneElementFindingField15 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion17 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -3666,15 +3522,7 @@ export type AtLeastOneElementFindingField16 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion18 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -3709,28 +3557,12 @@ export type AtLeastOneElementFindingField17 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion19 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion20 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType2 =
   | {
       [k: string]: unknown;
@@ -4949,7 +4781,7 @@ export type ElementCriteria4 =
       [k: string]: unknown;
     };
 /**
- * Wait for a specific element to be present. At least one finding field must be specified.
+ * Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.
  */
 export type ElementCriteria5 =
   | {
@@ -5177,15 +5009,7 @@ export type AtLeastOneElementFindingField18 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion21 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -5220,15 +5044,7 @@ export type AtLeastOneElementFindingField19 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion22 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -5263,15 +5079,7 @@ export type AtLeastOneElementFindingField20 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion23 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -5306,15 +5114,7 @@ export type AtLeastOneElementFindingField21 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion24 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -5349,15 +5149,7 @@ export type AtLeastOneElementFindingField22 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion25 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -5392,28 +5184,12 @@ export type AtLeastOneElementFindingField23 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion26 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion27 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType3 =
   | {
       [k: string]: unknown;
@@ -6055,7 +5831,7 @@ export type Routing147 =
 export type StartSurface3 = AppDescriptor2 | BrowserDescriptor2 | ProcessDescriptor2 | ParallelSurfaces1;
 export type DeviceByName3 = string;
 /**
- * Wait for a specific element to be present. At least one finding field must be specified.
+ * Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.
  */
 export type ElementCriteria6 =
   | {
@@ -6090,7 +5866,7 @@ export type ParallelSurfaces1 = [
 ];
 export type DeviceByName4 = string;
 /**
- * Wait for a specific element to be present. At least one finding field must be specified.
+ * Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.
  */
 export type ElementCriteria7 =
   | {
@@ -6858,15 +6634,7 @@ export type AtLeastOneElementFindingField24 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion28 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -6901,15 +6669,7 @@ export type AtLeastOneElementFindingField25 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion29 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -6944,15 +6704,7 @@ export type AtLeastOneElementFindingField26 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion30 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -6987,15 +6739,7 @@ export type AtLeastOneElementFindingField27 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion31 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -7030,15 +6774,7 @@ export type AtLeastOneElementFindingField28 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion32 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -7073,28 +6809,12 @@ export type AtLeastOneElementFindingField29 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion33 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion34 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType4 =
   | {
       [k: string]: unknown;
@@ -7156,15 +6876,7 @@ export type AtLeastOneElementFindingField30 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion35 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -7199,15 +6911,7 @@ export type AtLeastOneElementFindingField31 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion36 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -7242,15 +6946,7 @@ export type AtLeastOneElementFindingField32 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion37 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -7285,15 +6981,7 @@ export type AtLeastOneElementFindingField33 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion38 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -7328,15 +7016,7 @@ export type AtLeastOneElementFindingField34 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion39 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * Display text or selector of the element to annotate.
  */
@@ -7371,28 +7051,12 @@ export type AtLeastOneElementFindingField35 =
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion40 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 /**
  * A named spot, relative to the target element when the annotation has one, or to the capture when it doesn't.
  */
 export type NamedRegion41 =
-  | "top"
-  | "bottom"
-  | "left"
-  | "right"
-  | "center"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+  "top" | "bottom" | "left" | "right" | "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type ExactlyOneAnnotationType5 =
   | {
       [k: string]: unknown;

--- a/src/common/src/types/generated/type_v3.ts
+++ b/src/common/src/types/generated/type_v3.ts
@@ -118,7 +118,7 @@ export type ElementCriteria = {
   [k: string]: unknown;
 };
 /**
- * Wait for a specific element to be present. At least one finding field must be specified.
+ * Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.
  */
 export type ElementCriteria1 = {
   [k: string]: unknown;

--- a/src/common/src/types/generated/waitUntil_v3.ts
+++ b/src/common/src/types/generated/waitUntil_v3.ts
@@ -15,7 +15,7 @@ export type ElementCriteria = {
   [k: string]: unknown;
 };
 /**
- * Wait for a specific element to be present. At least one finding field must be specified.
+ * Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named.
  */
 export type ElementCriteria1 = {
   [k: string]: unknown;


### PR DESCRIPTION
`npm run build` on a clean `main` regenerates 18 committed build artifacts — the checked-in dereferenced schemas and generated types no longer match their authored sources. This commits the regenerated output so the tree is reproducible again.

## Two independent causes

**1. Stale descriptions** in `output_schemas/` and `schemas.json`. The dereferenced bundle carried description text older than `src_schemas/`.

I verified mechanically that this is text-only: stripping `description` / `title` / `$comment` from both sides and deep-comparing leaves the structures identical.

```
TEXT-ONLY (description/title/order): 10
SEMANTIC CHANGES: 0
```

So **no validation semantics change** — no field, type, enum, `required`, or constraint moves. Existing specs validate exactly as before.

**2. Prettier reformatting** of the generated types. `json-schema-to-typescript` formats through prettier, which moved **3.8.5 → 3.9.6** transitively in d4604af5 (the dependency sweep). Prettier 3.9 puts short union types on one line where 3.8 broke them per member:

```diff
-export type NamedRegion =
-  | "top"
-  | "bottom"
-  ...
+export type NamedRegion =
+  "top" | "bottom" | "left" | "right" | "center" | ...
```

That accounts for `annotate_v3`, `annotation_v3`, `screenshot_v3`, and `report_v3`, which did **not** drift before that bump — I confirmed by rebuilding at `f8b1c976`. The remaining files predate it.

## Why CI never caught it

The [Schema reference drift](.github/workflows/docs-schema-refs.yml) workflow regenerates the docs pages from the **committed `schemas.json` bundle**, not from the authored sources — its own comment says keeping the bundle in sync "is the common package's own concern." A stale bundle therefore stays self-consistent with the pages generated from it, and the check passes.

**Nothing currently gates `schemas.json` against `src_schemas/`.** That is the root cause, and it will drift again. I have deliberately *not* added that gate here: #690, #693, and #706 are all reworking schema generation right now, and a fourth competing gate would conflict. Worth adding once those land.

## Docs impact

One generated reference page changes, `docs/fern/pages/reference/schemas/app-readiness.mdx` — it was showing stale text for `find`:

```diff
-find | ... | Optional. Wait for a specific element to be present. At least one finding field must be specified. | —
+find | ... | Optional. Wait for a specific element to exist on the app surface. Fields with no accessibility mapping on the target platform fail at runtime with the supported alternative named. | —
```

Regenerated with `npm run docs:build-schema-refs`, so the drift check stays green.

## ADR

None. Regenerating committed build output is mechanical, and per `CLAUDE.md` mechanical changes don't warrant an ADR. There is no behavior or contract change to record — confirmed by the zero-semantic-diff check above.

## Verification

- `npm run build` → `npm test`: **4081 passing + 1041 passing, 0 failing**
- Re-running `npm run build` after committing produces no further diff (idempotent)
- `npm run docs:build-schema-refs` and `docs:build-cli-ref` both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how the `find` field waits for elements to appear on the app surface.
  * Documented runtime failures when fields lack target-platform accessibility mappings.
  * Removed the requirement to specify at least one finding field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->