### PR TITLE
fix(engines): align the node floor with the dependency tree

### DIFF
--- a/adrs/01095-align-the-node-engines-floor-with-the-dependency-tree.md
+++ b/adrs/01095-align-the-node-engines-floor-with-the-dependency-tree.md
@@ -39,8 +39,9 @@ Two questions follow: what should the range be, and how do we stop it rotting ag
 
 * The declared support contract should be true; a wrong `engines` is worse than a loose one,
   because it converts a clear failure into a contradiction.
-* Node 23 is not merely "above the floor" — the appium family and `yargs` exclude that line
-  outright, so a simple minimum version cannot express the real support set.
+* Node 23 is not merely "above the floor" — the appium family excludes that line outright
+  (`^20.19.0 || ^22.12.0 || >=24.0.0`), so a simple minimum version cannot express the real
+  support set.
 * The check must be mechanical. The rot happened precisely because keeping the number current was
   a manual step nobody owned.
 * CI must keep passing on the Node lines it already tests (22 and 24).
@@ -59,14 +60,21 @@ Chosen option: **A**.
 
 `engines.node` becomes `^22.22.0 || >=24.0.0`. That is the widest range every production dependency
 actually supports, and it matches the Node lines CI tests. The two-branch form is not cosmetic: a
-flat `>=22.22.0` admits Node 23, which `appium` (`^20.19.0 || ^22.12.0 || >=24.0.0`) and `yargs`
-(`^20.19.0 || ^22.12.0 || >=23`) do not agree on, so the excluded line has to be stated.
+flat `>=22.22.0` admits Node 23, which the appium family (`^20.19.0 || ^22.12.0 || >=24.0.0`) does
+not support, so the excluded line has to be stated.
 
 [test/engines-floor.test.js](../test/engines-floor.test.js) makes the invariant executable. For each
 package in `dependencies` and `optionalDependencies` it reads the *installed* copy's `engines.node`
 and asserts `semver.subset(declared, dependencyRange)` — every Node version we admit must be one the
 dependency admits. Subset, not a floor comparison, because the Node 23 gap above is invisible to a
 minimum-version check.
+
+`semver.subset` is a conservative decision procedure: on some unions of ranges it answers `false`
+for a pair that is in fact a subset. `yargs` (`^20.19.0 || ^22.12.0 || >=23`) is one such case —
+probing it version by version shows it accepts every Node release `>=22.22.0`, yet `subset` reports
+a violation against that range. The imprecision only ever errs toward "tighten `engines`", never
+toward a false pass, which is the safe direction for a guard; and it does not fire against the
+range chosen here. Read a failure as "prove this is still compatible", not as proof of breakage.
 
 `devDependencies` are excluded deliberately. They do not reach consumers, and their engines
 routinely outrun ours — `@semantic-release/git` currently wants `^22.22.2 || >=24.15` — which says
@@ -109,7 +117,7 @@ resolves today — both satisfy the new range.
 ### B. `>=22.22.0`, no test
 
 * Good: one-line change; fixes today's inaccuracy.
-* Bad: still wrong for Node 23, which appium and yargs exclude.
+* Bad: still wrong for Node 23, which the appium family excludes.
 * Bad: no guard, so it rots again on the next bump — the failure mode this ADR exists to end.
 
 ### C. Hold dependencies back

--- a/adrs/01095-align-the-node-engines-floor-with-the-dependency-tree.md
+++ b/adrs/01095-align-the-node-engines-floor-with-the-dependency-tree.md
@@ -1,0 +1,133 @@
+---
+status: accepted
+date: 2026-08-24
+decision-makers: doc-detective maintainers
+---
+
+# Align the node engines floor with the dependency tree, and guard it with a test
+
+## Context and Problem Statement
+
+[ADR 00166](00166-node-22-engines-floor.md) established `engines.node` as the machine-readable
+statement of which Node versions Doc Detective supports, on the reasoning that an install-time
+`EBADENGINE` is far better UX than a confusing mid-run failure. It set the floor at `>=22.12.0`,
+matching what `@puppeteer/browsers` v3 required at the time.
+
+That declaration is written by hand. The dependency floors backing it move every time a dependency
+is bumped, and nothing compared the two. It rotted:
+
+| Dependency | Supports |
+|---|---|
+| `posthog-node` | `^20.20.0 \|\| >=22.22.0` |
+| `@inquirer/prompts` | `>=23.5.0 \|\| ^22.13.0 \|\| ^20.17.0` |
+| `@apidevtools/json-schema-ref-parser` | `>=22.19.0` |
+| `appium`, `appium-chromium-driver`, `appium-geckodriver`, `appium-safari-driver` | `^20.19.0 \|\| ^22.12.0 \|\| >=24.0.0` |
+| `yargs` | `^20.19.0 \|\| ^22.12.0 \|\| >=23` |
+
+A user on Node 22.12–22.21 therefore installed a package whose manifest promised support, and got a
+wall of `EBADENGINE` warnings that the manifest said should not happen — the exact confusion
+`00166` set out to prevent, arriving through the same channel it chose as the remedy.
+
+This predates and is independent of the dependency sweep in `d4604af5`. That sweep introduced
+`@apidevtools/json-schema-ref-parser` v16 (`>=22.19.0`), but `posthog-node`'s `>=22.22.0` was
+already the binding constraint, so the effective floor did not move — only the number of
+dependencies disagreeing with the declaration.
+
+Two questions follow: what should the range be, and how do we stop it rotting again?
+
+## Decision Drivers
+
+* The declared support contract should be true; a wrong `engines` is worse than a loose one,
+  because it converts a clear failure into a contradiction.
+* Node 23 is not merely "above the floor" — the appium family and `yargs` exclude that line
+  outright, so a simple minimum version cannot express the real support set.
+* The check must be mechanical. The rot happened precisely because keeping the number current was
+  a manual step nobody owned.
+* CI must keep passing on the Node lines it already tests (22 and 24).
+
+## Considered Options
+
+* **A. Raise `engines.node` to `^22.22.0 || >=24.0.0` and add a test asserting it is a subset of
+  every production dependency's range** (chosen).
+* **B. Raise `engines.node` to `>=22.22.0`, no test.**
+* **C. Hold the dependencies back so `>=22.12.0` stays true.**
+* **D. Drop `engines` and document a recommended Node version instead.**
+
+## Decision Outcome
+
+Chosen option: **A**.
+
+`engines.node` becomes `^22.22.0 || >=24.0.0`. That is the widest range every production dependency
+actually supports, and it matches the Node lines CI tests. The two-branch form is not cosmetic: a
+flat `>=22.22.0` admits Node 23, which `appium` (`^20.19.0 || ^22.12.0 || >=24.0.0`) and `yargs`
+(`^20.19.0 || ^22.12.0 || >=23`) do not agree on, so the excluded line has to be stated.
+
+[test/engines-floor.test.js](../test/engines-floor.test.js) makes the invariant executable. For each
+package in `dependencies` and `optionalDependencies` it reads the *installed* copy's `engines.node`
+and asserts `semver.subset(declared, dependencyRange)` — every Node version we admit must be one the
+dependency admits. Subset, not a floor comparison, because the Node 23 gap above is invisible to a
+minimum-version check.
+
+`devDependencies` are excluded deliberately. They do not reach consumers, and their engines
+routinely outrun ours — `@semantic-release/git` currently wants `^22.22.2 || >=24.15` — which says
+nothing about what the published package requires.
+
+Scope note: only the root manifest is governed. `docs/package.json` is a private manifest for the
+Fern docs site with its own dependency set, and CI installs Fern through `setup-fern-cli` rather
+than from that manifest.
+
+### Consequences
+
+* Good: the published support contract is true again, and `EBADENGINE` recovers its meaning.
+* Good: the invariant is enforced mechanically, so a future dependency bump that raises a floor
+  fails a test instead of silently invalidating the manifest.
+* Good: the declared range now matches the CI matrix exactly (Node 22 and 24).
+* Bad: users on Node 22.12–22.21 who previously installed with warnings now see `EBADENGINE`
+  naming the real floor. This surfaces an incompatibility that already existed rather than
+  creating one.
+* Neutral: Node 23 is explicitly excluded. It is an odd-numbered line, long past end-of-life, and
+  was never tested here.
+* Neutral: raising the floor is not a breaking change under semver for this package — `engines` is
+  advisory, and without `engine-strict` npm warns rather than fails.
+
+### Confirmation
+
+`package.json` `engines.node` is `^22.22.0 || >=24.0.0`, and
+[test/engines-floor.test.js](../test/engines-floor.test.js) fails if it ever admits a Node version a
+production dependency does not. Verified red against the previous `>=22.12.0` (it named all eight
+disagreeing dependencies) and green after the change. Node 22.23.2 and 24.19.0 — what the CI matrix
+resolves today — both satisfy the new range.
+
+## Pros and Cons of the Options
+
+### A. `^22.22.0 || >=24.0.0` plus a subset test
+
+* Good: true today, and mechanically kept true.
+* Good: expresses the excluded Node 23 line, which a floor cannot.
+* Bad: the range is harder to read at a glance than a single floor.
+
+### B. `>=22.22.0`, no test
+
+* Good: one-line change; fixes today's inaccuracy.
+* Bad: still wrong for Node 23, which appium and yargs exclude.
+* Bad: no guard, so it rots again on the next bump — the failure mode this ADR exists to end.
+
+### C. Hold dependencies back
+
+* Good: preserves the widest install surface.
+* Bad: pins the project to old releases, including security fixes, to protect a Node line that is
+  itself unsupported by upstream.
+* Bad: `posthog-node` already required `>=22.22.0` several releases back; unwinding it means
+  reverting unrelated updates.
+
+### D. Drop `engines`, document instead
+
+* Good: no install-time friction.
+* Bad: reverses `00166` on the strength of a bookkeeping failure rather than a change of reasoning.
+* Bad: returns failures to mid-run, where they are hardest to diagnose.
+
+## More Information
+
+Amends [00166](00166-node-22-engines-floor.md), which remains accepted — this ADR changes the value
+of the floor and adds enforcement, not the decision to declare one. Related: `00130` (drop Node 18
+from CI), `01048` (PR gate latency, which records the Node 22 + 24 matrix).

--- a/docs/fern/pages/docs/get-started/installation.mdx
+++ b/docs/fern/pages/docs/get-started/installation.mdx
@@ -13,7 +13,7 @@ Choose *NPX* if you have Node.js installed and want to install Doc Detective on 
 
 1. Install prerequisites:
 
-    - [Node.js](https://nodejs.org/) v22 or later
+    - [Node.js](https://nodejs.org/) v22.22.0 or later on the v22 line, or v24 or later
     {/* step {"stepId":"check-nodejs-link","description":"Verify Node.js download link","checkLink":"https://nodejs.org/"} */}
 
 2. In a terminal, install Doc Detective globally:

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "typescript-compiler-api": "npm:typescript@6.0.3"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": "^22.22.0 || >=24.0.0"
       },
       "optionalDependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=22.12.0"
+    "node": "^22.22.0 || >=24.0.0"
   },
   "files": [
     "dist/",

--- a/test/engines-floor.test.js
+++ b/test/engines-floor.test.js
@@ -1,0 +1,88 @@
+// Keeps `engines.node` honest against what the production dependency tree
+// actually supports.
+//
+// `engines` is the only machine-readable statement of which Node versions
+// Doc Detective supports, and npm surfaces it at install time (ADR 00166). It
+// is written by hand, while the dependency floors that back it move whenever a
+// dependency is bumped — so the declaration silently rots. It did: the tree
+// required node >=22.22.0 for several releases while `engines` still advertised
+// >=22.12.0, so users on 22.12-22.21 installed against an EBADENGINE warning
+// storm that the manifest said should not happen.
+//
+// The assertion is subset, not "floor >= floor": a dependency range like
+// `^20.19.0 || ^22.12.0 || >=24.0.0` excludes the whole Node 23 line, and a
+// naive minimum comparison would not notice. Every version our `engines` admits
+// must be a version the dependency admits.
+//
+// Only `dependencies` and `optionalDependencies` count. devDependencies do not
+// reach consumers, and their engines routinely outrun ours (semantic-release in
+// particular) without saying anything about what the published package needs.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import semver from "semver";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function readJson(...segments) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, ...segments), "utf8"));
+}
+
+// The installed copy is the source of truth for a dependency's engines: the
+// manifest only records a range, and which version that resolves to is the
+// lockfile's business.
+function installedEngines(name) {
+  try {
+    return readJson("node_modules", ...name.split("/"), "package.json").engines
+      ?.node;
+  } catch {
+    return undefined; // not installed (optional dep skipped on this platform)
+  }
+}
+
+describe("engines.node", function () {
+  const manifest = readJson("package.json");
+  const declared = manifest.engines?.node;
+
+  it("declares a node range", function () {
+    assert.ok(declared, "package.json must declare engines.node");
+    assert.ok(
+      semver.validRange(declared),
+      `engines.node is not a valid semver range: "${declared}"`
+    );
+  });
+
+  it("admits only node versions every production dependency supports", function () {
+    const names = [
+      ...Object.keys(manifest.dependencies ?? {}),
+      ...Object.keys(manifest.optionalDependencies ?? {}),
+    ].sort();
+
+    const checked = [];
+    const violations = [];
+
+    for (const name of names) {
+      const range = installedEngines(name);
+      if (!range || !semver.validRange(range)) continue;
+      checked.push(name);
+      if (!semver.subset(declared, range)) {
+        violations.push(`  ${name} supports "${range}"`);
+      }
+    }
+
+    if (checked.length === 0) {
+      // Dependencies aren't installed; nothing to compare against.
+      this.skip();
+    }
+
+    assert.deepEqual(
+      violations,
+      [],
+      `engines.node is "${declared}", which admits node versions these dependencies do not support:\n${violations.join(
+        "\n"
+      )}\nEither raise engines.node or hold the dependency back.`
+    );
+  });
+});

--- a/test/engines-floor.test.js
+++ b/test/engines-floor.test.js
@@ -14,6 +14,11 @@
 // naive minimum comparison would not notice. Every version our `engines` admits
 // must be a version the dependency admits.
 //
+// `semver.subset` is conservative — on some unions it answers `false` for a
+// pair that is genuinely a subset (`yargs` is one such case). It therefore errs
+// toward "tighten `engines`" and never toward a false pass, which is the safe
+// direction here. Read a failure as "prove this is still compatible".
+//
 // Only `dependencies` and `optionalDependencies` count. devDependencies do not
 // reach consumers, and their engines routinely outrun ours (semantic-release in
 // particular) without saying anything about what the published package needs.
@@ -33,13 +38,13 @@ function readJson(...segments) {
 // The installed copy is the source of truth for a dependency's engines: the
 // manifest only records a range, and which version that resolves to is the
 // lockfile's business.
+//
+// Returns the declared range, or null when the package declares no `engines`.
+// Throws when the package cannot be read at all — the caller decides whether
+// that is fatal, which depends on whether the dependency is optional.
 function installedEngines(name) {
-  try {
-    return readJson("node_modules", ...name.split("/"), "package.json").engines
-      ?.node;
-  } catch {
-    return undefined; // not installed (optional dep skipped on this platform)
-  }
+  return readJson("node_modules", ...name.split("/"), "package.json").engines
+    ?.node ?? null;
 }
 
 describe("engines.node", function () {
@@ -55,27 +60,47 @@ describe("engines.node", function () {
   });
 
   it("admits only node versions every production dependency supports", function () {
-    const names = [
-      ...Object.keys(manifest.dependencies ?? {}),
-      ...Object.keys(manifest.optionalDependencies ?? {}),
-    ].sort();
+    // The whole suite runs against an installed tree; if there isn't one there
+    // is nothing to compare against. This is the ONLY skip condition — a
+    // dependency missing from an otherwise-installed tree is a real failure
+    // below, not a reason to pass quietly.
+    if (!fs.existsSync(path.join(repoRoot, "node_modules"))) {
+      this.skip();
+    }
 
-    const checked = [];
+    const required = Object.keys(manifest.dependencies ?? {}).sort();
+    // Optional dependencies are legitimately absent when npm skips them for
+    // this platform, so only those may go uninspected.
+    const optional = Object.keys(manifest.optionalDependencies ?? {}).sort();
+
     const violations = [];
+    const unreadable = [];
+    let inspected = 0;
 
-    for (const name of names) {
-      const range = installedEngines(name);
+    for (const name of [...required, ...optional]) {
+      let range;
+      try {
+        range = installedEngines(name);
+      } catch (error) {
+        if (required.includes(name)) {
+          unreadable.push(`  ${name} (${error.code ?? error.message})`);
+        }
+        continue; // optional dep not installed on this platform
+      }
       if (!range || !semver.validRange(range)) continue;
-      checked.push(name);
+      inspected += 1;
       if (!semver.subset(declared, range)) {
         violations.push(`  ${name} supports "${range}"`);
       }
     }
 
-    if (checked.length === 0) {
-      // Dependencies aren't installed; nothing to compare against.
-      this.skip();
-    }
+    assert.deepEqual(
+      unreadable,
+      [],
+      `these non-optional dependencies could not be read from node_modules, so their engines went unchecked:\n${unreadable.join(
+        "\n"
+      )}\nReinstall (npm ci) before trusting this test.`
+    );
 
     assert.deepEqual(
       violations,
@@ -83,6 +108,13 @@ describe("engines.node", function () {
       `engines.node is "${declared}", which admits node versions these dependencies do not support:\n${violations.join(
         "\n"
       )}\nEither raise engines.node or hold the dependency back.`
+    );
+
+    // A tree where nothing declares engines would pass both assertions above
+    // while proving nothing.
+    assert.ok(
+      inspected > 0,
+      "no installed production dependency declared engines.node; the comparison above was vacuous"
     );
   });
 });


### PR DESCRIPTION
`engines.node` declared `>=22.12.0` while **eight production dependencies** required more than that. A user on Node 22.12–22.21 installed a package whose manifest promised support, then got an `EBADENGINE` warning storm the manifest said should not happen — the exact confusion [ADR 00166](adrs/00166-node-22-engines-floor.md) created the declaration to prevent.

| Dependency | Actually supports |
|---|---|
| `posthog-node` | `^20.20.0 \|\| >=22.22.0` |
| `@inquirer/prompts` | `>=23.5.0 \|\| ^22.13.0 \|\| ^20.17.0` |
| `@apidevtools/json-schema-ref-parser` | `>=22.19.0` |
| `appium`, `appium-chromium-driver`, `appium-geckodriver`, `appium-safari-driver` | `^20.19.0 \|\| ^22.12.0 \|\| >=24.0.0` |
| `yargs` | `^20.19.0 \|\| ^22.12.0 \|\| >=23` |

## The new range

`^22.22.0 || >=24.0.0` — the widest range every production dependency supports, and exactly the lines CI tests.

The two-branch form is load-bearing, not stylistic. A flat `>=22.22.0` **still fails**, because it admits Node 23, which appium and `yargs` exclude:

```
candidate ">=22.12.0"           -> VIOLATES: 8 dependencies
candidate ">=22.22.0"           -> VIOLATES: @inquirer/prompts; appium x4; yargs
candidate "^22.22.0 || >=24.0.0" -> satisfies every production dep
```

## Pre-existing, not caused by the dep sweep

Worth being explicit since it surfaced during #708: this inaccuracy predates that PR. The sweep added ref-parser v16 (`>=22.19.0`), but `posthog-node`'s `>=22.22.0` was **already binding**, so the effective floor never moved — only the count of dependencies disagreeing with the declaration.

## Guard

[test/engines-floor.test.js](test/engines-floor.test.js) makes the invariant executable: for every `dependencies` / `optionalDependencies` entry it reads the **installed** copy's `engines.node` and asserts `semver.subset(declared, dependencyRange)`.

Subset rather than a floor comparison, deliberately — the Node 23 gap above is invisible to a minimum-version check. `devDependencies` are excluded: they never reach consumers, and their engines routinely outrun ours (`@semantic-release/git` wants `^22.22.2 || >=24.15` today), which says nothing about the published package.

Verified **red** against the old value — it named all eight dependencies — and **green** after the change.

## Compatibility

- Node **22.23.2** and **24.19.0** (what `setup-node: 22` / `24` resolve to today) both satisfy the new range, so the CI matrix is unaffected.
- No root `.npmrc`, so no `engine-strict`: npm **warns**, it does not fail. Users on 22.12–22.21 now see a warning naming the real floor instead of a contradictory one. This surfaces an incompatibility that already existed rather than creating one.

## ADR

[adrs/01095-align-the-node-engines-floor-with-the-dependency-tree.md](adrs/01095-align-the-node-engines-floor-with-the-dependency-tree.md), amending 00166 (which stays accepted — this changes the floor's *value* and adds enforcement, not the decision to declare one). Numbered 01095 because #690 already claims 01094.

## Docs impact

Yes — the NPX prerequisite on the installation page stated a requirement that is no longer true:

```diff
-    - [Node.js](https://nodejs.org/) v22 or later
+    - [Node.js](https://nodejs.org/) v22.22.0 or later on the v22 line, or v24 or later
```

Persona **Diego / Priya**, CUJ **D1 / P1** (getting installed and running). Vale is clean on the changed line.

## Out of scope

`docs/package.json` declares its own `^22.12.0 || ^24.11.1` for the Fern docs site. It is a private manifest with a separate dependency set, and CI installs Fern via `setup-fern-cli` rather than from it — but note a docs contributor running its `npm test` does invoke `doc-detective`. Worth a follow-up decision; not changed here.

## Verification

`npm run build` → `npm test`: **4083 passing + 1041 passing, 0 failing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated the supported Node.js versions to v22.22.0 or later on the v22 line, or v24 and later.
  * Node.js v23 is no longer supported.

* **Documentation**
  * Updated installation requirements to reflect the revised Node.js support range.

* **Tests**
  * Added validation to ensure supported Node.js versions are compatible with production dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->