### PR TITLE
fix(runtime): never execute a foreign-architecture driver binary

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -183,10 +183,18 @@ jobs:
         run: |
           set -euo pipefail
           npm run build
-          mkdir -p "$RUNNER_TEMP/pack"
-          tarball="$(npm pack --silent --pack-destination "$RUNNER_TEMP/pack")"
-          echo "tarball=$RUNNER_TEMP/pack/$tarball" >> "$GITHUB_OUTPUT"
-          echo "Packed $tarball from $(git rev-parse --short HEAD)"
+          dest="$RUNNER_TEMP/pack"
+          mkdir -p "$dest"
+          tarball="$(npm pack --silent --pack-destination "$dest")"
+          # Hand the build script a forward-slash path. RUNNER_TEMP is a
+          # backslash Windows path on the windows runner, and
+          # `npm run <script> -- --flag=<path>` forwards it through cmd.exe,
+          # which eats the backslashes (D:\a\_temp arrives as D:a_temp). Node
+          # accepts forward slashes on Windows, and this is a no-op on Linux.
+          full="$dest/$tarball"
+          full="${full//'\'/'/'}"
+          printf 'tarball=%s\n' "$full" >> "$GITHUB_OUTPUT"
+          echo "Packed $tarball from $(git rev-parse --short HEAD) at $full"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -455,10 +463,18 @@ jobs:
         run: |
           set -euo pipefail
           npm run build
-          mkdir -p "$RUNNER_TEMP/pack"
-          tarball="$(npm pack --silent --pack-destination "$RUNNER_TEMP/pack")"
-          echo "tarball=$RUNNER_TEMP/pack/$tarball" >> "$GITHUB_OUTPUT"
-          echo "Packed $tarball from $(git rev-parse --short HEAD)"
+          dest="$RUNNER_TEMP/pack"
+          mkdir -p "$dest"
+          tarball="$(npm pack --silent --pack-destination "$dest")"
+          # Hand the build script a forward-slash path. RUNNER_TEMP is a
+          # backslash Windows path on the windows runner, and
+          # `npm run <script> -- --flag=<path>` forwards it through cmd.exe,
+          # which eats the backslashes (D:\a\_temp arrives as D:a_temp). Node
+          # accepts forward slashes on Windows, and this is a no-op on Linux.
+          full="$dest/$tarball"
+          full="${full//'\'/'/'}"
+          printf 'tarball=%s\n' "$full" >> "$GITHUB_OUTPUT"
+          echo "Packed $tarball from $(git rev-parse --short HEAD) at $full"
 
       - name: Build Docker Image
         shell: bash

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -169,6 +169,25 @@ jobs:
         env:
           HUSKY: '0'
 
+      # Pull requests build the image around THIS branch's package rather than
+      # the published one. Without this the PR gate is blind to the change under
+      # review — a runtime defect that only reproduces inside the image (the
+      # arm64 chromedriver crash, ADR 01096) could not be proven fixed by the PR
+      # that fixes it, because the image installed the last npm release. Release
+      # and manual builds still install `doc-detective@<version>` from the
+      # registry, which is what they must ship. See ADR 01097.
+      - name: Pack this branch
+        if: github.event_name == 'pull_request'
+        id: pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run build
+          mkdir -p "$RUNNER_TEMP/pack"
+          tarball="$(npm pack --silent --pack-destination "$RUNNER_TEMP/pack")"
+          echo "tarball=$RUNNER_TEMP/pack/$tarball" >> "$GITHUB_OUTPUT"
+          echo "Packed $tarball from $(git rev-parse --short HEAD)"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -180,7 +199,17 @@ jobs:
         # cache is not shared with this build, but the Linux Dockerfile
         # is small enough that the duplicated work is acceptable.
         shell: bash
-        run: npm run container:build -- --version="$IMAGE_VERSION" ${{ inputs.no_cache && '--no-cache' || '' }}
+        env:
+          # Empty on every non-PR build, which makes build.cjs clear any staged
+          # tarball and install from the registry.
+          LOCAL_PACKAGE: ${{ steps.pack.outputs.tarball }}
+        run: |
+          set -eu
+          if [ -n "${LOCAL_PACKAGE:-}" ]; then
+            npm run container:build -- --version="$IMAGE_VERSION" ${{ inputs.no_cache && '--no-cache' || '' }} --local-package="$LOCAL_PACKAGE"
+          else
+            npm run container:build -- --version="$IMAGE_VERSION" ${{ inputs.no_cache && '--no-cache' || '' }}
+          fi
 
       - name: Post-build Test
         shell: bash
@@ -416,9 +445,24 @@ jobs:
           if ($os -ne 'windows') { throw "Docker is not in Windows mode; OSType=$os" }
           Write-Host "Docker OSType=$os"
 
+      # Same reasoning as build-linux: on a pull request the image is built
+      # around THIS branch's package so the gate tests the change under review.
+      # See ADR 01097.
+      - name: Pack this branch
+        if: github.event_name == 'pull_request'
+        id: pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run build
+          mkdir -p "$RUNNER_TEMP/pack"
+          tarball="$(npm pack --silent --pack-destination "$RUNNER_TEMP/pack")"
+          echo "tarball=$RUNNER_TEMP/pack/$tarball" >> "$GITHUB_OUTPUT"
+          echo "Packed $tarball from $(git rev-parse --short HEAD)"
+
       - name: Build Docker Image
         shell: bash
-        run: npm run container:build -- --version="$IMAGE_VERSION" ${{ inputs.no_cache && '--no-cache' || '' }}
+        run: npm run container:build -- --version="$IMAGE_VERSION" ${{ inputs.no_cache && '--no-cache' || '' }} ${{ steps.pack.outputs.tarball && format('--local-package={0}', steps.pack.outputs.tarball) || '' }}
 
       - name: Post-build Test
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,7 @@ src/common/node_modules/
 
 # Agent/dev scratch space (see CLAUDE.md "Testing behavior")
 .tmp/
+
+# Locally packed doc-detective tarballs staged for a container build
+# (src/container/scripts/localPackage.cjs). The directory itself is tracked.
+src/container/.local-package/*.tgz

--- a/adrs/01096-never-execute-a-foreign-architecture-driver-binary.md
+++ b/adrs/01096-never-execute-a-foreign-architecture-driver-binary.md
@@ -1,0 +1,204 @@
+---
+status: accepted
+date: 2026-09-04
+decision-makers: doc-detective maintainers
+---
+
+# Never execute a foreign-architecture driver binary
+
+## Context and Problem Statement
+
+The `build-linux (ubuntu-24.04-arm, linux/arm64, arm64)` leg of the "Docker build" workflow failed on
+every run — on `main`, and on pull requests carrying nothing but a docs diff. Its `linux/amd64` twin
+passed on the same commits, so the failure was architecture-specific rather than change-specific.
+
+[ADR 01053](01053-best-effort-browser-asset-install.md) already made *installing* browser assets
+best-effort, and the log confirms that half works: `[browser] chromedriver — skipped (...)` and the
+`RUN doc-detective install all --yes` layer completes. The build then failed later, in the container
+smoke test (`src/container/test/runTests.test.cjs`), with:
+
+```
+(WARNING) Excluding chrome from available browsers: its chromedriver driver is present but did not
+validate (chromedriver exited with code 2: …/chromedriver: 1: ELF: not found
+…/chromedriver: 5: Syntax error: Unterminated quoted string)
+ENOENT: no such file or directory, stat '/app/<binary garbage>'
+Child process closed with code 1
+```
+
+The second line is the one that mattered, and it is not a cosmetic artifact of the first. Tracing it
+(reproduced end-to-end in a Linux container) gives this chain:
+
+1. Google's Chrome for Testing publishes no native `linux-arm64` chromedriver, and
+   `@puppeteer/browsers` maps `BrowserPlatform.LINUX_ARM` to the **x64** asset. A native arm64 host
+   therefore has an x86-64 ELF sitting at
+   `…/chromedriver/linux_arm-<version>/chromedriver-linux64/chromedriver`.
+2. `verifyDriverBinary` runs it via `execFile`. `execve` returns **ENOEXEC** — and glibc's `execvp`,
+   which libuv (and therefore Node's `spawn`) goes through, responds to ENOEXEC by **retrying the
+   file through `/bin/sh`**.
+3. `/bin/sh` then interprets 21 MB of binary as a shell script, **in the caller's working
+   directory** (`/app`, the mounted input tree). It reports `ELF: not found` for the first "word" and
+   dies on a syntax error at line 5 — but not before any byte sequence that happens to parse as a
+   redirection has already **created a file**, whose name is raw binary and therefore not valid
+   UTF-8.
+4. `qualifyFiles` (`src/core/detectTests.ts`) then scans the input directory. `fs.readdirSync`
+   decodes that name lossily into U+FFFD replacement characters, so the re-resolved path no longer
+   matches anything on disk, and the **unguarded** `fs.statSync` throws `ENOENT`. The throw escapes
+   to the CLI's top-level catch, which prints the message and exits 1 — before a single spec is
+   parsed.
+
+So a platform gap in an upstream vendor's binary distribution was turning into arbitrary shell
+interpretation of an untrusted 21 MB file inside the user's project directory, and any debris it left
+behind was fatal to the run. Two questions follow: how should driver verification handle a binary
+this host cannot execute, and how should the multi-arch image's smoke test treat a platform where no
+browser is available at all?
+
+## Decision Drivers
+
+* Executing a foreign-architecture binary is not a contained failure. The ENOEXEC → `/bin/sh`
+  fallback is a property of glibc, not of our code, and it hands the file's contents to a shell with
+  the user's cwd and privileges. "Run it and report the error" is not a safe verification strategy.
+* The runtime already degrades correctly once a browser is known to be unavailable — ADR 01008's
+  cross-engine fallback and the runner's context gating skip the affected contexts with a diagnostic.
+  What was missing was getting *to* that state without collateral damage.
+* A single unreadable neighbor in the input directory must never cost the whole run. `readdir`
+  listing an entry has never guaranteed it can be `stat`ed (dangling symlinks, permissions holes,
+  files removed mid-scan); this bug is one instance of a class.
+* The arm64 image genuinely cannot run Chrome today. The smoke test has to tolerate that without
+  becoming a gate that passes on an image which runs nothing at all.
+* Uncertainty must degrade to today's behavior. A header check that guesses wrong in the *strict*
+  direction would refuse a working driver, which is worse than the bug it fixes.
+
+## Considered Options
+
+* **A. Refuse to execute a provably foreign image, plus scratch-cwd hardening, plus a guarded input
+  scan** (chosen).
+* **B. Guard the input scan only** — catch the `statSync`, leave the driver probe alone.
+* **C. Hard-code "no chrome on linux/arm64"** in the runtime or in `linux.Dockerfile`, so the asset is
+  never installed or considered on that platform.
+* **D. Run the driver probe through an explicit interpreter guard** — e.g. `spawn` with `shell:
+  false` and a pre-`access(X_OK)` check.
+
+## Decision Outcome
+
+Chosen option: **A**, in three parts.
+
+1. **`foreignExecutableImageReason(header, {platform, arch})`** (`src/runtime/browsers.ts`) — a pure
+   function that reads an executable's first bytes and returns a reason string *only* when it can
+   prove the image cannot run on this host. `verifyDriverBinary` reads the first 64 bytes and, on a
+   verdict, returns `{ ok: false, error }` **without ever spawning a child process**. It is
+   deliberately narrow:
+   * Linux/ELF only. macOS runs x86-64 binaries on arm64 through Rosetta 2 and Windows on ARM
+     emulates x64, so a mismatch there proves nothing.
+   * Only architectures with an unambiguous `e_machine` mapping produce a verdict.
+   * A non-ELF image, a truncated header, an unreadable file, or an unmapped architecture yields no
+     verdict, and the pre-existing execute-and-report path still runs.
+2. **`driverExecOptions`** pins the driver probe's `cwd` to the OS temp directory. This is defense in
+   depth for the ENOEXEC cases the header check cannot predict (a well-formed but truncated image, a
+   missing dynamic loader): if a shell does end up interpreting the binary, its redirections land in
+   a scratch directory instead of the user's input tree. A `--version` probe has no
+   working-directory dependency, so relocating it is invisible.
+3. **`qualifyFiles`'s directory scan guards its `fs.statSync`**, logging at debug level and skipping
+   the entry. One unreadable neighbor costs that entry, not the run.
+
+For the smoke test, the arm64 image keeps attempting Chrome and lets the **runner's existing
+availability-driven gating** skip the browser-backed specs (they land as `SKIPPED` with a diagnostic
+naming the engine). The gate itself moves from `assert.equal(summary.specs.fail, 0)` to
+`assertRunOutcome` (`src/container/test/runOutcome.cjs`): **no failed specs *and* at least one spec
+actually passed**. On arm64 the shell / HTTP / link-checking specs still run for real, so the second
+half holds — while an image broken badly enough to run nothing no longer slips through on
+`fail === 0` alone.
+
+B was rejected as a fix: it converts a crash into a warning while leaving a shell interpreting an
+untrusted binary in the user's project on every arm64 run — the debris was the symptom, not the
+disease. (Its content is kept, as part 3, for the general class of unreadable entries.) C encodes in
+our tree a fact that belongs upstream: the day Google ships a `linux-arm64` chromedriver, a
+hard-coded exclusion becomes a silent capability regression, and it would not protect the many other
+ways a driver can be unrunnable. D does not work — the fallback lives in glibc's `execvp`, below
+Node's `shell` option, and `access(X_OK)` returns success for a foreign-architecture file that is
+mode `+x`.
+
+### Consequences
+
+* Good: the arm64 Docker build's smoke test completes. Browser specs SKIP with a diagnostic; shell
+  and HTTP specs pass; the image is published instead of being blocked by a platform gap.
+* Good: an unrunnable driver is now reported as what it is — "the binary targets x86-64 but this host
+  is linux/arm64 (AArch64)" — instead of a page of shell parse errors quoting binary.
+* Good: doc-detective no longer lets a shell interpret an untrusted downloaded binary inside the
+  user's working directory. That was reachable by any user on a platform whose driver asset doesn't
+  match their architecture, not only in CI.
+* Good: a corrupt, vanished, or undecodable entry in an input directory no longer aborts detection.
+* Bad (accepted): the header check is a heuristic over `e_machine`. A binary that passes it can still
+  fail to execute (missing loader, truncated body, wrong libc), so it narrows the ENOEXEC window
+  rather than closing it — which is why the scratch-cwd hardening and the guarded scan are part of
+  the same decision rather than alternatives to it.
+* Bad (accepted): the smoke test no longer proves that browser specs ran on *every* arch. It proves
+  no spec failed and at least one passed. Chrome coverage on linux/amd64 (and the fixture bundles)
+  remains the place browser behavior is actually gated.
+* Neutral: `geckodriver` also fails to install in this image on **both** architectures
+  (`Refusing to execute '/opt/doc-detective/browsers'` — the cache probe falls back to the cache
+  directory itself when the extracted binary isn't found at the expected name). That is a separate,
+  pre-existing defect; `linux/amd64` is green with it, so it is tracked separately rather than folded
+  in here.
+
+### Confirmation
+
+* **Red→green unit tests.** `test/runtime-browsers.test.js`: `foreignExecutableImageReason` flags an
+  x86-64 ELF on `linux/arm64`, accepts a matching image, and stays silent for non-ELF images, off
+  Linux, and for unmapped architectures; `verifyDriverBinary` refuses a foreign image **and the
+  injected `exec` is asserted never to have been called**; an unreadable header falls open to the
+  spawn path. `driverExecOptions` pins `cwd` to the temp dir.
+* **Red→green regression test for the crash.** `test/detecttests-qualify-coverage.test.js` creates a
+  directory entry whose raw name is not valid UTF-8 alongside a valid spec. Before the fix this
+  reproduced the exact CI failure — `ENOENT: no such file or directory, stat
+  '…/���-side-effect'` thrown from `qualifyFiles` — and after it, detection returns
+  the valid spec. POSIX-only (a Windows filename is UTF-16 by construction, so the failure cannot be
+  built there); verified red then green by running the file under `node:22-slim`.
+* **Gate rule unit test.** `test/container-run-outcome.test.js` covers `assertRunOutcome`: accepts an
+  arm64-shaped run (some passed, browser specs skipped), rejects any failure, rejects an all-skipped
+  run, rejects a missing summary.
+* **End-to-end.** The published Linux image, with the built `dist` mounted over it and its
+  chromedriver's ELF `e_machine` patched to an unhandled value to force ENOEXEC: the driver is
+  refused by the header check, `/app` gains no shell-created entries, and the run completes with
+  browser specs skipped instead of crashing.
+* **CI.** The `build-linux (ubuntu-24.04-arm, linux/arm64, arm64)` leg of the "Docker build" workflow
+  passes, with `build-linux (ubuntu-latest, linux/amd64, amd64)` unchanged as the control. This is
+  only observable on the pull request because
+  [ADR 01097](01097-build-pull-request-images-from-the-branch.md) lands alongside it: the image
+  otherwise installs `doc-detective@latest` from npm, so a PR build would exercise the published
+  runtime and stay red until this fix was released.
+
+No Doc Detective feature fixture accompanies this change: it adds no user-facing knob (no step type,
+action option, config/CLI flag, engine, or output format), and its trigger — a driver binary built
+for another CPU architecture — cannot be authored in a spec. The container smoke test *is* the
+end-to-end fixture for this behavior, and it now runs on both architectures.
+
+## Pros and Cons of the Options
+
+### A. Refuse a provably foreign image + scratch cwd + guarded scan
+
+* Good: removes the cause (shell interpretation of an untrusted binary), not just the visible
+  symptom.
+* Good: fails open on every uncertain input, so it cannot refuse a driver that would have worked.
+* Good: benefits every user on a mismatched platform, not only the Docker build.
+* Bad: three coordinated changes rather than a one-line catch; the header check is a heuristic and
+  needs a new `e_machine` entry if Node ever reports an architecture not in the table (which, failing
+  open, degrades to today's behavior rather than breaking).
+
+### B. Guard the input scan only
+
+* Good: one line, fixes the observed crash.
+* Bad: leaves a shell interpreting a 21 MB untrusted binary in the user's project on every affected
+  run, and leaves the debris behind — it just stops complaining about it.
+
+### C. Hard-code "no chrome on linux/arm64"
+
+* Good: trivially makes the arm64 build green.
+* Bad: encodes an upstream vendor's current matrix as our permanent behavior, becoming a silent
+  capability regression the day it changes; and it addresses exactly one of the many ways a driver
+  binary can be unrunnable.
+
+### D. Interpreter guard around the probe
+
+* Good: would be the most general fix if it worked.
+* Bad: it doesn't. The retry lives in glibc's `execvp`, beneath Node's `shell` option, and an
+  `access(X_OK)` check passes for a mode-`+x` foreign-architecture file.

--- a/adrs/01096-never-execute-a-foreign-architecture-driver-binary.md
+++ b/adrs/01096-never-execute-a-foreign-architecture-driver-binary.md
@@ -89,9 +89,13 @@ Chosen option: **A**, in three parts.
    deliberately narrow:
    * Linux/ELF only. macOS runs x86-64 binaries on arm64 through Rosetta 2 and Windows on ARM
      emulates x64, so a mismatch there proves nothing.
-   * Only architectures with an unambiguous `e_machine` mapping produce a verdict.
-   * A non-ELF image, a truncated header, an unreadable file, or an unmapped architecture yields no
-     verdict, and the pre-existing execute-and-report path still runs.
+   * A verdict needs the *host* architecture to be in the `e_machine` table. When it isn't, there is
+     nothing to compare against and the helper stays silent. An unmapped value in the *binary's*
+     `e_machine` is the opposite case: the host is known, so the mismatch is proven, and the image is
+     refused under a generic `ELF machine 0x…` label.
+   * A non-ELF image, a truncated header, a header whose `EI_DATA` declares no valid byte order, an
+     unreadable file, or an unmapped host architecture all yield no verdict, and the pre-existing
+     execute-and-report path still runs.
 2. **`driverExecOptions`** pins the driver probe's `cwd` to the OS temp directory. This is defense in
    depth for the ENOEXEC cases the header check cannot predict (a well-formed but truncated image, a
    missing dynamic loader): if a shell does end up interpreting the binary, its redirections land in
@@ -143,9 +147,10 @@ mode `+x`.
 ### Confirmation
 
 * **Red→green unit tests.** `test/runtime-browsers.test.js`: `foreignExecutableImageReason` flags an
-  x86-64 ELF on `linux/arm64`, accepts a matching image, and stays silent for non-ELF images, off
-  Linux, and for unmapped architectures; `verifyDriverBinary` refuses a foreign image **and the
-  injected `exec` is asserted never to have been called**; an unreadable header falls open to the
+  x86-64 ELF on `linux/arm64`, accepts a matching image, decodes a big-endian header in its own byte
+  order, and stays silent for non-ELF images, off Linux, for an unmapped host architecture, and for a
+  header whose `EI_DATA` declares no byte order; `verifyDriverBinary` refuses a foreign image **and
+  the injected `exec` is asserted never to have been called**; an unreadable header falls open to the
   spawn path. `driverExecOptions` pins `cwd` to the temp dir.
 * **Red→green regression test for the crash.** `test/detecttests-qualify-coverage.test.js` creates a
   directory entry whose raw name is not valid UTF-8 alongside a valid spec. Before the fix this
@@ -155,7 +160,8 @@ mode `+x`.
   built there); verified red then green by running the file under `node:22-slim`.
 * **Gate rule unit test.** `test/container-run-outcome.test.js` covers `assertRunOutcome`: accepts an
   arm64-shaped run (some passed, browser specs skipped), rejects any failure, rejects an all-skipped
-  run, rejects a missing summary.
+  run, rejects a missing summary, and rejects a `fail` count that is missing, non-numeric, negative,
+  or fractional rather than coercing it to zero.
 * **End-to-end.** The published Linux image, with the built `dist` mounted over it and its
   chromedriver's ELF `e_machine` patched to an unhandled value to force ENOEXEC: the driver is
   refused by the header check, `/app` gains no shell-created entries, and the run completes with

--- a/adrs/01097-build-pull-request-images-from-the-branch.md
+++ b/adrs/01097-build-pull-request-images-from-the-branch.md
@@ -1,0 +1,144 @@
+---
+status: accepted
+date: 2026-09-04
+decision-makers: doc-detective maintainers
+---
+
+# Build pull-request container images from the branch, not the registry
+
+## Context and Problem Statement
+
+Both container images install doc-detective from npm:
+
+```dockerfile
+RUN npm install -g doc-detective@$PACKAGE_VERSION
+```
+
+`PACKAGE_VERSION` comes from `inputs.version || 'latest'`, and a pull-request run of the "Docker
+build" workflow supplies no version — so a PR build installs **the last published release** and then
+runs the container smoke test against it. The workflow's `paths:` filter (`src/container/**`) implies
+the gate exists to review container changes, but what it actually tests is the published package
+wearing the PR's Dockerfile.
+
+[ADR 01096](01096-never-execute-a-foreign-architecture-driver-binary.md) made the cost concrete. The
+`build-linux (arm64)` leg failed on every run because of a runtime defect that only reproduces inside
+the image on arm64 hardware. The fix lives in `src/runtime` and `src/core` — code that reaches the
+image only through the npm package — so the PR carrying the fix could not turn its own gate green.
+The leg would have stayed red through review and merge, and only gone green after semantic-release
+published the fix and the release chain rebuilt the image. A gate that can't be satisfied by the
+change that satisfies it teaches reviewers to ignore it.
+
+How should a pull-request build get the code under review into the image?
+
+## Decision Drivers
+
+* A gate should test the change under review. This one is the only place doc-detective runs inside
+  its own published container, on both architectures.
+* Release builds must not change. They install a specific published version by design — that is the
+  artifact being shipped, and it must keep coming from the registry.
+* The fixture matrix already solved the equivalent problem for the runner
+  ([ADR 01022](01022-parallel-feature-fixture-jobs.md)): build the PR, `npm link` it, drive the
+  action with an empty `version` so `npx doc-detective` resolves the local build. The container gate
+  should follow that precedent rather than invent a different story.
+* A partial mechanism is worse than none. If a locally staged package can linger, a release build
+  could silently ship someone's working tree.
+
+## Considered Options
+
+* **A. Stage a locally packed tarball into the Docker build context; the Dockerfiles prefer it when
+  present** (chosen).
+* **B. Publish a prerelease to npm per PR** and build the image from that version.
+* **C. Build the package inside the Dockerfile** — `COPY` the repo in and compile it there.
+* **D. Leave it, and verify container-affecting fixes after release.**
+
+## Decision Outcome
+
+Chosen option: **A**.
+
+`src/container/scripts/localPackage.cjs` stages a tarball into `src/container/.local-package/`, a
+directory inside the Docker build context. Both Dockerfiles `COPY` that directory and install from
+the tarball when it holds one, falling back to `npm install -g doc-detective@$PACKAGE_VERSION`
+otherwise. `scripts/build.cjs` gains `--local-package=<tarball>`; the `build-linux` and
+`build-windows` jobs run `npm pack` and pass it **only on `pull_request`**.
+
+Two properties make the mechanism safe rather than merely convenient, and both are enforced in code
+and pinned by tests:
+
+* **The directory always exists.** `COPY .local-package/ …` fails outright on a missing source, so a
+  registry-only build would break without it. A committed `.gitkeep` covers a fresh checkout;
+  `ensureLocalPackageDir` covers everything else.
+* **A build not asked for a local package clears it.** Otherwise a tarball left from an earlier local
+  build keeps overriding the registry install silently — an image labelled version X running a stale
+  working tree. `stageLocalPackage` also clears before copying, so two tarballs can never make
+  `npm install -g /tmp/local-package/*.tgz` pick one arbitrarily.
+
+B would give the truest fidelity (the PR's artifact installed exactly as a user would) but pollutes
+the public registry with a version per PR, needs publish credentials on fork PRs, and couples a
+review gate to release infrastructure. C changes what the image *is*: the published image installs a
+published package, and building from source inside it would mean the thing we test is no longer the
+thing we ship — and it would drag the toolchain into a runtime image. D is the status quo this ADR
+exists to end.
+
+### Consequences
+
+* Good: a PR that fixes a defect reproducible only inside the image can prove the fix on both
+  architectures, on the PR, before merge. That is what makes ADR 01096 verifiable.
+* Good: release and `workflow_dispatch` builds are untouched — they still install the published
+  version from the registry, which is the artifact being shipped.
+* Good: the mechanism is symmetric across `linux.Dockerfile` and `windows.Dockerfile`, so the Windows
+  leg doesn't quietly remain a published-package test.
+* Bad (accepted): PR builds get slower — a `npm run build` plus `npm pack` per job, and the
+  `.local-package/` COPY layer invalidates the install layer on every PR build, so that layer is
+  never cached. Correctness of the gate is worth the minutes.
+* Bad (accepted): the PR image installs the branch's package but resolves its **dependencies** from
+  the registry as usual, so a PR that changes a dependency range is tested against whatever npm
+  resolves at build time. That matches how a user's install behaves, so it is a fidelity limit rather
+  than a flaw.
+* Neutral: the workflow's `pull_request` trigger still filters on `src/container/**`, so a PR that
+  changes only `src/runtime` does not build an image at all. This ADR makes the gate honest when it
+  runs; widening *when* it runs is a separate cost/coverage decision (three image builds on every PR)
+  and is deliberately not taken here.
+
+### Confirmation
+
+* **Red→green unit tests** in `test/container-local-package.test.js`: the staging directory name is a
+  contract with the Dockerfiles; `ensureLocalPackageDir` is idempotent; staging replaces rather than
+  accumulates tarballs; `clearLocalPackage` empties the directory but keeps it, so a registry build
+  stays a registry build; a missing file and a non-`.tgz` file are rejected.
+* **Local end-to-end**: `npm pack` followed by
+  `npm run container:build -- --version=latest --local-package=<tarball>` produces an image whose
+  installed doc-detective is the packed tree, confirmed by the build log's
+  `[build] installing the locally packed …` line and by running the container smoke test against it.
+* **CI**: the `build-linux` and `build-windows` legs of a pull request report packing the branch and
+  installing the local tarball, and the `build-linux (ubuntu-24.04-arm, linux/arm64, arm64)` leg
+  passes with ADR 01096's fix in the tree.
+
+No Doc Detective feature fixture accompanies this change: it alters how CI builds an image and adds
+no user-facing surface (no step type, action option, config/CLI flag, engine, or output format).
+
+## Pros and Cons of the Options
+
+### A. Stage a locally packed tarball
+
+* Good: the PR gate tests the PR; release builds are byte-for-byte unchanged.
+* Good: mirrors the fixture matrix's existing "build the PR, use it instead of the registry" shape.
+* Bad: two Dockerfiles now carry a conditional install; a staging directory has to exist in git and
+  be clearable, and getting that wrong could ship a stale tree — which is why it is unit-tested.
+
+### B. Publish a prerelease per PR
+
+* Good: highest fidelity — the exact published-install path.
+* Bad: registry pollution, publish credentials on PRs (impossible for forks), and a review gate that
+  depends on release infrastructure.
+
+### C. Build the package inside the Dockerfile
+
+* Good: no staging step, no build-context choreography.
+* Bad: the image would stop being "a published package installed", diverging from what ships; it
+  drags build toolchain into a runtime image and inflates it.
+
+### D. Leave it
+
+* Good: no change, no added build time.
+* Bad: a container-affecting fix cannot be verified before it is released — exactly the gap that made
+  the arm64 failure survive multiple releases.

--- a/docs/fern/pages/docs/troubleshooting/setup-issues.mdx
+++ b/docs/fern/pages/docs/troubleshooting/setup-issues.mdx
@@ -149,7 +149,9 @@ You have three options:
 - Run the `linux/amd64` container image under emulation.
 - Use a browser whose driver ships for your architecture.
 
-Doc Detective marks contexts that need the unavailable browser as `SKIPPED`. The rest of the run still executes and still gates your build, including shell steps, HTTP requests, and link checks.
+Contexts that need the unavailable browser follow the same fallback rules as any other unusable driver. The previous section describes those three outcomes. `SKIPPED` is only the last of them, when no browser can start a session at all.
+
+Either way, the rest of the run still executes and still gates your build. That includes shell steps, HTTP requests, and link checks.
 
 ### Version mismatch warning
 

--- a/docs/fern/pages/docs/troubleshooting/setup-issues.mdx
+++ b/docs/fern/pages/docs/troubleshooting/setup-issues.mdx
@@ -113,7 +113,7 @@ doc-detective install browsers
 
 ### A browser is present but its driver won't run
 
-Sometimes a browser driver exists on disk but won't run. The most common case is a partially downloaded `geckodriver`. Doc Detective validates each driver by running it, not just by checking that the file is present, so a broken driver no longer silently drops that browser's coverage.
+Sometimes a browser driver exists on disk but won't run. The most common case is a partially downloaded `geckodriver`. Doc Detective validates each driver by running it, not just by checking that the file is present, so a broken driver no longer silently drops that browser's coverage. Doc Detective catches a driver from the wrong CPU architecture earlier, and never runs it. See [A driver was built for a different CPU architecture](#a-driver-was-built-for-a-different-cpu-architecture).
 
 When a driver can't start a session, Doc Detective falls back to another available browser. Chrome, Firefox, and Safari/WebKit can each substitute for one another. The run then reports one of the following:
 
@@ -132,6 +132,24 @@ doc-detective install browsers
 ```
 
 To control whether Doc Detective falls back across browsers, set the `browserFallback` policy in your config or on an individual context. See [Browser fallback](/docs/test-docs/platforms-and-browsers#browser-fallback) for the full behavior.
+
+### A driver was built for a different CPU architecture
+
+On Linux, Doc Detective checks a driver binary's architecture before it runs it. When the binary targets a different CPU than the host, the run reports:
+
+```
+Excluding chrome from available browsers: its chromedriver driver is present but did not validate (chromedriver cannot run on this host: the binary targets x86-64 but this host is linux/arm64 (AArch64); it cannot be executed here (upstream may publish no native build for this platform)).
+```
+
+Reinstalling doesn't fix this one. The download worked as intended, and the vendor ships no build for your architecture. The common case is ChromeDriver on arm64 Linux, because Google's Chrome for Testing publishes x64 binaries only.
+
+You have three options:
+
+- Run Doc Detective on an `x86_64` host.
+- Run the `linux/amd64` container image under emulation.
+- Use a browser whose driver ships for your architecture.
+
+Doc Detective marks contexts that need the unavailable browser as `SKIPPED`. The rest of the run still executes and still gates your build, including shell steps, HTTP requests, and link checks.
 
 ### Version mismatch warning
 

--- a/src/container/.local-package/.gitkeep
+++ b/src/container/.local-package/.gitkeep
@@ -1,0 +1,4 @@
+# Keeps this directory in git so the Dockerfiles COPY of it always resolves.
+# scripts/build.cjs --local-package=<tarball> stages a locally packed
+# doc-detective here; a build without that flag clears it. See
+# scripts/localPackage.cjs and ADR 01097.

--- a/src/container/linux.Dockerfile
+++ b/src/container/linux.Dockerfile
@@ -52,7 +52,23 @@ RUN apt-get update \
 # command line in root help text IS reliable. Real `install all`
 # failures (transient npm errors, partial cache writes) then propagate
 # normally and fail the build instead of being swallowed.
-RUN npm install -g doc-detective@$PACKAGE_VERSION \
+#
+# A CI build of a pull request has nothing to gain from installing the last
+# PUBLISHED package — that image can't show whether the change under review
+# works. `scripts/build.cjs --local-package=<tarball>` stages a locally packed
+# tarball into `.local-package/`, and the install below prefers it when it's
+# there. The directory is always present (a committed `.gitkeep`, plus
+# `ensureLocalPackageDir`) because COPY fails on a missing source, and a build
+# that wasn't asked for a local package clears it so a registry build stays a
+# registry build. See src/container/scripts/localPackage.cjs and ADR 01097.
+COPY .local-package/ /tmp/local-package/
+
+RUN if ls /tmp/local-package/*.tgz >/dev/null 2>&1; then \
+      echo "[build] installing the locally packed $(ls /tmp/local-package/*.tgz) instead of doc-detective@$PACKAGE_VERSION"; \
+      npm install -g /tmp/local-package/*.tgz; \
+    else \
+      npm install -g doc-detective@$PACKAGE_VERSION; \
+    fi \
     && if doc-detective --help 2>&1 | grep -q "install <subcommand>"; then \
          doc-detective install all --yes; \
        else \

--- a/src/container/scripts/build.cjs
+++ b/src/container/scripts/build.cjs
@@ -11,6 +11,10 @@
 const { execFileSync, execSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
+const {
+  clearLocalPackage,
+  stageLocalPackage,
+} = require("./localPackage.cjs");
 
 const containerDir = path.resolve(__dirname, "..");
 
@@ -46,6 +50,12 @@ if (target !== "app" && target !== "base") {
   console.error(`Invalid --target: ${target} (expected 'app' or 'base')`);
   process.exit(1);
 }
+
+// `--local-package=<path/to/doc-detective-X.Y.Z.tgz>` builds the image around a
+// locally packed tarball instead of the published npm package, so a CI build can
+// test the tree it was invoked from (ADR 01097). Absent, any previously staged
+// tarball is cleared so the build genuinely uses the registry.
+const localPackage = readFlagValue("--local-package");
 
 const shouldPush = args.includes("--push");
 const noCache = args.includes("--no-cache");
@@ -234,6 +244,15 @@ try {
   if (target === "base") {
     buildBaseImage();
   } else {
+    // Stage (or deliberately un-stage) the local package BEFORE the build, so
+    // what lands in the Docker context is exactly what this invocation asked
+    // for — never a leftover from a previous one.
+    if (localPackage) {
+      const staged = stageLocalPackage(containerDir, localPackage);
+      console.log(`Building from the local package ${staged} (not the npm registry)`);
+    } else {
+      clearLocalPackage(containerDir);
+    }
     console.log(`Building Docker image with version: ${version}`);
     buildAppImage();
   }

--- a/src/container/scripts/localPackage.cjs
+++ b/src/container/scripts/localPackage.cjs
@@ -1,0 +1,75 @@
+// Staging for a locally packed doc-detective tarball, so a container build can
+// test the tree it was invoked from instead of the published npm package
+// (ADR 01097).
+//
+// Both Dockerfiles install `doc-detective@$PACKAGE_VERSION` from the registry.
+// That is right for a release build, but it means a pull-request build of the
+// image proves nothing about the pull request: the image under test is the last
+// published one. The fix is a fixed directory inside the Docker build context
+// that a local build stages a tarball into; the Dockerfiles COPY that directory
+// and prefer the tarball when it holds one.
+//
+// Two rules keep the mechanism honest, and both are load-bearing:
+//   1. The directory ALWAYS exists — `COPY .local-package/ …` fails outright on
+//      a missing source, so a registry-only build would break without it. The
+//      committed `.gitkeep` covers a fresh checkout; `ensureLocalPackageDir`
+//      covers everything else.
+//   2. A build that was NOT asked for a local package CLEARS the directory. A
+//      tarball left over from an earlier local build would otherwise keep
+//      overriding the registry install silently — an image that claims to be
+//      version X while running someone's week-old working tree.
+
+const fs = require("fs");
+const path = require("path");
+
+// The Dockerfiles COPY this literal path. Renaming it means editing them too.
+const LOCAL_PACKAGE_DIRNAME = ".local-package";
+
+function localPackageDir(containerDir) {
+  return path.join(containerDir, LOCAL_PACKAGE_DIRNAME);
+}
+
+function ensureLocalPackageDir(containerDir) {
+  const dir = localPackageDir(containerDir);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Remove any staged tarballs, keeping the directory itself. */
+function clearLocalPackage(containerDir) {
+  const dir = ensureLocalPackageDir(containerDir);
+  for (const entry of fs.readdirSync(dir)) {
+    if (entry.endsWith(".tgz")) fs.rmSync(path.join(dir, entry), { force: true });
+  }
+  return dir;
+}
+
+/**
+ * Copy `tarballPath` into the build context, replacing anything staged before.
+ *
+ * @returns {string} the staged tarball's path.
+ */
+function stageLocalPackage(containerDir, tarballPath) {
+  if (!tarballPath || !fs.existsSync(tarballPath)) {
+    throw new Error(`Local package not found: ${tarballPath}`);
+  }
+  if (!tarballPath.endsWith(".tgz")) {
+    throw new Error(
+      `Local package must be an npm pack tarball (.tgz): ${tarballPath}`
+    );
+  }
+  // Clear first: leaving two tarballs behind would make the Dockerfile's
+  // `npm install -g /tmp/local-package/*.tgz` pick one arbitrarily.
+  const dir = clearLocalPackage(containerDir);
+  const staged = path.join(dir, path.basename(tarballPath));
+  fs.copyFileSync(tarballPath, staged);
+  return staged;
+}
+
+module.exports = {
+  LOCAL_PACKAGE_DIRNAME,
+  localPackageDir,
+  ensureLocalPackageDir,
+  clearLocalPackage,
+  stageLocalPackage,
+};

--- a/src/container/test/runOutcome.cjs
+++ b/src/container/test/runOutcome.cjs
@@ -30,7 +30,19 @@ function assertRunOutcome(results) {
       "Results file has no `summary.specs` — the run produced no usable summary."
     );
   }
-  const fail = Number(specs.fail) || 0;
+  // `fail` is the half of the gate that can only ever say "stop", so a value it
+  // can't trust must not be coerced to 0. Every scenario this gate exists to
+  // catch involves a run that went wrong, and `Number(x) || 0` would turn a
+  // missing, garbled, or negative count into a clean bill of health as soon as
+  // one spec passed.
+  const fail = Number(specs.fail);
+  if (!Number.isInteger(fail) || fail < 0) {
+    throw new Error(
+      `Results file has an unusable spec fail count (${JSON.stringify(
+        specs.fail
+      )}); refusing to treat the run as clean.`
+    );
+  }
   const pass = Number(specs.pass) || 0;
   const skipped = Number(specs.skipped) || 0;
   if (fail > 0) {

--- a/src/container/test/runOutcome.cjs
+++ b/src/container/test/runOutcome.cjs
@@ -1,0 +1,50 @@
+// The pass/fail rule for the container smoke test, kept separate from the
+// docker plumbing so it is unit-testable without building an image
+// (test/container-run-outcome.test.js).
+//
+// Why it isn't simply `fail === 0`: the image ships for linux/amd64 AND
+// linux/arm64, and browser support differs between them. Google's Chrome for
+// Testing publishes no native linux-arm64 chromedriver, so on arm64 the driver
+// is unavailable and every browser-backed spec resolves to SKIPPED through the
+// runner's normal context gating, while the shell / HTTP / link-checking specs
+// still execute for real. Demanding "everything passed" would make the arm64
+// leg permanently red for a platform gap the runner already handles correctly.
+//
+// But "nothing failed" alone is a gate that can go blind: an image broken badly
+// enough to run nothing at all also reports `fail === 0`. So the rule carries a
+// second half — at least one spec must actually have PASSED. That keeps the
+// arm64 tolerance honest without weakening what the gate proves.
+//
+// Mirrors the shape of the fixtures gate in scripts/check-fixture-results.cjs,
+// which likewise fails on FAILed specs or a run that produced nothing.
+
+/**
+ * Throw with a diagnostic message unless the run is acceptable.
+ *
+ * @param {unknown} results Parsed contents of the runner's results JSON.
+ */
+function assertRunOutcome(results) {
+  const specs = results && results.summary && results.summary.specs;
+  if (!specs || typeof specs !== "object") {
+    throw new Error(
+      "Results file has no `summary.specs` — the run produced no usable summary."
+    );
+  }
+  const fail = Number(specs.fail) || 0;
+  const pass = Number(specs.pass) || 0;
+  const skipped = Number(specs.skipped) || 0;
+  if (fail > 0) {
+    throw new Error(
+      `${fail} spec(s) failed (pass: ${pass}, skipped: ${skipped}).`
+    );
+  }
+  if (pass === 0) {
+    throw new Error(
+      `no spec passed (skipped: ${skipped}). A platform without a browser is ` +
+        `expected to SKIP the browser specs, but the shell/HTTP specs must ` +
+        `still run — an all-skipped run means the image is not working.`
+    );
+  }
+}
+
+module.exports = { assertRunOutcome };

--- a/src/container/test/runTests.test.cjs
+++ b/src/container/test/runTests.test.cjs
@@ -1,6 +1,6 @@
 const path = require("path");
-const assert = require("assert").strict;
 const fs = require("fs");
+const { assertRunOutcome } = require("./runOutcome.cjs");
 const artifactPath = path.resolve(__dirname, "./artifacts");
 const outputFile = path.resolve(artifactPath, "results.json");
 const publicDir = path.resolve(__dirname, "../../../test/server/public");
@@ -233,7 +233,11 @@ describe("Run tests successfully", function () {
               fs.readFileSync(outputFile, { encoding: "utf8" })
             );
             console.log(JSON.stringify(result, null, 2));
-            assert.equal(result.summary.specs.fail, 0);
+            // No failures AND at least one real pass — see runOutcome.cjs for
+            // why the arm64 image (no upstream linux-arm64 chromedriver) must
+            // be allowed to SKIP its browser specs without the gate going
+            // blind to an image that runs nothing at all.
+            assertRunOutcome(result);
             fs.unlinkSync(outputFile);
             resolve();
           } catch (error) {

--- a/src/container/windows.Dockerfile
+++ b/src/container/windows.Dockerfile
@@ -42,8 +42,22 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # `try/catch` doesn't trap native-command non-zero exits under the
 # SHELL-level `$ErrorActionPreference = 'Stop'`, so real `install all`
 # failures throw explicitly via `$LASTEXITCODE` check.
+#
+# Same local-package escape hatch as linux.Dockerfile: a CI build of a pull
+# request installs the tarball staged in `.local-package/` when there is one, so
+# the image under test is the change under review rather than the last published
+# package. See src/container/scripts/localPackage.cjs and ADR 01097.
+COPY .local-package/ C:/local-package/
+
 RUN Set-ExecutionPolicy Bypass -Scope Process -Force; \
-    npm install -g doc-detective@$env:PACKAGE_VERSION; \
+    $localPkg = @(Get-ChildItem -Path 'C:/local-package' -Filter '*.tgz' -ErrorAction SilentlyContinue); \
+    if ($localPkg.Count -gt 0) { \
+      $pkgPath = $localPkg[0].FullName; \
+      Write-Host "[build] installing the locally packed $($localPkg[0].Name) instead of doc-detective@$env:PACKAGE_VERSION"; \
+      npm install -g $pkgPath \
+    } else { \
+      npm install -g doc-detective@$env:PACKAGE_VERSION \
+    }; \
     if ($LASTEXITCODE -ne 0) { throw "npm install -g doc-detective failed with exit code $LASTEXITCODE" }; \
     $help = (doc-detective --help 2>&1 | Out-String); \
     if ($help -match 'install <subcommand>') { \

--- a/src/core/detectTests.ts
+++ b/src/core/detectTests.ts
@@ -453,9 +453,28 @@ async function qualifyFiles({ config }: { config: any }) {
           // One statSync, reused for both predicates (same value per path).
           // statSync (not the Dirent from readdirSync withFileTypes) is kept
           // deliberately so symlink following is unchanged from before.
-          const stat = fs.statSync(content);
-          const isFile = stat.isFile();
-          const isDir = stat.isDirectory();
+          //
+          // Guarded because readdir listing an entry does NOT guarantee it can
+          // be stat'd: a dangling symlink, a permissions hole, a file removed
+          // mid-scan, or — the case that motivated this (ADR 01096) — a name
+          // whose raw bytes aren't valid UTF-8, which readdir decodes lossily
+          // into U+FFFD so the re-resolved path no longer exists on disk. An
+          // unguarded throw here aborts the ENTIRE run before a single spec is
+          // parsed; one unreadable neighbor must only cost that entry.
+          let isFile = false;
+          let isDir = false;
+          try {
+            const stat = fs.statSync(content);
+            isFile = stat.isFile();
+            isDir = stat.isDirectory();
+          } catch (err: any) {
+            log(
+              config,
+              "debug",
+              `Skipping unreadable directory entry ${content}: ${err?.message ?? err}`
+            );
+            continue;
+          }
           if (
             isFile &&
             (await isValidSourceFile({ config, files, allowedExtensions, source: content }))

--- a/src/runtime/browsers.ts
+++ b/src/runtime/browsers.ts
@@ -115,8 +115,11 @@ const ELF_MACHINE_LABELS: Record<number, string> = Object.fromEntries(
  * Deliberately Linux/ELF-only and deliberately conservative:
  *   - macOS runs x86-64 binaries on arm64 through Rosetta 2, and Windows on ARM
  *     emulates x64 — a mismatch there is not proof of anything, so no verdict.
- *   - A non-ELF image, a truncated header, or an architecture with no mapping
- *     yields no verdict, and the normal execute-and-report path still runs.
+ *   - A non-ELF image, a truncated header, a header with no valid byte order, or
+ *     a *host* architecture this table doesn't map yields no verdict, and the
+ *     normal execute-and-report path still runs. (An unmapped value in the
+ *     *binary's* e_machine is different: the host arch is known, so the
+ *     mismatch is proven and the image is refused under a generic label.)
  * The result is a check that only ever converts a *provable* platform gap into
  * a clear message; every uncertain case degrades to the pre-existing behavior.
  */
@@ -141,9 +144,15 @@ export function foreignExecutableImageReason(
   }
   const expected = ELF_MACHINE_BY_NODE_ARCH[arch];
   if (!expected) return undefined;
-  // EI_DATA (byte 5): 1 = little-endian, 2 = big-endian. e_machine is a
-  // 2-byte field at offset 18 in the header's own byte order.
-  const littleEndian = header[5] !== 2;
+  // EI_DATA (byte 5): 1 = little-endian, 2 = big-endian, and nothing else
+  // defines a byte order. A header declaring anything else is malformed, so
+  // e_machine can't be decoded from it — and a verdict read out of an
+  // undecodable field would be an invented refusal, which is exactly what this
+  // helper must never produce.
+  const elfData = header[5];
+  if (elfData !== 1 && elfData !== 2) return undefined;
+  // e_machine is a 2-byte field at offset 18, in the header's own byte order.
+  const littleEndian = elfData === 1;
   const machine = littleEndian
     ? header[18] | (header[19] << 8)
     : (header[18] << 8) | header[19];

--- a/src/runtime/browsers.ts
+++ b/src/runtime/browsers.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import {
   getBrowsersDir,
@@ -67,12 +68,116 @@ function parseDriverVersion(output: string): string | undefined {
   return m ? m[1] : undefined;
 }
 
+// Number of leading bytes `verifyDriverBinary` reads to identify the image.
+// An ELF header is 64 bytes; everything the arch check needs sits in the first
+// 20.
+const EXECUTABLE_HEADER_BYTES = 64;
+
+// e_machine values (ELF) for the architectures Node reports in `process.arch`.
+// Only architectures with an unambiguous mapping are listed — an arch that
+// isn't here yields no verdict at all, so the check can only ever *add* a
+// refusal it can prove, never invent one.
+const ELF_MACHINE_BY_NODE_ARCH: Record<string, { machine: number; label: string }> = {
+  x64: { machine: 0x3e, label: "x86-64" },
+  ia32: { machine: 0x03, label: "x86" },
+  arm64: { machine: 0xb7, label: "arm64 (AArch64)" },
+  arm: { machine: 0x28, label: "arm" },
+  ppc64: { machine: 0x15, label: "ppc64" },
+  s390x: { machine: 0x16, label: "s390x" },
+  riscv64: { machine: 0xf3, label: "riscv64" },
+  loong64: { machine: 0x102, label: "loong64" },
+};
+
+const ELF_MACHINE_LABELS: Record<number, string> = Object.fromEntries(
+  Object.values(ELF_MACHINE_BY_NODE_ARCH).map((m) => [m.machine, m.label])
+);
+
+/**
+ * Explain why an executable image definitely cannot run on this host, or
+ * `undefined` when there is no proof that it can't.
+ *
+ * WHY this exists at all: executing a foreign-architecture binary is NOT a
+ * benign "it fails and we report it". `execve` returns ENOEXEC, and glibc's
+ * `execvp` — which libuv/Node's `spawn` goes through — then *retries the file
+ * through `/bin/sh`*. The shell proceeds to interpret tens of megabytes of
+ * binary as a shell script in the caller's working directory: it reports
+ * `ELF: not found` for the first "word", and any byte sequence that happens to
+ * parse as a redirection creates a file (with an undecodable, non-UTF-8 name)
+ * right there in the user's project. That is exactly how the arm64 Docker build
+ * failed — a stray `/app/<binary garbage>` entry then crashed the input scan.
+ * So the only safe move is to never hand such an image to a child process.
+ *
+ * This bites in practice because Google's Chrome for Testing publishes no
+ * native `linux-arm64` chromedriver and `@puppeteer/browsers` maps
+ * `BrowserPlatform.LINUX_ARM` to the **x64** asset, so a native arm64 Linux
+ * host "installs" an x86-64 binary.
+ *
+ * Deliberately Linux/ELF-only and deliberately conservative:
+ *   - macOS runs x86-64 binaries on arm64 through Rosetta 2, and Windows on ARM
+ *     emulates x64 — a mismatch there is not proof of anything, so no verdict.
+ *   - A non-ELF image, a truncated header, or an architecture with no mapping
+ *     yields no verdict, and the normal execute-and-report path still runs.
+ * The result is a check that only ever converts a *provable* platform gap into
+ * a clear message; every uncertain case degrades to the pre-existing behavior.
+ */
+export function foreignExecutableImageReason(
+  header: Uint8Array,
+  env: { platform?: string; arch?: string } = {}
+): string | undefined {
+  const platform = env.platform ?? process.platform;
+  const arch = env.arch ?? process.arch;
+  // Only Linux refuses a foreign image outright; every other platform we
+  // support has transparent emulation for the mismatch that matters.
+  if (platform !== "linux") return undefined;
+  if (!header || header.length < 20) return undefined;
+  // ELF magic: 0x7F 'E' 'L' 'F'
+  if (
+    header[0] !== 0x7f ||
+    header[1] !== 0x45 ||
+    header[2] !== 0x4c ||
+    header[3] !== 0x46
+  ) {
+    return undefined;
+  }
+  const expected = ELF_MACHINE_BY_NODE_ARCH[arch];
+  if (!expected) return undefined;
+  // EI_DATA (byte 5): 1 = little-endian, 2 = big-endian. e_machine is a
+  // 2-byte field at offset 18 in the header's own byte order.
+  const littleEndian = header[5] !== 2;
+  const machine = littleEndian
+    ? header[18] | (header[19] << 8)
+    : (header[18] << 8) | header[19];
+  if (machine === expected.machine) return undefined;
+  const found = ELF_MACHINE_LABELS[machine] ?? `ELF machine 0x${machine.toString(16)}`;
+  return `the binary targets ${found} but this host is linux/${expected.label}; it cannot be executed here (upstream may publish no native build for this platform)`;
+}
+
+/**
+ * Child-process options for executing a driver binary.
+ *
+ * `cwd` is pinned to the OS temp directory rather than inherited. This is
+ * defense in depth for the ENOEXEC → `/bin/sh` fallback that
+ * `foreignExecutableImageReason` can't always predict (a truncated but
+ * well-formed image, a missing dynamic loader): if a shell does end up
+ * interpreting the binary, its redirections land in a scratch directory
+ * instead of littering the user's input tree with undecodable filenames.
+ * A driver's `--version` probe has no working-directory dependency, so
+ * relocating it is invisible to the check itself.
+ */
+export function driverExecOptions(timeoutMs: number): {
+  timeout: number;
+  windowsHide: boolean;
+  cwd: string;
+} {
+  return { timeout: timeoutMs, windowsHide: true, cwd: os.tmpdir() };
+}
+
 const defaultDriverExec: DriverExec = (binaryPath, args, timeoutMs) =>
   new Promise((resolve) => {
     execFile(
       binaryPath,
       args,
-      { timeout: timeoutMs, windowsHide: true },
+      driverExecOptions(timeoutMs),
       (err: any, stdout, stderr) => {
         const out = typeof stdout === "string" ? stdout : String(stdout ?? "");
         const errOut = typeof stderr === "string" ? stderr : String(stderr ?? "");
@@ -100,7 +205,12 @@ const defaultDriverExec: DriverExec = (binaryPath, args, timeoutMs) =>
 export async function verifyDriverBinary(
   driverName: string,
   binaryPath: string,
-  options: { exec?: DriverExec; timeoutMs?: number } = {}
+  options: {
+    exec?: DriverExec;
+    timeoutMs?: number;
+    /** Host identity for the foreign-image check. Injectable for tests. */
+    imageEnv?: { platform?: string; arch?: string };
+  } = {}
 ): Promise<DriverVerifyResult> {
   if (!binaryPath || typeof binaryPath !== "string") {
     return { ok: false, error: "No driver binary path to verify." };
@@ -114,6 +224,35 @@ export async function verifyDriverBinary(
       error: `Refusing to execute '${binaryPath}': not a recognized driver binary path.`,
     };
   }
+  // Identify the image BEFORE spawning. A foreign-architecture binary must
+  // never reach a child process: execve returns ENOEXEC and glibc's execvp
+  // retries it through /bin/sh, which interprets the binary as a shell script
+  // in the caller's cwd (see foreignExecutableImageReason). Reading the header
+  // is best-effort — an unreadable file falls through to the spawn path, which
+  // reports the real error.
+  let header: Uint8Array | undefined;
+  try {
+    const fd = fs.openSync(binaryPath, "r");
+    try {
+      const buf = Buffer.alloc(EXECUTABLE_HEADER_BYTES);
+      const read = fs.readSync(fd, buf, 0, EXECUTABLE_HEADER_BYTES, 0);
+      header = buf.subarray(0, read);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    header = undefined;
+  }
+  if (header) {
+    const foreign = foreignExecutableImageReason(header, options.imageEnv);
+    if (foreign) {
+      return {
+        ok: false,
+        error: `${driverName} cannot run on this host: ${foreign}.`,
+      };
+    }
+  }
+
   const key = String(driverName ?? "").toLowerCase();
   const args = DRIVER_VERSION_ARGS[key] ?? ["--version"];
   const exec = options.exec ?? defaultDriverExec;

--- a/test/container-local-package.test.js
+++ b/test/container-local-package.test.js
@@ -1,0 +1,113 @@
+// Cover for the local-package staging the container build uses to test the
+// branch's own code (ADR 01097).
+//
+// The Dockerfiles install `doc-detective@<version>` from the npm registry, so a
+// pull-request build of the image exercises the PUBLISHED package and is blind
+// to the change under review — which is how a runtime crash could sit red on the
+// arm64 leg with no way for the fixing PR to prove itself. The build script can
+// now stage a locally packed tarball into a fixed directory inside the Docker
+// build context; the Dockerfiles prefer it when present and fall back to the
+// registry when it isn't.
+//
+// The staging is what these tests pin, because getting it subtly wrong is how
+// this feature would betray you: a leftover tarball silently overriding a
+// registry build is worse than no feature at all.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  LOCAL_PACKAGE_DIRNAME,
+  localPackageDir,
+  ensureLocalPackageDir,
+  clearLocalPackage,
+  stageLocalPackage,
+} from "../src/container/scripts/localPackage.cjs";
+
+describe("container build: local package staging", function () {
+  let containerDir;
+  let workDir;
+  beforeEach(function () {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "dd-localpkg-"));
+    containerDir = path.join(root, "container");
+    workDir = path.join(root, "work");
+    fs.mkdirSync(containerDir);
+    fs.mkdirSync(workDir);
+  });
+  afterEach(function () {
+    fs.rmSync(path.dirname(containerDir), { recursive: true, force: true });
+  });
+
+  const tarball = (name) => {
+    const p = path.join(workDir, name);
+    fs.writeFileSync(p, "not really a tarball");
+    return p;
+  };
+
+  it("resolves the staging directory inside the Docker build context", function () {
+    // The Dockerfiles COPY this exact path, so the name is a contract.
+    assert.equal(
+      localPackageDir(containerDir),
+      path.join(containerDir, LOCAL_PACKAGE_DIRNAME)
+    );
+  });
+
+  it("ensures the directory exists so the Dockerfile COPY never fails", function () {
+    // `COPY .local-package/ ...` errors out when the source is missing, so the
+    // directory has to exist on every build, local package or not.
+    ensureLocalPackageDir(containerDir);
+    assert.ok(fs.statSync(localPackageDir(containerDir)).isDirectory());
+    ensureLocalPackageDir(containerDir); // idempotent
+    assert.ok(fs.statSync(localPackageDir(containerDir)).isDirectory());
+  });
+
+  it("stages a tarball and reports where it landed", function () {
+    const staged = stageLocalPackage(containerDir, tarball("doc-detective-9.9.9.tgz"));
+    assert.equal(
+      staged,
+      path.join(containerDir, LOCAL_PACKAGE_DIRNAME, "doc-detective-9.9.9.tgz")
+    );
+    assert.equal(fs.readFileSync(staged, "utf8"), "not really a tarball");
+  });
+
+  it("replaces a previously staged tarball instead of leaving two", function () {
+    // Two tarballs in the directory would make `npm install -g *.tgz`
+    // non-deterministic about which build actually ends up in the image.
+    stageLocalPackage(containerDir, tarball("doc-detective-1.0.0.tgz"));
+    stageLocalPackage(containerDir, tarball("doc-detective-2.0.0.tgz"));
+    const staged = fs
+      .readdirSync(localPackageDir(containerDir))
+      .filter((f) => f.endsWith(".tgz"));
+    assert.deepEqual(staged, ["doc-detective-2.0.0.tgz"]);
+  });
+
+  it("clears a stale tarball so a registry build stays a registry build", function () {
+    // The failure this prevents: someone runs a local-package build once, then
+    // builds normally, and silently keeps shipping the old local tarball.
+    stageLocalPackage(containerDir, tarball("doc-detective-1.0.0.tgz"));
+    clearLocalPackage(containerDir);
+    assert.deepEqual(
+      fs
+        .readdirSync(localPackageDir(containerDir))
+        .filter((f) => f.endsWith(".tgz")),
+      []
+    );
+    // …and the directory itself survives, because the COPY still needs it.
+    assert.ok(fs.statSync(localPackageDir(containerDir)).isDirectory());
+  });
+
+  it("rejects a missing tarball", function () {
+    assert.throws(
+      () => stageLocalPackage(containerDir, path.join(workDir, "nope.tgz")),
+      /not found/i
+    );
+  });
+
+  it("rejects a file that isn't a .tgz", function () {
+    assert.throws(
+      () => stageLocalPackage(containerDir, tarball("doc-detective.zip")),
+      /\.tgz/i
+    );
+  });
+});

--- a/test/container-run-outcome.test.js
+++ b/test/container-run-outcome.test.js
@@ -1,0 +1,50 @@
+// Unit cover for the container smoke test's pass/fail rule
+// (src/container/test/runOutcome.cjs), per ADR 01096.
+//
+// The published image is built for linux/amd64 AND linux/arm64, and the two
+// arches do not have the same browser support: upstream publishes no native
+// linux-arm64 chromedriver, so on arm64 every browser-backed spec resolves to
+// SKIPPED while the shell / HTTP / link-checking specs still run for real.
+// The gate therefore can't demand "everything passed" — but it also must not
+// degrade into "nothing failed", which an image that runs *nothing* would
+// satisfy. The rule is: no failures, and at least one spec actually passed.
+
+import assert from "node:assert/strict";
+import { assertRunOutcome } from "../src/container/test/runOutcome.cjs";
+
+const summary = (specs) => ({ summary: { specs } });
+
+describe("container smoke test: assertRunOutcome", function () {
+  it("accepts a run where browser specs skipped but others passed (arm64)", function () {
+    assert.doesNotThrow(() =>
+      assertRunOutcome(summary({ pass: 5, fail: 0, warning: 0, skipped: 8 }))
+    );
+  });
+
+  it("accepts a fully passing run (amd64)", function () {
+    assert.doesNotThrow(() =>
+      assertRunOutcome(summary({ pass: 13, fail: 0, warning: 0, skipped: 0 }))
+    );
+  });
+
+  it("rejects any failed spec", function () {
+    assert.throws(
+      () => assertRunOutcome(summary({ pass: 5, fail: 1, warning: 0, skipped: 8 })),
+      /1 spec\(s\) failed/
+    );
+  });
+
+  it("rejects a vacuous run where every spec skipped", function () {
+    // The failure mode the tolerance could otherwise hide: an image so broken
+    // that nothing runs still reports fail === 0.
+    assert.throws(
+      () => assertRunOutcome(summary({ pass: 0, fail: 0, warning: 0, skipped: 13 })),
+      /no spec passed/i
+    );
+  });
+
+  it("rejects a results file with no spec summary at all", function () {
+    assert.throws(() => assertRunOutcome({}), /summary/i);
+    assert.throws(() => assertRunOutcome(null), /summary/i);
+  });
+});

--- a/test/container-run-outcome.test.js
+++ b/test/container-run-outcome.test.js
@@ -48,3 +48,29 @@ describe("container smoke test: assertRunOutcome", function () {
     assert.throws(() => assertRunOutcome(null), /summary/i);
   });
 });
+
+describe("container smoke test: assertRunOutcome rejects an untrustworthy summary", function () {
+  // The gate decides whether an image ships, and it reads a JSON file written by
+  // a process that just crashed in every scenario it exists to catch. A `fail`
+  // count it can't trust must not be coerced to 0 — with any passing spec that
+  // would turn a broken run green.
+  const withFail = (fail) => ({ summary: { specs: { pass: 1, fail, skipped: 0 } } });
+
+  it("rejects a missing fail count", function () {
+    assert.throws(() => assertRunOutcome(withFail(undefined)), /fail count/i);
+  });
+
+  it("rejects a non-numeric fail count", function () {
+    assert.throws(() => assertRunOutcome(withFail("some")), /fail count/i);
+    assert.throws(() => assertRunOutcome(withFail(NaN)), /fail count/i);
+  });
+
+  it("rejects a negative or fractional fail count", function () {
+    assert.throws(() => assertRunOutcome(withFail(-1)), /fail count/i);
+    assert.throws(() => assertRunOutcome(withFail(1.5)), /fail count/i);
+  });
+
+  it("still accepts a well-formed zero", function () {
+    assert.doesNotThrow(() => assertRunOutcome(withFail(0)));
+  });
+});

--- a/test/detecttests-qualify-coverage.test.js
+++ b/test/detecttests-qualify-coverage.test.js
@@ -81,14 +81,19 @@ describe("detectTests qualifyFiles coverage: skip/error branches", function () {
 //
 // Regression cover for the arm64 Docker build (ADR 01096): a foreign-arch
 // chromedriver reached `execFile`, glibc's ENOEXEC fallback handed it to
-// /bin/sh, and the shell — running in the input directory — interpreted the
+// /bin/sh, and the shell, running in the input directory, interpreted the
 // binary as a script and left a file behind whose name is not valid UTF-8.
 // `fs.readdirSync` decodes such a name lossily (U+FFFD), so re-resolving it and
 // calling `fs.statSync` throws ENOENT. That unguarded throw killed the whole
 // run ("ENOENT: no such file or directory, stat '/app/<binary garbage>'")
-// before a single spec was parsed. The driver-side fix is the real cure; this
-// asserts the scan is resilient regardless of how an entry became unreadable
-// (a dangling symlink, a permissions hole, a file removed mid-scan).
+// before a single spec was parsed.
+//
+// The driver-side fix is the real cure; this asserts the scan is resilient
+// however an entry became unreadable. Two shapes are covered because no single
+// one is buildable everywhere: an undecodable filename needs Linux (APFS and
+// NTFS both reject one outright), and a dangling symlink needs privileges
+// Windows doesn't grant by default. Each case skips where its filesystem
+// refuses to build it rather than pretending to have run.
 describe("detectTests qualifyFiles: unreadable directory entries", function () {
   let tmp;
   beforeEach(function () {
@@ -98,31 +103,52 @@ describe("detectTests qualifyFiles: unreadable directory entries", function () {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("skips an entry whose name can't be round-tripped and still detects the valid specs", async function () {
-    if (process.platform === "win32") {
-      // Windows filenames are UTF-16 by construction, so a name that survives
-      // readdir but not a stat() round-trip can't be created here.
-      this.skip();
-    }
-    const spec = {
-      tests: [{ steps: [{ wait: 1 }] }],
-    };
-    fs.writeFileSync(path.join(tmp, "good.spec.json"), JSON.stringify(spec));
-    // Raw bytes that are not valid UTF-8 — the shape /bin/sh leaves behind when
-    // it interprets an ELF image as a script.
+  const writeGoodSpec = () =>
     fs.writeFileSync(
-      Buffer.concat([
-        Buffer.from(tmp + "/"),
-        Buffer.from([0xff, 0xfe, 0xfd]),
-        Buffer.from("-side-effect"),
-      ]),
-      ""
+      path.join(tmp, "good.spec.json"),
+      JSON.stringify({ tests: [{ steps: [{ wait: 1 }] }] })
     );
 
+  const expectOnlyTheGoodSpec = async () => {
     const specs = await detectTests({
       config: { ...baseConfig(), input: [tmp], recursive: true },
     });
     assert.equal(specs.length, 1);
     assert.match(String(specs[0].specId), /good\.spec\.json/);
+  };
+
+  it("skips an entry whose name can't be round-tripped (the arm64 case)", async function () {
+    writeGoodSpec();
+    try {
+      // Raw bytes that are not valid UTF-8 — the shape /bin/sh leaves behind
+      // when it interprets an ELF image as a script in the input directory.
+      fs.writeFileSync(
+        Buffer.concat([
+          Buffer.from(tmp + path.sep),
+          Buffer.from([0xff, 0xfe, 0xfd]),
+          Buffer.from("-side-effect"),
+        ]),
+        ""
+      );
+    } catch {
+      // APFS raises EILSEQ and Windows rejects the name outright; only Linux
+      // lets a non-UTF-8 filename exist, which is why the bug was Linux-only.
+      this.skip();
+    }
+    await expectOnlyTheGoodSpec();
+  });
+
+  it("skips a dangling symlink", async function () {
+    writeGoodSpec();
+    try {
+      fs.symlinkSync(
+        path.join(tmp, "does-not-exist.json"),
+        path.join(tmp, "dangling.spec.json")
+      );
+    } catch {
+      // Windows needs Developer Mode or elevation to create a symlink.
+      this.skip();
+    }
+    await expectOnlyTheGoodSpec();
   });
 });

--- a/test/detecttests-qualify-coverage.test.js
+++ b/test/detecttests-qualify-coverage.test.js
@@ -76,3 +76,53 @@ describe("detectTests qualifyFiles coverage: skip/error branches", function () {
     assert.deepEqual(specs, []);
   });
 });
+
+// A directory entry that `fs.statSync` cannot resolve must not abort the run.
+//
+// Regression cover for the arm64 Docker build (ADR 01096): a foreign-arch
+// chromedriver reached `execFile`, glibc's ENOEXEC fallback handed it to
+// /bin/sh, and the shell — running in the input directory — interpreted the
+// binary as a script and left a file behind whose name is not valid UTF-8.
+// `fs.readdirSync` decodes such a name lossily (U+FFFD), so re-resolving it and
+// calling `fs.statSync` throws ENOENT. That unguarded throw killed the whole
+// run ("ENOENT: no such file or directory, stat '/app/<binary garbage>'")
+// before a single spec was parsed. The driver-side fix is the real cure; this
+// asserts the scan is resilient regardless of how an entry became unreadable
+// (a dangling symlink, a permissions hole, a file removed mid-scan).
+describe("detectTests qualifyFiles: unreadable directory entries", function () {
+  let tmp;
+  beforeEach(function () {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "dd-detect-badentry-"));
+  });
+  afterEach(function () {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("skips an entry whose name can't be round-tripped and still detects the valid specs", async function () {
+    if (process.platform === "win32") {
+      // Windows filenames are UTF-16 by construction, so a name that survives
+      // readdir but not a stat() round-trip can't be created here.
+      this.skip();
+    }
+    const spec = {
+      tests: [{ steps: [{ wait: 1 }] }],
+    };
+    fs.writeFileSync(path.join(tmp, "good.spec.json"), JSON.stringify(spec));
+    // Raw bytes that are not valid UTF-8 — the shape /bin/sh leaves behind when
+    // it interprets an ELF image as a script.
+    fs.writeFileSync(
+      Buffer.concat([
+        Buffer.from(tmp + "/"),
+        Buffer.from([0xff, 0xfe, 0xfd]),
+        Buffer.from("-side-effect"),
+      ]),
+      ""
+    );
+
+    const specs = await detectTests({
+      config: { ...baseConfig(), input: [tmp], recursive: true },
+    });
+    assert.equal(specs.length, 1);
+    assert.match(String(specs[0].specId), /good\.spec\.json/);
+  });
+});

--- a/test/runtime-browsers.test.js
+++ b/test/runtime-browsers.test.js
@@ -686,6 +686,36 @@ describe("foreignExecutableImageReason", function () {
       })
     ).to.equal(undefined);
   });
+
+  it("decodes a big-endian header in its own byte order", function () {
+    // s390x is the one big-endian architecture in the table, so the e_machine
+    // field has to be read big-endian or every verdict on that host is noise.
+    expect(
+      foreignExecutableImageReason(
+        elfHeader({ machine: 0x16, littleEndian: false }),
+        { platform: "linux", arch: "s390x" }
+      ),
+      "a matching big-endian image must be accepted"
+    ).to.equal(undefined);
+    expect(
+      foreignExecutableImageReason(
+        elfHeader({ machine: EM_X86_64, littleEndian: false }),
+        { platform: "linux", arch: "s390x" }
+      ),
+      "a foreign big-endian image must be refused"
+    ).to.match(/x86-64/i);
+  });
+
+  it("stays silent when EI_DATA declares neither byte order (malformed header)", function () {
+    // Only 1 (LE) and 2 (BE) define a byte order. Anything else means the
+    // e_machine field can't be decoded, so there is no proof of a mismatch and
+    // the normal execute-and-report path must still run.
+    const header = elfHeader({ machine: EM_X86_64 });
+    header[5] = 7;
+    expect(
+      foreignExecutableImageReason(header, { platform: "linux", arch: "arm64" })
+    ).to.equal(undefined);
+  });
 });
 
 describe("verifyDriverBinary — foreign-architecture images", function () {

--- a/test/runtime-browsers.test.js
+++ b/test/runtime-browsers.test.js
@@ -5,6 +5,8 @@ import {
   requiredBrowserAssets,
   verifyDriverBinary,
   geckodriverBinaryInCache,
+  foreignExecutableImageReason,
+  driverExecOptions,
 } from "../dist/runtime/browsers.js";
 import {
   readInstalledRecord,
@@ -590,5 +592,168 @@ describe("runtime/browsers", function () {
     }
     expect(threw).to.equal(true);
     expect(downloads).to.equal(2); // initial + one re-download
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Foreign-architecture driver images (ADR 01096).
+//
+// Google publishes no native linux-arm64 chromedriver, and @puppeteer/browsers
+// maps BrowserPlatform.LINUX_ARM to the x64 asset — so on a native arm64 Linux
+// host the "installed" chromedriver is an x86-64 ELF. Handing that to
+// execFile() is not a benign failure: execve() returns ENOEXEC, glibc's execvp
+// retries the file through /bin/sh, and the shell then interprets 21 MB of
+// binary as a shell script *in the caller's working directory*. That is how the
+// arm64 Docker build ended up with an undecodable filename in /app.
+//
+// The guard is a header check that runs BEFORE any child process.
+// ---------------------------------------------------------------------------
+
+// Minimal 20-byte ELF header prefix: magic, class, data, version, ABI, then
+// e_type/e_machine. Enough for the check under test; nothing executes it.
+function elfHeader({ machine, class64 = true, littleEndian = true }) {
+  const h = Buffer.alloc(64);
+  h.write("\x7fELF", 0, "binary");
+  h[4] = class64 ? 2 : 1; // EI_CLASS
+  h[5] = littleEndian ? 1 : 2; // EI_DATA
+  h[6] = 1; // EI_VERSION
+  h.writeUInt16LE(2, 16); // e_type = ET_EXEC
+  if (littleEndian) h.writeUInt16LE(machine, 18);
+  else h.writeUInt16BE(machine, 18);
+  return h;
+}
+const EM_X86_64 = 0x3e;
+const EM_AARCH64 = 0xb7;
+
+describe("foreignExecutableImageReason", function () {
+  it("flags an x86-64 ELF on linux/arm64 (the chromedriver-on-arm64 case)", function () {
+    const reason = foreignExecutableImageReason(
+      elfHeader({ machine: EM_X86_64 }),
+      { platform: "linux", arch: "arm64" }
+    );
+    expect(reason).to.be.a("string");
+    expect(reason).to.match(/x86-64/i);
+    expect(reason).to.match(/arm64/i);
+  });
+
+  it("accepts a matching ELF for the host architecture", function () {
+    expect(
+      foreignExecutableImageReason(elfHeader({ machine: EM_AARCH64 }), {
+        platform: "linux",
+        arch: "arm64",
+      })
+    ).to.equal(undefined);
+    expect(
+      foreignExecutableImageReason(elfHeader({ machine: EM_X86_64 }), {
+        platform: "linux",
+        arch: "x64",
+      })
+    ).to.equal(undefined);
+  });
+
+  it("stays silent for a non-ELF image (no positive proof of a mismatch)", function () {
+    expect(
+      foreignExecutableImageReason(Buffer.from("#!/bin/sh\necho hi\n"), {
+        platform: "linux",
+        arch: "arm64",
+      })
+    ).to.equal(undefined);
+    expect(
+      foreignExecutableImageReason(Buffer.alloc(0), {
+        platform: "linux",
+        arch: "arm64",
+      })
+    ).to.equal(undefined);
+  });
+
+  it("stays silent off Linux — macOS and Windows on ARM emulate x64 transparently", function () {
+    for (const platform of ["darwin", "win32"]) {
+      expect(
+        foreignExecutableImageReason(elfHeader({ machine: EM_X86_64 }), {
+          platform,
+          arch: "arm64",
+        }),
+        platform
+      ).to.equal(undefined);
+    }
+  });
+
+  it("stays silent for an architecture it has no mapping for (fail open)", function () {
+    expect(
+      foreignExecutableImageReason(elfHeader({ machine: EM_X86_64 }), {
+        platform: "linux",
+        arch: "sparc64",
+      })
+    ).to.equal(undefined);
+  });
+});
+
+describe("verifyDriverBinary — foreign-architecture images", function () {
+  let dir;
+  beforeEach(function () {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "dd-foreign-drv-"));
+  });
+  afterEach(function () {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("refuses an x86-64 chromedriver on linux/arm64 WITHOUT spawning it", async function () {
+    const bin = path.join(dir, "chromedriver");
+    fs.writeFileSync(bin, elfHeader({ machine: EM_X86_64 }));
+    let execCalled = false;
+    const res = await verifyDriverBinary("chromedriver", bin, {
+      imageEnv: { platform: "linux", arch: "arm64" },
+      exec: async () => {
+        execCalled = true;
+        return { code: 0, stdout: "ChromeDriver 1.2.3\n", stderr: "" };
+      },
+    });
+    expect(res.ok).to.equal(false);
+    expect(res.error).to.match(/x86-64/i);
+    // The whole point: never hand a foreign image to execFile, because the
+    // ENOEXEC → /bin/sh fallback executes it as a shell script.
+    expect(execCalled, "must not spawn a foreign-architecture image").to.equal(
+      false
+    );
+  });
+
+  it("still executes a matching-architecture driver", async function () {
+    const bin = path.join(dir, "chromedriver");
+    fs.writeFileSync(bin, elfHeader({ machine: EM_AARCH64 }));
+    const res = await verifyDriverBinary("chromedriver", bin, {
+      imageEnv: { platform: "linux", arch: "arm64" },
+      exec: async () => ({ code: 0, stdout: "ChromeDriver 1.2.3\n", stderr: "" }),
+    });
+    expect(res.ok, res.error).to.equal(true);
+    expect(res.version).to.equal("1.2.3");
+  });
+
+  it("falls open when the header can't be read (unreadable file, races)", async function () {
+    // Missing file: the header probe fails, so the existing spawn path still
+    // runs and reports the real failure rather than a bogus arch verdict.
+    const res = await verifyDriverBinary(
+      "chromedriver",
+      path.join(dir, "chromedriver"),
+      {
+        imageEnv: { platform: "linux", arch: "arm64" },
+        exec: async () => ({ code: null, stdout: "", stderr: "ENOENT" }),
+      }
+    );
+    expect(res.ok).to.equal(false);
+    expect(res.error).to.match(/spawn failed/i);
+  });
+});
+
+describe("driverExecOptions", function () {
+  it("runs the driver in a scratch directory, never the caller's cwd", function () {
+    // Defense in depth for the ENOEXEC → /bin/sh fallback the header check
+    // can't catch (a truncated but well-formed image, a missing loader): the
+    // shell then interprets the binary in a temp dir instead of the user's
+    // project, where its redirections would litter the input tree.
+    const opts = driverExecOptions(5000);
+    expect(opts.cwd).to.equal(os.tmpdir());
+    expect(opts.cwd).to.not.equal(process.cwd());
+    expect(opts.timeout).to.equal(5000);
+    expect(opts.windowsHide).to.equal(true);
   });
 });


### PR DESCRIPTION
Fixes the `build-linux (ubuntu-24.04-arm, linux/arm64, arm64)` leg of the **Docker build** workflow, which has failed on every run — on `main` and on PRs carrying nothing but a docs diff.

## Root cause

Confirmed by reproducing the whole chain in a Linux container:

1. Google publishes no native `linux-arm64` chromedriver, and `@puppeteer/browsers` maps `BrowserPlatform.LINUX_ARM` to the **x64** asset. A native arm64 host "installs" an x86-64 ELF.
2. `verifyDriverBinary` runs it via `execFile`. `execve` returns **ENOEXEC**, and glibc's `execvp` — which libuv goes through — responds by **retrying the file through `/bin/sh`**.
3. `/bin/sh` interprets 21 MB of binary as a shell script **in the caller's working directory** (`/app`, the mounted input tree). Any byte sequence that parses as a redirection creates a file whose name is raw binary.
4. `qualifyFiles` scans that directory. `readdir` decodes the name lossily into U+FFFD, so the re-resolved path no longer exists, and an **unguarded** `fs.statSync` throws. The run dies with `ENOENT: no such file or directory, stat '/app/<binary garbage>'` before a single spec is parsed.

[ADR 01053](adrs/01053-best-effort-browser-asset-install.md) had already fixed the *install* half; this is the *run* half, and the `stat` error was a real second defect, not an artifact of the first.

## What changed

- **Never hand a provably foreign image to a child process.** `foreignExecutableImageReason` reads the first 64 bytes and, on Linux, refuses an ELF whose `e_machine` can't run here — without spawning anything. Deliberately conservative: no verdict off Linux (Rosetta 2 and Windows on ARM emulate x64), for a non-ELF image, an unreadable header, or an unmapped architecture. Every uncertain case degrades to today's execute-and-report path.
- **Pin the driver probe's `cwd` to a scratch directory**, so an ENOEXEC the header check can't predict can no longer litter the user's project.
- **Guard the input scan's `statSync`**, so one unreadable entry costs that entry rather than the whole run.
- **The container smoke test's gate becomes "no failed specs AND at least one spec passed"** (`assertRunOutcome`). The arm64 image genuinely can't run Chrome, so its browser specs SKIP through the runner's existing availability gating — but a tolerance of `fail === 0` alone would also pass an image that runs nothing.
- **PR container builds now install this branch's package** instead of `doc-detective@latest` from npm. Without this the gate is blind to the change under review, and this PR could not turn its own arm64 leg green.

## Verification

- Red→green unit tests for the arch gate, the scratch cwd, the guarded scan, the smoke-test rule, and the local-package staging.
- The `qualifyFiles` regression test reproduces the exact CI error (`ENOENT … stat '…/���-side-effect'`) before the fix; POSIX-only, verified red then green under `node:22-slim`.
- End-to-end against a locally built image (packed from this branch), with chromedriver's ELF `e_machine` patched to force ENOEXEC and the Chrome download hosts blackholed so the repair can't succeed — i.e. the arm64 end state: container exits **0**, the driver is refused with a clear message, **zero** shell-parse debris, `/app` gains nothing but the run's own output, and the run reports **6 pass / 0 fail / 8 skipped**.
- Full suite: 4097 passing, 0 failing.

## ADRs

- [01096 — Never execute a foreign-architecture driver binary](adrs/01096-never-execute-a-foreign-architecture-driver-binary.md)
- [01097 — Build pull-request container images from the branch](adrs/01097-build-pull-request-images-from-the-branch.md)

## Documentation impact

**Yes.** A new user-visible failure mode with a distinct remedy: reinstalling does not fix an architecture mismatch. Added *A driver was built for a different CPU architecture* to [Setup issues](docs/fern/pages/docs/troubleshooting/setup-issues.mdx) (Priya / Diego, cross-cutting CUJ X1), cross-linked from the existing present-but-broken-driver section. No new page, so no IA content-set change. No feature fixture: the change adds no user-facing knob, and its trigger — a driver built for another CPU — can't be authored in a spec; the container smoke test is the end-to-end cover and now runs on both architectures.

## Noted separately

`geckodriver` also fails to install in this image, on **both** architectures (`Refusing to execute '/opt/doc-detective/browsers'` — the cache probe misses the version-suffixed binary name and falls back to the cache directory). Pre-existing and independent of this fix; `linux/amd64` is green with it, so it's tracked separately rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull-request container images now test the branch’s locally built package instead of the latest published release.
  * Linux detects incompatible browser-driver architectures before execution.
  * Driver checks run from a temporary directory for improved isolation.
  * Directory scans continue when individual entries cannot be read.

* **Bug Fixes**
  * Container smoke tests require at least one successful check and reject failed checks.
  * Unreadable or invalid directory entries no longer abort test discovery.

* **Documentation**
  * Added guidance for diagnosing browser drivers built for a different CPU architecture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->